### PR TITLE
feat(cosmic): enable cosmic-radio-applet on p620 and samsung

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -113,6 +113,12 @@ in
   # COSMIC BG NG - Enhanced backgrounds with animated, video, and shader wallpaper support
   services.cosmic-bg-ng.enable = true;
 
+  # COSMIC Radio Applet - Internet radio player for COSMIC Desktop panel
+  programs.cosmic-radio-applet = {
+    enable = true;
+    autostart = true;
+  };
+
   # COSMIC Connect - Device connectivity solution for COSMIC Desktop
   # DISABLED: webkit2gtk dependency issue in upstream package
   # TODO: Re-enable when cosmic-connect package is fixed

--- a/hosts/samsung/configuration.nix
+++ b/hosts/samsung/configuration.nix
@@ -90,6 +90,12 @@ in
   # COSMIC BG NG - Enhanced backgrounds with animated, video, and shader wallpaper support
   services.cosmic-bg-ng.enable = true;
 
+  # COSMIC Radio Applet - Internet radio player for COSMIC Desktop panel
+  programs.cosmic-radio-applet = {
+    enable = true;
+    autostart = true;
+  };
+
   # COSMIC Connect - Device connectivity solution for COSMIC Desktop
   # DISABLED: webkit2gtk dependency issue in upstream package
   # TODO: Re-enable when cosmic-connect package is fixed


### PR DESCRIPTION
## Summary
Enable cosmic-radio-applet on all COSMIC Desktop hosts for internet radio playback.

## Hosts Updated
- [x] p620 (workstation) - **NEW**
- [x] samsung (laptop) - **NEW**
- [x] razer (laptop) - already enabled in PR #209

## Testing
- [x] p620 configuration builds successfully
- [x] samsung configuration builds successfully
- [x] razer configuration builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)