### PR TITLE
feat(cosmic): add COSMIC music player applet (disabled due to upstream issue)

### DIFF
--- a/modules/desktop/cosmic.nix
+++ b/modules/desktop/cosmic.nix
@@ -45,6 +45,19 @@ in
       default = true;
       description = "Enable next meeting calendar applet for COSMIC panel. Shows upcoming meetings with one-click join for video calls. Requires Evolution Data Server.";
     };
+
+    enableMusicPlayerApplet = mkOption {
+      type = types.bool;
+      default = false; # Disabled by default due to upstream Cargo.lock duplicate entries issue
+      description = ''
+        Enable music player applet for COSMIC panel with MPRIS control.
+
+        Note: Currently disabled by default due to upstream Cargo.lock duplicate entries issue.
+        See: https://github.com/olafkfreund/nixos_config/issues/128
+
+        Provides play/pause, track navigation, album artwork, and volume control for MPRIS-compatible music players.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -161,7 +174,10 @@ in
           # Evolution Data Server for calendar access
           pkgs.evolution-data-server
           pkgs.gnome-online-accounts # For Google Calendar integration
-        ];
+        ]
+        ++ optional cfg.enableMusicPlayerApplet
+          # Music player applet with MPRIS control (wrapped for proper Wayland library loading)
+          (wrapCosmicApp "cosmic-ext-applet-music-player" pkgs.customPkgs.cosmic-ext-applet-music-player);
 
       # COSMIC-specific environment variables
       sessionVariables = {

--- a/pkgs/cosmic-applets/music-player/default.nix
+++ b/pkgs/cosmic-applets/music-player/default.nix
@@ -1,0 +1,87 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, dbus
+, openssl
+, libpulseaudio
+, libxkbcommon
+, wayland
+}:
+
+# NOTE: This package currently has a known build issue due to duplicate Cargo.lock entries
+# in the upstream libcosmic dependencies. See: https://github.com/olafkfreund/nixos_config/issues/128
+#
+# The issue is that Cargo.lock contains duplicate package entries for cosmic-config, iced_core,
+# iced_futures, and cosmic-config-derive due to inconsistent git URL formatting in libcosmic.
+# This causes cargo vendor to fail with FileExistsError during vendoring.
+#
+# The package is disabled by default in the COSMIC module until this upstream issue is resolved.
+
+rustPlatform.buildRustPackage rec {
+  pname = "cosmic-ext-applet-music-player";
+  version = "1.0.0-unstable-2026-01-08";
+
+  src = fetchFromGitHub {
+    owner = "olafkfreund";
+    repo = "cosmic-applet-music-player";
+    rev = "0aa17bd7e1cfde219657c434b334c0c39ca530cb"; # Latest commit as of 2026-01-08
+    hash = "sha256-MxwxJHxdg44B6rvoDpIERoiP4TA6AAU/LdCTxF2G+PA=";
+  };
+
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+    outputHashes = {
+      # All libcosmic dependencies use the same commit, consolidate to single hash
+      "cosmic-client-toolkit-0.1.0" = "sha256-Brmxt10B7aRoISDbxX1ORIj76ygVi5kVgUJGW9hXGwY=";
+      "cosmic-config-0.1.0" = "sha256-Brmxt10B7aRoISDbxX1ORIj76ygVi5kVgUJGW9hXGwY=";
+      "cosmic-config-derive-0.1.0" = "sha256-Brmxt10B7aRoISDbxX1ORIj76ygVi5kVgUJGW9hXGwY=";
+      "iced_core-0.14.0" = "sha256-Brmxt10B7aRoISDbxX1ORIj76ygVi5kVgUJGW9hXGwY=";
+      "iced_futures-0.14.0" = "sha256-Brmxt10B7aRoISDbxX1ORIj76ygVi5kVgUJGW9hXGwY=";
+    };
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    dbus # MPRIS D-Bus communication
+    openssl # HTTPS album artwork fetching
+    libpulseaudio # PulseAudio/PipeWire volume control
+    libxkbcommon # Keyboard input
+    wayland # Wayland support
+  ];
+
+  # This is a workspace project, we need to build the music-player member
+  buildAndTestSubdir = "music-player";
+
+  strictDeps = true;
+
+  meta = with lib; {
+    description = "COSMIC panel applet for controlling MPRIS-compatible music players with album artwork";
+    longDescription = ''
+      A music player applet for the COSMIC desktop panel that provides integrated
+      music controls using the MPRIS D-Bus protocol.
+
+      Features:
+      - Play/pause, track navigation (previous/next)
+      - Real-time status display with song metadata
+      - Album artwork rendering with HTTPS fetching
+      - Volume adjustment via precision slider
+      - Auto-discovery of MPRIS-compatible players
+      - Player selection via radio buttons
+      - Toggleable auto-detection for newly-launched apps
+
+      Compatible with: Spotify, VLC, MPD, ncspot, plexamp, spotify-player,
+      musicpod, and any other MPRIS-compatible media player.
+
+      Note: Requires MPRIS-compatible music players to be installed.
+    '';
+    homepage = "https://github.com/Ebbo/cosmic-applet-music-player";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ ];
+    platforms = platforms.linux;
+    mainProgram = "cosmic-ext-applet-music-player";
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -28,4 +28,5 @@
   # COSMIC applets
   cosmic-ext-applet-tailscale = pkgs.callPackage ./cosmic-applets/tailscale { };
   cosmic-ext-applet-next-meeting = pkgs.callPackage ./cosmic-applets/next-meeting { };
+  cosmic-ext-applet-music-player = pkgs.callPackage ./cosmic-applets/music-player { };
 }


### PR DESCRIPTION
## Summary

Implements package derivation and module integration for COSMIC music player applet with MPRIS control. **Package is disabled by default** due to known upstream Cargo.lock duplicate entries issue documented in #128.

## Features Implemented

✅ **Package Derivation** (`pkgs/cosmic-applets/music-player/`)
- Complete buildRustPackage derivation for cosmic-ext-applet-music-player
- Fork repository: olafkfreund/cosmic-applet-music-player (commit 0aa17bd)
- Dependencies: dbus, openssl, libpulseaudio, libxkbcommon, wayland
- Workspace build configuration with buildAndTestSubdir

✅ **Module Integration** (`modules/desktop/cosmic.nix`)
- New option: `features.desktop.cosmic.enableMusicPlayerApplet`
- Default: `false` (disabled until upstream issue resolved)
- Wayland library wrapping via wrapCosmicApp helper
- Package registry entry in `pkgs/default.nix`

✅ **Music Player Features**
- Play/pause, track navigation (previous/next)
- Real-time status display with song metadata
- Album artwork rendering with HTTPS fetching
- Volume adjustment via precision slider
- Auto-discovery of MPRIS-compatible players
- Player selection via radio buttons
- Toggleable auto-detection for newly-launched apps

## 🚨 Known Blocking Issue

The upstream Cargo.lock contains duplicate package entries that cause cargo vendor to fail:

**Affected Packages:**
- `cosmic-config` (0.1.0) - 2 entries
- `cosmic-config-derive` (0.1.0) - 2 entries
- `iced_core` (0.14.0-dev) - 2 entries
- `iced_futures` (0.14.0-dev) - 2 entries

**Root Cause:**
Inconsistent libcosmic git URL formatting in Cargo.lock:
```
git+https://github.com/pop-os/libcosmic.git?rev=f6039597#hash
git+https://github.com/pop-os/libcosmic#hash
```

Both URLs point to the same commit (`f6039597b72d3eefe2ee1d6528a04077982db238`), but Cargo treats them as different sources, creating duplicate [[package]] entries.

**Build Error:**
```
FileExistsError: [Errno 17] File exists: '.../cosmic-config-0.1.0'
```

**Attempted Solutions:**
1. ❌ Simple `cargoHash` approach - Nix does NOT automatically deduplicate
2. ❌ Cargo.lock patching with sed - Still leaves duplicate entries
3. ❌ Python-based deduplication - Nix/bash escaping issues with embedded Python
4. ❌ `cargoLock` with `outputHashes` - Not designed for this use case

**Path Forward:**
- **Short term:** Package disabled by default with documentation
- **Medium term:** Report to https://github.com/pop-os/libcosmic requesting consistent URL formatting
- **Long term:** Enable once upstream Cargo.lock is fixed

## Testing

✅ Configuration validation passes with applet disabled
✅ Pre-commit hooks pass (formatting, linting, dead code check)
✅ All hosts build successfully
✅ Module options properly documented

```bash
just validate  # ✅ Passes
```

## Deployment

**To enable (once upstream issue is resolved):**
```nix
features.desktop.cosmic.enableMusicPlayerApplet = true;
```

**Compatible music players:**
- Spotify, VLC, MPD, ncspot, plexamp, spotify-player, musicpod
- Any MPRIS-compatible media player

## Files Changed

- `pkgs/cosmic-applets/music-player/default.nix` - New package derivation
- `pkgs/default.nix` - Package registry entry
- `modules/desktop/cosmic.nix` - Module integration with new option

## Related Issues

Closes #128 (partially - infrastructure in place, blocked on upstream fix)

## Next Steps

1. ✅ Merge PR to establish infrastructure
2. ⏳ Monitor upstream libcosmic for Cargo.lock fixes
3. ⏳ Re-enable applet once build issue resolved

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)