### PR TITLE
feat(gaming): Add NVIDIA GeForce NOW native Linux client support

### DIFF
--- a/home/games/steam.nix
+++ b/home/games/steam.nix
@@ -11,6 +11,7 @@
     # lutris REMOVED: depends on moddb which has slow pyrate-limiter dependency (25+ min test phase)
     # Alternative: Install Lutris as flatpak or override to skip tests
     # gfn-electron REMOVED: Abandoned upstream and removed from nixpkgs
-    # Alternative: Use GeForce NOW via web browser (works great in Chrome/Chromium)
+    # GeForce NOW: Now using official NVIDIA Flatpak via modules.services.geforcenow
+    # Enable with: modules.services.geforcenow.enable = true
   ];
 }

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -163,6 +163,12 @@ in
 
   # AI alerting removed - was non-functional, handled by DEX5550 monitoring server via Prometheus/Grafana/Alertmanager
 
+  # NVIDIA GeForce NOW cloud gaming (official Flatpak)
+  modules.services.geforcenow = {
+    enable = true;
+    autoInstall = true;
+  };
+
   # Use the new features system instead of multiple lib.mkForce calls
   features = {
     development = {

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -110,6 +110,12 @@ in
   #   aiProvider = "openai";
   # };
 
+  # NVIDIA GeForce NOW cloud gaming (official Flatpak)
+  modules.services.geforcenow = {
+    enable = true;
+    autoInstall = true;
+  };
+
   # Enable XDG portal for GNOME screen sharing
   modules.services.xdg-portal = {
     enable = true;

--- a/hosts/samsung/configuration.nix
+++ b/hosts/samsung/configuration.nix
@@ -100,6 +100,12 @@ in
     profile = "laptop";
   };
 
+  # NVIDIA GeForce NOW cloud gaming (official Flatpak)
+  modules.services.geforcenow = {
+    enable = true;
+    autoInstall = true;
+  };
+
   # Enable XDG portal for GNOME screen sharing
   modules.services.xdg-portal = {
     enable = true;

--- a/modules/services/default.nix
+++ b/modules/services/default.nix
@@ -48,5 +48,8 @@ _: {
 
     # File synchronization
     ./syncthing.nix
+
+    # Gaming - Cloud streaming
+    ./geforcenow/default.nix
   ];
 }

--- a/modules/services/geforcenow/default.nix
+++ b/modules/services/geforcenow/default.nix
@@ -1,0 +1,165 @@
+# NVIDIA GeForce NOW Cloud Gaming Module
+# Enables GeForce NOW native Linux client via Flatpak
+{ config
+, lib
+, pkgs
+, ...
+}:
+with lib; let
+  cfg = config.modules.services.geforcenow;
+in
+{
+  options.modules.services.geforcenow = {
+    enable = mkEnableOption "NVIDIA GeForce NOW cloud gaming client";
+
+    autoInstall = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Automatically install GeForce NOW Flatpak on system startup.
+        If disabled, the remote will be added but installation must be done manually.
+      '';
+      example = false;
+    };
+
+    waylandFix = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Apply Wayland fix by disabling Wayland socket for GeForce NOW.
+        Enable this if the application window doesn't open on Wayland.
+      '';
+      example = true;
+    };
+
+    remoteSetup = {
+      maxRetries = mkOption {
+        type = types.int;
+        default = 3;
+        description = ''Maximum number of retry attempts for repository setup'';
+        example = 5;
+      };
+
+      retryDelay = mkOption {
+        type = types.int;
+        default = 10;
+        description = ''Base delay in seconds between retry attempts'';
+        example = 15;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Ensure Flatpak is enabled (dependency)
+    modules.services.flatpak.enable = true;
+
+    # Add NVIDIA GeForce NOW Flatpak remote and install app
+    systemd.services.geforcenow-setup = {
+      description = "Setup NVIDIA GeForce NOW Flatpak repository and install app";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" "flatpak-repo.service" ];
+      wants = [ "network-online.target" ];
+      requires = [ "flatpak-repo.service" ];
+      path = [ pkgs.flatpak ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        Restart = "on-failure";
+        RestartSec = "${toString cfg.remoteSetup.retryDelay}s";
+      };
+
+      script = ''
+        max_attempts=${toString cfg.remoteSetup.maxRetries}
+        attempt=1
+
+        # Step 1: Add GeForce NOW Flatpak remote
+        echo "Adding NVIDIA GeForce NOW Flatpak remote..."
+        while [ $attempt -le $max_attempts ]; do
+          echo "Attempt $attempt to add GeForce NOW repository..."
+
+          if flatpak remote-add --user --if-not-exists GeForceNOW \
+               https://international.download.nvidia.com/GFNLinux/flatpak/geforcenow.flatpakrepo; then
+            echo "Successfully added GeForce NOW repository."
+            break
+          fi
+
+          if [ $attempt -lt $max_attempts ]; then
+            sleep_time=$((attempt * ${toString cfg.remoteSetup.retryDelay}))
+            echo "Failed to add repository. Retrying in $sleep_time seconds..."
+            sleep $sleep_time
+          fi
+
+          attempt=$((attempt + 1))
+        done
+
+        if [ $attempt -gt $max_attempts ]; then
+          echo "Failed to add GeForce NOW repository after $max_attempts attempts."
+          exit 1
+        fi
+
+        ${optionalString cfg.autoInstall ''
+          # Step 2: Install GeForce NOW app
+          echo "Installing NVIDIA GeForce NOW..."
+          attempt=1
+
+          while [ $attempt -le $max_attempts ]; do
+            echo "Attempt $attempt to install GeForce NOW..."
+
+            # Install required runtimes first
+            flatpak install -y --user flathub org.freedesktop.Sdk//24.08 || true
+            flatpak install -y --user flathub org.freedesktop.Platform//24.08 || true
+
+            if flatpak install -y --user GeForceNOW com.nvidia.geforcenow; then
+              echo "Successfully installed GeForce NOW."
+              break
+            fi
+
+            if [ $attempt -lt $max_attempts ]; then
+              sleep_time=$((attempt * ${toString cfg.remoteSetup.retryDelay}))
+              echo "Failed to install. Retrying in $sleep_time seconds..."
+              sleep $sleep_time
+            fi
+
+            attempt=$((attempt + 1))
+          done
+
+          if [ $attempt -gt $max_attempts ]; then
+            echo "Warning: Failed to install GeForce NOW after $max_attempts attempts."
+            echo "You can try manually: flatpak install --user GeForceNOW com.nvidia.geforcenow"
+          fi
+        ''}
+
+        ${optionalString cfg.waylandFix ''
+          # Step 3: Apply Wayland fix if enabled
+          echo "Applying Wayland fix for GeForce NOW..."
+          flatpak override --user --nosocket=wayland com.nvidia.geforcenow || true
+          echo "Wayland fix applied."
+        ''}
+
+        echo "GeForce NOW setup completed."
+      '';
+    };
+
+    # Validation
+    assertions = [
+      {
+        assertion = cfg.remoteSetup.maxRetries > 0;
+        message = "GeForce NOW remote setup max retries must be greater than 0";
+      }
+      {
+        assertion = cfg.remoteSetup.retryDelay > 0;
+        message = "GeForce NOW remote setup retry delay must be greater than 0 seconds";
+      }
+    ];
+
+    # Information message
+    warnings = mkIf (!cfg.autoInstall) [
+      ''
+        GeForce NOW module is enabled but autoInstall is disabled.
+        The GeForce NOW remote will be added, but you need to install manually:
+          flatpak install --user GeForceNOW com.nvidia.geforcenow
+      ''
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

- Add NVIDIA GeForce NOW official Linux client via Flatpak integration
- Create new module at `modules/services/geforcenow/default.nix`
- Enable GeForce NOW on p620, razer, and samsung hosts

## Technical Details

The new module provides:
- **Automatic Flatpak remote setup**: Adds NVIDIA's official Flatpak repository
- **Auto-installation**: Installs `com.nvidia.geforcenow` Flatpak package
- **Wayland fix option**: Can disable Wayland socket if needed for compatibility
- **Proper dependency management**: Automatically enables the Flatpak module
- **Retry logic**: Robust setup with configurable retry attempts and delays

## Module Options

```nix
modules.services.geforcenow = {
  enable = true;           # Enable GeForce NOW
  autoInstall = true;      # Auto-install the Flatpak app
  waylandFix = false;      # Apply Wayland compatibility fix
  remoteSetup = {
    maxRetries = 3;        # Retry attempts for repository setup
    retryDelay = 10;       # Delay between retries
  };
};
```

## Test Plan

- [x] Syntax validation passed (`just check-syntax`)
- [x] Build test passed for razer
- [x] Build test passed for p620
- [x] Build test passed for samsung
- [ ] Manual verification after deployment

## References

- Closes #194
- [NVIDIA Blog Announcement](https://blogs.nvidia.com/blog/geforce-now-thursday-linux/)
- [Official Installation Guide](https://nvidia.custhelp.com/app/answers/detail/a_id/5765/)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)