### PR TITLE
fix(cosmic): radio applet Wayland wrapping and dependency update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -268,11 +268,11 @@
         "rust-overlay": "rust-overlay_3"
       },
       "locked": {
-        "lastModified": 1770997168,
-        "narHash": "sha256-9s4USXD7kMy9CzHVnK8rpOFWYJBRe5BqBmJ8kTwH56E=",
+        "lastModified": 1771408769,
+        "narHash": "sha256-7EZbG6FDuy59MHejPMnRJiRHOt/cXJrtXoZOgjTrHdY=",
         "owner": "olafkfreund",
         "repo": "cosmic-ext-radio-applet",
-        "rev": "53e74527297e20b8cffd5af90a64727184dd9041",
+        "rev": "c595113c212db1ccc3db32dfd95871e7eb60b186",
         "type": "github"
       },
       "original": {

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -115,10 +115,8 @@ in
   # services.cosmic-ext-bg.enable = true;
 
   # COSMIC Radio Applet - Internet radio player for COSMIC Desktop panel
-  programs.cosmic-ext-applet-radio = {
-    enable = true;
-    autostart = true;
-  };
+  # Add to panel via: COSMIC Settings > Panel > Applets
+  programs.cosmic-ext-applet-radio.enable = true;
 
   # COSMIC Connect - Device connectivity solution for COSMIC Desktop
   services.cosmic-ext-connect = {

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -86,10 +86,8 @@ in
   # services.cosmic-ext-bg.enable = true;
 
   # COSMIC Radio Applet - Internet radio player for COSMIC Desktop panel
-  programs.cosmic-ext-applet-radio = {
-    enable = true;
-    autostart = true;
-  };
+  # Add to panel via: COSMIC Settings > Panel > Applets
+  programs.cosmic-ext-applet-radio.enable = true;
 
   # COSMIC Connect - Device connectivity solution for COSMIC Desktop
   # TEMPORARILY DISABLED: Rust compilation errors in cosmic-ext-connect-protocol (issue #79)

--- a/hosts/samsung/configuration.nix
+++ b/hosts/samsung/configuration.nix
@@ -111,10 +111,8 @@ in
   };
 
   # COSMIC Radio Applet - Internet radio player for COSMIC Desktop panel
-  programs.cosmic-ext-applet-radio = {
-    enable = true;
-    autostart = true;
-  };
+  # Add to panel via: COSMIC Settings > Panel > Applets
+  programs.cosmic-ext-applet-radio.enable = true;
 
   # COSMIC Connect - Device connectivity solution for COSMIC Desktop
   # DISABLED: webkit2gtk dependency issue in upstream package

--- a/modules/services/cosmic-ext-radio-applet/default.nix
+++ b/modules/services/cosmic-ext-radio-applet/default.nix
@@ -1,11 +1,32 @@
 # COSMIC Radio Applet - Internet radio player for COSMIC Desktop panel
 # Local module to work around upstream mkPackageOption 'description' arg bug
+# Note: This is a COSMIC panel applet (X-CosmicApplet=true). It must be added
+# to the panel via COSMIC Settings > Panel > Applets, not via XDG autostart.
 { config, lib, pkgs, ... }:
 
 with lib;
 
 let
   cfg = config.programs.cosmic-ext-applet-radio;
+
+  # Wayland library path required for all libcosmic/COSMIC applets
+  waylandLibs = lib.makeLibraryPath [
+    pkgs.wayland
+    pkgs.libxkbcommon
+    pkgs.vulkan-loader
+    pkgs.libglvnd
+  ];
+
+  # Wrap the applet binary with Wayland libraries (matches cosmic.nix wrapCosmicApp pattern)
+  wrappedPackage = pkgs.symlinkJoin {
+    name = "cosmic-ext-applet-radio-wrapped";
+    paths = [ cfg.package ];
+    buildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      wrapProgram $out/bin/cosmic-ext-applet-radio \
+        --prefix LD_LIBRARY_PATH : "${waylandLibs}"
+    '';
+  };
 in
 {
   options.programs.cosmic-ext-applet-radio = {
@@ -17,25 +38,10 @@ in
       defaultText = literalExpression "pkgs.cosmic-ext-applet-radio";
       description = "The cosmic-ext-applet-radio package to use.";
     };
-
-    autostart = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to automatically start the applet with COSMIC Desktop.
-        When enabled, the applet will appear in the panel on login.
-      '';
-    };
   };
 
   config = mkIf cfg.enable {
-    # Add the package to system packages (includes mpv as runtime dependency)
-    environment.systemPackages = [ cfg.package pkgs.mpv ];
-
-    # Add autostart entry if enabled
-    environment.etc = mkIf cfg.autostart {
-      "xdg/autostart/com.marcos.RadioApplet.desktop".source =
-        "${cfg.package}/share/applications/com.marcos.RadioApplet.desktop";
-    };
+    # Install the wrapped applet with Wayland libraries and mpv runtime dependency
+    environment.systemPackages = [ wrappedPackage pkgs.mpv ];
   };
 }


### PR DESCRIPTION
## Summary

- Wrap radio applet binary with Wayland libraries (wayland, libxkbcommon, vulkan-loader, libglvnd) matching the `wrapCosmicApp` pattern used by other COSMIC applets
- Remove broken XDG autostart mechanism (panel applets use `X-CosmicApplet=true` and are managed by the COSMIC panel)
- Update upstream fork dependencies to align libcosmic with COSMIC Desktop 1.0.5 epoch, fixing protocol mismatch causing exit 137 (SIGKILL) on launch
- Simplify host configs to single-line enable

## Test plan

- [x] P620 deployed and verified - applet process running, no more exit 137 crashes
- [x] All pre-commit hooks passed (nix fmt, statix, deadnix, flake check)
- [ ] Razer/Samsung deploy after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)