### PR TITLE
fix(razer): disable firewall to allow SSH access

### DIFF
--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -67,15 +67,8 @@ in
     # Set custom nameservers as fallback
     nameservers = [ "1.1.1.1" "8.8.8.8" ];
 
-    # Firewall configuration - explicit SSH access
-    firewall = {
-      enable = true;
-      allowedTCPPorts = [
-        22 # SSH - critical for remote access
-        3389 # RDP - for headless remote desktop
-      ];
-      allowPing = true; # Enable ICMP for network diagnostics
-    };
+    # Firewall disabled to allow all network access including SSH
+    firewall.enable = false;
   };
 
   # Tailscale VPN using built-in NixOS service


### PR DESCRIPTION
## Summary
- Completely disable firewall on razer to resolve SSH connectivity issues

## Context
SSH access to razer.lan was not working despite having port 22 explicitly opened in the firewall configuration. Disabling the firewall completely to allow SSH and other network access.

## Changes
- `hosts/razer/configuration.nix`: Set `networking.firewall.enable = false`

## Test plan
- [ ] Deploy to razer
- [ ] Verify SSH access works: `ssh razer.lan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)