### PR TITLE
chore(gemini-cli): update to version 0.27.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -238,7 +238,7 @@
         (final: _prev: {
           claude-code-native = final.callPackage ./pkgs/claude-code-native { };
         })
-        # Custom package: gemini-cli - Google Gemini AI CLI tool with version 0.26.0
+        # Custom package: gemini-cli - Google Gemini AI CLI tool with version 0.27.0
         (final: _prev: {
           gemini-cli = final.callPackage ./home/development/gemini-cli { };
         })

--- a/home/development/gemini-cli/default.nix
+++ b/home/development/gemini-cli/default.nix
@@ -14,16 +14,16 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "gemini-cli";
-  version = "0.26.0";
+  version = "0.27.0";
 
   src = fetchFromGitHub {
     owner = "google-gemini";
     repo = "gemini-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wvCSYr5BUS5gggTFHfG+SRvgAyRE63nYdaDwH98wurI=";
+    hash = "sha256-ptx+aBlw6Koyv5NWZNXOunPJfedv1JwprG1SaRLwrGg=";
   };
 
-  npmDepsHash = "sha256-nfmIt+wUelhz3KiW4/pp/dGE71f2jsPbxwpBRT8gtYc=";
+  npmDepsHash = "sha256-0bS3yl5EG2KyfBrw8SO1BfKwxb1f2LVsudeaQTb5/DQ=";
 
   nodejs = nodejs_22;
 


### PR DESCRIPTION
## Summary
- Update gemini-cli package from 0.26.0 to 0.27.0
- Updated source hash for new release
- Updated npmDepsHash for new dependencies

## Test plan
- [x] Package builds successfully
- [x] Version outputs `0.27.0`
- [x] Configuration syntax valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)