### PR TITLE
chore(claude-code): update to version 2.1.32

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.31";
+    version = "2.1.32";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-YZrcQyi9c5B/9YJU3h2Lz4XUWGPh0qg8CypEmo7fEdE=";
+      hash = "sha256-qMCPsYVxWnn46Hah9Qd+rSN6eOQ/8Qafd35IfHkLAe0=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 


### PR DESCRIPTION
## Summary
- Update claude-code from version 2.1.31 to 2.1.32
- Updated source hash for new version

## Testing
- [x] Package builds successfully
- [x] Version verified: `claude --version` returns `2.1.32 (Claude Code)`

## Changes
- `home/development/claude-code/default.nix`: Updated version and hash

🤖 Generated with [Claude Code](https://claude.ai/code)