### PR TITLE
fix(nixpkgs): replace removed neofetch with fastfetch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1191,11 +1191,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772569491,
-        "narHash": "sha256-bdr6ueeXO1Xg91sFkuvaysYF0mVdwHBpdyhTjBEWv+s=",
+        "lastModified": 1772633327,
+        "narHash": "sha256-jl+DJB2DUx7EbWLRng+6HNWW/1/VQOnf0NsQB4PlA7I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "924e61f5c2aeab38504028078d7091077744ab17",
+        "rev": "5a75730e6f21ee624cbf86f4915c6e7489c74acc",
         "type": "github"
       },
       "original": {
@@ -1625,11 +1625,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1772542754,
-        "narHash": "sha256-WGV2hy+VIeQsYXpsLjdr4GvHv5eECMISX1zKLTedhdg=",
+        "lastModified": 1772624091,
+        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8c809a146a140c5c8806f13399592dbcb1bb5dc4",
+        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
         "type": "github"
       },
       "original": {
@@ -1656,11 +1656,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1772542754,
-        "narHash": "sha256-WGV2hy+VIeQsYXpsLjdr4GvHv5eECMISX1zKLTedhdg=",
+        "lastModified": 1772624091,
+        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8c809a146a140c5c8806f13399592dbcb1bb5dc4",
+        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
         "type": "github"
       },
       "original": {
@@ -1704,11 +1704,11 @@
     },
     "nixpkgs_14": {
       "locked": {
-        "lastModified": 1772542754,
-        "narHash": "sha256-WGV2hy+VIeQsYXpsLjdr4GvHv5eECMISX1zKLTedhdg=",
+        "lastModified": 1772624091,
+        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8c809a146a140c5c8806f13399592dbcb1bb5dc4",
+        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
         "type": "github"
       },
       "original": {
@@ -1881,11 +1881,11 @@
         "nixpkgs": "nixpkgs_14"
       },
       "locked": {
-        "lastModified": 1772610418,
-        "narHash": "sha256-m+lEo81Q9Pv8kNe/jhj13U2Jy3cU6d4xjyrhytVcPho=",
+        "lastModified": 1772702743,
+        "narHash": "sha256-xWuVvD+Zp9L1IKY6kV43rTwWwWJLCvqAUVfhcPZ4RZk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "252e95e8f8bfb833daf59ba88256acb00a481417",
+        "rev": "2267978f02542a8717456df16861549ecd9c1dec",
         "type": "github"
       },
       "original": {

--- a/home/desktop/neofetch/default.nix
+++ b/home/desktop/neofetch/default.nix
@@ -1,5 +1,5 @@
 # Enhanced System Information and Monitoring
-# Includes neofetch configuration plus system monitoring utilities
+# System monitoring utilities with fastfetch
 { pkgs
 , lib
 , ...
@@ -7,18 +7,12 @@
 with lib; let
   # Feature flags for system monitoring
   cfg = {
-    neofetch = {
-      enable = true;
-      customLogo = true;
-      imageSupport = true;
-    };
-
     systemMonitors = {
       btop = true;
       htop = true;
       nvtop = true;
       iotop = true;
-      fastfetch = true; # Modern neofetch alternative
+      fastfetch = true;
     };
 
     utilities = {
@@ -34,7 +28,6 @@ in
   home.packages = with pkgs;
     flatten [
       # Core system info
-      (optionals cfg.neofetch.enable [ neofetch ])
       (optionals cfg.systemMonitors.fastfetch [ fastfetch ])
 
       # System monitors
@@ -102,7 +95,6 @@ in
           # System info
           echo "📊 System Information:"
           ${optionalString cfg.systemMonitors.fastfetch "${pkgs.fastfetch}/bin/fastfetch --config small"}
-          ${optionalString (!cfg.systemMonitors.fastfetch && cfg.neofetch.enable) "${pkgs.neofetch}/bin/neofetch --disable packages"}
           echo
 
           # Resource usage
@@ -130,40 +122,9 @@ in
           #!/bin/sh
           # Quick system information
           ${optionalString cfg.systemMonitors.fastfetch "${pkgs.fastfetch}/bin/fastfetch"}
-          ${optionalString (!cfg.systemMonitors.fastfetch && cfg.neofetch.enable) "${pkgs.neofetch}/bin/neofetch"}
         '';
         executable = true;
       };
-    }
-
-    # Neofetch configuration
-    {
-      ".config/neofetch/config.conf".text = ''
-        print_info() {
-            prin "$(color 6)  NIXOS "
-            info underline
-            info "$(color 7)  VER" kernel
-            info "$(color 2)  UP " uptime
-            info "$(color 4)  PKG" packages
-            info "$(color 6)  DE " de
-            info "$(color 5)  TER" term
-            info "$(color 3)  CPU" cpu
-            info "$(color 7)  GPU" gpu
-            info "$(color 5)  MEM" memory
-            prin " "
-            prin "$(color 1) $(color 2) $(color 3) $(color 4) $(color 5) $(color 6) $(color 7) $(color 8)"
-        }
-        distro_shorthand="on"
-        memory_unit="gib"
-        cpu_temp="C"
-        separator=" $(color 4)>"
-        stdout="off"
-        image_backend="kitty"
-        image_source=$HOME/Pictures/assets/wallpapers/gruvbox/finalizer.png
-        image_size="100px"
-        crop_mode="normal"
-        crop_offset="west"
-      '';
     }
   ];
 }

--- a/home/desktop/terminals/default.nix
+++ b/home/desktop/terminals/default.nix
@@ -463,8 +463,7 @@ in
 
         # Terminal utilities
         btop # System monitor
-        neofetch # System info
-        fastfetch # Fast system info
+        fastfetch # System info
 
         # File managers
         lf # Terminal file manager

--- a/home/shell/bash.nix
+++ b/home/shell/bash.nix
@@ -46,7 +46,7 @@
       gitp = "git push";
       gitc = "git checkout";
       #icat = "kitty +kitten icat";
-      neofetch = "neofetch --iterm2 ~/Pictures/1_d2RiMW4zoHLUK-751E38gQ.png --size 200";
+      neofetch = "fastfetch";
       nri = "sudo nixos-rebuild switch --impure|& nom";
       nr = "sudo nixos-rebuild switch|& nom";
       today = "curl -s https://wttr.in/London?1";


### PR DESCRIPTION
## Summary
- Replace `neofetch` (removed from nixpkgs as unmaintained) with `fastfetch`
- Remove neofetch config, package references, and fallback paths
- Update bash alias `neofetch` to run `fastfetch`
- Update flake inputs (nixpkgs-unstable, home-manager)

## Test plan
- [x] P620 host build succeeds
- [x] No remaining neofetch package references in .nix files
- [x] fastfetch already configured as primary system info tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)