### PR TITLE
chore(claude-code): update to version 2.1.37

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,16 +9,16 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.34";
+    version = "2.1.37";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-9poksTheZl3zwxmGwTNwAmUmTooZCY5huFqe73RYh1A=";
+      hash = "sha256-JBarNxtzDn6sdgl5yLPIUgrrUoyDZNjiLqrYVPPpjlo=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 
     # No npm dependencies to cache - all dependencies are vendored
-    npmDepsHash = "sha256-K5re0co3Tkz5peXHe/UUlsqAWq4YzSULdY9+xncfL5A=";
+    npmDepsHash = "sha256-2if3LsTEnC2OQjEgojqgzs8YOXdpoqJijEmVlxmEfzw=";
 
     inherit nodejs;
 

--- a/home/development/claude-code/package-lock.json
+++ b/home/development/claude-code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthropic-ai/claude-code",
-  "version": "2.1.15",
+  "version": "2.1.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthropic-ai/claude-code",
-      "version": "2.1.15",
+      "version": "2.1.37",
       "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "cli.js"


### PR DESCRIPTION
## Summary
- Update claude-code from 2.1.34 to 2.1.37
- Updated source hash and npm dependencies hash
- Updated vendored package-lock.json

## Test plan
- [x] `nix build` for p620 completes successfully
- [x] Built package confirms version 2.1.37

🤖 Generated with [Claude Code](https://claude.com/claude-code)