### PR TITLE
fix(razer): switch to open NVIDIA kernel modules for 590 driver

### DIFF
--- a/hosts/razer/nixos/nvidia.nix
+++ b/hosts/razer/nixos/nvidia.nix
@@ -8,9 +8,9 @@
       powerManagement.enable = true;
       powerManagement.finegrained = false;
       nvidiaPersistenced = false;
-      open = false; # Use proprietary drivers for better Wayland compatibility
-      nvidiaSettings = false;
-      package = config.boot.kernelPackages.nvidiaPackages.beta; # Use beta for cutting edge support
+      open = true; # NVIDIA 590+ requires open kernel modules for Turing GPUs (RTX 2070 Super)
+      nvidiaSettings = true;
+      package = config.boot.kernelPackages.nvidiaPackages.beta;
 
       prime = {
         sync.enable = true;
@@ -29,8 +29,7 @@
         vulkan-loader
         vulkan-tools
 
-        # Video acceleration - proper order matters
-        libva-vdpau-driver
+        # Video acceleration
         libva-vdpau-driver
         nvidia-vaapi-driver
 


### PR DESCRIPTION
## Summary
- Switch `hardware.nvidia.open` from `false` to `true` for Razer's RTX 2070 Super (Turing)
- NVIDIA 590+ drivers require open kernel modules for Turing GPUs — proprietary modules cause loading failures on kernel 6.18
- Fixed duplicate `libva-vdpau-driver` entry in graphics.extraPackages
- Enabled `nvidiaSettings` for GPU debugging tools

## Context
- [Arch Linux announcement: NVIDIA 590 switches to open kernel modules](https://archlinux.org/news/nvidia-590-driver-drops-pascal-support-main-packages-switch-to-open-kernel-modules/)
- [Known Turing regression with 590 D3 power management](https://forums.developer.nvidia.com/t/regression-turing-gtx-1650-ti-runtime-d3-broken-on-driver-590-works-on-580/356397)

## Test plan
- [x] Configuration evaluates cleanly
- [x] Pre-commit hooks pass
- [ ] Deploy to Razer and verify `nvidia-smi` works (Razer currently offline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)