### PR TITLE
fix: remove chatmcp - removed from nixpkgs as unmaintained

### DIFF
--- a/modules/ai/default.nix
+++ b/modules/ai/default.nix
@@ -17,7 +17,6 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [
       pkgs.yai
-      pkgs.chatmcp
     ]
     ++ optionals cfg.claude-desktop [ pkgs.customPkgs.claude-desktop ];
   };

--- a/modules/ai/mcp-servers.nix
+++ b/modules/ai/mcp-servers.nix
@@ -233,7 +233,6 @@ in
           playwright-mcp # Browser automation
           playwright-driver.browsers # NixOS-compatible Playwright browsers
           github-mcp-server # GitHub integration
-          chatmcp # AI chat client
         ])
       ++ [
         mcp-nixos-pkg # NixOS package/option queries (v2.1.0 from flake - conflict resolved)
@@ -268,7 +267,6 @@ in
         Core Servers (Always Enabled):
         - playwright-mcp: Browser automation for AI agents
         - github-mcp-server: GitHub repository integration
-        - chatmcp: AI chat client with MCP support
         - mcp-nixos: NixOS packages and configuration options queries
 
         Optional Servers (Configured):

--- a/modules/packages/sets.nix
+++ b/modules/packages/sets.nix
@@ -231,7 +231,6 @@
     # Core MCP servers - recommended for all systems
     playwright-mcp # Browser automation for AI agents
     github-mcp-server # GitHub integration
-    chatmcp # AI chat client (already in use)
 
     # Infrastructure MCP servers - optional but valuable
     mcp-grafana # Grafana integration


### PR DESCRIPTION
## Summary
- Remove `chatmcp` package from all references — it has been removed from nixpkgs upstream as unmaintained
- This was causing build failures: `error: chatmcp has been removed, as it is unmaintained`

## Files Changed
- `modules/ai/default.nix` — removed `pkgs.chatmcp` from systemPackages
- `modules/ai/mcp-servers.nix` — removed from core packages list and comment block
- `modules/packages/sets.nix` — removed from mcp package set

## Testing
- `nix build .#nixosConfigurations.razer.config.system.build.toplevel` — ✅ builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)