### PR TITLE
chore(cosmic): reduce notifications-ng max_image_size to 32

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -107,7 +107,7 @@ in
   # COSMIC Notifications NG - Enhanced notifications with rich content support
   services.cosmic-notifications-ng = {
     enable = true;
-    settings.max_image_size = 64;
+    settings.max_image_size = 32;
   };
 
   # COSMIC BG NG - Enhanced backgrounds with animated, video, and shader wallpaper support

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -81,7 +81,7 @@ in
   # COSMIC Notifications NG - Enhanced notifications with rich content support
   services.cosmic-notifications-ng = {
     enable = true;
-    settings.max_image_size = 64;
+    settings.max_image_size = 32;
   };
 
   # COSMIC BG NG - Enhanced backgrounds with animated, video, and shader wallpaper support

--- a/hosts/samsung/configuration.nix
+++ b/hosts/samsung/configuration.nix
@@ -84,7 +84,7 @@ in
   # COSMIC Notifications NG - Enhanced notifications with rich content support
   services.cosmic-notifications-ng = {
     enable = true;
-    settings.max_image_size = 64;
+    settings.max_image_size = 32;
   };
 
   # COSMIC BG NG - Enhanced backgrounds with animated, video, and shader wallpaper support


### PR DESCRIPTION
## Summary
- Reduce `settings.max_image_size` from 64 to 32 for `cosmic-notifications-ng` on p620, razer, and samsung

## Test plan
- [x] Configuration change only (integer value update)
- [ ] Verify notification images render correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)