### PR TITLE
chore: Update Claude Code to version 2.0.56

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,16 +9,16 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.0.55";
+    version = "2.0.56";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-XK+B3oGrcnAi19a7Ttgv2Zpx0+M/nDQenhHQWESumZE=";
+      hash = "sha256-lv8ORG3GYq+ujxEx+IDI7NVyY6q9CwT6QiOH4vn1vwQ=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 
     # No npm dependencies to cache - all dependencies are vendored
-    npmDepsHash = "sha256-k7sCE3dyHz69qlxxrX+lnPuJUf8w/FAAUQtFuEdlTqA=";
+    npmDepsHash = "sha256-yoVNRg7XdVBHGJPlmZ3g/vQ/0qSroKUVaN91N2XWtEs=";
 
     inherit nodejs;
 


### PR DESCRIPTION
## Summary

Updates Claude Code from version 2.0.55 to 2.0.56 to ensure access to the latest features and fixes.

## Changes

- **Version**: 2.0.55 → 2.0.56
- **Source Hash**: Updated to `sha256-lv8ORG3GYq+ujxEx+IDI7NVyY6q9CwT6QiOH4vn1vwQ=`
- **npmDepsHash**: Updated to `sha256-yoVNRg7XdVBHGJPlmZ3g/vQ/0qSroKUVaN91N2XWtEs=`

## Testing

✅ **Package Build**: Successfully built with Nix  
✅ **CLI Version**: Verified `claude --version` outputs 2.0.56  
✅ **Validation**: Package derivation validated successfully  
✅ **Module Checks**: All NixOS modules pass validation  

## Implementation

- Used automated update script: `./update-claude-code-lock.sh --version 2.0.56`
- Manually updated npmDepsHash (script had minor sed issue)
- Verified all changes in default.nix

## Related Issues

Closes #51

## Checklist

- [x] Version updated to 2.0.56
- [x] Source hash calculated and updated
- [x] npmDepsHash calculated and updated  
- [x] Package builds successfully
- [x] CLI version verified
- [x] Validation tests pass
- [x] Follows NixOS best practices (no anti-patterns)
- [x] Commit message follows conventional commits format

## Next Steps

After merge:
1. Deploy to P620: `just quick-deploy p620`
2. Verify Claude Code functionality in production
3. Monitor for any issues