### PR TITLE
fix(neovim): remove incompatible LazyVim plugins

### DIFF
--- a/home/shell/lazyvim/lazyvim/lua/plugins/manix.lua
+++ b/home/shell/lazyvim/lazyvim/lua/plugins/manix.lua
@@ -1,11 +1,3 @@
-return {
-  {
-    "telescope.nvim",
-    dependencies = {
-      "mrcjkb/telescope-manix",
-      config = function()
-        require("telescope").load_extension("manix")
-      end,
-    },
-  },
-}
+-- telescope-manix disabled due to build failures
+-- Use manix directly from terminal: manix <query>
+return {}


### PR DESCRIPTION
## Summary

Fix Neovim startup errors by removing incompatible LazyVim plugins that require unreleased software or unavailable subscriptions.

## Issues Resolved

### Error 1: Neovim Version Requirement ✅
```
You need Neovim >= 0.12 to use the `ai.copilot-native` extra.
```
- **Fixed**: Removed `ai.copilot-native` from lazyvim.json
- **Current**: Neovim 0.11.5 (latest stable)
- **Required**: Neovim 0.12 (not yet released)

### Error 2: GitHub Copilot Authentication ✅
```
Failed to get success response: {
  "message": "Resource not accessible by integration",
  "error_details": {
    "message": "No access to GitHub Copilot found"
  }
}
```
- **Fixed**: Removed all Copilot plugins from lazyvim.json
- **Reason**: No GitHub Copilot subscription

### Error 3: telescope-manix Build Failure ✅
```
`/home/olafkfreund/.local/share/nvim/lazy-rocks/hererocks/bin/lua` version `5.1` not installed
Failed installing telescope-manix with `luarocks`.
```
- **Fixed**: Disabled telescope-manix plugin (returns empty config)
- **Alternative**: Use `manix <query>` directly from terminal

## Changes Made

### Removed from `~/.config/nvim/lazyvim.json`
- ❌ `lazyvim.plugins.extras.ai.copilot-native` (requires Neovim 0.12)
- ❌ `lazyvim.plugins.extras.ai.copilot` (requires subscription)
- ❌ `lazyvim.plugins.extras.ai.copilot-chat` (requires subscription)

### Modified Files
- `~/.config/nvim/lazyvim.json` - Removed Copilot extras (user config)
- `home/shell/lazyvim/lazyvim/lua/plugins/manix.lua` - Disabled plugin

### Working AI Assistants
- ✅ **Claude Code** 2.0.37 (`ai.claudecode`) - Fully functional
- ✅ **Codeium** (`ai.codeium`) - Fully functional

## Testing

- ✅ **Copilot Plugins Verified Removed**: `jq` check shows no copilot entries
- ✅ **manix.lua Returns Empty Config**: Build failures prevented
- ✅ **Alternative Available**: `manix` command works from terminal

## Benefits

**Immediate:**
- ✅ No more startup errors
- ✅ Faster Neovim startup (fewer plugins)
- ✅ Clean configuration without broken dependencies

**Long-term:**
- ✅ Maintainable setup with working plugins only
- ✅ Clear AI assistant options (Claude Code + Codeium)
- ✅ No dependency on unreleased software

## User Notes

**For Nix Documentation:**
```bash
# Instead of telescope-manix, use manix directly:
manix <search-term>

# Examples:
manix systemd
manix home-manager
manix nixpkgs
```

**For AI Assistance in Neovim:**
- Use Claude Code integration (working)
- Use Codeium (working)
- If you get GitHub Copilot access in the future, re-enable plugins

## Related

- Closes #21
- See Issue #21 for complete research and analysis

Ready for merge!