### PR TITLE
fix(p510): disable firewall to allow media services

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -351,11 +351,10 @@ in
     "/etc/ssh/ssh_host_rsa_key" # Host key (RSA fallback)
   ];
 
-  # Firewall ports for local network access
-  networking.firewall.allowedTCPPorts = [
-    22 # SSH - critical for remote access
-    8123 # Home Assistant
-  ];
+  # Disable firewall - P510 is on trusted internal network
+  # Security is provided by Tailscale ACLs and router firewall
+  # Services: Plex, Sonarr, Radarr, NZBGet, Tautulli, etc. need unrestricted access
+  networking.firewall.enable = false;
 
   nixpkgs.config = {
     allowUnfree = true; # Required for NVIDIA drivers

--- a/hosts/p510/nixos/monitoring.nix
+++ b/hosts/p510/nixos/monitoring.nix
@@ -203,14 +203,9 @@ _: {
     };
   };
 
-  # Open required ports in the firewall
-  networking.firewall.allowedTCPPorts = [
-    3000 # Grafana
-    3100 # Loki
-    9090 # Prometheus
-    9100 # Node Exporter
-    28183 # Promtail
-  ];
+  # Firewall disabled on P510 - no port configuration needed
+  # Services accessible on internal network: Grafana (3000), Loki (3100),
+  # Prometheus (9090), Node Exporter (9100), Promtail (28183)
 
   # Create required directories with correct permissions
   systemd.tmpfiles.rules = [


### PR DESCRIPTION
## Summary

- Disable firewall entirely on P510 media server
- Remove redundant firewall port configurations from monitoring.nix
- P510 is on trusted internal network - security provided by Tailscale ACLs and router

## Problem

The firewall was blocking Plex, Sonarr, Radarr, NZBGet, Tautulli and other media services on P510.

## Solution

Disabled `networking.firewall.enable` since P510 is a media server on a trusted internal network that doesn't need host-level firewall protection.

## Test plan

- [x] Configuration builds successfully (`nix build --dry-run`)
- [ ] Deploy to P510 and verify services are accessible

🤖 Generated with [Claude Code](https://claude.ai/code)