### PR TITLE
feat(desktop): add terminal app desktop entries for k9s, Claude Code, and Neovim (#16 #17)

### DIFF
--- a/home/desktop/default.nix
+++ b/home/desktop/default.nix
@@ -5,6 +5,7 @@
     ./terminals/default.nix
     ./rofi/default.nix
     ./swaync/default.nix
+    ./terminal-apps-desktop-entries.nix
 
     # Core desktop modules (now enhanced)
     ./theme/default.nix

--- a/home/desktop/terminal-apps-desktop-entries.nix
+++ b/home/desktop/terminal-apps-desktop-entries.nix
@@ -1,0 +1,86 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs;
+in
+{
+  options.programs = {
+    k9s.desktopEntry = {
+      enable = mkEnableOption "k9s desktop entry for application launchers";
+    };
+
+    claude-code.desktopEntry = {
+      enable = mkEnableOption "Claude Code desktop entry for application launchers";
+    };
+
+    neovim.desktopEntry = {
+      enable = mkEnableOption "Neovim desktop entry for application launchers and file associations";
+    };
+  };
+
+  config = mkMerge [
+    # K9s Desktop Entry
+    (mkIf cfg.k9s.desktopEntry.enable {
+      xdg.desktopEntries.k9s = {
+        name = "K9s";
+        genericName = "Kubernetes CLI Manager";
+        comment = "Kubernetes CLI To Manage Your Clusters In Style";
+        exec = "${pkgs.k9s}/bin/k9s";
+        icon = "k9s";
+        terminal = true;
+        type = "Application";
+        categories = [ "System" "TerminalEmulator" "Development" ];
+        keywords = [ "kubernetes" "k8s" "cluster" "management" "container" "pod" ];
+      };
+    })
+
+    # Claude Code Desktop Entry
+    (mkIf cfg.claude-code.desktopEntry.enable {
+      xdg.desktopEntries.claude-code = {
+        name = "Claude Code";
+        genericName = "AI-Powered Code Assistant";
+        comment = "Claude Code CLI for AI-assisted development";
+        exec = "claude";
+        icon = "claude-code";
+        terminal = true;
+        type = "Application";
+        categories = [ "Development" "TextEditor" "Utility" ];
+        keywords = [ "ai" "claude" "code" "assistant" "development" "anthropic" ];
+      };
+    })
+
+    # Neovim Desktop Entry with File Associations
+    (mkIf cfg.neovim.desktopEntry.enable {
+      xdg.desktopEntries.neovim = {
+        name = "Neovim";
+        genericName = "Text Editor";
+        comment = "Hyperextensible Vim-based text editor";
+        exec = "nvim %F";
+        icon = "nvim";
+        terminal = true;
+        type = "Application";
+        categories = [ "Development" "TextEditor" "Utility" ];
+        keywords = [ "vim" "neovim" "editor" "text" "code" ];
+        mimeType = [
+          "text/plain"
+          "text/x-csrc"
+          "text/x-c++src"
+          "text/x-python"
+          "text/x-shellscript"
+          "text/x-markdown"
+          "text/x-yaml"
+          "application/x-yaml"
+          "application/json"
+          "text/x-rust"
+          "text/x-go"
+          "text/x-java"
+          "text/x-lua"
+          "text/x-makefile"
+          "text/x-nix"
+        ];
+      };
+    })
+  ];
+}

--- a/hosts/p620/home-manager-options.nix
+++ b/hosts/p620/home-manager-options.nix
@@ -2,6 +2,12 @@
   programs.obs.enable = lib.mkForce true;
   programs.kdeconnect.enable = lib.mkForce true;
   programs.slack.enable = lib.mkForce true;
+
+  # Terminal app desktop entries
+  programs.k9s.desktopEntry.enable = lib.mkForce true;
+  programs.claude-code.desktopEntry.enable = lib.mkForce true;
+  programs.neovim.desktopEntry.enable = lib.mkForce true;
+
   # Terminals
   # alacritty.enable = lib.mkForce true;
   foot.enable = lib.mkForce true;

--- a/hosts/razer/home-manager-options.nix
+++ b/hosts/razer/home-manager-options.nix
@@ -1,4 +1,9 @@
-_: {
+{ lib, ... }: {
+  # Terminal app desktop entries
+  programs.k9s.desktopEntry.enable = lib.mkForce true;
+  programs.claude-code.desktopEntry.enable = lib.mkForce true;
+  programs.neovim.desktopEntry.enable = lib.mkForce true;
+
   # Host-specific features configuration
   # This replaces all the individual lib.mkForce calls with a unified approach
   features = {

--- a/hosts/samsung/home-manager-options.nix
+++ b/hosts/samsung/home-manager-options.nix
@@ -1,4 +1,9 @@
-{ ... }: {
+{ lib, ... }: {
+  # Terminal app desktop entries
+  programs.k9s.desktopEntry.enable = lib.mkForce true;
+  programs.claude-code.desktopEntry.enable = lib.mkForce true;
+  programs.neovim.desktopEntry.enable = lib.mkForce true;
+
   # Host-specific features configuration
   # This replaces all the individual lib.mkForce calls with a unified approach
   features = {


### PR DESCRIPTION
Implement comprehensive desktop application shortcuts for terminal-based
tools to enable launching from application menus, launchers, and docks.

Features:
- Unified terminal apps desktop entries module
- K9s desktop entry for Kubernetes management
- Claude Code desktop entry for AI-assisted development
- Neovim desktop entry with file associations and MIME types

Implementation:
- Created home/desktop/terminal-apps-desktop-entries.nix module
- Added module to home manager desktop imports
- Enabled on all desktop hosts (P620, Razer, Samsung)
- Follows freedesktop.org Desktop Entry Specification

Benefits:
- Launch terminal apps from Rofi, application menus, docks
- Neovim file associations for Open With functionality
- Consistent desktop integration across all tools
- Declarative NixOS configuration

Testing:
- P620 build successful
- Module properly integrated with Home Manager
- Desktop entries configured for all supported hosts

Closes #16
Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
