### PR TITLE
fix(boot): add configurationLimit to prevent /boot from filling up

### DIFF
--- a/hosts/p510/nixos/boot.nix
+++ b/hosts/p510/nixos/boot.nix
@@ -1,6 +1,7 @@
 { pkgs, lib, ... }: {
   # Bootloader.
   boot.loader.systemd-boot.enable = true;
+  boot.loader.systemd-boot.configurationLimit = 10; # Limit boot entries to prevent /boot from filling up
   boot.loader.efi.canTouchEfiVariables = true;
   boot.kernelPackages = pkgs.linuxPackages_6_18; # Use kernel 6.18 for NVIDIA driver compatibility
   boot.plymouth.enable = true;

--- a/hosts/p620/nixos/boot.nix
+++ b/hosts/p620/nixos/boot.nix
@@ -1,6 +1,7 @@
 { pkgs, ... }: {
   # Bootloader.
   boot.loader.systemd-boot.enable = true;
+  boot.loader.systemd-boot.configurationLimit = 10; # Limit boot entries to prevent /boot from filling up
   boot.loader.efi.canTouchEfiVariables = true;
   boot.kernelPackages = pkgs.linuxPackages_latest; # Use the beta kernel for better hardware support
   boot.plymouth.enable = true;


### PR DESCRIPTION
## Summary
- Add `boot.loader.systemd-boot.configurationLimit = 10` to p620 and p510
- Prevents boot partition from filling up with old kernel/initrd files
- Automatically cleans up old boot entries when limit is exceeded

## Context
The p620 boot partition filled up (100%) causing bootloader installation to fail. This fix ensures old boot entries are automatically removed.

## Changes
- `hosts/p620/nixos/boot.nix`: Added configurationLimit = 10
- `hosts/p510/nixos/boot.nix`: Added configurationLimit = 10
- razer/samsung already had configurationLimit = 3 (no changes needed)

## Test plan
- [x] Configuration syntax validated
- [x] Setting is standard NixOS option

🤖 Generated with [Claude Code](https://claude.com/claude-code)