### PR TITLE
chore(claude-code): update to version 2.1.41

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.39";
+    version = "2.1.41";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-iJB/LuXYACOu6Y5czpP7eGFdrvZTbVUeK7K8pBmjxvY=";
+      hash = "sha256-xouJ8RZC8CEYxb6DpMZa9cpTNDo5VHAxPVCDbwGCdpk=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 


### PR DESCRIPTION
## Summary
- Update Claude Code from 2.1.39 to 2.1.41
- Source hash updated, npmDepsHash unchanged

## Test plan
- [x] Package builds successfully
- [x] Binary verified: `claude --version` shows 2.1.41
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)