### PR TITLE
fix(network): remove nftables and fix razer firewall for SSH

### DIFF
--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -65,7 +65,7 @@ in
     nameservers = [ "1.1.1.1" "8.8.8.8" ];
 
     # Firewall disabled to allow all network access including SSH
-    firewall.enable = false;
+    firewall.enable = lib.mkForce false;
   };
 
   # Tailscale VPN using built-in NixOS service

--- a/modules/common/networking.nix
+++ b/modules/common/networking.nix
@@ -45,7 +45,6 @@ with lib; {
         useNetworkd = false;
         useHostResolvConf = false;
         firewall.enable = lib.mkDefault true; # Allow hosts to override
-        nftables.enable = true;
         timeServers = [ "pool.ntp.org" ];
       };
 
@@ -66,7 +65,6 @@ with lib; {
         useNetworkd = true;
         useHostResolvConf = false;
         firewall.enable = lib.mkDefault true; # Allow hosts to override
-        nftables.enable = true;
         timeServers = [ "pool.ntp.org" ];
       };
 


### PR DESCRIPTION
## Summary
- Remove `nftables.enable = true` from desktop and server network profiles — no host uses nftables and it was silently creating default-deny filter chains blocking all incoming connections on razer
- Upgrade razer's `firewall.enable` to `lib.mkForce false` to match p620's pattern

## Test plan
- [x] All 4 hosts (p620, razer, p510, samsung) build successfully
- [x] Pre-commit hooks pass (nix format, lint, dead code, flake check)
- [ ] Rebuild razer and verify SSH from p620 works

🤖 Generated with [Claude Code](https://claude.com/claude-code)