### PR TITLE
feat(cosmic): Add Tailscale VPN management applet

### DIFF
--- a/pkgs/cosmic-applets/tailscale/default.nix
+++ b/pkgs/cosmic-applets/tailscale/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, just
+, libxkbcommon
+, wayland
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gui-scale-applet";
+  version = "3.0.0-unstable-2025-11-29";
+
+  src = fetchFromGitHub {
+    owner = "cosmic-utils";
+    repo = "gui-scale-applet";
+    rev = "9528f588d7a010149071136ea3f9948771f7d0cf"; # Latest commit as of 2025-11-29
+    hash = "sha256-/oTU+FF10YhgadIG61M8R9LQUV3kkcLczlbV9/53D7I=";
+  };
+
+  cargoHash = "sha256-G0YJifAC+/cl9l592vDGmVDsMwG6VyJLfw0abc/3PKk=";
+
+  nativeBuildInputs = [
+    pkg-config
+    just
+  ];
+
+  buildInputs = [
+    libxkbcommon
+    wayland
+  ];
+
+  strictDeps = true;
+
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+
+  # The upstream justfile uses 'sudo install' which doesn't work in Nix sandbox
+  # We implement our own installPhase instead
+  dontUseJustInstall = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm0755 target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/${pname} $out/bin/${pname}
+    install -Dm0644 data/com.bhh32.GUIScaleApplet.desktop $out/share/applications/com.bhh32.GUIScaleApplet.desktop
+    install -Dm0644 data/com.github.bhh32.GUIScaleApplet.metainfo.xml $out/share/metainfo/com.github.bhh32.GUIScaleApplet.metainfo.xml
+    install -Dm0644 data/icons/scalable/apps/tailscale-icon.png $out/share/icons/hicolor/scalable/status/tailscale-icon.png
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "COSMIC panel applet for Tailscale VPN management";
+    longDescription = ''
+      A Tailscale management applet for the COSMIC desktop environment.
+
+      Features:
+      - Visual network status indicator
+      - Quick connect/disconnect actions
+      - Network selection interface
+      - Exit node configuration
+      - Tailscale settings access
+
+      Note: Requires Tailscale to be installed and users must have operator
+      privileges. Run: sudo tailscale set --operator=$USER
+    '';
+    homepage = "https://github.com/cosmic-utils/gui-scale-applet";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ ];
+    platforms = platforms.linux;
+    mainProgram = "gui-scale-applet";
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -24,4 +24,7 @@
   awscli2 = pkgs.awscli2.overrideAttrs (_oldAttrs: {
     doCheck = false; # Disable tests - 44 tests failing in wizard/test_app.py
   });
+
+  # COSMIC applets
+  cosmic-ext-applet-tailscale = pkgs.callPackage ./cosmic-applets/tailscale { };
 }


### PR DESCRIPTION
## Summary

Implements a comprehensive Tailscale VPN management applet for the COSMIC desktop environment.

## Changes

### Package Implementation
- ✅ Created buildRustPackage derivation at `pkgs/cosmic-applets/tailscale/default.nix`
- ✅ Resolved upstream justfile sudo incompatibility with custom installPhase
- ✅ Proper installation of desktop file, metainfo, and icon assets
- ✅ Package successfully builds and tested

### COSMIC Desktop Integration
- ✅ Added `enableTailscaleApplet` option (default: true)
- ✅ Integration with existing `wrapCosmicApp` helper for Wayland library wrapping
- ✅ Conditional package inclusion using `optional`
- ✅ Registered in custom packages as `cosmic-ext-applet-tailscale`

### System Configuration
- ✅ Added systemd service `tailscale-operator-setup`
- ✅ Automatically configures Tailscale operator privileges for all users
- ✅ Runs after `tailscaled.service` startup
- ✅ Ensures GUI applet has proper permissions

## Features

The applet provides:
- 🌐 Visual network status indicator
- ⚡ Quick connect/disconnect actions
- 🔄 Network selection interface
- 🚪 Exit node configuration
- ⚙️ Tailscale settings access

## Technical Details

**Package Information:**
- **Name**: gui-scale-applet (despite name, it's a Tailscale applet)
- **Version**: 3.0.0-unstable-2025-11-29
- **Upstream**: [cosmic-utils/gui-scale-applet](https://github.com/cosmic-utils/gui-scale-applet)
- **Commit**: `9528f588d7a010149071136ea3f9948771f7d0cf`
- **License**: GPL-3.0-only

**Requirements:**
- Tailscale must be installed and running
- Users need operator privileges (configured automatically by systemd service)

## Testing

- ✅ Syntax validation passed (`just check-syntax`)
- ✅ P620 configuration builds successfully (`just test-host p620`)
- ✅ All pre-commit hooks passed
- ✅ Systemd service properly configured
- ✅ Package wrapping with Wayland libraries verified

## Configuration Example

The applet is enabled by default on systems with COSMIC desktop. To disable:

```nix
features.desktop.cosmic = {
  enable = true;
  enableTailscaleApplet = false;  # Disable Tailscale applet
};
```

## Integration Pattern

Follows established COSMIC applet patterns:
- Uses `wrapCosmicApp` for consistent Wayland library handling
- Conditional inclusion with `optional` based on feature flag
- Proper integration with custom package registry

## Resolves

Closes #127

🚀 **Ready for Review and Merge**