### PR TITLE
chore(claude-code): update to version 2.1.38

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,7 +156,7 @@ repos:
 
       - id: end-of-file
         name: Fix end of file
-        entry: bash -c 'for f in "$@"; do [ -n "$(tail -c1 "$f")" ] && echo >> "$f"; done'
+        entry: "bash -c 'r=0; for f in \"$@\"; do if [ -s \"$f\" ] && [ -n \"$(tail -c1 \"$f\")\" ]; then echo >> \"$f\"; echo \"Fixed: $f\"; r=1; fi; done; exit $r' _"
         language: system
         files: '\.(nix|sh|lua|toml|yaml|yml|json|md|py)$'
         description: Ensure files end with newline

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,68 @@
+# typos configuration - exclude false positives
+# See: https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+[default.extend-words]
+# AMD HSA (Heterogeneous System Architecture) - valid technical term
+HSA = "HSA"
+hsa = "hsa"
+
+# k3sserver is a hostname, not a typo
+sserver = "sserver"
+
+# nitch is a system info tool package name
+nitch = "nitch"
+
+# dbe is a shell alias for "distrobox enter"
+dbe = "dbe"
+
+# AGS is "Aylur's GTK Shell" - valid acronym
+AGS = "AGS"
+
+# serie is a valid Nix package name (system info tool)
+serie = "serie"
+
+# darcula is a valid theme name (different from dracula)
+darcula = "darcula"
+
+# exportfs is a valid NFS command/config option
+exportfs = "exportfs"
+
+# enew is a valid Neovim buffer function
+enew = "enew"
+
+# hdinsight is Azure HDInsight service name
+hdinsight = "hdinsight"
+
+# styl is a valid file extension (Stylus CSS)
+styl = "styl"
+
+# edn is a valid file extension (Extensible Data Notation)
+edn = "edn"
+
+# toogle is a GNOME extension config key (upstream typo)
+toogle = "toogle"
+
+# usig is in a third-party plugin comment
+usig = "usig"
+
+# nd is a valid lsblk flag (-nd = no headings, no dependents)
+nd = "nd"
+
+[default.extend-identifiers]
+# Santa Claus - not "Clause"
+Claus = "Claus"
+
+[files]
+# Skip archive directory and binary/data files
+extend-exclude = [
+  "archive/",
+  "assets/",
+  "home/files/emoji",
+  "home/files/base16-themes",
+  "home/shell/lf/icons",
+  "home/shell/lazyvim/",
+  "*.age",
+  "*.lock",
+  "*.svg",
+  "result",
+]

--- a/home/desktop/theme/gtk-cosmic-fix.nix
+++ b/home/desktop/theme/gtk-cosmic-fix.nix
@@ -123,47 +123,51 @@ in
   };
 
   config = mkIf cfg.enable {
-    # Systemd path unit to watch for changes to dark.css
-    systemd.user.paths.cosmic-gtk-watcher = {
-      Unit = {
-        Description = "Watch COSMIC GTK CSS for changes";
+    systemd.user = {
+      # Watch for changes to dark.css
+      paths.cosmic-gtk-watcher = {
+        Unit = {
+          Description = "Watch COSMIC GTK CSS for changes";
+        };
+        Path = {
+          PathChanged = "%h/.config/gtk-4.0/cosmic/dark.css";
+          Unit = "cosmic-gtk-patcher.service";
+        };
+        Install = {
+          WantedBy = [ "default.target" ];
+        };
       };
-      Path = {
-        PathChanged = "%h/.config/gtk-4.0/cosmic/dark.css";
-        Unit = "cosmic-gtk-patcher.service";
-      };
-      Install = {
-        WantedBy = [ "default.target" ];
-      };
-    };
 
-    # Systemd service to patch the CSS
-    systemd.user.services.cosmic-gtk-patcher = {
-      Unit = {
-        Description = "Patch COSMIC GTK CSS with Gruvbox theme";
-      };
-      Service = {
-        Type = "oneshot";
-        ExecStart = "${patchScript}";
-        # Small delay to ensure COSMIC finished writing
-        ExecStartPre = "${pkgs.coreutils}/bin/sleep 1";
-      };
-    };
+      services = {
+        # Patch the CSS when dark.css changes
+        cosmic-gtk-patcher = {
+          Unit = {
+            Description = "Patch COSMIC GTK CSS with Gruvbox theme";
+          };
+          Service = {
+            Type = "oneshot";
+            ExecStart = "${patchScript}";
+            # Small delay to ensure COSMIC finished writing
+            ExecStartPre = "${pkgs.coreutils}/bin/sleep 1";
+          };
+        };
 
-    # Also run on login to ensure it's patched
-    systemd.user.services.cosmic-gtk-patcher-init = {
-      Unit = {
-        Description = "Initial patch of COSMIC GTK CSS with Gruvbox theme";
-        After = [ "graphical-session.target" ];
-      };
-      Service = {
-        Type = "oneshot";
-        ExecStart = "${patchScript}";
-        # Delay to let COSMIC initialize
-        ExecStartPre = "${pkgs.coreutils}/bin/sleep 3";
-      };
-      Install = {
-        WantedBy = [ "graphical-session.target" ];
+        # Also run on login to ensure it's patched
+        cosmic-gtk-patcher-init = {
+          Unit = {
+            Description = "Initial patch of COSMIC GTK CSS with Gruvbox theme";
+            After = [ "graphical-session.target" ];
+          };
+          Service = {
+            Type = "oneshot";
+            ExecStart = "${patchScript}";
+            # Delay to let COSMIC initialize
+            ExecStartPre = "${pkgs.coreutils}/bin/sleep 3";
+          };
+          Install = {
+            WantedBy = [ "graphical-session.target" ];
+          };
+        };
       };
     };
   };

--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.37";
+    version = "2.1.38";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-JBarNxtzDn6sdgl5yLPIUgrrUoyDZNjiLqrYVPPpjlo=";
+      hash = "sha256-+o8u2I7EKv10+SUaaf9HdRLl1CxOHuKVm4KzilJHmkk=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 

--- a/tools/dev.nix
+++ b/tools/dev.nix
@@ -21,6 +21,8 @@ pkgs.mkShell {
     statix # Advanced linting
     deadnix # Dead code detection
     nixpkgs-fmt # Code formatting
+    typos # Spell checking
+    taplo # TOML formatting
 
     # Documentation and analysis
     mdbook # Documentation generation


### PR DESCRIPTION
## Summary
- Updated claude-code from v2.1.37 to v2.1.38
- Fixed pre-commit infrastructure issues

## Changes
- `home/development/claude-code/default.nix`: Version bump and source hash update
- `home/desktop/theme/gtk-cosmic-fix.nix`: Fix statix warning (consolidate repeated systemd keys)
- `tools/dev.nix`: Add typos and taplo to devShell
- `_typos.toml`: New config for typos spell checker false positives
- `.pre-commit-config.yaml`: Fix end-of-file hook exit code logic

## Test plan
- [x] Build succeeds: `nix build .#claude-code`
- [x] Binary verified: `claude --version` shows 2.1.38
- [x] All pre-commit hooks pass
- [x] No anti-patterns introduced

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)