### PR TITLE
chore(gemini-cli): update to version 0.26.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -214,7 +214,7 @@
         (final: _prev: {
           claude-code-native = final.callPackage ./pkgs/claude-code-native { };
         })
-        # Custom package: gemini-cli - Google Gemini AI CLI tool with version 0.25.1
+        # Custom package: gemini-cli - Google Gemini AI CLI tool with version 0.26.0
         (final: _prev: {
           gemini-cli = final.callPackage ./home/development/gemini-cli { };
         })
@@ -404,7 +404,6 @@
           codex-cli = pkgs.callPackage ./home/development/codex-cli {
             inherit (pkgs) nodejs_24;
           };
-          # gemini-cli provided by pkgs/default.nix overlay (version 0.8.0-preview.1)
           glim = pkgs.callPackage ./overlays/glim { };
           intune-portal = pkgs.callPackage ./pkgs/intune-portal { };
           kosli-cli = pkgs.callPackage ./pkgs/kosli-cli { };

--- a/home/development/gemini-cli/default.nix
+++ b/home/development/gemini-cli/default.nix
@@ -14,16 +14,16 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "gemini-cli";
-  version = "0.25.2";
+  version = "0.26.0";
 
   src = fetchFromGitHub {
     owner = "google-gemini";
     repo = "gemini-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2Fl6bkoAgu+KvwVIkQEIAPYKQRYyEQPWMRv3vsfnNA4=";
+    hash = "sha256-wvCSYr5BUS5gggTFHfG+SRvgAyRE63nYdaDwH98wurI=";
   };
 
-  npmDepsHash = "sha256-4peAAxCws5IjWaiNwkRBiaL+n1fE+zsK0qbk1owueeY=";
+  npmDepsHash = "sha256-nfmIt+wUelhz3KiW4/pp/dGE71f2jsPbxwpBRT8gtYc=";
 
   nodejs = nodejs_22;
 
@@ -55,16 +55,10 @@ buildNpmPackage (finalAttrs: {
     substituteInPlace packages/core/src/tools/ripGrep.ts \
       --replace-fail "await ensureRgPath();" "'${lib.getExe ripgrep}';"
 
-    # Ideal method to disable auto-update
-    sed -i '/disableAutoUpdate: {/,/}/ s/default: false/default: true/' packages/cli/src/config/settingsSchema.ts
-
-    # Disable auto-update for real because the default value in settingsSchema isn't cleanly applied
-    # https://github.com/google-gemini/gemini-cli/issues/13569
-    substituteInPlace packages/cli/src/utils/handleAutoUpdate.ts \
-      --replace-fail "settings.merged.general?.disableAutoUpdate ?? false" "settings.merged.general?.disableAutoUpdate ?? true" \
-      --replace-fail "settings.merged.general?.disableAutoUpdate" "(settings.merged.general?.disableAutoUpdate ?? true)"
-    substituteInPlace packages/cli/src/ui/utils/updateCheck.ts \
-      --replace-fail "settings.merged.general?.disableUpdateNag" "(settings.merged.general?.disableUpdateNag ?? true)"
+    # Disable auto-update and update notifications by changing defaults in settingsSchema
+    # (API changed in 0.26.0 from disableAutoUpdate to enableAutoUpdate)
+    sed -i '/enableAutoUpdate: {/,/default: true/ s/default: true/default: false/' packages/cli/src/config/settingsSchema.ts
+    sed -i '/enableAutoUpdateNotification: {/,/default: true/ s/default: true/default: false/' packages/cli/src/config/settingsSchema.ts
   '';
 
   installPhase = ''

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -10,7 +10,7 @@
   whatsapp-mcp = pkgs.callPackage ./whatsapp-mcp { };
   mpris-album-art = pkgs.callPackage ./mpris-album-art { };
   weather-popup = pkgs.callPackage ./weather-popup { };
-  # gemini-cli provided via flake overlay (version 0.24.4)
+  # gemini-cli provided via flake overlay (version 0.26.0)
   # Claude Desktop - using working Linux build from k3d3/claude-desktop-linux-flake
   claude-desktop = pkgs.claude-desktop-linux or (pkgs.callPackage ./claude-desktop { });
   neuwaita-icon-theme = pkgs.callPackage ./neuwaita-icon-theme { };


### PR DESCRIPTION
## Summary

- Update Gemini CLI from 0.25.2 to 0.26.0

## Changes

### Package (`home/development/gemini-cli/default.nix`)
- Version: 0.25.2 → 0.26.0
- Source hash: updated
- npmDepsHash: updated
- postPatch: Updated for new API

### API Changes
The auto-update settings API changed in 0.26.0:
- Old: `disableAutoUpdate`, `disableUpdateNag`
- New: `enableAutoUpdate`, `enableAutoUpdateNotification`

Patches updated to disable auto-updates by setting new defaults to `false`.

### Version Comments
- Updated in `flake.nix`
- Updated in `pkgs/default.nix`
- Removed stale comment

## Test plan

- [x] Flake check passes
- [x] Package builds successfully
- [x] Binary runs correctly

Closes #188

🤖 Generated with [Claude Code](https://claude.ai/claude-code)