### PR TITLE
chore(claude-code): update to version 2.1.42

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.41";
+    version = "2.1.42";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-xouJ8RZC8CEYxb6DpMZa9cpTNDo5VHAxPVCDbwGCdpk=";
+      hash = "sha256-ZfaruxpZqc3GGUTIcI0V1vGKE7Imo+eTjZ7ODwMMcZM=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 


### PR DESCRIPTION
## Summary
- Update claude-code package from 2.1.41 to 2.1.42
- Source hash recalculated for new tarball
- npmDepsHash unchanged (same dependencies)

## Test plan
- [x] Package builds successfully
- [x] Binary verified: `claude --version` → `2.1.42 (Claude Code)`
- [x] Pre-commit hooks pass (nix fmt, statix, deadnix, spelling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)