### PR TITLE
chore(claude-code): update to version 2.1.70

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.69";
+    version = "2.1.70";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-RbQCHPNBdLrMT0DSIAZyRIovSkDf8JBPJbpbIVD5EK0=";
+      hash = "sha256-YGPF83dBBfYlAZftP9wLpPZPx2y8Q9jSmX12gvB5Z9I=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 


### PR DESCRIPTION
## Summary

Update Claude Code to version 2.1.70

## Changes

- Updated version from 2.1.69 → 2.1.70
- Source hash recalculated for new version
- npmDepsHash unchanged

## Testing Evidence

- Built successfully on P620
- Binary verified: `claude --version` shows `2.1.70 (Claude Code)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)