### PR TITLE
feat(packages): add Claude Code native binary package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -749,11 +749,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769397130,
-        "narHash": "sha256-TTM4KV9IHwa181X7afBRbhLJIrgynpDjAXJFMUOWfyU=",
+        "lastModified": 1769450270,
+        "narHash": "sha256-pdVm/zJazDUAasTyHFX/Pbrlk9Upjxi0yzgn7GjGe4g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c37679d37bdbecf11bbe3c5eb238d89ca4f60641",
+        "rev": "a10c1e8f5ad2589414407f4851c221cb66270257",
         "type": "github"
       },
       "original": {
@@ -1303,11 +1303,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1769417138,
-        "narHash": "sha256-muWNYS5y2usbgrd0B1QGpaDLPi8RKb0FPB2IAGTVhXQ=",
+        "lastModified": 1769457887,
+        "narHash": "sha256-PxZFOFoUQecyhXGkAsqv8oDdPnQLfquXU94ltqv1Pzk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9084d7dfa643245c31011c3680672032cae6ad4b",
+        "rev": "51821ea769a2fb24fd8fa0431708558922b271c0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -210,6 +210,10 @@
         (final: _prev: {
           zsh-ai-cmd = final.callPackage ./pkgs/zsh-ai-cmd { };
         })
+        # Custom package: claude-code-native - Native binary alternative to npm-based claude-code
+        (final: _prev: {
+          claude-code-native = final.callPackage ./pkgs/claude-code-native { };
+        })
         # Custom package: gemini-cli - Google Gemini AI CLI tool with version 0.25.1
         (final: _prev: {
           gemini-cli = final.callPackage ./home/development/gemini-cli { };
@@ -396,6 +400,7 @@
           claude-code = import ./home/development/claude-code {
             inherit (pkgs) lib buildNpmPackage fetchurl nodejs makeWrapper writeShellScriptBin;
           };
+          claude-code-native = pkgs.callPackage ./pkgs/claude-code-native { };
           codex-cli = pkgs.callPackage ./home/development/codex-cli {
             inherit (pkgs) nodejs_24;
           };

--- a/home/default.nix
+++ b/home/default.nix
@@ -13,8 +13,18 @@
     ./files.nix
   ];
 
+  # Enable Claude Code via home-manager's built-in module
+  # Options for package:
+  #   - inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.claude-code  # Our npm package (latest: 2.1.19)
+  #   - pkgs.claude-code-native  # Native binary (faster startup, version: 2.1.19)
+  #   - pkgs.claude-code  # nixpkgs version (may be older)
+  programs.claude-code = {
+    enable = true;
+    # Use our npm package for the latest version
+    package = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
+  };
+
   home.packages = [
-    inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.claude-code
     inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.opencode
     (pkgs.callPackage ../pkgs/weather-popup/default.nix { })
   ];

--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -1,0 +1,121 @@
+# Claude Code Native Binary Package
+#
+# This package downloads pre-built Claude Code binaries from Anthropic's
+# official distribution channel and patches them for NixOS compatibility.
+#
+# Benefits over npm-based package:
+# - No Node.js runtime dependency
+# - Faster startup time
+# - Smaller closure size
+# - Direct binary execution
+#
+# Update process:
+# 1. Run: ./scripts/update-claude-code-native.sh
+# 2. Update version and hashes below
+# 3. Test: nix build .#claude-code-native
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, makeWrapper
+, openssl
+, zlib
+, glibc
+,
+}:
+
+let
+  # Version from Anthropic's latest channel (matches npm)
+  # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
+  version = "2.1.19";
+
+  # Anthropic's official distribution bucket
+  gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
+
+  # Platform-specific binary sources with checksums from manifest.json
+  # Run ./scripts/update-claude-code-native.sh to update these
+  sources = {
+    x86_64-linux = {
+      url = "${gcs_bucket}/${version}/linux-x64/claude";
+      hash = "sha256-Tiocc4cezzsTM3a1fe0DMzp6Y4fy0qOmJ5u5Cgf3qUQ=";
+    };
+    aarch64-linux = {
+      url = "${gcs_bucket}/${version}/linux-arm64/claude";
+      hash = "sha256-jEthskynYNb3qi8ZcnFj0SLp/Qw86R8QaiG2kYp7G7s=";
+    };
+  };
+
+  currentSource = sources.${stdenv.hostPlatform.system}
+    or (throw "Unsupported system: ${stdenv.hostPlatform.system}. Supported: x86_64-linux, aarch64-linux");
+in
+stdenv.mkDerivation {
+  pname = "claude-code-native";
+  inherit version;
+
+  src = fetchurl {
+    url = currentSource.url;
+    hash = currentSource.hash;
+    # The binary is downloaded as-is, no archive extraction
+    name = "claude-${version}-${stdenv.hostPlatform.system}";
+  };
+
+  # Don't try to unpack - it's a single binary
+  dontUnpack = true;
+
+  # Don't try to strip - binary is already optimized
+  dontStrip = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  # Runtime dependencies for the binary
+  # autoPatchelfHook will automatically find and link these
+  buildInputs = [
+    openssl
+    zlib
+    glibc
+    stdenv.cc.cc.lib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # Create output directories
+    mkdir -p $out/bin
+    mkdir -p $out/lib/claude-code
+
+    # Install the binary
+    cp $src $out/lib/claude-code/claude
+    chmod +x $out/lib/claude-code/claude
+
+    # Create wrapper with environment variables to disable auto-update
+    makeWrapper $out/lib/claude-code/claude $out/bin/claude \
+      --set DISABLE_AUTOUPDATER "1" \
+      --set CLAUDE_CODE_SKIP_UPDATE_CHECK "1"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Claude Code CLI - Native binary (Anthropic's AI coding assistant)";
+    longDescription = ''
+      Claude Code is Anthropic's official CLI tool for AI-assisted coding.
+      This package provides the native pre-built binary, which offers:
+      - No Node.js runtime dependency
+      - Faster startup times
+      - Direct binary execution
+      - Smaller closure size
+
+      For the npm-based version, use the claude-code package instead.
+      Both packages track the latest version (${version}).
+    '';
+    homepage = "https://github.com/anthropics/claude-code";
+    license = licenses.unfree; # Anthropic proprietary
+    maintainers = [ ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    mainProgram = "claude";
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -31,4 +31,7 @@
   newelle = pkgs.callPackage ./newelle { };
 
   add-skill = pkgs.callPackage ./add-skill { };
+
+  # Claude Code native binary (alternative to npm-based package)
+  claude-code-native = pkgs.callPackage ./claude-code-native { };
 }

--- a/scripts/update-claude-code-native.sh
+++ b/scripts/update-claude-code-native.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Update script for claude-code-native package
+# Usage: ./scripts/update-claude-code-native.sh [version]
+#
+# This script fetches the latest version and calculates hashes for the native binary.
+# If no version is specified, it uses the stable version.
+
+set -euo pipefail
+
+GCS_BUCKET="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+PKG_DIR="$(dirname "$0")/../pkgs/claude-code-native"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+info() {
+  echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+warn() {
+  echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+error() {
+  echo -e "${RED}[ERROR]${NC} $1"
+  exit 1
+}
+
+# Get stable version from distribution channel
+get_stable_version() {
+  info "Fetching stable version..."
+  curl -fsSL "$GCS_BUCKET/stable" 2>/dev/null || error "Failed to fetch stable version"
+}
+
+# Get latest version from distribution channel
+get_latest_version() {
+  info "Fetching latest version..."
+  curl -fsSL "$GCS_BUCKET/latest" 2>/dev/null || error "Failed to fetch latest version"
+}
+
+# Get manifest for a version
+get_manifest() {
+  local version="$1"
+  info "Fetching manifest for version $version..."
+  curl -fsSL "$GCS_BUCKET/$version/manifest.json" 2>/dev/null || error "Failed to fetch manifest"
+}
+
+# Calculate SRI hash for a URL
+calculate_hash() {
+  local url="$1"
+  local platform="$2"
+
+  info "Downloading $platform binary..."
+
+  # Create temp file
+  local tmpfile
+  tmpfile=$(mktemp)
+  trap 'rm -f "$tmpfile"' RETURN
+
+  if curl -fsSL "$url" -o "$tmpfile" 2>/dev/null; then
+    # Calculate SRI hash
+    local hash
+    hash=$(nix hash file --sri "$tmpfile" 2>/dev/null)
+    local size
+    size=$(stat -c %s "$tmpfile" 2>/dev/null || stat -f %z "$tmpfile" 2>/dev/null)
+    echo "$hash|$size"
+  else
+    warn "Failed to download $platform binary"
+    echo ""
+  fi
+}
+
+# Main update logic
+main() {
+  local version="${1:-}"
+
+  echo -e "${BLUE}=========================================="
+  echo "Claude Code Native Binary Update Tool"
+  echo -e "==========================================${NC}"
+  echo ""
+
+  # Show available versions
+  local stable_ver latest_ver
+  stable_ver=$(get_stable_version)
+  latest_ver=$(get_latest_version)
+
+  echo ""
+  echo "Available versions:"
+  echo "  Stable: $stable_ver"
+  echo "  Latest: $latest_ver"
+  echo ""
+
+  # Use provided version or default to stable
+  if [ -z "$version" ]; then
+    version="$stable_ver"
+    info "Using stable version: $version"
+  else
+    info "Using specified version: $version"
+  fi
+
+  echo ""
+
+  # Get manifest to verify version exists
+  local manifest
+  manifest=$(get_manifest "$version")
+  if [ -z "$manifest" ]; then
+    error "Version $version not found"
+  fi
+
+  # Extract checksums from manifest (for verification)
+  local x64_manifest_checksum arm64_manifest_checksum
+  x64_manifest_checksum=$(echo "$manifest" | jq -r '.platforms["linux-x64"].checksum // empty' 2>/dev/null)
+  arm64_manifest_checksum=$(echo "$manifest" | jq -r '.platforms["linux-arm64"].checksum // empty' 2>/dev/null)
+
+  echo "Manifest checksums (SHA256):"
+  echo "  linux-x64:   ${x64_manifest_checksum:-NOT AVAILABLE}"
+  echo "  linux-arm64: ${arm64_manifest_checksum:-NOT AVAILABLE}"
+  echo ""
+
+  # Calculate SRI hashes
+  local x64_url="${GCS_BUCKET}/${version}/linux-x64/claude"
+  local arm64_url="${GCS_BUCKET}/${version}/linux-arm64/claude"
+
+  local x64_result arm64_result
+  x64_result=$(calculate_hash "$x64_url" "x86_64-linux")
+  arm64_result=$(calculate_hash "$arm64_url" "aarch64-linux")
+
+  # Parse results
+  local x64_hash x64_size arm64_hash arm64_size
+  x64_hash=$(echo "$x64_result" | cut -d'|' -f1)
+  x64_size=$(echo "$x64_result" | cut -d'|' -f2)
+  arm64_hash=$(echo "$arm64_result" | cut -d'|' -f1)
+  arm64_size=$(echo "$arm64_result" | cut -d'|' -f2)
+
+  echo ""
+  echo -e "${GREEN}=========================================="
+  echo "Update Results"
+  echo -e "==========================================${NC}"
+  echo ""
+  echo "Version: $version"
+  echo ""
+
+  if [ -n "$x64_hash" ]; then
+    echo "x86_64-linux:"
+    echo "  URL:  $x64_url"
+    echo "  Hash: $x64_hash"
+    echo "  Size: $x64_size bytes"
+  else
+    echo "x86_64-linux: NOT AVAILABLE"
+  fi
+  echo ""
+
+  if [ -n "$arm64_hash" ]; then
+    echo "aarch64-linux:"
+    echo "  URL:  $arm64_url"
+    echo "  Hash: $arm64_hash"
+    echo "  Size: $arm64_size bytes"
+  else
+    echo "aarch64-linux: NOT AVAILABLE"
+  fi
+  echo ""
+
+  # Generate Nix snippet
+  if [ -n "$x64_hash" ] || [ -n "$arm64_hash" ]; then
+    echo -e "${BLUE}=========================================="
+    echo "Nix Expression Update"
+    echo -e "==========================================${NC}"
+    echo ""
+    echo "Update pkgs/claude-code-native/default.nix with:"
+    echo ""
+    echo "  version = \"$version\";"
+    echo ""
+    echo "  sources = {"
+    if [ -n "$x64_hash" ]; then
+      echo "    x86_64-linux = {"
+      echo "      url = \"\${gcs_bucket}/\${version}/linux-x64/claude\";"
+      echo "      hash = \"$x64_hash\";"
+      echo "    };"
+    fi
+    if [ -n "$arm64_hash" ]; then
+      echo "    aarch64-linux = {"
+      echo "      url = \"\${gcs_bucket}/\${version}/linux-arm64/claude\";"
+      echo "      hash = \"$arm64_hash\";"
+      echo "    };"
+    fi
+    echo "  };"
+    echo ""
+  else
+    error "No binaries found for version $version"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add native binary package for Claude Code as alternative to npm-based installation
- Native package downloads pre-built binaries from Anthropic's official GCS distribution
- Both npm and native variants now available for flexibility

## Changes

### New Files
- `pkgs/claude-code-native/default.nix` - Native binary derivation using autoPatchelfHook
- `scripts/update-claude-code-native.sh` - Script to fetch versions and calculate SRI hashes

### Modified Files
- `pkgs/default.nix` - Added claude-code-native export
- `flake.nix` - Added to packages and overlays
- `home/default.nix` - Uses home-manager's built-in programs.claude-code module

## Benefits of Native Binary

- No Node.js runtime dependency
- Faster startup time
- Smaller closure size
- Direct binary execution

## Usage

```nix
# Default: npm package (current behavior)
programs.claude-code = {
  enable = true;
  package = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
};

# Alternative: native binary
programs.claude-code = {
  enable = true;
  package = pkgs.claude-code-native;
};
```

## Test plan

- [x] Native package builds successfully
- [x] Binary runs: `./result/bin/claude --version` → `2.1.19 (Claude Code)`
- [x] P620 configuration builds with changes
- [x] All Nix linting/formatting checks pass

Closes #184

🤖 Generated with [Claude Code](https://claude.ai/claude-code)