### PR TITLE
fix(samsung): update cosmic-comp-rdp to 24764d6 with build fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         "rust": "rust"
       },
       "locked": {
-        "lastModified": 1770932025,
-        "narHash": "sha256-S4hYnfuF5U9jnyHIYFY+9DZBurllhtBtbgLFodqejug=",
+        "lastModified": 1770933235,
+        "narHash": "sha256-RVvgf2vNaui2t6UjVFstNAntYb0Afi2Rx4DS7rewb2g=",
         "owner": "olafkfreund",
         "repo": "cosmic-ext-comp-rdp",
-        "rev": "1fb66ab950d8478d1f863e76b60e531e4587e2f6",
+        "rev": "24764d6138fc4aea2d1b1f39368bdfa86963dd3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updates `cosmic-comp-rdp` flake input to commit `24764d6` which adds the missing `PointGlobalExt` import needed for `as_logical()` calls in pointer motion and touch handlers
- Previous lock (commit `1fb66ab`) failed to build on NixOS due to this missing trait import

## Test plan
- [ ] Verify `nixos-rebuild build --flake .#samsung` completes successfully
- [ ] Verify EIS remote desktop input still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)