### PR TITLE
feat(cosmic): Add next-meeting calendar applet

### DIFF
--- a/modules/desktop/cosmic.nix
+++ b/modules/desktop/cosmic.nix
@@ -39,6 +39,12 @@ in
       default = true;
       description = "Enable Tailscale management applet for COSMIC panel. Requires Tailscale to be installed and users to have operator privileges.";
     };
+
+    enableNextMeetingApplet = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable next meeting calendar applet for COSMIC panel. Shows upcoming meetings with one-click join for video calls. Requires Evolution Data Server.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -147,7 +153,15 @@ in
         ]
         ++ optional cfg.enableTailscaleApplet
           # Tailscale VPN management applet (wrapped for proper Wayland library loading)
-          (wrapCosmicApp "gui-scale-applet" pkgs.customPkgs.cosmic-ext-applet-tailscale);
+          (wrapCosmicApp "gui-scale-applet" pkgs.customPkgs.cosmic-ext-applet-tailscale)
+        ++ optional cfg.enableNextMeetingApplet
+          # Next meeting calendar applet (wrapped for proper Wayland library loading)
+          (wrapCosmicApp "cosmic-next-meeting" pkgs.customPkgs.cosmic-ext-applet-next-meeting)
+        ++ optionals cfg.enableNextMeetingApplet [
+          # Evolution Data Server for calendar access
+          pkgs.evolution-data-server
+          pkgs.gnome-online-accounts # For Google Calendar integration
+        ];
 
       # COSMIC-specific environment variables
       sessionVariables = {

--- a/pkgs/cosmic-applets/next-meeting/default.nix
+++ b/pkgs/cosmic-applets/next-meeting/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, just
+, libxkbcommon
+, wayland
+, evolution-data-server
+, glib
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cosmic-next-meeting";
+  version = "0.9.0-unstable-2026-01-08";
+
+  src = fetchFromGitHub {
+    owner = "dangrover";
+    repo = "next-meeting-for-cosmic";
+    rev = "7a4213e808c1d440a105898cea807a38cd6a8c0f"; # Latest commit as of 2026-01-08
+    hash = "sha256-1IQ7/tWj5jRDXMHLAbsjDgRcCthPlp61/LDdi8PcBZw=";
+  };
+
+  cargoHash = "sha256-idB3kVzc2BlsjWpHfE9urRcR+QYO6gwiqhWC7uZc/AA=";
+
+  nativeBuildInputs = [
+    pkg-config
+    just
+  ];
+
+  buildInputs = [
+    libxkbcommon
+    wayland
+    evolution-data-server
+    glib
+  ];
+
+  strictDeps = true;
+
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+  dontUseJustInstall = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm0755 target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/${pname} $out/bin/${pname}
+    install -Dm0644 resources/app.desktop $out/share/applications/com.dangrover.next-meeting-app.desktop
+    install -Dm0644 resources/app.metainfo.xml $out/share/metainfo/com.dangrover.next-meeting-app.metainfo.xml
+    install -Dm0644 resources/icon.svg $out/share/icons/hicolor/scalable/apps/com.dangrover.next-meeting-app.svg
+    install -Dm0644 resources/icon-symbolic.svg $out/share/icons/hicolor/symbolic/apps/com.dangrover.next-meeting-app-symbolic.svg
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "COSMIC panel applet showing next meeting with one-click join for video calls";
+    longDescription = ''
+      A COSMIC desktop panel applet that displays upcoming calendar events with
+      one-click join buttons for video calls (Google Meet, Zoom, Teams, Webex).
+
+      Features:
+      - Shows meeting title, time, and location in the panel
+      - Provides one-click join for video calls
+      - Integrates with Evolution Data Server (EDS) calendars
+      - Supports flexible formatting (absolute/relative time, location info, calendar colors)
+      - Smart filtering by calendar, all-day events, or acceptance status
+
+      Note: Requires Evolution Data Server for calendar access. Configure calendars
+      via GNOME Online Accounts or Evolution directly.
+    '';
+    homepage = "https://github.com/dangrover/next-meeting-for-cosmic";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ ];
+    platforms = platforms.linux;
+    mainProgram = "cosmic-next-meeting";
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -27,4 +27,5 @@
 
   # COSMIC applets
   cosmic-ext-applet-tailscale = pkgs.callPackage ./cosmic-applets/tailscale { };
+  cosmic-ext-applet-next-meeting = pkgs.callPackage ./cosmic-applets/next-meeting { };
 }


### PR DESCRIPTION
## Summary

Implements a comprehensive calendar meeting applet for the COSMIC desktop environment that displays upcoming meetings with one-click join buttons for video calls.

## Changes

### Package Implementation
- ✅ Created buildRustPackage derivation at `pkgs/cosmic-applets/next-meeting/default.nix`
- ✅ Proper Evolution Data Server integration for calendar access
- ✅ Custom installPhase for desktop file, metainfo, and icon installation
- ✅ Package successfully builds and tested

### COSMIC Desktop Integration
- ✅ Added `enableNextMeetingApplet` option (default: true)
- ✅ Integration with existing `wrapCosmicApp` helper for Wayland library wrapping
- ✅ Conditional package inclusion using `optional`
- ✅ Registered in custom packages as `cosmic-ext-applet-next-meeting`

### Dependencies
- ✅ Evolution Data Server for calendar access
- ✅ GNOME Online Accounts for cloud calendar integration (Google, Microsoft 365)
- ✅ Conditional dependency installation based on feature flag

## Features

The applet provides:
- 📅 Meeting title, time, and location display in panel
- 🎥 One-click join for video calls (Google Meet, Zoom, Teams, Webex)
- 🔄 Evolution Data Server (EDS) calendar integration
- ⏰ Flexible time formatting (absolute/relative, location info, calendar colors)
- 🎯 Smart filtering by calendar, all-day events, acceptance status

## Technical Details

**Package Information:**
- **Name**: cosmic-next-meeting
- **Version**: 0.9.0-unstable-2026-01-08
- **Upstream**: [dangrover/next-meeting-for-cosmic](https://github.com/dangrover/next-meeting-for-cosmic)
- **Commit**: `7a4213e808c1d440a105898cea807a38cd6a8c0f`
- **License**: GPL-3.0-only

**Requirements:**
- Evolution Data Server (installed automatically)
- Calendar configuration via GNOME Online Accounts or Evolution
- Supports Google Calendar, Microsoft 365, CalDAV sources

## Testing

- ✅ Syntax validation passed (`just check-syntax`)
- ✅ P620 configuration builds successfully (`just test-host p620`)
- ✅ All pre-commit hooks passed
- ✅ Evolution Data Server dependencies verified
- ✅ Package wrapping with Wayland libraries verified

## Configuration

The applet is enabled by default on systems with COSMIC desktop. To disable:

```nix
features.desktop.cosmic = {
  enable = true;
  enableNextMeetingApplet = false;  # Disable meeting applet
};
```

### Setting Up Calendars

**Via GNOME Online Accounts:**
1. Install and configure: `gnome-online-accounts` (included automatically)
2. Add accounts for Google, Microsoft 365, etc.
3. Calendars automatically sync to Evolution Data Server

**Via Evolution:**
1. Install: `evolution`
2. Configure calendars in Evolution preferences
3. EDS provides data to COSMIC applet

## Integration Pattern

Follows established COSMIC applet patterns:
- Uses `wrapCosmicApp` for consistent Wayland library handling
- Conditional inclusion with `optional` and `optionals` based on feature flag
- Proper integration with custom package registry
- Evolution Data Server as conditional dependency

## Resolves

Closes #124

🚀 **Ready for Review and Merge**