### PR TITLE
chore: remove abandoned gfn-electron package

### DIFF
--- a/home/games/steam.nix
+++ b/home/games/steam.nix
@@ -10,6 +10,7 @@
     steam-run
     # lutris REMOVED: depends on moddb which has slow pyrate-limiter dependency (25+ min test phase)
     # Alternative: Install Lutris as flatpak or override to skip tests
-    gfn-electron
+    # gfn-electron REMOVED: Abandoned upstream and removed from nixpkgs
+    # Alternative: Use GeForce NOW via web browser (works great in Chrome/Chromium)
   ];
 }

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -597,7 +597,7 @@ in
       "olm-3.2.16"
       "python3.12-youtube-dl-2021.12.17"
       "libsoup-2.74.3" # Temporary: Required by some GNOME packages until migration to libsoup-3
-      "electron-35.7.5" # Required by gfn-electron (GeForce NOW client)
+      "electron-35.7.5" # Temporary: Required until upstream packages migrate to newer electron
     ];
   };
 }


### PR DESCRIPTION
## Summary

Remove gfn-electron from gaming packages as it has been abandoned upstream and removed from nixpkgs.

## Changes Made

- ✅ Removed `gfn-electron` from `home/games/steam.nix` package list
- ✅ Added explanatory comment with browser alternative (Chrome/Chromium works great)
- ✅ Updated `electron-35.7.5` permit comment to generic message in P620 config
  - Kept the permit since samsung and razer hosts still require it for other packages

## Testing

- ✅ Syntax check passed: `just check-syntax`
- ✅ Build test passed: `just test-host p620`
- ✅ Configuration builds successfully without gfn-electron

## Alternative Solution

Users can access GeForce NOW via web browser, which works excellently in Chrome/Chromium browsers as a replacement for the abandoned gfn-electron desktop application.

## Related Issues

Closes #10

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)