### PR TITLE
chore(claude-code): update to version 2.1.1 (#122)

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.0.76";
+    version = "2.1.1";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-/KOZNv+OkxDI5MaDPWRVNBuSrNkjF3hfD3c+50ORudk=";
+      hash = "sha256-oMmivRpTwwRAP/m+A5zniU7PgWeLsPr/Z427VRtAFus=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 


### PR DESCRIPTION
## Summary

Updates Claude Code package from version 2.0.76 to 2.1.1 with comprehensive testing and validation.

## Changes

### Package Updates
- **Version**: 2.0.76 → 2.1.1
- **Source Hash**: `sha256-oMmivRpTwwRAP/m+A5zniU7PgWeLsPr/Z427VRtAFus=`
- **NPM Dependencies**: Hash unchanged (identical dependency structure)

### Files Modified
- `home/development/claude-code/default.nix`:
  - Line 12: Updated `version` attribute
  - Line 16: Updated `hash` for source tarball

## Testing Evidence

### ✅ Build Validation

**Isolated Package Build (nix-build)**:
```
Output: /nix/store/6402s7hbj5pdy5k7hf7ds9xjd2w520yk-claude-code-2.1.1
Status: ✅ SUCCESS
```

**System Integration Test (nh os build)**:
```
[CHANGED]
[U.] claude-code 2.0.76 -> 2.1.1
SIZE: 83.4 GiB -> 83.4 GiB
DIFF: -4.52 KiB
Status: ✅ SUCCESS
```

### ✅ Binary Verification

```bash
$ ./result/bin/claude --version
2.1.1 (Claude Code)
```

### ✅ Pre-commit Hooks

All pre-commit hooks passed:
- ✅ Format Nix files
- ✅ Lint Nix files
- ✅ Check for dead Nix code
- ✅ Trim trailing whitespace
- ✅ Fix end of files
- ✅ Check for merge conflicts
- ✅ Mixed line ending
- ✅ Check executable shebangs

## Risk Assessment

**Risk Level**: LOW

- Minor version update with no breaking changes
- No configuration changes required
- All dependencies unchanged (verified via npmDepsHash)
- Successfully tested on P620 workstation
- Easy rollback via NixOS generations if needed

## Deployment Plan

After merge, deploy to all hosts:

1. **P620** (primary workstation) - Priority: High
2. **Razer** (mobile development) - Priority: Medium
3. **P510** (media server) - Priority: Medium
4. **Samsung** (mobile) - Priority: Low

Commands:
```bash
just quick-deploy p620
just quick-deploy razer
just quick-deploy p510
just quick-deploy samsung
```

## Checklist

- [x] Code follows PATTERNS.md best practices
- [x] No anti-patterns from NIXOS-ANTI-PATTERNS.md
- [x] Package builds successfully
- [x] System integration tested
- [x] Binary functionality verified
- [x] Pre-commit hooks pass
- [x] Commit message follows conventional commits
- [x] Testing evidence documented

## Related

Closes #122

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)