### PR TITLE
chore(claude-code): update to version 2.1.76

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.74";
+    version = "2.1.76";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-3OM+J+r4knZZjp2uUJnhJsJYDOpR62Rx4cN0eICdGBg=";
+      hash = "sha256-9jZLd7ZQN49skILYN4SHUMWf2w/esCp4+crohwK7eqU=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 


### PR DESCRIPTION
## Summary
- Update claude-code package from 2.1.74 to 2.1.76
- Source hash recalculated, npmDepsHash unchanged
- Build verified and binary confirmed working

## Test plan
- [x] Package builds successfully (`nix build .#claude-code`)
- [x] Binary reports correct version (2.1.76)
- [x] Pre-commit hooks pass (lint, format, deadnix, spelling)
- [ ] Deploy to hosts and verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)