### PR TITLE
chore(claude-code): update to version 2.1.56 (#249)

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,16 +9,16 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.52";
+    version = "2.1.56";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-MjKXEH5w+Kuw4joeA6BsgtBEfbKzcjGpRbabnxkyJuU=";
+      hash = "sha256-uXzE+o1iOHJlVx5f3nvxm/xLGA1EbRuRqIcA41m5B7k=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 
     # No npm dependencies to cache - all dependencies are vendored
-    npmDepsHash = "sha256-ZE+qjgNNbA6p5HLZU+9Flla4S0v8m1Svu/kziC9Jz58=";
+    npmDepsHash = "sha256-BEbGA/e0ZkzByvpbDBJS/iUent3PMveN4eQEjkNmD7E=";
 
     inherit nodejs;
 

--- a/home/development/claude-code/package-lock.json
+++ b/home/development/claude-code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthropic-ai/claude-code",
-  "version": "2.1.52",
+  "version": "2.1.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthropic-ai/claude-code",
-      "version": "2.1.52",
+      "version": "2.1.56",
       "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "cli.js"


### PR DESCRIPTION
## Summary
- Updated claude-code package from v2.1.52 to v2.1.56
- Recalculated source hash and npmDepsHash
- Regenerated package-lock.json for new version

## Testing
- Build tested on samsung host ✅
- All pre-commit hooks passed ✅

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)