### PR TITLE
fix(cosmic): resolve greetd unit file error when using cosmic-greeter

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770122927,
-        "narHash": "sha256-k/m/z0nH/CxZbncBdeOlucfCKTdPb5qJ650LJYH6eoU=",
+        "lastModified": 1770135878,
+        "narHash": "sha256-uTK+CirAwWrjGPcNQiCWTBcKXlCAw3FovFYz7JdMrg8=",
         "owner": "olafkfreund",
         "repo": "cosmic-bg-ng",
-        "rev": "1198de7b76d2465e2d7af69fe61e23656d2a69b7",
+        "rev": "d7c1db8fa55ea866cb4d04d4e2f192f60ca9e068",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1770123189,
-        "narHash": "sha256-xTFYlUn0HVDMycWzmP+KjB5LayGbmqBr3LZJOWxW/m0=",
+        "lastModified": 1770136116,
+        "narHash": "sha256-Tue9cpUy9b5z2jIqZBnCZ+d+X/WV+6KcwlzaibZoF0A=",
         "owner": "olafkfreund",
         "repo": "cosmic-connect-desktop-app",
-        "rev": "9093051260828bb0d8d55c759b3a448a1cb7be97",
+        "rev": "23ca3a44bf38bad6f5faf7c272b314d86c213046",
         "type": "github"
       },
       "original": {
@@ -1336,11 +1336,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1770019141,
-        "narHash": "sha256-VKS4ZLNx4PNrABoB0L8KUpc1fE7CLpQXQs985tGfaCU=",
+        "lastModified": 1770115704,
+        "narHash": "sha256-KHFT9UWOF2yRPlAnSXQJh6uVcgNcWlFqqiAZ7OVlHNc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cb369ef2efd432b3cdf8622b0ffc0a97a02f3137",
+        "rev": "e6eae2ee2110f3d31110d5c222cd395303343b08",
         "type": "github"
       },
       "original": {
@@ -1368,11 +1368,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1770019141,
-        "narHash": "sha256-VKS4ZLNx4PNrABoB0L8KUpc1fE7CLpQXQs985tGfaCU=",
+        "lastModified": 1770115704,
+        "narHash": "sha256-KHFT9UWOF2yRPlAnSXQJh6uVcgNcWlFqqiAZ7OVlHNc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cb369ef2efd432b3cdf8622b0ffc0a97a02f3137",
+        "rev": "e6eae2ee2110f3d31110d5c222cd395303343b08",
         "type": "github"
       },
       "original": {
@@ -1511,11 +1511,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1770019141,
-        "narHash": "sha256-VKS4ZLNx4PNrABoB0L8KUpc1fE7CLpQXQs985tGfaCU=",
+        "lastModified": 1770115704,
+        "narHash": "sha256-KHFT9UWOF2yRPlAnSXQJh6uVcgNcWlFqqiAZ7OVlHNc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cb369ef2efd432b3cdf8622b0ffc0a97a02f3137",
+        "rev": "e6eae2ee2110f3d31110d5c222cd395303343b08",
         "type": "github"
       },
       "original": {
@@ -1547,11 +1547,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1770120029,
-        "narHash": "sha256-3UkghT5vQVBslKiZ+wIpgPze8eyMha8mT/T7IIRuRdc=",
+        "lastModified": 1770132504,
+        "narHash": "sha256-WaP6QZ2n1qJ4suxMpeKaT6R2KCOGdgB+saHhAE1Js8Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "70877f9a9aa4f7034ca74a0c42b8c3268f943636",
+        "rev": "0ce7c6797b843145e88f50d441ca32dcfdd5343f",
         "type": "github"
       },
       "original": {

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -105,7 +105,10 @@ in
   };
 
   # COSMIC Notifications NG - Enhanced notifications with rich content support
-  services.cosmic-notifications-ng.enable = true;
+  services.cosmic-notifications-ng = {
+    enable = true;
+    settings.max_image_size = 64;
+  };
 
   # COSMIC BG NG - Enhanced backgrounds with animated, video, and shader wallpaper support
   services.cosmic-bg-ng.enable = true;

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -86,7 +86,10 @@ in
   };
 
   # COSMIC Notifications NG - Enhanced notifications with rich content support
-  services.cosmic-notifications-ng.enable = true;
+  services.cosmic-notifications-ng = {
+    enable = true;
+    settings.max_image_size = 64;
+  };
 
   # COSMIC BG NG - Enhanced backgrounds with animated, video, and shader wallpaper support
   services.cosmic-bg-ng.enable = true;

--- a/hosts/samsung/configuration.nix
+++ b/hosts/samsung/configuration.nix
@@ -82,7 +82,10 @@ in
   };
 
   # COSMIC Notifications NG - Enhanced notifications with rich content support
-  services.cosmic-notifications-ng.enable = true;
+  services.cosmic-notifications-ng = {
+    enable = true;
+    settings.max_image_size = 64;
+  };
 
   # COSMIC BG NG - Enhanced backgrounds with animated, video, and shader wallpaper support
   services.cosmic-bg-ng.enable = true;

--- a/modules/desktop/cosmic.nix
+++ b/modules/desktop/cosmic.nix
@@ -356,7 +356,8 @@ in
 
         # Fix for greetd service not inheriting LD_LIBRARY_PATH
         # This ensures cosmic-comp can find libEGL.so.1 from libglvnd
-        greetd = mkIf cfg.useCosmicGreeter {
+        # Only apply when NOT using cosmic-greeter (i.e., when greetd is actually enabled)
+        greetd = mkIf (!cfg.useCosmicGreeter) {
           path = [ pkgs.libglvnd pkgs.mesa ];
           serviceConfig = {
             Environment = [


### PR DESCRIPTION
## Summary

- Fixed greetd unit file error causing "bad unit file setting" on Samsung
- The greetd systemd config was being applied when `useCosmicGreeter=true` but greetd was disabled, creating an incomplete unit file
- Inverted the condition to only apply greetd config when NOT using cosmic-greeter

## Changes

- `modules/desktop/cosmic.nix`: Changed `mkIf cfg.useCosmicGreeter` to `mkIf (!cfg.useCosmicGreeter)` for greetd systemd config
- `hosts/*/configuration.nix`: Updated cosmic-notifications-ng settings
- `flake.lock`: Updated flake inputs

## Test plan

- [x] Validated configuration with `nix flake check`
- [x] Deployed to Samsung - cosmic-greeter-daemon now running properly
- [x] Verified greetd unit file no longer exists when using cosmic-greeter (correct behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)