### PR TITLE
feat(cosmic): add cosmic-web-apps from flake for COSMIC Desktop

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -304,6 +304,28 @@
         "type": "github"
       }
     },
+    "cosmic-web-apps": {
+      "inputs": {
+        "crane": "crane_5",
+        "flake-utils": "flake-utils_10",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770648314,
+        "narHash": "sha256-+INzDS3l9Oo5IIj7y/eduCyDmoAFmBiV2DozWV0SUYY=",
+        "owner": "olafkfreund",
+        "repo": "cosmic-web-apps",
+        "rev": "817d7c4d86bad7965c67b0a4efe03dff649474bb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "olafkfreund",
+        "repo": "cosmic-web-apps",
+        "type": "github"
+      }
+    },
     "crane": {
       "locked": {
         "lastModified": 1769737823,
@@ -365,6 +387,21 @@
       }
     },
     "crane_5": {
+      "locked": {
+        "lastModified": 1770419512,
+        "narHash": "sha256-o8Vcdz6B6bkiGUYkZqFwH3Pv1JwZyXht3dMtS7RchIo=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "2510f2cbc3ccd237f700bb213756a8f35c32d8d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_6": {
       "inputs": {
         "nixpkgs": [
           "lanzaboote",
@@ -385,7 +422,7 @@
         "type": "github"
       }
     },
-    "crane_6": {
+    "crane_7": {
       "locked": {
         "lastModified": 1765739568,
         "narHash": "sha256-gQYx35Of4UDKUjAYvmxjUEh/DdszYeTtT6MDin4loGE=",
@@ -694,6 +731,24 @@
         "systems": "systems_12"
       },
       "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_12": {
+      "inputs": {
+        "systems": "systems_13"
+      },
+      "locked": {
         "lastModified": 1710146030,
         "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
@@ -707,7 +762,7 @@
         "type": "github"
       }
     },
-    "flake-utils_12": {
+    "flake-utils_13": {
       "locked": {
         "lastModified": 1637014545,
         "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
@@ -722,9 +777,9 @@
         "type": "github"
       }
     },
-    "flake-utils_13": {
+    "flake-utils_14": {
       "inputs": {
-        "systems": "systems_15"
+        "systems": "systems_16"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -740,9 +795,9 @@
         "type": "github"
       }
     },
-    "flake-utils_14": {
+    "flake-utils_15": {
       "inputs": {
-        "systems": "systems_16"
+        "systems": "systems_17"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -1037,10 +1092,10 @@
     },
     "lanzaboote": {
       "inputs": {
-        "crane": "crane_5",
+        "crane": "crane_6",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
-        "flake-utils": "flake-utils_11",
+        "flake-utils": "flake-utils_12",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -1246,7 +1301,7 @@
     "nixpkgs-fmt": {
       "inputs": {
         "fenix": "fenix_3",
-        "flake-utils": "flake-utils_12",
+        "flake-utils": "flake-utils_13",
         "nixpkgs": [
           "nixpkgs-f2k",
           "nixpkgs"
@@ -1682,7 +1737,8 @@
         "cosmic-notifications-ng": "cosmic-notifications-ng",
         "cosmic-package-updater": "cosmic-package-updater",
         "cosmic-radio-applet": "cosmic-radio-applet",
-        "flake-utils": "flake-utils_10",
+        "cosmic-web-apps": "cosmic-web-apps",
+        "flake-utils": "flake-utils_11",
         "home-manager": "home-manager_2",
         "lan-mouse": "lan-mouse",
         "lanzaboote": "lanzaboote",
@@ -1942,7 +1998,7 @@
     "spicetify-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_12",
-        "systems": "systems_13"
+        "systems": "systems_14"
       },
       "locked": {
         "lastModified": 1769986820,
@@ -1971,7 +2027,7 @@
           "nixpkgs"
         ],
         "nur": "nur_2",
-        "systems": "systems_14",
+        "systems": "systems_15",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
@@ -2098,6 +2154,21 @@
       }
     },
     "systems_16": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_17": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -2315,7 +2386,7 @@
     },
     "yt-x": {
       "inputs": {
-        "flake-utils": "flake-utils_13",
+        "flake-utils": "flake-utils_14",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -2336,8 +2407,8 @@
     },
     "zjstatus": {
       "inputs": {
-        "crane": "crane_6",
-        "flake-utils": "flake-utils_14",
+        "crane": "crane_7",
+        "flake-utils": "flake-utils_15",
         "nixpkgs": "nixpkgs_13",
         "rust-overlay": "rust-overlay_7"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -122,6 +122,12 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # COSMIC Web Apps - Web application manager for COSMIC Desktop
+    cosmic-web-apps = {
+      url = "github:olafkfreund/cosmic-web-apps";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # COSMIC Notifications NG - Enhanced notifications with rich content support
     cosmic-notifications-ng = {
       url = "github:olafkfreund/cosmic-notifications-ng";
@@ -222,6 +228,7 @@
           cosmic-ext-applet-music-player = inputs.cosmic-music-player.packages.${prev.stdenv.hostPlatform.system}.default;
           cosmic-applet-spotify = inputs.cosmic-applet-spotify.packages.${prev.stdenv.hostPlatform.system}.default;
           cosmic-radio-applet = inputs.cosmic-radio-applet.packages.${prev.stdenv.hostPlatform.system}.default;
+          cosmic-web-apps = inputs.cosmic-web-apps.packages.${prev.stdenv.hostPlatform.system}.default;
         })
         # COSMIC Connect - KDE Connect alternative for COSMIC Desktop
         inputs.cosmic-connect.overlays.default

--- a/modules/desktop/cosmic.nix
+++ b/modules/desktop/cosmic.nix
@@ -199,6 +199,9 @@ in
           cosmic-screenshot # Screenshot tool
           cosmic-randr # Display configuration
 
+          # Web applications
+          cosmic-web-apps # Web app manager for COSMIC Desktop
+
           # Extensions and tweaks
           cosmic-ext-calculator # Calculator application
           cosmic-ext-tweaks # Advanced tweaking tool


### PR DESCRIPTION
## Summary
- Add `cosmic-web-apps` as a flake input from `github:olafkfreund/cosmic-web-apps`
- Add overlay to expose `pkgs.cosmic-web-apps` package
- Integrate into COSMIC desktop module's `installAllApps` package list

## Test plan
- [x] `nix eval` succeeds for samsung host
- [x] `nix eval` succeeds for p620 host
- [x] Pre-commit checks pass (flake check, formatting, dead code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)