### PR TITLE
chore(claude-code): update to version 2.1.66

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.63";
+    version = "2.1.66";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-eHztBWax0Rp5AMuSJvd9Kv5dAiueu6hef9XNB758unc=";
+      hash = "sha256-mp9VthSzxX/NXtMCg/OPqJc6cfmvNXpBKvNomkp2kPY=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 


### PR DESCRIPTION
## Summary
- Updated claude-code from 2.1.63 → 2.1.66
- Source hash updated, npmDepsHash unchanged

## Test plan
- [x] `just test-host p620` passes
- [ ] CI checks pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>