### PR TITLE
chore(claude-code): update to version 2.0.37

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.0.36";
+    version = "2.0.37";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-QglarMjjnYt9XAFi+0TYc6HMOUMGgSabrEksAEz9DhM=";
+      hash = "sha256-pcWFz29LglRB3ZPPOVuPSGXBanYye8pEfpTtu/UdFRk=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 

--- a/home/development/claude-code/package.json
+++ b/home/development/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthropic-ai/claude-code",
-  "version": "2.0.32",
+  "version": "2.0.37",
   "main": "sdk.mjs",
   "types": "sdk.d.ts",
   "bin": {


### PR DESCRIPTION
## Summary

Update Claude Code CLI from version 2.0.36 to 2.0.37, bringing bug fixes and new features for improved developer experience.

## Changes

### Version Update
- **Version**: 2.0.36 → 2.0.37
- **Source Hash**: Updated for new tarball
- **Package.json**: Updated version number
- **npmDepsHash**: Unchanged (dependencies identical)

### New Features in 2.0.37

**Bug Fixes:**
- ✅ Fixed `claude doctor` incorrectly detecting Homebrew vs npm-global installations by properly resolving symlinks
- ✅ Fixed `claude mcp serve` exposing tools with incompatible outputSchemas
- ✅ Fixed hook progress messages not updating correctly during PostToolUse hook execution

**Features:**
- ✨ Un-deprecated output styles based on community feedback
- ✨ Added `companyAnnouncements` setting for displaying announcements on startup
- ✨ Windows: native installation uses shift+tab as shortcut for mode switching (instead of alt+m)
- ✨ Vertex: added support for Web Search on supported models
- ✨ VSCode: added `respectGitIgnore` configuration to include .gitignored files in file searches (defaults to true)

## Testing

- ✅ **Syntax Check**: `just check-syntax` - Passed
- ✅ **Full Validation**: `just validate` - Passed
- ✅ **Local Build**: Package builds successfully
- ✅ **Version Verification**: `./result/bin/claude --version` shows 2.0.37
- ✅ **P620 Configuration**: `just test-host p620` - Passed
- ✅ **P620 Deployment**: `just quick-deploy p620` - Successful
- ✅ **Runtime Verification**: `claude --version` shows 2.0.37 on system

## Files Changed

- `home/development/claude-code/default.nix` - Updated version and source hash
- `home/development/claude-code/package.json` - Updated version number

## References

- Closes #19
- [Official Changelog](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md)
- [NPM Package](https://www.npmjs.com/package/@anthropic-ai/claude-code)

## Deployment Notes

This is a patch release with no breaking changes. The update has been:
- Tested locally with successful build
- Validated against all configuration checks
- Deployed and verified on P620 workstation

Ready for merge.