### PR TITLE
feat(cosmic): add cosmic-bg-ng and fix lock/logout on laptops

### DIFF
--- a/docs/guides/HOST_SETUP.md
+++ b/docs/guides/HOST_SETUP.md
@@ -178,7 +178,7 @@ nixos-rebuild switch --flake .#new-hostname
   hardware.graphics.extraPackages = with pkgs; [
     intel-media-driver
     vaapiIntel
-    vaapiVdpau
+    libva-vdpau-driver # Renamed from vaapiVdpau
   ];
 }
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -167,20 +167,44 @@
         "type": "github"
       }
     },
+    "cosmic-bg-ng": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-utils": "flake-utils_4",
+        "nix-filter": "nix-filter",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770122927,
+        "narHash": "sha256-k/m/z0nH/CxZbncBdeOlucfCKTdPb5qJ650LJYH6eoU=",
+        "owner": "olafkfreund",
+        "repo": "cosmic-bg-ng",
+        "rev": "1198de7b76d2465e2d7af69fe61e23656d2a69b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "olafkfreund",
+        "repo": "cosmic-bg-ng",
+        "type": "github"
+      }
+    },
     "cosmic-connect": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_5",
         "nixpkgs": [
           "nixpkgs"
         ],
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1769965567,
-        "narHash": "sha256-+LrMm60B50P1LDWEe66kLMn9vc6/yWBRKzrfCKxi8oU=",
+        "lastModified": 1770123189,
+        "narHash": "sha256-xTFYlUn0HVDMycWzmP+KjB5LayGbmqBr3LZJOWxW/m0=",
         "owner": "olafkfreund",
         "repo": "cosmic-connect-desktop-app",
-        "rev": "39c6de38cf1f06c905bcd873bcab9f8b191eda67",
+        "rev": "9093051260828bb0d8d55c759b3a448a1cb7be97",
         "type": "github"
       },
       "original": {
@@ -191,8 +215,8 @@
     },
     "cosmic-music-player": {
       "inputs": {
-        "crane": "crane",
-        "flake-utils": "flake-utils_5",
+        "crane": "crane_2",
+        "flake-utils": "flake-utils_6",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -213,20 +237,20 @@
     },
     "cosmic-notifications-ng": {
       "inputs": {
-        "crane": "crane_2",
-        "fenix": "fenix",
-        "flake-utils": "flake-utils_6",
-        "nix-filter": "nix-filter",
+        "crane": "crane_3",
+        "fenix": "fenix_2",
+        "flake-utils": "flake-utils_7",
+        "nix-filter": "nix-filter_2",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1769976460,
-        "narHash": "sha256-X76LAG+BepvOhaaw4cJrggJm3IbqfS67r7Fq3+V6Yh0=",
+        "lastModified": 1770117637,
+        "narHash": "sha256-RCQa0KScQLm8P8XdQ93vnl8nhxBvFBSe/ZKHBZnokbA=",
         "owner": "olafkfreund",
         "repo": "cosmic-notifications-ng",
-        "rev": "d1fc5ea07453dfa2c42e29a64baadd0d1063c137",
+        "rev": "ba243622e7a368dcbafaed2800e1ae31cc5418dd",
         "type": "github"
       },
       "original": {
@@ -237,8 +261,8 @@
     },
     "cosmic-package-updater": {
       "inputs": {
-        "crane": "crane_3",
-        "flake-utils": "flake-utils_7",
+        "crane": "crane_4",
+        "flake-utils": "flake-utils_8",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -260,6 +284,21 @@
     },
     "crane": {
       "locked": {
+        "lastModified": 1769737823,
+        "narHash": "sha256-DrBaNpZ+sJ4stXm+0nBX7zqZT9t9P22zbk6m5YhQxS4=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "b2f45c3830aa96b7456a4c4bc327d04d7a43e1ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_2": {
+      "locked": {
         "lastModified": 1767744144,
         "narHash": "sha256-9/9ntI0D+HbN4G0TrK3KmHbTvwgswz7p8IEJsWyef8Q=",
         "owner": "ipetkov",
@@ -273,7 +312,7 @@
         "type": "github"
       }
     },
-    "crane_2": {
+    "crane_3": {
       "locked": {
         "lastModified": 1769737823,
         "narHash": "sha256-DrBaNpZ+sJ4stXm+0nBX7zqZT9t9P22zbk6m5YhQxS4=",
@@ -288,7 +327,7 @@
         "type": "github"
       }
     },
-    "crane_3": {
+    "crane_4": {
       "locked": {
         "lastModified": 1767744144,
         "narHash": "sha256-9/9ntI0D+HbN4G0TrK3KmHbTvwgswz7p8IEJsWyef8Q=",
@@ -303,7 +342,7 @@
         "type": "github"
       }
     },
-    "crane_4": {
+    "crane_5": {
       "inputs": {
         "nixpkgs": [
           "lanzaboote",
@@ -324,7 +363,7 @@
         "type": "github"
       }
     },
-    "crane_5": {
+    "crane_6": {
       "locked": {
         "lastModified": 1765739568,
         "narHash": "sha256-gQYx35Of4UDKUjAYvmxjUEh/DdszYeTtT6MDin4loGE=",
@@ -367,11 +406,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1769914881,
-        "narHash": "sha256-J+/h02BfL/oo7vhNv/KZ410nktVYmHr1GM4rpUWWC+U=",
+        "lastModified": 1770084350,
+        "narHash": "sha256-hm3W7wXdikalvqB1JmC135iB3H95iLXsytql9x4Mxnw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "475e1d3aab316ba2403605a2feee7685c806723f",
+        "rev": "b21888ec68579b6ec52e4a2933b4ad9ad11e5c22",
         "type": "github"
       },
       "original": {
@@ -383,10 +422,32 @@
     "fenix": {
       "inputs": {
         "nixpkgs": [
-          "cosmic-notifications-ng",
+          "cosmic-bg-ng",
           "nixpkgs"
         ],
         "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1770102568,
+        "narHash": "sha256-VYwA9FmakKJ3zLfAd7bdj9xIB9PzfISLoYh6eZl+EuQ=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "592daa37b5a3175c61541329b64d6c1972303bc1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "fenix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "cosmic-notifications-ng",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
         "lastModified": 1769966877,
@@ -402,14 +463,14 @@
         "type": "github"
       }
     },
-    "fenix_2": {
+    "fenix_3": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs-f2k",
           "nixpkgs-fmt",
           "nixpkgs"
         ],
-        "rust-analyzer-src": "rust-analyzer-src_2"
+        "rust-analyzer-src": "rust-analyzer-src_3"
       },
       "locked": {
         "lastModified": 1637475807,
@@ -589,6 +650,24 @@
       }
     },
     "flake-utils_10": {
+      "inputs": {
+        "systems": "systems_11"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_11": {
       "locked": {
         "lastModified": 1637014545,
         "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
@@ -603,9 +682,9 @@
         "type": "github"
       }
     },
-    "flake-utils_11": {
+    "flake-utils_12": {
       "inputs": {
-        "systems": "systems_13"
+        "systems": "systems_14"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -621,9 +700,9 @@
         "type": "github"
       }
     },
-    "flake-utils_12": {
+    "flake-utils_13": {
       "inputs": {
-        "systems": "systems_14"
+        "systems": "systems_15"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -770,11 +849,11 @@
         "systems": "systems_10"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -868,11 +947,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769872935,
-        "narHash": "sha256-07HMIGQ/WJeAQJooA7Kkg1SDKxhAiV6eodvOwTX6WKI=",
+        "lastModified": 1769978395,
+        "narHash": "sha256-gj1yP3spUb1vGtaF5qPhshd2j0cg4xf51pklDsIm19Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f4ad5068ee8e89e4a7c2e963e10dd35cd77b37b7",
+        "rev": "984708c34d3495a518e6ab6b8633469bbca2f77a",
         "type": "github"
       },
       "original": {
@@ -918,10 +997,10 @@
     },
     "lanzaboote": {
       "inputs": {
-        "crane": "crane_4",
+        "crane": "crane_5",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
-        "flake-utils": "flake-utils_9",
+        "flake-utils": "flake-utils_10",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -968,11 +1047,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1769907691,
-        "narHash": "sha256-9OwKfEJMR8cxwDqKoJywdWa0LIcMGYZitMSsvAjAsMs=",
+        "lastModified": 1770074118,
+        "narHash": "sha256-3JFYOqJGLgn5QsEnBwOm6K+vFX3uckiiyVt3b9VT5h0=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "f9bf64e6e53ef21603cc65fd2d285c68184d0917",
+        "rev": "4f7e75d2be8a4c99778275ad3b3e4421029dcde0",
         "type": "github"
       },
       "original": {
@@ -1001,6 +1080,21 @@
       }
     },
     "nix-filter": {
+      "locked": {
+        "lastModified": 1757882181,
+        "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nix-filter_2": {
       "locked": {
         "lastModified": 1757882181,
         "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
@@ -1096,11 +1190,11 @@
         "parts": "parts"
       },
       "locked": {
-        "lastModified": 1769920338,
-        "narHash": "sha256-n0ZgPGW6VoLgEtDw1U36V1pTWt5g7yPOSguSzIzbCCk=",
+        "lastModified": 1770092339,
+        "narHash": "sha256-/g8k7QEVIxL9fknvcH6OjVMPww9QKTjo8affSzXxyyg=",
         "owner": "moni-dz",
         "repo": "nixpkgs-f2k",
-        "rev": "aae2c4980d823c2205bf3a80a1ef3950e7c6e495",
+        "rev": "d7648c39d811e56abb75a8aa8036209ead7321ff",
         "type": "github"
       },
       "original": {
@@ -1111,8 +1205,8 @@
     },
     "nixpkgs-fmt": {
       "inputs": {
-        "fenix": "fenix_2",
-        "flake-utils": "flake-utils_10",
+        "fenix": "fenix_3",
+        "flake-utils": "flake-utils_11",
         "nixpkgs": [
           "nixpkgs-f2k",
           "nixpkgs"
@@ -1179,11 +1273,11 @@
     },
     "nixpkgs-lib_4": {
       "locked": {
-        "lastModified": 1765674936,
-        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
         "type": "github"
       },
       "original": {
@@ -1242,11 +1336,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1769789167,
-        "narHash": "sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8=",
+        "lastModified": 1770019141,
+        "narHash": "sha256-VKS4ZLNx4PNrABoB0L8KUpc1fE7CLpQXQs985tGfaCU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "62c8382960464ceb98ea593cb8321a2cf8f9e3e5",
+        "rev": "cb369ef2efd432b3cdf8622b0ffc0a97a02f3137",
         "type": "github"
       },
       "original": {
@@ -1258,11 +1352,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1769918707,
-        "narHash": "sha256-dty2mzorKglaImd53o+F1t0+V12eWQ4alwoUbao+M/E=",
+        "lastModified": 1770091355,
+        "narHash": "sha256-OKch8lChU/qEF392gHeT9CcbKvkNYXlBxKkmSXIK6Ok=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3ab3bf806bd38c82f463bd55c9dadacf9cd34e08",
+        "rev": "ac7c30e2ca1f70e82222e1d95a0221c1edee9228",
         "type": "github"
       },
       "original": {
@@ -1274,11 +1368,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1769789167,
-        "narHash": "sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8=",
+        "lastModified": 1770019141,
+        "narHash": "sha256-VKS4ZLNx4PNrABoB0L8KUpc1fE7CLpQXQs985tGfaCU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "62c8382960464ceb98ea593cb8321a2cf8f9e3e5",
+        "rev": "cb369ef2efd432b3cdf8622b0ffc0a97a02f3137",
         "type": "github"
       },
       "original": {
@@ -1417,11 +1511,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1769789167,
-        "narHash": "sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8=",
+        "lastModified": 1770019141,
+        "narHash": "sha256-VKS4ZLNx4PNrABoB0L8KUpc1fE7CLpQXQs985tGfaCU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "62c8382960464ceb98ea593cb8321a2cf8f9e3e5",
+        "rev": "cb369ef2efd432b3cdf8622b0ffc0a97a02f3137",
         "type": "github"
       },
       "original": {
@@ -1433,11 +1527,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1769461804,
-        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
+        "lastModified": 1770019141,
+        "narHash": "sha256-VKS4ZLNx4PNrABoB0L8KUpc1fE7CLpQXQs985tGfaCU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
+        "rev": "cb369ef2efd432b3cdf8622b0ffc0a97a02f3137",
         "type": "github"
       },
       "original": {
@@ -1453,11 +1547,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1769946407,
-        "narHash": "sha256-dFwjZq7CxYFklU4slK+rFVLb31dnhIQ2dtAJThQFSR4=",
+        "lastModified": 1770120029,
+        "narHash": "sha256-3UkghT5vQVBslKiZ+wIpgPze8eyMha8mT/T7IIRuRdc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e43b7fc2c514a37af7923ed375b35e3e991efaff",
+        "rev": "70877f9a9aa4f7034ca74a0c42b8c3268f943636",
         "type": "github"
       },
       "original": {
@@ -1496,11 +1590,11 @@
         "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
         "type": "github"
       },
       "original": {
@@ -1542,11 +1636,12 @@
         "antigravity-nix": "antigravity-nix",
         "claude-desktop-linux": "claude-desktop-linux",
         "cosmic-applet-spotify": "cosmic-applet-spotify",
+        "cosmic-bg-ng": "cosmic-bg-ng",
         "cosmic-connect": "cosmic-connect",
         "cosmic-music-player": "cosmic-music-player",
         "cosmic-notifications-ng": "cosmic-notifications-ng",
         "cosmic-package-updater": "cosmic-package-updater",
-        "flake-utils": "flake-utils_8",
+        "flake-utils": "flake-utils_9",
         "home-manager": "home-manager_2",
         "lan-mouse": "lan-mouse",
         "lanzaboote": "lanzaboote",
@@ -1571,6 +1666,23 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
+        "lastModified": 1770026591,
+        "narHash": "sha256-VZlloygYDmozJwbZZkCSNpiPhNdOW/AA0b6LmNBZ3xU=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "74eca73f3b0a41b80228b8e499c7547cc8b2effa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-analyzer-src_2": {
+      "flake": false,
+      "locked": {
         "lastModified": 1769857242,
         "narHash": "sha256-3eKpRRzKz0KzY7CJzRXFm4POwEqbuTohyQ2ajI/zKvg=",
         "owner": "rust-lang",
@@ -1585,7 +1697,7 @@
         "type": "github"
       }
     },
-    "rust-analyzer-src_2": {
+    "rust-analyzer-src_3": {
       "flake": false,
       "locked": {
         "lastModified": 1637439871,
@@ -1736,11 +1848,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769921679,
-        "narHash": "sha256-twBMKGQvaztZQxFxbZnkg7y/50BW9yjtCBWwdjtOZew=",
+        "lastModified": 1770110318,
+        "narHash": "sha256-NUVGVtYBTC96WhPh4Y3SVM7vf0o1z5W4uqRBn9v1pfo=",
         "owner": "mic92",
         "repo": "sops-nix",
-        "rev": "1e89149dcfc229e7e2ae24a8030f124a31e4f24f",
+        "rev": "f990b0a334e96d3ef9ca09d4bd92778b42fd84f9",
         "type": "github"
       },
       "original": {
@@ -1768,14 +1880,14 @@
     "spicetify-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_12",
-        "systems": "systems_11"
+        "systems": "systems_12"
       },
       "locked": {
-        "lastModified": 1769923635,
-        "narHash": "sha256-GeeKHM5kXrkRvXFta455o09IZ5sNklQzpKpAD0QRbvI=",
+        "lastModified": 1769986820,
+        "narHash": "sha256-O9OQ44dk9TJdtRIG828DUI54XdkfZET7AlN1RgTsPis=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "46e80ec47220788400daf62b021345ed219ade29",
+        "rev": "68de6434cfaa8983f3775b858b8b76e7c5dbd29c",
         "type": "github"
       },
       "original": {
@@ -1797,7 +1909,7 @@
           "nixpkgs"
         ],
         "nur": "nur_2",
-        "systems": "systems_12",
+        "systems": "systems_13",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
@@ -1805,11 +1917,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1769888473,
-        "narHash": "sha256-4KWbaJwaYnZ60bFyTudZYAKskjr7Sa17R3/yh+oXS7w=",
+        "lastModified": 1769978605,
+        "narHash": "sha256-Vjniae6HHJCb9xZLeUOP15aRQXSZuKeeaZFM+gRDCgo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ae5c0239ae4f82a8c7e33ad8a456535d5a9ba813",
+        "rev": "ce22070ec5ce6169a6841da31baea33ce930ed38",
         "type": "github"
       },
       "original": {
@@ -1894,6 +2006,21 @@
       }
     },
     "systems_14": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_15": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -2111,7 +2238,7 @@
     },
     "yt-x": {
       "inputs": {
-        "flake-utils": "flake-utils_11",
+        "flake-utils": "flake-utils_12",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -2132,8 +2259,8 @@
     },
     "zjstatus": {
       "inputs": {
-        "crane": "crane_5",
-        "flake-utils": "flake-utils_12",
+        "crane": "crane_6",
+        "flake-utils": "flake-utils_13",
         "nixpkgs": "nixpkgs_13",
         "rust-overlay": "rust-overlay_6"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,12 @@
       url = "github:olafkfreund/cosmic-notifications-ng";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # COSMIC BG NG - Enhanced background service with animated, video, and shader wallpaper support
+    cosmic-bg-ng = {
+      url = "github:olafkfreund/cosmic-bg-ng";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -214,6 +220,8 @@
         inputs.cosmic-connect.overlays.default
         # COSMIC Notifications NG - Enhanced notifications with images, links, progress
         inputs.cosmic-notifications-ng.overlays.default
+        # COSMIC BG NG - Enhanced backgrounds with animated, video, and shader support
+        inputs.cosmic-bg-ng.overlays.default
         # Custom package: glim - GitLab CI/CD TUI
         (final: _prev: {
           glim = final.callPackage ./overlays/glim { };
@@ -330,6 +338,7 @@
               nix-index-database.nixosModules.nix-index
               inputs.cosmic-connect.nixosModules.default
               inputs.cosmic-notifications-ng.nixosModules.default
+              inputs.cosmic-bg-ng.nixosModules.default
               ./home/shell/zellij/zjstatus.nix
             ]
             ++ stylixModule

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -107,6 +107,9 @@ in
   # COSMIC Notifications NG - Enhanced notifications with rich content support
   services.cosmic-notifications-ng.enable = true;
 
+  # COSMIC BG NG - Enhanced backgrounds with animated, video, and shader wallpaper support
+  services.cosmic-bg-ng.enable = true;
+
   # COSMIC Connect - Device connectivity solution for COSMIC Desktop
   # DISABLED: webkit2gtk dependency issue in upstream package
   # TODO: Re-enable when cosmic-connect package is fixed

--- a/hosts/p620/nixos/boot.nix
+++ b/hosts/p620/nixos/boot.nix
@@ -24,7 +24,7 @@
   # v4l2loopback for OBS Virtual Camera support
   boot.extraModulePackages = with pkgs.linuxPackages_latest; [ v4l2loopback ];
   boot.extraModprobeConfig = ''
-    options v4l2loopback devices=2 video_nr=1,2 card_label="OBS Virtual Cam 1","OBS Virtual Cam 2" exclusive_caps=1
+    options v4l2loopback devices=3 video_nr=1,2,10 card_label="OBS Virtual Cam 1","OBS Virtual Cam 2","COSMIC Camera" exclusive_caps=1,1,1
   '';
   systemd.tmpfiles.rules = [
     "f /dev/shm/scream 0660 olafkfreund qemu-libvirtd -"

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -88,6 +88,9 @@ in
   # COSMIC Notifications NG - Enhanced notifications with rich content support
   services.cosmic-notifications-ng.enable = true;
 
+  # COSMIC BG NG - Enhanced backgrounds with animated, video, and shader wallpaper support
+  services.cosmic-bg-ng.enable = true;
+
   # COSMIC Connect - Device connectivity solution for COSMIC Desktop
   # TEMPORARILY DISABLED: Rust compilation errors in cosmic-connect-protocol (issue #79)
   # services.cosmic-connect = {

--- a/hosts/razer/nixos/boot.nix
+++ b/hosts/razer/nixos/boot.nix
@@ -35,6 +35,6 @@
   boot.kernelModules = [ "v4l2loopback" ];
   boot.extraModulePackages = with pkgs.linuxPackages_6_18; [ v4l2loopback ];
   boot.extraModprobeConfig = ''
-    options v4l2loopback devices=2 video_nr=1,2 card_label="OBS Virtual Cam 1","OBS Virtual Cam 2" exclusive_caps=1
+    options v4l2loopback devices=3 video_nr=1,2,10 card_label="OBS Virtual Cam 1","OBS Virtual Cam 2","COSMIC Camera" exclusive_caps=1,1,1
   '';
 }

--- a/hosts/razer/nixos/greetd.nix
+++ b/hosts/razer/nixos/greetd.nix
@@ -2,19 +2,24 @@
 , pkgs
 , ...
 }: {
-  services.greetd = {
-    enable = true;
-    settings = {
-      terminal.vt = 1;
-      default_session = {
-        command = "${pkgs.tuigreet}/bin/tuigreet --time --remember --remember-user-session --asterisks --power-shutdown 'systemctl poweroff' --power-reboot 'systemctl reboot' --greeting 'Welcome to Razer Gaming Laptop'";
-        user = "greeter";
-      };
-    };
-  };
-
-  # Install greetd-related packages
-  # greetd packages moved to main configuration.nix for consolidation
+  # NOTE: greetd display manager disabled - using COSMIC Greeter instead
+  # COSMIC Greeter is enabled via features.desktop.cosmic.useCosmicGreeter = true
+  # which provides proper lock/logout functionality for COSMIC Desktop
+  #
+  # If you need to fall back to tuigreet, disable cosmic-greeter first:
+  # features.desktop.cosmic.useCosmicGreeter = false;
+  # Then uncomment the greetd configuration below:
+  #
+  # services.greetd = {
+  #   enable = true;
+  #   settings = {
+  #     terminal.vt = 1;
+  #     default_session = {
+  #       command = "${pkgs.tuigreet}/bin/tuigreet --time --remember --remember-user-session --asterisks --power-shutdown 'systemctl poweroff' --power-reboot 'systemctl reboot' --greeting 'Welcome to Razer Gaming Laptop'";
+  #       user = "greeter";
+  #     };
+  #   };
+  # };
 
   # Security and authentication configuration
   security = {

--- a/hosts/samsung/configuration.nix
+++ b/hosts/samsung/configuration.nix
@@ -84,6 +84,9 @@ in
   # COSMIC Notifications NG - Enhanced notifications with rich content support
   services.cosmic-notifications-ng.enable = true;
 
+  # COSMIC BG NG - Enhanced backgrounds with animated, video, and shader wallpaper support
+  services.cosmic-bg-ng.enable = true;
+
   # COSMIC Connect - Device connectivity solution for COSMIC Desktop
   # DISABLED: webkit2gtk dependency issue in upstream package
   # TODO: Re-enable when cosmic-connect package is fixed

--- a/hosts/samsung/nixos/boot.nix
+++ b/hosts/samsung/nixos/boot.nix
@@ -15,6 +15,6 @@
   boot.kernelModules = [ "v4l2loopback" ];
   boot.extraModulePackages = with pkgs.linuxPackages_latest; [ v4l2loopback ];
   boot.extraModprobeConfig = ''
-    options v4l2loopback devices=2 video_nr=1,2 card_label="OBS Virtual Cam 1","OBS Virtual Cam 2" exclusive_caps=1
+    options v4l2loopback devices=3 video_nr=1,2,10 card_label="OBS Virtual Cam 1","OBS Virtual Cam 2","COSMIC Camera" exclusive_caps=1,1,1
   '';
 }

--- a/hosts/samsung/nixos/greetd.nix
+++ b/hosts/samsung/nixos/greetd.nix
@@ -1,17 +1,24 @@
 { pkgs, ... }: {
-  # Enhanced greetd display manager with tuigreet
-  services.greetd = {
-    enable = true;
-    settings = {
-      terminal.vt = 1;
-      default_session = {
-        command = "${pkgs.tuigreet}/bin/tuigreet --time --remember --remember-user-session --asterisks --greeting 'Welcome to P620 AMD Workstation'";
-        user = "greeter";
-      };
-    };
-  };
+  # NOTE: greetd display manager disabled - using COSMIC Greeter instead
+  # COSMIC Greeter is enabled via features.desktop.cosmic.useCosmicGreeter = true
+  # which provides proper lock/logout functionality for COSMIC Desktop
+  #
+  # If you need to fall back to tuigreet, disable cosmic-greeter first:
+  # features.desktop.cosmic.useCosmicGreeter = false;
+  # Then uncomment the greetd configuration below:
+  #
+  # services.greetd = {
+  #   enable = true;
+  #   settings = {
+  #     terminal.vt = 1;
+  #     default_session = {
+  #       command = "${pkgs.tuigreet}/bin/tuigreet --time --remember --remember-user-session --asterisks --greeting 'Welcome to Samsung Laptop'";
+  #       user = "greeter";
+  #     };
+  #   };
+  # };
 
-  # Install greetd-related packages
+  # Install greetd-related packages (kept for potential fallback)
   environment.systemPackages = with pkgs; [
     tuigreet
   ];

--- a/lib/hostTemplate.nix
+++ b/lib/hostTemplate.nix
@@ -91,7 +91,7 @@
         extraPackages = with pkgs; [
           intel-media-driver
           vaapiIntel
-          vaapiVdpau
+          libva-vdpau-driver # Renamed from vaapiVdpau
           # libvdpau-va-gl removed - old unmaintained package with CMake compatibility issues
           # Modern Intel systems work perfectly with intel-media-driver and vaapiIntel
         ];

--- a/modules/desktop/cosmic.nix
+++ b/modules/desktop/cosmic.nix
@@ -111,6 +111,9 @@ in
         cosmic-greeter.enable = cfg.useCosmicGreeter;
         defaultSession = mkIf cfg.defaultSession "cosmic";
       };
+      # Disable greetd when using cosmic-greeter to prevent display manager conflicts
+      # cosmic-greeter handles lock/logout - greetd would interfere with these functions
+      greetd.enable = mkIf cfg.useCosmicGreeter (lib.mkForce false);
     };
 
     # Wrap cosmic-comp with proper library paths to fix libEGL.so.1 loading


### PR DESCRIPTION
## Summary
- Add cosmic-bg-ng for animated, video, and shader wallpaper support
- Fix COSMIC lock/logout not working on Samsung and Razer laptops
- Add v4l2loopback COSMIC Camera device on desktop hosts
- Fix deprecated package warnings (vaapiVdpau)

## Changes

### New Features
- **cosmic-bg-ng integration**: Animated, video, and shader wallpaper support from olafkfreund/cosmic-bg-ng
- **COSMIC Camera**: Added third v4l2loopback device (`/dev/video10`) for COSMIC Camera on p620, razer, samsung

### Bug Fixes
- **COSMIC lock/logout**: Fixed by disabling greetd when cosmic-greeter is enabled
  - Root cause: Multiple display managers (greetd + cosmic-greeter) conflicting
  - cosmic-greeter handles COSMIC session management including lock/logout
- **vaapiVdpau deprecation**: Updated to `libva-vdpau-driver` in lib/hostTemplate.nix
- **cosmic-bg-ng upstream**: Fixed deprecated packages in upstream repo (PR #20 merged)

## Test plan
- [ ] Deploy to Samsung: `just quick-deploy samsung`
- [ ] Deploy to Razer: `just quick-deploy razer`
- [ ] Deploy to P620: `just quick-deploy p620`
- [ ] Reboot and test COSMIC Lock from menu
- [ ] Test COSMIC Log out from menu
- [ ] Verify v4l2loopback devices: `ls -la /dev/video*`

## Files changed
- `flake.nix` - Added cosmic-bg-ng input, overlay, nixosModule
- `flake.lock` - Updated with cosmic-bg-ng dependency
- `modules/desktop/cosmic.nix` - Disable greetd when useCosmicGreeter=true
- `hosts/*/configuration.nix` - Enable cosmic-bg-ng service
- `hosts/*/nixos/boot.nix` - Add COSMIC Camera to v4l2loopback
- `hosts/*/nixos/greetd.nix` - Comment out greetd, document cosmic-greeter
- `lib/hostTemplate.nix` - Fix vaapiVdpau deprecation
- `docs/guides/HOST_SETUP.md` - Update documentation

🤖 Generated with [Claude Code](https://claude.ai/code)