### PR TITLE
fix(nixpkgs): resolve 7 nixpkgs-unstable build regressions (#247)

### DIFF
--- a/home/development/nvim.nix
+++ b/home/development/nvim.nix
@@ -50,8 +50,8 @@ with lib; let
       pkgs.libuv # libuv (libluv dependency)
       pkgs.unibilium # Terminal info library
 
-      # Ruby gems for Neovim
-      pkgs.ruby_3_3 # Ruby 3.3 interpreter
+      # Ruby for Neovim (use default ruby, same as line 84 to avoid version conflict)
+      # pkgs.ruby included via home.packages below
 
       # Additional Python dependencies
       pkgs.python313Packages.tomlkit # TOML parsing for Python

--- a/modules/consolidated/development.nix
+++ b/modules/consolidated/development.nix
@@ -29,7 +29,7 @@ with lib; let
     ];
 
     python = with pkgs; [
-      python311Full
+      python311
       python311Packages.pip
       python311Packages.virtualenv
       python311Packages.poetry

--- a/modules/development/python.nix
+++ b/modules/development/python.nix
@@ -5,20 +5,6 @@
 }:
 with lib; let
   cfg = config.modules.development.python;
-
-  # Override sse-starlette: fix missing starlette runtime dependency (nixpkgs-unstable
-  # regression) and disable flaky tests (timing issues cause failures)
-  # See: https://github.com/olafkfreund/nixos_config/issues/118
-  sse-starlette-nocheck = pkgs.python312Packages.sse-starlette.overridePythonAttrs (old: {
-    doCheck = false; # Disable flaky timing tests
-    pythonImportsCheck = [ ]; # Disable import check (has test-time dependency issues)
-    dependencies = (old.dependencies or [ ]) ++ [ pkgs.python312Packages.starlette ];
-  });
-
-  # Override mcp to use our fixed sse-starlette
-  mcp-fixed = pkgs.python312Packages.mcp.override {
-    sse-starlette = sse-starlette-nocheck;
-  };
 in
 {
   options.modules.development.python = {
@@ -49,7 +35,7 @@ in
         pkgs.python312Packages.pycairo
         pkgs.python312Packages.pillow
         pkgs.python312Packages.requests
-        mcp-fixed # Use our override with disabled sse-starlette tests
+        pkgs.python312Packages.mcp # sse-starlette fix applied via overlay in flake.nix
 
       ]
       ++ cfg.packages;


### PR DESCRIPTION
## Summary

- Fix 7 cascading nixpkgs-unstable build regressions blocking p620 deployment
- Add 6 overlays in flake.nix for broken Python packages and azure-cli
- Fix ruby version conflict in nvim.nix
- Simplify python.nix (sse-starlette now handled by global overlay)

## Test plan

- [x] p620 deployed successfully with all fixes
- [ ] Test razer deployment
- [ ] Test samsung deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)