### PR TITLE
chore(claude-code): update to version 2.1.52 (#243)

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,16 +9,16 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.50";
+    version = "2.1.52";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-TXq2sExmbr8slmqdIuW49XcGwNWllBUjubAq+fhORdU=";
+      hash = "sha256-MjKXEH5w+Kuw4joeA6BsgtBEfbKzcjGpRbabnxkyJuU=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 
     # No npm dependencies to cache - all dependencies are vendored
-    npmDepsHash = "sha256-/oQxdQjMVS8r7e1DUPEjhWOLOD/hhVCx8gjEWb3ipZQ=";
+    npmDepsHash = "sha256-ZE+qjgNNbA6p5HLZU+9Flla4S0v8m1Svu/kziC9Jz58=";
 
     inherit nodejs;
 

--- a/home/development/claude-code/package-lock.json
+++ b/home/development/claude-code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthropic-ai/claude-code",
-  "version": "2.1.50",
+  "version": "2.1.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthropic-ai/claude-code",
-      "version": "2.1.50",
+      "version": "2.1.52",
       "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "cli.js"


### PR DESCRIPTION
## Summary
- Update claude-code from v2.1.49 to v2.1.52

## Test plan
- [x] Package builds successfully
- [x] Binary verified: `claude --version` shows `2.1.52`
- [x] All pre-commit hooks pass (format, lint, deadnix, flake check, spelling)
- [ ] Deploy to hosts

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)