### PR TITLE
chore: update flake inputs, fix live images, and yazi config

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770196631,
-        "narHash": "sha256-neRXwIILc8BUFHeT0UM2Mj8Wt1oo4UPpmm4NkfBwQOY=",
+        "lastModified": 1771198383,
+        "narHash": "sha256-mOq7ks7gdWyVStIUAp7U8wztanYKt0GgCnIZtPUJ6n8=",
         "owner": "jacopone",
         "repo": "antigravity-nix",
-        "rev": "acc9baf089a67ef7456117ef31285e34c3294984",
+        "rev": "703d29149cc127d1ec7c1885ff14f85d4e6a01ce",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1770928838,
-        "narHash": "sha256-SSARx9xHPUQtjXSGKMT7whNmjnD3VRljhqO/QNtzMG4=",
+        "lastModified": 1771245012,
+        "narHash": "sha256-34I7jBgSdJF8OUk776CIEtEoQPaIFpE7EZoQMwoAKXM=",
         "owner": "olafkfreund",
         "repo": "cosmic-ext-connect-desktop-app",
-        "rev": "0fa66746323f60c886b4c85851a282dac1ffd3d5",
+        "rev": "3613bf5f0665f4330f3deb87748a617164822125",
         "type": "github"
       },
       "original": {
@@ -268,11 +268,11 @@
         "rust-overlay": "rust-overlay_3"
       },
       "locked": {
-        "lastModified": 1770918791,
-        "narHash": "sha256-J3QxmPgcFreUukkbcRFejaTFQt85DUv9m6d8lIgGeDY=",
+        "lastModified": 1770997168,
+        "narHash": "sha256-9s4USXD7kMy9CzHVnK8rpOFWYJBRe5BqBmJ8kTwH56E=",
         "owner": "olafkfreund",
         "repo": "cosmic-ext-radio-applet",
-        "rev": "9d08d2728040bc8ec9f46ce7996acd98e349529b",
+        "rev": "53e74527297e20b8cffd5af90a64727184dd9041",
         "type": "github"
       },
       "original": {
@@ -305,17 +305,16 @@
     "cosmic-ext-web-apps": {
       "inputs": {
         "crane": "crane_5",
-        "flake-utils": "flake-utils_9",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1770914938,
-        "narHash": "sha256-bY2BeyUqL1dHHSK7ihuSRmucDjrBVkV76RCw49OvcsU=",
+        "lastModified": 1771005472,
+        "narHash": "sha256-KkWmFsME1bR1rbhnX8zGXpDEMw08upQroLi5rg22QVE=",
         "owner": "olafkfreund",
         "repo": "cosmic-ext-web-apps",
-        "rev": "331ac0cc1659eb9dad785a0d58bf75a5ca86404e",
+        "rev": "f7a799e3296877688de2b5aa72f34b091152b7f3",
         "type": "github"
       },
       "original": {
@@ -327,7 +326,7 @@
     "cosmic-music-player": {
       "inputs": {
         "crane": "crane_6",
-        "flake-utils": "flake-utils_10",
+        "flake-utils": "flake-utils_9",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -349,7 +348,7 @@
     "cosmic-package-updater": {
       "inputs": {
         "crane": "crane_7",
-        "flake-utils": "flake-utils_11",
+        "flake-utils": "flake-utils_10",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -373,7 +372,7 @@
       "inputs": {
         "crane": "crane_8",
         "fenix": "fenix_3",
-        "flake-utils": "flake-utils_12",
+        "flake-utils": "flake-utils_11",
         "nix-filter": "nix-filter_5",
         "nixpkgs": "nixpkgs_6"
       },
@@ -575,11 +574,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1770602774,
-        "narHash": "sha256-eRcZ279Oaf8ViHtvdWVTpcD9x7bvJ3ipQ1Xq9bd+qlk=",
+        "lastModified": 1771383252,
+        "narHash": "sha256-AOozGKt/K56xB7ZBnDsHOaMrKoDjbRB79gIwfvGM8UY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a3d87c21d1464f1069d8125cafe6adb84d200185",
+        "rev": "47a9693387f25587860f447e77d116fc77d018c6",
         "type": "github"
       },
       "original": {
@@ -899,24 +898,6 @@
         "systems": "systems_14"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_14": {
-      "inputs": {
-        "systems": "systems_15"
-      },
-      "locked": {
         "lastModified": 1710146030,
         "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
@@ -930,7 +911,7 @@
         "type": "github"
       }
     },
-    "flake-utils_15": {
+    "flake-utils_14": {
       "locked": {
         "lastModified": 1637014545,
         "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
@@ -945,9 +926,9 @@
         "type": "github"
       }
     },
-    "flake-utils_16": {
+    "flake-utils_15": {
       "inputs": {
-        "systems": "systems_18"
+        "systems": "systems_17"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -963,9 +944,9 @@
         "type": "github"
       }
     },
-    "flake-utils_17": {
+    "flake-utils_16": {
       "inputs": {
-        "systems": "systems_19"
+        "systems": "systems_18"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -1210,11 +1191,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770936159,
-        "narHash": "sha256-INksKY2oo1hDNrDYh0r+uK0Fd4hBxkQwD4qQAl8lYyg=",
+        "lastModified": 1771269455,
+        "narHash": "sha256-BZ31eN5F99YH6vkc4AhzKGE+tJgJ52kl8f01K7wCs8w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9bdb6938109884cb8b6a79ab79ba18e7b585a881",
+        "rev": "5f1d42a97b19803041434f66681d5c44c9ae62e3",
         "type": "github"
       },
       "original": {
@@ -1263,7 +1244,7 @@
         "crane": "crane_9",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
-        "flake-utils": "flake-utils_14",
+        "flake-utils": "flake-utils_13",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -1310,11 +1291,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1770310890,
-        "narHash": "sha256-lyWAs4XKg3kLYaf4gm5qc5WJrDkYy3/qeV5G733fJww=",
+        "lastModified": 1771365290,
+        "narHash": "sha256-1XJOslVyF7yzf6yd/yl1VjGLywsbtwmQh3X1LuJcLI4=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "68c9f9c6ca91841f04f726a298c385411b7bfcd5",
+        "rev": "789c90b164b55b4379e7a94af8b9c01489024c18",
         "type": "github"
       },
       "original": {
@@ -1424,11 +1405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770315571,
-        "narHash": "sha256-hy0gcAgAcxrnSWKGuNO+Ob0x6jQ2xkR6hoaR0qJBHYs=",
+        "lastModified": 1771130777,
+        "narHash": "sha256-UIKOwG0D9XVIJfNWg6+gENAvQP+7LO46eO0Jpe+ItJ0=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "2684bb8080a6f2ca5f9d494de5ef875bc1c4ecdb",
+        "rev": "efec7aaad8d43f8e5194df46a007456093c40f88",
         "type": "github"
       },
       "original": {
@@ -1459,11 +1440,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1770882871,
-        "narHash": "sha256-nw5g+xl3veea+maxJ2/81tMEA/rPq9aF1H5XF35X+OE=",
+        "lastModified": 1771257191,
+        "narHash": "sha256-H1l+zHq+ZinWH7F1IidpJ2farmbfHXjaxAm1RKWE1KI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "af04cb78aa85b2a4d1c15fc7270347e0d0eda97b",
+        "rev": "66e1a090ded57a0f88e2b381a7d4daf4a5722c3f",
         "type": "github"
       },
       "original": {
@@ -1498,11 +1479,11 @@
         "parts": "parts_2"
       },
       "locked": {
-        "lastModified": 1770870427,
-        "narHash": "sha256-p3FyHgwBrlLSqlQ4ieJwYo1PjglkUDj+/66ptshOxG8=",
+        "lastModified": 1771388703,
+        "narHash": "sha256-ziAnC87Nh6n2HLG2FzBbYSk+oLXrLWaBZnwc/ywOibk=",
         "owner": "moni-dz",
         "repo": "nixpkgs-f2k",
-        "rev": "280c2196928a6475f9f9b73ffb59da3b1e46500a",
+        "rev": "2f2c85376d3b5e33dfbaf96ffebd7e0944d378c6",
         "type": "github"
       },
       "original": {
@@ -1514,7 +1495,7 @@
     "nixpkgs-fmt": {
       "inputs": {
         "fenix": "fenix_4",
-        "flake-utils": "flake-utils_15",
+        "flake-utils": "flake-utils_14",
         "nixpkgs": [
           "nixpkgs-f2k",
           "nixpkgs"
@@ -1644,11 +1625,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1770562336,
-        "narHash": "sha256-ub1gpAONMFsT/GU2hV6ZWJjur8rJ6kKxdm9IlCT0j84=",
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d6c71932130818840fc8fe9509cf50be8c64634f",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
         "type": "github"
       },
       "original": {
@@ -1675,11 +1656,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1770562336,
-        "narHash": "sha256-ub1gpAONMFsT/GU2hV6ZWJjur8rJ6kKxdm9IlCT0j84=",
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d6c71932130818840fc8fe9509cf50be8c64634f",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
         "type": "github"
       },
       "original": {
@@ -1691,11 +1672,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1770562336,
-        "narHash": "sha256-ub1gpAONMFsT/GU2hV6ZWJjur8rJ6kKxdm9IlCT0j84=",
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d6c71932130818840fc8fe9509cf50be8c64634f",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
         "type": "github"
       },
       "original": {
@@ -1707,11 +1688,11 @@
     },
     "nixpkgs_13": {
       "locked": {
-        "lastModified": 1770869822,
-        "narHash": "sha256-Q+i9ECqxx2Y5f2QGln4qBxb7t4ruJ9PN0NMJsGobsgQ=",
+        "lastModified": 1771385682,
+        "narHash": "sha256-+AvM7waTbiyZbWQ2gZbrk0kcn6wINcrxPZ05UL9vGvs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fae19804cf7ee5024f133719e55d4697487dc04a",
+        "rev": "239a9bdc24e8faa6b406a9b28a87fdf0c062c716",
         "type": "github"
       },
       "original": {
@@ -1723,11 +1704,11 @@
     },
     "nixpkgs_14": {
       "locked": {
-        "lastModified": 1770562336,
-        "narHash": "sha256-ub1gpAONMFsT/GU2hV6ZWJjur8rJ6kKxdm9IlCT0j84=",
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d6c71932130818840fc8fe9509cf50be8c64634f",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
         "type": "github"
       },
       "original": {
@@ -1903,11 +1884,11 @@
         "nixpkgs": "nixpkgs_14"
       },
       "locked": {
-        "lastModified": 1770930688,
-        "narHash": "sha256-obeaLTWYJgcUHvuE/dvXIhjoQW/bWlTkeaTbQgNCSms=",
+        "lastModified": 1771401850,
+        "narHash": "sha256-+WTitqBwIW+SXKXz/HflLOPASLJ5pMuKgdCqGFyy90s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1b8cec019f155baf4fbc51b45a14ca56443455c8",
+        "rev": "3e1c92e2f136a33196ddf3670ee0286d20568539",
         "type": "github"
       },
       "original": {
@@ -2023,7 +2004,7 @@
         "cosmic-music-player": "cosmic-music-player",
         "cosmic-package-updater": "cosmic-package-updater",
         "cosmic-portal-rdp": "cosmic-portal-rdp",
-        "flake-utils": "flake-utils_13",
+        "flake-utils": "flake-utils_12",
         "home-manager": "home-manager_2",
         "lan-mouse": "lan-mouse",
         "lanzaboote": "lanzaboote",
@@ -2289,11 +2270,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770683991,
-        "narHash": "sha256-xVfPvXDf9QN3Eh9dV+Lw6IkWG42KSuQ1u2260HKvpnc=",
+        "lastModified": 1771166946,
+        "narHash": "sha256-UFc4lfGBr+wJmwgDGJDn1cVD6DTr0/8TdronNUiyXlU=",
         "owner": "mic92",
         "repo": "sops-nix",
-        "rev": "8b89f44c2cc4581e402111d928869fe7ba9f7033",
+        "rev": "2d0cf89b4404529778bc82de7e42b5754e0fe4fa",
         "type": "github"
       },
       "original": {
@@ -2321,14 +2302,14 @@
     "spicetify-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_15",
-        "systems": "systems_16"
+        "systems": "systems_15"
       },
       "locked": {
-        "lastModified": 1770846656,
-        "narHash": "sha256-wdYpo8++TqKp3GdRgLFykjuIVW1m9GlUnxID2FG74cE=",
+        "lastModified": 1771268051,
+        "narHash": "sha256-nGqPcngnezoT+/xAvw3UDjwdKP2MC4fO315A/Otb9eE=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "40e65cfc4608402674e1efaac3fccce20d2a72d3",
+        "rev": "b930de84c561f62a0c39a6a57c2ab553a97e8495",
         "type": "github"
       },
       "original": {
@@ -2350,7 +2331,7 @@
           "nixpkgs"
         ],
         "nur": "nur_2",
-        "systems": "systems_17",
+        "systems": "systems_16",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
@@ -2358,11 +2339,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1770914701,
-        "narHash": "sha256-QHFYyngohNhih4w+3IqQty5DV+p1txsx1kkk6XJWar8=",
+        "lastModified": 1771330061,
+        "narHash": "sha256-qBWXy3mSOEYjvZB/RZHT0joVPhNWU8GQZQljLzyMTq0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "db03fed72e5ca02be34e1d24789345a943329738",
+        "rev": "fa45bf2d70517a8643a0edb44b02b8e6c0453d06",
         "type": "github"
       },
       "original": {
@@ -2507,21 +2488,6 @@
       }
     },
     "systems_18": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_19": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -2739,7 +2705,7 @@
     },
     "yt-x": {
       "inputs": {
-        "flake-utils": "flake-utils_16",
+        "flake-utils": "flake-utils_15",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -2761,16 +2727,16 @@
     "zjstatus": {
       "inputs": {
         "crane": "crane_10",
-        "flake-utils": "flake-utils_17",
+        "flake-utils": "flake-utils_16",
         "nixpkgs": "nixpkgs_16",
         "rust-overlay": "rust-overlay_7"
       },
       "locked": {
-        "lastModified": 1766016463,
-        "narHash": "sha256-aWp608krMtk5I+c3GXyuHkb6ugah40cBI0R52fNqMiI=",
+        "lastModified": 1771148613,
+        "narHash": "sha256-nLzdw8jskekSRrunxBDCA0NCHr/2aJjcXqZ1Fcqm5eY=",
         "owner": "dj95",
         "repo": "zjstatus",
-        "rev": "9a4b88fdceee8eb2b8c28111c53e94254d61c994",
+        "rev": "7a039f56da80681408454d6e175fde3f54b9e592",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -178,7 +178,10 @@
         p510 = [ "olafkfreund" ];
       };
 
-      # Note: MicroVM packages and live images temporarily disabled during refactoring
+      # Live image builder
+      liveImages = import ./lib/live-images.nix {
+        inherit nixpkgs inputs hostUsers;
+      };
 
       # ========================================
       # HELPER FUNCTIONS
@@ -541,12 +544,8 @@
             };
           };
 
-          # Live ISO images (temporarily disabled during flake restructuring)
-          # live-iso-p620 = liveImages.liveImages.p620.config.system.build.isoImage;
-          # live-iso-razer = liveImages.liveImages.razer.config.system.build.isoImage;
-          # live-iso-p510 = liveImages.liveImages.p510.config.system.build.isoImage;
-          # live-iso-dex5550 = liveImages.liveImages.dex5550.config.system.build.isoImage;
-          # live-iso-samsung = liveImages.liveImages.samsung.config.system.build.isoImage;
+          # Live ISO images
+          live-iso-razer = liveImages.liveImages.live-iso-razer.config.system.build.isoImage;
 
           # Development and deployment tools available as packages
           # (Apps are available separately via apps.x86_64-linux)

--- a/home/shell/yazi/default.nix
+++ b/home/shell/yazi/default.nix
@@ -16,6 +16,7 @@ in
   config = mkIf cfg.enable {
     programs.yazi = {
       enable = true;
+      shellWrapperName = "y";
       package = pkgs.yazi;
       enableBashIntegration = true;
       enableZshIntegration = true;

--- a/lib/live-images.nix
+++ b/lib/live-images.nix
@@ -27,7 +27,7 @@ let
       networking = {
         hostName = lib.mkDefault "${host}-installer";
         networkmanager.enable = true;
-        wireless.enable = false; # Disable wpa_supplicant in favor of NetworkManager
+        wireless.enable = lib.mkForce false; # Disable wpa_supplicant in favor of NetworkManager
         firewall.enable = false; # Disable for installation convenience
       };
 
@@ -90,8 +90,8 @@ let
         # Hardware tools
         inputs.nixpkgs.legacyPackages.x86_64-linux.lshw
         inputs.nixpkgs.legacyPackages.x86_64-linux.dmidecode
-        inputs.nixpkgs.legacyPackages.x86_64-linux.lscpu
-        inputs.nixpkgs.legacyPackages.x86_64-linux.lsusb
+        inputs.nixpkgs.legacyPackages.x86_64-linux.util-linux
+        inputs.nixpkgs.legacyPackages.x86_64-linux.usbutils
         inputs.nixpkgs.legacyPackages.x86_64-linux.pciutils
 
         # Network tools
@@ -183,6 +183,7 @@ let
         boot.kernelModules = [ "i915" "nvidia" ];
         services.xserver.videoDrivers = [ "nvidia" ];
         hardware.nvidia.modesetting.enable = true;
+        hardware.nvidia.open = true; # Required for >= 560 drivers, Razer has RTX GPU
       };
 
     p510 =


### PR DESCRIPTION
## Summary
- Update flake.lock with latest input revisions
- Re-enable live ISO images in flake.nix (razer)
- Fix live-images.nix: correct package names (util-linux, usbutils), mkForce for wireless.enable, add nvidia.open for razer
- Set yazi shellWrapperName to "y" (fixes deprecation warning)

## Test plan
- [x] All pre-commit hooks passed (format, lint, deadnix, flake-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)