### PR TITLE
chore(claude-code): update to version 2.1.31

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.30";
+    version = "2.1.31";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-uoo1GJgQSWUrYKqh8B0hUJCMtDDA6vkd/fC5cyqZGSY=";
+      hash = "sha256-YZrcQyi9c5B/9YJU3h2Lz4XUWGPh0qg8CypEmo7fEdE=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 


### PR DESCRIPTION
## Summary
- Update Claude Code CLI tool from 2.1.30 to 2.1.31
- Updated source hash for the new version

## Changes
- `home/development/claude-code/default.nix`: Updated version and hash

## Testing
- ✅ Built successfully with `nix build`
- ✅ Verified version output: `2.1.31 (Claude Code)`

## Verification
```bash
nix build .#claude-code
./result/bin/claude --version
# Output: 2.1.31 (Claude Code)
```

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>