### PR TITLE
fix(razer): remove non-existent security.sshHardening option

### DIFF
--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -396,19 +396,6 @@ in
       NH_FLAKE = vars.paths.flakeDir;
     };
 
-  # SSH security hardening DISABLED - blocking remote access
-  # TODO: Re-enable with proper network configuration after testing
-  security.sshHardening = {
-    enable = false; # DISABLED to restore SSH access
-    allowedUsers = hostUsers;
-    allowPasswordAuthentication = false;
-    allowRootLogin = false;
-    maxAuthTries = 3;
-    enableFail2Ban = false;
-    enableKeyOnlyAccess = true;
-    trustedNetworks = [ "192.168.1.0/24" "10.0.0.0/8" "100.64.0.0/10" ];
-  };
-
   # Enable secrets management
   modules.security.secrets = {
     enable = true;


### PR DESCRIPTION
## Summary

- Remove `security.sshHardening` block from `hosts/razer/configuration.nix`
- This option does not exist in NixOS (no custom module defines it)
- It crept in during conflict resolution in PR #241

## Root Cause

The `fix/razer-ssh-hardening-disable` branch added `security.sshHardening = { enable = false; ... }` but this custom option was never implemented as a module. The build fails with:

```
error: The option `security.sshHardening' does not exist.
```

## Fix

Simply remove the entire block. SSH access is preserved via:
- `networking.firewall.enable = false` (already set)
- Standard OpenSSH service configuration

## Test plan

- [x] `nix build .#nixosConfigurations.razer.config.system.build.toplevel` — passes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)