### PR TITLE
fix(cosmic): update cosmic-ext-notifications with session symlink fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         "rust": "rust"
       },
       "locked": {
-        "lastModified": 1770932025,
-        "narHash": "sha256-S4hYnfuF5U9jnyHIYFY+9DZBurllhtBtbgLFodqejug=",
+        "lastModified": 1770935694,
+        "narHash": "sha256-5rQjedvsM9ZonEXArMoqSYGL9F84Ywuiyilhr82Th+w=",
         "owner": "olafkfreund",
         "repo": "cosmic-ext-comp-rdp",
-        "rev": "1fb66ab950d8478d1f863e76b60e531e4587e2f6",
+        "rev": "d27861390d64bceb4db6bc9dd45dc356d740fbdb",
         "type": "github"
       },
       "original": {
@@ -246,11 +246,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770928500,
-        "narHash": "sha256-CI5KK7FStucE5ZiWfZfshH9kV3KNlKGO41E//VGTwN4=",
+        "lastModified": 1770938034,
+        "narHash": "sha256-bhs80fDEq1UKmSfJlRECNp5Wigby+161wt0gKupdvTg=",
         "owner": "olafkfreund",
         "repo": "cosmic-ext-notifications-ng",
-        "rev": "c7abdc9611b506fadf468cdae1fa10b0f93bed79",
+        "rev": "6339f08fd6576548eed10eb8bf7611f68daa2454",
         "type": "github"
       },
       "original": {
@@ -1210,11 +1210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770915843,
-        "narHash": "sha256-ZwU5wXKNqpOQvjNz6aBp1j5peiBZow1++6pLnk5VAhs=",
+        "lastModified": 1770936159,
+        "narHash": "sha256-INksKY2oo1hDNrDYh0r+uK0Fd4hBxkQwD4qQAl8lYyg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6a1f7101d2c3ee87d485a87880d73b4665c6a4bd",
+        "rev": "9bdb6938109884cb8b6a79ab79ba18e7b585a881",
         "type": "github"
       },
       "original": {
@@ -1903,11 +1903,11 @@
         "nixpkgs": "nixpkgs_14"
       },
       "locked": {
-        "lastModified": 1770928852,
-        "narHash": "sha256-ML+OxqptdmMQix7RaJgKdOplkCWGYeh6gUjRUv9wXmU=",
+        "lastModified": 1770930688,
+        "narHash": "sha256-obeaLTWYJgcUHvuE/dvXIhjoQW/bWlTkeaTbQgNCSms=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "589df2665700b8a5814855a749677c6d3871d6cf",
+        "rev": "1b8cec019f155baf4fbc51b45a14ca56443455c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updates `cosmic-ext-notifications-ng` flake input to pick up upstream fix
- Upstream now adds a `cosmic-notifications` → `cosmic-ext-notifications` symlink in the package output
- Fixes COSMIC session crash on Samsung where `cosmic-session` expects the `cosmic-notifications` binary

## Root Cause
`cosmic-session` hardcodes launching `cosmic-notifications` as the notifications daemon. The enhanced `cosmic-ext-notifications` package replaces `pkgs.cosmic-notifications` via overlay but the binary was only named `cosmic-ext-notifications`, causing a "No such file or directory" panic at `src/main.rs:307`.

## Test plan
- [x] Samsung config evaluates successfully (`nix build --dry-run`)
- [x] Razer config evaluates successfully
- [x] P620 config evaluates successfully
- [ ] Deploy to Samsung and verify COSMIC session starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)