### PR TITLE
chore(claude-code): update to version 2.1.72

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.70";
+    version = "2.1.72";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-YGPF83dBBfYlAZftP9wLpPZPx2y8Q9jSmX12gvB5Z9I=";
+      hash = "sha256-4R+JdPZrwJv+BCKwebJb2nMYHLxcyert/FRP5MMXuhI=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 


### PR DESCRIPTION
## Summary
- Update claude-code from 2.1.70 → 2.1.72
- Source hash recalculated, npmDepsHash unchanged

## Test plan
- [x] Package builds successfully
- [x] `claude --version` shows 2.1.72
- [x] P620 host build passes
- [x] All pre-commit linting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)