### PR TITLE
enhancement(cosmic): add Forecast weather app to COSMIC desktop (#149)

### DIFF
--- a/modules/desktop/cosmic.nix
+++ b/modules/desktop/cosmic.nix
@@ -68,6 +68,17 @@ in
         Requires Spotify with MPRIS support on Wayland.
       '';
     };
+
+    enableForecastApp = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Enable Forecast weather application for COSMIC desktop.
+
+        Weather app written in Rust and libcosmic providing weather information display.
+        Integrates with COSMIC desktop environment for native experience.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -190,7 +201,10 @@ in
           (wrapCosmicApp "cosmic-ext-applet-music-player" pkgs.cosmic-ext-applet-music-player)
         ++ optional cfg.enableSpotifyApplet
           # Spotify applet for displaying currently playing track information (wrapped for proper Wayland library loading)
-          (wrapCosmicApp "cosmic-applet-spotify" pkgs.cosmic-applet-spotify);
+          (wrapCosmicApp "cosmic-applet-spotify" pkgs.cosmic-applet-spotify)
+        ++ optional cfg.enableForecastApp
+          # Forecast weather application for COSMIC desktop
+          pkgs.forecast;
 
       # COSMIC-specific environment variables
       sessionVariables = {


### PR DESCRIPTION
Add Forecast weather application to COSMIC desktop environment configuration.

Features:
- New enableForecastApp option (enabled by default)
- Forecast package conditional on the option
- Native Rust/libcosmic implementation
- Integrates with COSMIC desktop environment

The Forecast app provides weather information display using COSMIC
desktop conventions and is part of the official cosmic-utils project.

Implementation details:
- Added to modules/desktop/cosmic.nix
- Follows existing applet pattern for consistency
- Package available in nixpkgs (no custom derivation needed)

Closes #149

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
