### PR TITLE
fix(flake): add overlay for nix-prefetch-git binary naming regression

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -309,6 +309,21 @@
             buildInputs = (oldAttrs.buildInputs or [ ]) ++ [ prev.cxxopts prev.icu ];
           });
         })
+        # Fix nix-prefetch-git binary name (nixpkgs-unstable regression: binary named
+        # "nix-prefetch-git-VERSION" instead of "nix-prefetch-git", breaking fetchCargoVendor)
+        (_final: prev: {
+          nix-prefetch-git = prev.nix-prefetch-git.overrideAttrs (_oldAttrs: {
+            postFixup =
+              let
+                versionedName = prev.nix-prefetch-git.name;
+              in
+              ''
+                if [ ! -e "$out/bin/nix-prefetch-git" ] && [ -e "$out/bin/${versionedName}" ]; then
+                  ln -s "${versionedName}" "$out/bin/nix-prefetch-git"
+                fi
+              '';
+          });
+        })
       ];
 
       makeNixosSystem = host:


### PR DESCRIPTION
## Summary
- Fix nixpkgs-unstable regression where `nix-prefetch-git` binary is named `nix-prefetch-git-26.05pre-git` instead of `nix-prefetch-git`
- This broke `fetchCargoVendor` for all Rust packages with git dependencies (e.g., `cosmic-next-meeting`)
- Add overlay with symlink via `postFixup` that propagates through `.override { git-lfs = null; }`

## Test plan
- [x] Verified `nix-prefetch-git` symlink created in overlay output
- [x] Verified symlink propagates through `git-lfs = null` override used by `fetchCargoVendor`
- [x] Full `samsung` host build succeeds (includes `cosmic-next-meeting` with git cargo deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)