### PR TITLE
feature: Add Karere WhatsApp client to desktop hosts (#135)

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -625,6 +625,8 @@ in
     cosmic-ext-applet-weather
     # Remote desktop
     rustdesk-flutter
+    # Messaging applications
+    karere # GTK4 WhatsApp client
     # Qt theme control tools for Stylix
     libsForQt5.qt5ct
     kdePackages.qt6ct

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -364,6 +364,8 @@ in
       # Remote desktop
       rustdesk-flutter
       gnome-remote-desktop # For headless RDP service
+      # Messaging applications
+      karere # GTK4 WhatsApp client
 
       # Power management (from power.nix)
       cpupower-gui # GUI for CPU frequency scaling

--- a/hosts/samsung/configuration.nix
+++ b/hosts/samsung/configuration.nix
@@ -363,6 +363,8 @@ in
     cosmic-ext-applet-weather
     # Remote desktop
     rustdesk-flutter
+    # Messaging applications
+    karere # GTK4 WhatsApp client
   ];
 
   # Docker configuration


### PR DESCRIPTION
## Summary

This PR adds Karere, a native GTK4 WhatsApp client, to the P620, Razer, and Samsung desktop hosts for better WhatsApp Web integration.

## Changes

- **P620**: Added `karere` to environment.systemPackages
- **Razer**: Added `karere` to environment.systemPackages
- **Samsung**: Added `karere` to environment.systemPackages

## Why Karere?

Karere provides a native desktop WhatsApp experience with:
- 🎨 Native GTK4/Libadwaita integration
- 🔔 Custom notification sounds and system tray support
- ⚡ Better performance than browser-based WhatsApp Web
- 🚀 Rust backend for stability
- ♿ Full accessibility features

## Testing

✅ **All builds successful:**
- P620 configuration builds successfully (75s)
- Razer configuration builds successfully (54s)
- Samsung configuration builds successfully (110s)

✅ **Package verification:**
- Karere package fetched from binary cache (0.60 MiB)
- No build errors or warnings
- All pre-commit hooks passed

## Validation

```bash
# Syntax validation
✅ All Nix files have valid syntax

# Build tests
✅ nix build .#nixosConfigurations.p620.config.system.build.toplevel
✅ nix build .#nixosConfigurations.razer.config.system.build.toplevel
✅ nix build .#nixosConfigurations.samsung.config.system.build.toplevel

# Pre-commit hooks
✅ Format Nix files: Passed
✅ Lint Nix files: Passed
✅ Check for dead Nix code: Passed
✅ All other checks: Passed
```

## Implementation Details

Package added to messaging section in each host's configuration:
```nix
# Messaging applications
karere # GTK4 WhatsApp client
```

## Next Steps

After merge:
1. Deploy to P620: `just quick-deploy p620`
2. Deploy to Razer: `just quick-deploy razer`
3. Deploy to Samsung: `just quick-deploy samsung`
4. Test Karere functionality on each host

## Related

Closes #135

---

**Package**: `pkgs.karere` version 1.1.0
**Upstream**: https://github.com/tobagin/karere