### PR TITLE
chore(claude-code): update to version 2.1.20

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.19";
+    version = "2.1.20";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-8nJWc74kVvRzFr6KSHbiv5mB6tb+29PJ1o9wkteypKw=";
+      hash = "sha256-3jxynyQtyP0/Mt+kNMoo47YoBplqJLYvSC3nAvRu8Ek=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 

--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.19";
+  version = "2.1.20";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-Tiocc4cezzsTM3a1fe0DMzp6Y4fy0qOmJ5u5Cgf3qUQ=";
+      hash = "sha256-+dNpj1N4pIbbLU7qXID5XCzrQQ+86p/8VwO1qslXT8w=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-jEthskynYNb3qi8ZcnFj0SLp/Qw86R8QaiG2kYp7G7s=";
+      hash = "sha256-64gBx6SoUBshwjXzZnTxcyjmXnls+KYZazv5ojrhb5k=";
     };
   };
 


### PR DESCRIPTION
## Summary

- Update Claude Code packages (npm and native) from 2.1.19 to 2.1.20

## Changes

### npm package (`home/development/claude-code/default.nix`)
- Version: 2.1.19 → 2.1.20
- Source hash: updated

### Native binary (`pkgs/claude-code-native/default.nix`)
- Version: 2.1.19 → 2.1.20
- x86_64-linux hash: updated
- aarch64-linux hash: updated

## Test plan

- [x] Flake check passes
- [x] Native package builds successfully (`nix build .#claude-code-native`)
- [x] npm package builds successfully (`nix build .#claude-code`)
- [x] Both binaries verified: `claude --version` shows `2.1.20 (Claude Code)`

Closes #186

🤖 Generated with [Claude Code](https://claude.ai/claude-code)