### PR TITLE
chore(claude-code): update to version 2.1.63

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.62";
+    version = "2.1.63";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-TtogpvydBItoSYgQDXu3hBVC1UomQSGFaSubZfklzS4=";
+      hash = "sha256-eHztBWax0Rp5AMuSJvd9Kv5dAiueu6hef9XNB758unc=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 


### PR DESCRIPTION
## Summary

- Update claude-code package from 2.1.62 to 2.1.63
- Source hash recalculated, npmDepsHash unchanged

## Test plan

- [x] Build succeeds (`nix build`)
- [x] Binary reports correct version: `claude --version` → `2.1.63`
- [x] `just test-host p620` passes
- [x] Pre-commit hooks pass (nix format, lint, dead code, spelling, flake check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)