### PR TITLE
fix(cosmic): update cosmic-ext-bg with session symlink fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770923990,
-        "narHash": "sha256-UMoI4e8F6v4BrHG4z/VqqPqcox6qK0Dgccr3EdjFp8g=",
+        "lastModified": 1770938672,
+        "narHash": "sha256-cHIrwiqxJHwgUVL9hYLDugf544HEPHFSFRtii50SFec=",
         "owner": "olafkfreund",
         "repo": "cosmic-ext-bg",
-        "rev": "d800d922dde1eed5f8f91fd984723705184b562a",
+        "rev": "e76cc28fadaf9848889c197f7b9afb4293f56065",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Updates `cosmic-ext-bg` flake input to pick up upstream symlink fix (olafkfreund/cosmic-ext-bg#31)
- Adds `cosmic-bg → cosmic-ext-bg` and `cosmic-bg-ctl → cosmic-ext-bg-ctl` symlinks
- Fixes `cosmic-session` error: `failed to start cosmic-bg: No such file or directory`

## Test plan
- [x] `nix build --dry-run` passes for Samsung
- [x] Upstream build verified with symlinks present in `result/bin/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)