### PR TITLE
chore(razer): disable Ollama for resource optimization (#67)

### DIFF
--- a/hosts/razer/nixos-options.nix
+++ b/hosts/razer/nixos-options.nix
@@ -41,8 +41,8 @@
   # VPN
   vpn.tailscale.enable = lib.mkForce true;
 
-  # AI
-  ai.ollama.enable = lib.mkForce true;
+  # AI (Ollama disabled on mobile hosts for resource optimization - Issue #67)
+  ai.ollama.enable = lib.mkForce false;
 
   # Printing
   services.print.enable = lib.mkForce true;


### PR DESCRIPTION
Disable Ollama on Razer laptop to optimize system resources. Ollama is not
currently being used and consumes ~2-4GB RAM and background CPU cycles.

Changes:
- Set ai.ollama.enable to false in hosts/razer/nixos-options.nix
- Samsung already has Ollama disabled (confirmed)
- Build test passed successfully (77 seconds, 9 derivations)

Benefits:
- Free up 2-4GB RAM
- Reduce background processes and idle CPU usage
- Improve battery life on mobile device
- Ollama remains enabled on P620 for local AI inference

Testing:
- Build test completed successfully
- Ready for deployment

Closes #67
