### PR TITLE
chore(kosli-cli): upgrade to version 2.11.32

### DIFF
--- a/pkgs/kosli-cli/default.nix
+++ b/pkgs/kosli-cli/default.nix
@@ -5,17 +5,17 @@
 
 buildGoModule rec {
   pname = "kosli-cli";
-  version = "2.11.31";
+  version = "2.11.32";
 
   src = fetchFromGitHub {
     owner = "kosli-dev";
     repo = "cli";
     rev = "v${version}";
-    hash = "sha256-nlMiTUPhR9S/exrWk95oWmrKTC/r2rxFFzWKMGFEVsU=";
+    hash = "sha256-j/yLfb2XJFqODk2jIEWyX12txk+gztHFmz8DHZmSEvQ=";
   };
 
   # Vendor hash calculated from go.mod dependencies
-  vendorHash = "sha256-81SVz4Vs+NVk013JlfEz99zKiJUhjSE2K3xCU+xJ0Qw=";
+  vendorHash = "sha256-POG6l82VIpD98d4hKscyBBmcTIw6ykpicRbLiY9rbW4=";
 
   # Enable strict dependency separation for cross-compilation
   strictDeps = true;


### PR DESCRIPTION
## Summary

Upgrades Kosli CLI from version 2.11.31 to 2.11.32, incorporating the latest documentation updates and improvements.

## Changes

- ✅ Updated version from 2.11.31 to 2.11.32
- ✅ Updated source hash: `sha256-j/yLfb2XJFqODk2jIEWyX12txk+gztHFmz8DHZmSEvQ=`
- ✅ Updated vendorHash: `sha256-POG6l82VIpD98d4hKscyBBmcTIw6ykpicRbLiY9rbW4=`

## Release Notes (Nov 21, 2025)

- Documentation updates regarding mandatory policies for compliance checks
- Enhanced compliance check handling and environment management

## Testing

✅ **Build Validation:**
```bash
nix build .#kosli-cli
```

✅ **Version Verification:**
```bash
./result/bin/kosli version
# Output: version.BuildInfo{Version:"2.11.32", GitCommit:"v2.11.32", GitTreeState:"clean", GoVersion:"go1.25.4"}
```

✅ **System Integration:**
```bash
nix build .#nixosConfigurations.p620.config.system.build.toplevel --dry-run
# P620 configuration validates successfully
```

## Deployment Plan

1. Merge this PR
2. Deploy to P620: `just quick-deploy p620`
3. Verify kosli-cli functionality post-deployment

Closes #43