### PR TITLE
chore(claude-code): update to version 2.1.68

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.66";
+    version = "2.1.68";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-mp9VthSzxX/NXtMCg/OPqJc6cfmvNXpBKvNomkp2kPY=";
+      hash = "sha256-KHNv6nuvgj6X5b4h11ywaxSp1wX1YWYumx9XeQxHU8Q=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 


### PR DESCRIPTION
## Summary
- Update Claude Code from 2.1.66 to 2.1.68
- Source hash recalculated, npmDepsHash unchanged (same dependencies)

## Test plan
- [x] Package builds successfully
- [x] Binary outputs correct version (`2.1.68`)
- [x] P620 host build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)