### PR TITLE
fix: disable stylix qt target to silence qt.style warning

### DIFF
--- a/Users/common/base-home.nix
+++ b/Users/common/base-home.nix
@@ -62,6 +62,7 @@
     wezterm.enable = true;
     ghostty.enable = true;
     gtk.enable = false; # Let COSMIC manage GTK theming (writes to cosmic/dark.css)
+    qt.enable = false; # Let home/desktop/theme/qt.nix manage Qt theming
   };
 
   # COSMIC GTK theme fix - auto-patches COSMIC's gtk.css with Gruvbox theme


### PR DESCRIPTION
## Summary
- Disable `stylix.targets.qt` in `Users/common/base-home.nix` to stop the conflict between stylix and our custom Qt theme module
- Our `home/desktop/theme/qt.nix` already manages Qt theming (Breeze dark) — stylix shouldn't override it

## Warning Fixed
```
evaluation warning: olafkfreund profile: stylix: qt: Changing `config.qt.style` is unsupported and may result in breakage!
```

## Warnings NOT Fixed (upstream nixpkgs)
The following warnings come from inside nixpkgs packages we consume and cannot be fixed from our config:
- `'hostPlatform' has been renamed to 'stdenv.hostPlatform'` — from `bibata-cursors` package
- `'system' has been renamed to 'stdenv.hostPlatform.system'` — from `bibata-cursors` package  
- `xorg.libX* deprecated` — from cursor/input packages

## Testing
- `nix eval .#nixosConfigurations.razer.config.system.build.toplevel.drvPath` — ✅ stylix qt warning gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)