### PR TITLE
fix(python): add missing starlette dependency to sse-starlette

### DIFF
--- a/modules/development/python.nix
+++ b/modules/development/python.nix
@@ -6,11 +6,13 @@
 with lib; let
   cfg = config.modules.development.python;
 
-  # Override sse-starlette to disable flaky tests (timing issues cause failures)
+  # Override sse-starlette: fix missing starlette runtime dependency (nixpkgs-unstable
+  # regression) and disable flaky tests (timing issues cause failures)
   # See: https://github.com/olafkfreund/nixos_config/issues/118
-  sse-starlette-nocheck = pkgs.python312Packages.sse-starlette.overridePythonAttrs (_old: {
+  sse-starlette-nocheck = pkgs.python312Packages.sse-starlette.overridePythonAttrs (old: {
     doCheck = false; # Disable flaky timing tests
     pythonImportsCheck = [ ]; # Disable import check (has test-time dependency issues)
+    dependencies = (old.dependencies or [ ]) ++ [ pkgs.python312Packages.starlette ];
   });
 
   # Override mcp to use our fixed sse-starlette


### PR DESCRIPTION
## Summary

- Fix `python312Packages.sse-starlette` build failure caused by nixpkgs-unstable regression where `starlette` is no longer propagated as a runtime dependency
- The `pythonRuntimeDepsCheck` hook fails with `starlette not installed`, cascading to break `python312Packages.mcp` and the full p620 build
- Adds `starlette` to `sse-starlette`'s dependencies via `overridePythonAttrs`

## Test plan

- [x] `just check-syntax` passes
- [x] Nix evaluation succeeds (`nix build --dry-run` for p620)
- [x] All pre-commit hooks pass
- [ ] Deploy to p620 and verify MCP package works

🤖 Generated with [Claude Code](https://claude.com/claude-code)