### PR TITLE
chore(claude-code): update to version 2.1.74

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.72";
+    version = "2.1.74";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-4R+JdPZrwJv+BCKwebJb2nMYHLxcyert/FRP5MMXuhI=";
+      hash = "sha256-3OM+J+r4knZZjp2uUJnhJsJYDOpR62Rx4cN0eICdGBg=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 


### PR DESCRIPTION
## Summary
- Update claude-code from 2.1.72 → 2.1.74
- Source hash recalculated, npmDepsHash unchanged

## Test plan
- [x] Package builds successfully
- [x] Binary verified: `claude --version` shows 2.1.74
- [x] All linting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)