### PR TITLE
fix: comment out cosmic-ext-notifications, bg, rdp, and package-updater

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -167,55 +167,9 @@
         "type": "github"
       }
     },
-    "cosmic-comp-rdp": {
-      "inputs": {
-        "crane": "crane",
-        "nix-filter": "nix-filter",
-        "nixpkgs": "nixpkgs_3",
-        "parts": "parts",
-        "rust": "rust"
-      },
-      "locked": {
-        "lastModified": 1770935694,
-        "narHash": "sha256-5rQjedvsM9ZonEXArMoqSYGL9F84Ywuiyilhr82Th+w=",
-        "owner": "olafkfreund",
-        "repo": "cosmic-ext-comp-rdp",
-        "rev": "d27861390d64bceb4db6bc9dd45dc356d740fbdb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "olafkfreund",
-        "repo": "cosmic-ext-comp-rdp",
-        "type": "github"
-      }
-    },
-    "cosmic-ext-bg": {
-      "inputs": {
-        "crane": "crane_2",
-        "fenix": "fenix",
-        "flake-utils": "flake-utils_4",
-        "nix-filter": "nix-filter_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1770938672,
-        "narHash": "sha256-cHIrwiqxJHwgUVL9hYLDugf544HEPHFSFRtii50SFec=",
-        "owner": "olafkfreund",
-        "repo": "cosmic-ext-bg",
-        "rev": "e76cc28fadaf9848889c197f7b9afb4293f56065",
-        "type": "github"
-      },
-      "original": {
-        "owner": "olafkfreund",
-        "repo": "cosmic-ext-bg",
-        "type": "github"
-      }
-    },
     "cosmic-ext-connect": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_4",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -235,33 +189,9 @@
         "type": "github"
       }
     },
-    "cosmic-ext-notifications": {
-      "inputs": {
-        "crane": "crane_3",
-        "fenix": "fenix_2",
-        "flake-utils": "flake-utils_6",
-        "nix-filter": "nix-filter_3",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773396615,
-        "narHash": "sha256-S6T7bh4YwNDZc5YWuczn9S8gbqLCpVpDBUtkgsoj7hE=",
-        "owner": "olafkfreund",
-        "repo": "cosmic-ext-notifications-ng",
-        "rev": "20623699db605fcee0d3588b3ab417d7fed48826",
-        "type": "github"
-      },
-      "original": {
-        "owner": "olafkfreund",
-        "repo": "cosmic-ext-notifications-ng",
-        "type": "github"
-      }
-    },
     "cosmic-ext-radio-applet": {
       "inputs": {
-        "flake-utils": "flake-utils_7",
+        "flake-utils": "flake-utils_5",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -281,30 +211,9 @@
         "type": "github"
       }
     },
-    "cosmic-ext-rdp-server": {
-      "inputs": {
-        "crane": "crane_4",
-        "flake-utils": "flake-utils_8",
-        "nix-filter": "nix-filter_4",
-        "nixpkgs": "nixpkgs_5"
-      },
-      "locked": {
-        "lastModified": 1774354432,
-        "narHash": "sha256-NL4ReMN5Kzh9RB0WK/X7IKnLL6+8f7Mx/f2PZ2o61ws=",
-        "owner": "olafkfreund",
-        "repo": "cosmic-ext-rdp-server",
-        "rev": "a91a9a40f4ca6ed8c04b5e2b488942eada79ffff",
-        "type": "github"
-      },
-      "original": {
-        "owner": "olafkfreund",
-        "repo": "cosmic-ext-rdp-server",
-        "type": "github"
-      }
-    },
     "cosmic-ext-web-apps": {
       "inputs": {
-        "crane": "crane_5",
+        "crane": "crane",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -325,8 +234,8 @@
     },
     "cosmic-music-player": {
       "inputs": {
-        "crane": "crane_6",
-        "flake-utils": "flake-utils_9",
+        "crane": "crane_2",
+        "flake-utils": "flake-utils_6",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -345,51 +254,6 @@
         "type": "github"
       }
     },
-    "cosmic-package-updater": {
-      "inputs": {
-        "crane": "crane_7",
-        "flake-utils": "flake-utils_10",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-overlay": "rust-overlay_4"
-      },
-      "locked": {
-        "lastModified": 1770884949,
-        "narHash": "sha256-hJby17MdxKa+DhJjv8Q9rXHosVfcycfOjl459CyHJRc=",
-        "owner": "olafkfreund",
-        "repo": "cosmic-applet-package-updater",
-        "rev": "603af7ab2a8e867df649d6f4f75f539306903332",
-        "type": "github"
-      },
-      "original": {
-        "owner": "olafkfreund",
-        "repo": "cosmic-applet-package-updater",
-        "type": "github"
-      }
-    },
-    "cosmic-portal-rdp": {
-      "inputs": {
-        "crane": "crane_8",
-        "fenix": "fenix_3",
-        "flake-utils": "flake-utils_11",
-        "nix-filter": "nix-filter_5",
-        "nixpkgs": "nixpkgs_6"
-      },
-      "locked": {
-        "lastModified": 1770927915,
-        "narHash": "sha256-vqPP6imvxFOjCsOa/20gQKeOyBtIrg7tbBm0pMXPujc=",
-        "owner": "olafkfreund",
-        "repo": "xdg-desktop-portal-cosmic",
-        "rev": "b8a29510ab02bcf4bafa4652f483627875faf9d8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "olafkfreund",
-        "repo": "xdg-desktop-portal-cosmic",
-        "type": "github"
-      }
-    },
     "crane": {
       "locked": {
         "lastModified": 1770419512,
@@ -405,28 +269,13 @@
         "type": "github"
       }
     },
-    "crane_10": {
-      "locked": {
-        "lastModified": 1765739568,
-        "narHash": "sha256-gQYx35Of4UDKUjAYvmxjUEh/DdszYeTtT6MDin4loGE=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "67d2baff0f9f677af35db61b32b5df6863bcc075",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
     "crane_2": {
       "locked": {
-        "lastModified": 1769737823,
-        "narHash": "sha256-DrBaNpZ+sJ4stXm+0nBX7zqZT9t9P22zbk6m5YhQxS4=",
+        "lastModified": 1767744144,
+        "narHash": "sha256-9/9ntI0D+HbN4G0TrK3KmHbTvwgswz7p8IEJsWyef8Q=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "b2f45c3830aa96b7456a4c4bc327d04d7a43e1ba",
+        "rev": "2fb033290bf6b23f226d4c8b32f7f7a16b043d7e",
         "type": "github"
       },
       "original": {
@@ -436,96 +285,6 @@
       }
     },
     "crane_3": {
-      "locked": {
-        "lastModified": 1773189535,
-        "narHash": "sha256-E1G/Or6MWeP+L6mpQ0iTFLpzSzlpGrITfU2220Gq47g=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "6fa2fb4cf4a89ba49fc9dd5a3eb6cde99d388269",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_4": {
-      "locked": {
-        "lastModified": 1770419512,
-        "narHash": "sha256-o8Vcdz6B6bkiGUYkZqFwH3Pv1JwZyXht3dMtS7RchIo=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "2510f2cbc3ccd237f700bb213756a8f35c32d8d7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_5": {
-      "locked": {
-        "lastModified": 1770419512,
-        "narHash": "sha256-o8Vcdz6B6bkiGUYkZqFwH3Pv1JwZyXht3dMtS7RchIo=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "2510f2cbc3ccd237f700bb213756a8f35c32d8d7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_6": {
-      "locked": {
-        "lastModified": 1767744144,
-        "narHash": "sha256-9/9ntI0D+HbN4G0TrK3KmHbTvwgswz7p8IEJsWyef8Q=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "2fb033290bf6b23f226d4c8b32f7f7a16b043d7e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_7": {
-      "locked": {
-        "lastModified": 1767744144,
-        "narHash": "sha256-9/9ntI0D+HbN4G0TrK3KmHbTvwgswz7p8IEJsWyef8Q=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "2fb033290bf6b23f226d4c8b32f7f7a16b043d7e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_8": {
-      "locked": {
-        "lastModified": 1770419512,
-        "narHash": "sha256-o8Vcdz6B6bkiGUYkZqFwH3Pv1JwZyXht3dMtS7RchIo=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "2510f2cbc3ccd237f700bb213756a8f35c32d8d7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_9": {
       "inputs": {
         "nixpkgs": [
           "lanzaboote",
@@ -538,6 +297,21 @@
         "owner": "ipetkov",
         "repo": "crane",
         "rev": "55e7754ec31dac78980c8be45f8a28e80e370946",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_4": {
+      "locked": {
+        "lastModified": 1765739568,
+        "narHash": "sha256-gQYx35Of4UDKUjAYvmxjUEh/DdszYeTtT6MDin4loGE=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "67d2baff0f9f677af35db61b32b5df6863bcc075",
         "type": "github"
       },
       "original": {
@@ -570,7 +344,7 @@
     },
     "emacs": {
       "inputs": {
-        "nixpkgs": "nixpkgs_12",
+        "nixpkgs": "nixpkgs_9",
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
@@ -590,77 +364,11 @@
     "fenix": {
       "inputs": {
         "nixpkgs": [
-          "cosmic-ext-bg",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1770102568,
-        "narHash": "sha256-VYwA9FmakKJ3zLfAd7bdj9xIB9PzfISLoYh6eZl+EuQ=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "592daa37b5a3175c61541329b64d6c1972303bc1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "fenix_2": {
-      "inputs": {
-        "nixpkgs": [
-          "cosmic-ext-notifications",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src_2"
-      },
-      "locked": {
-        "lastModified": 1773299640,
-        "narHash": "sha256-kTsZ5xGZqaeJ8jWsfZNACo/VsW3riVuIQEPWVGiqWKM=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "8ac78ff968869cd05d9cb42fbf63bdbc6851ec19",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "fenix_3": {
-      "inputs": {
-        "nixpkgs": [
-          "cosmic-portal-rdp",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src_3"
-      },
-      "locked": {
-        "lastModified": 1770621632,
-        "narHash": "sha256-pp7visGpp5SYL1O/eF1ZyiSqk4AJ5xkEJXw7pw0f4EI=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "de681afb16166786926b05a0b528545ad511507a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "fenix_4": {
-      "inputs": {
-        "nixpkgs": [
           "nixpkgs-f2k",
           "nixpkgs-fmt",
           "nixpkgs"
         ],
-        "rust-analyzer-src": "rust-analyzer-src_4"
+        "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
         "lastModified": 1637475807,
@@ -841,7 +549,7 @@
     },
     "flake-utils_10": {
       "inputs": {
-        "systems": "systems_11"
+        "systems": "systems_12"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -859,94 +567,7 @@
     },
     "flake-utils_11": {
       "inputs": {
-        "systems": "systems_12"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_12": {
-      "inputs": {
         "systems": "systems_13"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_13": {
-      "inputs": {
-        "systems": "systems_14"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_14": {
-      "locked": {
-        "lastModified": 1637014545,
-        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_15": {
-      "inputs": {
-        "systems": "systems_17"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_16": {
-      "inputs": {
-        "systems": "systems_18"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -1075,11 +696,11 @@
         "systems": "systems_9"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -1089,15 +710,12 @@
       }
     },
     "flake-utils_9": {
-      "inputs": {
-        "systems": "systems_10"
-      },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "lastModified": 1637014545,
+        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
         "type": "github"
       },
       "original": {
@@ -1220,8 +838,8 @@
     },
     "lan-mouse": {
       "inputs": {
-        "nixpkgs": "nixpkgs_7",
-        "rust-overlay": "rust-overlay_5"
+        "nixpkgs": "nixpkgs_4",
+        "rust-overlay": "rust-overlay_4"
       },
       "locked": {
         "lastModified": 1775729061,
@@ -1239,15 +857,15 @@
     },
     "lanzaboote": {
       "inputs": {
-        "crane": "crane_9",
+        "crane": "crane_3",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
-        "flake-utils": "flake-utils_13",
+        "flake-utils": "flake-utils_8",
         "nixpkgs": [
           "nixpkgs"
         ],
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
-        "rust-overlay": "rust-overlay_6"
+        "rust-overlay": "rust-overlay_5"
       },
       "locked": {
         "lastModified": 1718178907,
@@ -1267,7 +885,7 @@
     "mcp-nixos": {
       "inputs": {
         "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1775229475,
@@ -1285,7 +903,7 @@
     },
     "microvm": {
       "inputs": {
-        "nixpkgs": "nixpkgs_9",
+        "nixpkgs": "nixpkgs_6",
         "spectrum": "spectrum"
       },
       "locked": {
@@ -1321,81 +939,6 @@
         "type": "github"
       }
     },
-    "nix-filter": {
-      "locked": {
-        "lastModified": 1757882181,
-        "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "type": "github"
-      }
-    },
-    "nix-filter_2": {
-      "locked": {
-        "lastModified": 1757882181,
-        "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "type": "github"
-      }
-    },
-    "nix-filter_3": {
-      "locked": {
-        "lastModified": 1757882181,
-        "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "type": "github"
-      }
-    },
-    "nix-filter_4": {
-      "locked": {
-        "lastModified": 1757882181,
-        "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "type": "github"
-      }
-    },
-    "nix-filter_5": {
-      "locked": {
-        "lastModified": 1757882181,
-        "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "type": "github"
-      }
-    },
     "nix-index-database": {
       "inputs": {
         "nixpkgs": [
@@ -1420,7 +963,7 @@
       "inputs": {
         "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_10"
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1761703712,
@@ -1472,9 +1015,9 @@
       "inputs": {
         "emacs": "emacs",
         "infuse": "infuse",
-        "nixpkgs": "nixpkgs_13",
+        "nixpkgs": "nixpkgs_10",
         "nixpkgs-fmt": "nixpkgs-fmt",
-        "parts": "parts_2"
+        "parts": "parts"
       },
       "locked": {
         "lastModified": 1775796632,
@@ -1492,8 +1035,8 @@
     },
     "nixpkgs-fmt": {
       "inputs": {
-        "fenix": "fenix_4",
-        "flake-utils": "flake-utils_14",
+        "fenix": "fenix",
+        "flake-utils": "flake-utils_9",
         "nixpkgs": [
           "nixpkgs-f2k",
           "nixpkgs"
@@ -1639,15 +1182,16 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1761442529,
-        "narHash": "sha256-8aDps5fCt0Ndw56ZgeBvdT7E5zeUSFi3CJaNR7ZJKnA=",
-        "owner": "nixos",
+        "lastModified": 1775794914,
+        "narHash": "sha256-gwIypCqF9Qg46GldnFYXiFEIAwiy3wzosxLm6+EVxoQ=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "75762615e96b1a7f172dcdadf62aa9f3aebedf7b",
+        "rev": "822bb2a0c5e163f93784a41d62414cea365d6dc4",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
+        "ref": "master",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1670,54 +1214,6 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1775423009,
-        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_13": {
-      "locked": {
-        "lastModified": 1775794914,
-        "narHash": "sha256-gwIypCqF9Qg46GldnFYXiFEIAwiy3wzosxLm6+EVxoQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "822bb2a0c5e163f93784a41d62414cea365d6dc4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "master",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_14": {
-      "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_15": {
-      "locked": {
         "lastModified": 1775036866,
         "narHash": "sha256-ByAX1LkhCwZ94+KnFAmnJSMAvui7kgCxjHgUHsWAbfI=",
         "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
@@ -1729,7 +1225,7 @@
         "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
-    "nixpkgs_16": {
+    "nixpkgs_13": {
       "locked": {
         "lastModified": 1765934234,
         "narHash": "sha256-pJjWUzNnjbIAMIc5gRFUuKCDQ9S1cuh3b2hKgA7Mc4A=",
@@ -1763,22 +1259,6 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1770537093,
-        "narHash": "sha256-pF1quXG5wsgtyuPOHcLfYg/ft/QMr8NnX0i6tW2187s=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fef9403a3e4d31b0a23f0bacebbec52c248fbb51",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
@@ -1793,39 +1273,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1770537093,
-        "narHash": "sha256-pF1quXG5wsgtyuPOHcLfYg/ft/QMr8NnX0i6tW2187s=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fef9403a3e4d31b0a23f0bacebbec52c248fbb51",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_6": {
-      "locked": {
-        "lastModified": 1770537093,
-        "narHash": "sha256-pF1quXG5wsgtyuPOHcLfYg/ft/QMr8NnX0i6tW2187s=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fef9403a3e4d31b0a23f0bacebbec52c248fbb51",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_7": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1772963539,
         "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
@@ -1841,7 +1289,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1767640445,
         "narHash": "sha256-UWYqmD7JFBEDBHWYcqE6s6c77pWdcU/i+bwD6XxMb8A=",
@@ -1857,7 +1305,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_9": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1772773019,
         "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
@@ -1873,10 +1321,57 @@
         "type": "github"
       }
     },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1761442529,
+        "narHash": "sha256-8aDps5fCt0Ndw56ZgeBvdT7E5zeUSFi3CJaNR7ZJKnA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "75762615e96b1a7f172dcdadf62aa9f3aebedf7b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_8": {
+      "locked": {
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1775423009,
+        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_4",
-        "nixpkgs": "nixpkgs_14"
+        "nixpkgs": "nixpkgs_11"
       },
       "locked": {
         "lastModified": 1775803654,
@@ -1918,27 +1413,6 @@
       }
     },
     "parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "cosmic-comp-rdp",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "parts_2": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib_4"
       },
@@ -1989,17 +1463,11 @@
         "antigravity-nix": "antigravity-nix",
         "claude-desktop-linux": "claude-desktop-linux",
         "cosmic-applet-spotify": "cosmic-applet-spotify",
-        "cosmic-comp-rdp": "cosmic-comp-rdp",
-        "cosmic-ext-bg": "cosmic-ext-bg",
         "cosmic-ext-connect": "cosmic-ext-connect",
-        "cosmic-ext-notifications": "cosmic-ext-notifications",
         "cosmic-ext-radio-applet": "cosmic-ext-radio-applet",
-        "cosmic-ext-rdp-server": "cosmic-ext-rdp-server",
         "cosmic-ext-web-apps": "cosmic-ext-web-apps",
         "cosmic-music-player": "cosmic-music-player",
-        "cosmic-package-updater": "cosmic-package-updater",
-        "cosmic-portal-rdp": "cosmic-portal-rdp",
-        "flake-utils": "flake-utils_12",
+        "flake-utils": "flake-utils_7",
         "home-manager": "home-manager_2",
         "lan-mouse": "lan-mouse",
         "lanzaboote": "lanzaboote",
@@ -2009,7 +1477,7 @@
         "nix-index-database": "nix-index-database",
         "nix-snapd": "nix-snapd",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_11",
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-f2k": "nixpkgs-f2k",
         "nixpkgs-stable": "nixpkgs-stable_3",
         "nixpkgs-unstable": "nixpkgs-unstable",
@@ -2021,79 +1489,7 @@
         "zjstatus": "zjstatus"
       }
     },
-    "rust": {
-      "inputs": {
-        "nixpkgs": [
-          "cosmic-comp-rdp",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1770693064,
-        "narHash": "sha256-Pomhlz+3/6uRJUhKz/kJwmJUux8GTWbXlCX4/RxlXLo=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "a5f6d8a6a6868db2a3055cfe2b5dd01422780433",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
     "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1770026591,
-        "narHash": "sha256-VZlloygYDmozJwbZZkCSNpiPhNdOW/AA0b6LmNBZ3xU=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "74eca73f3b0a41b80228b8e499c7547cc8b2effa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
-    "rust-analyzer-src_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1773194001,
-        "narHash": "sha256-50PPXBtH2xfKuNfQfUNOyuIFgZPEz5QVertQWS2MQJE=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "8ed3cca4d30610fd0d3c1179c85418de2dc0a7c1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
-    "rust-analyzer-src_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1770616416,
-        "narHash": "sha256-S6qG5sNG76JitdRRY0dyEq9+n+4TJuqKrFrtTpripAo=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "c75729db6845c73605115b18d819917dbf6a8972",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
-    "rust-analyzer-src_4": {
       "flake": false,
       "locked": {
         "lastModified": 1637439871,
@@ -2133,7 +1529,7 @@
     },
     "rust-overlay_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1768359079,
@@ -2173,27 +1569,6 @@
     "rust-overlay_4": {
       "inputs": {
         "nixpkgs": [
-          "cosmic-package-updater",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1767926800,
-        "narHash": "sha256-x0n73J6ufD/EhDlVdcoAmF0OQHZ+b0a2cKDc8RZyt+o=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "499e9eed88ff9494b6604205b42847e847dfeb91",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "rust-overlay_5": {
-      "inputs": {
-        "nixpkgs": [
           "lan-mouse",
           "nixpkgs"
         ]
@@ -2212,7 +1587,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_6": {
+    "rust-overlay_5": {
       "inputs": {
         "flake-utils": [
           "lanzaboote",
@@ -2237,7 +1612,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_7": {
+    "rust-overlay_6": {
       "inputs": {
         "nixpkgs": [
           "zjstatus",
@@ -2296,8 +1671,8 @@
     },
     "spicetify-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_15",
-        "systems": "systems_15"
+        "nixpkgs": "nixpkgs_12",
+        "systems": "systems_10"
       },
       "locked": {
         "lastModified": 1775421933,
@@ -2326,7 +1701,7 @@
           "nixpkgs"
         ],
         "nur": "nur_2",
-        "systems": "systems_16",
+        "systems": "systems_11",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
@@ -2407,81 +1782,6 @@
       }
     },
     "systems_13": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_14": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_15": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_16": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_17": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_18": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -2682,7 +1982,7 @@
     },
     "yt-x": {
       "inputs": {
-        "flake-utils": "flake-utils_15",
+        "flake-utils": "flake-utils_10",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -2703,10 +2003,10 @@
     },
     "zjstatus": {
       "inputs": {
-        "crane": "crane_10",
-        "flake-utils": "flake-utils_16",
-        "nixpkgs": "nixpkgs_16",
-        "rust-overlay": "rust-overlay_7"
+        "crane": "crane_4",
+        "flake-utils": "flake-utils_11",
+        "nixpkgs": "nixpkgs_13",
+        "rust-overlay": "rust-overlay_6"
       },
       "locked": {
         "lastModified": 1773119656,

--- a/flake.nix
+++ b/flake.nix
@@ -103,10 +103,11 @@
     };
 
     # COSMIC Desktop applets
-    cosmic-package-updater = {
-      url = "github:olafkfreund/cosmic-applet-package-updater";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    # cosmic-package-updater - Disabled: removed from active config
+    # cosmic-package-updater = {
+    #   url = "github:olafkfreund/cosmic-applet-package-updater";
+    #   inputs.nixpkgs.follows = "nixpkgs";
+    # };
     cosmic-music-player = {
       url = "github:olafkfreund/cosmic-applet-music-player";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -128,25 +129,23 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # COSMIC Notifications NG - Enhanced notifications with rich content support
-    cosmic-ext-notifications = {
-      url = "github:olafkfreund/cosmic-ext-notifications-ng";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    # COSMIC Notifications NG - Disabled: removed from active config
+    # cosmic-ext-notifications = {
+    #   url = "github:olafkfreund/cosmic-ext-notifications-ng";
+    #   inputs.nixpkgs.follows = "nixpkgs";
+    # };
 
-    # COSMIC BG - Enhanced background service with animated, video, and shader wallpaper support
-    cosmic-ext-bg = {
-      url = "github:olafkfreund/cosmic-ext-bg";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    # COSMIC BG - Disabled: pending upstream fix for startup race condition
+    # See: https://github.com/olafkfreund/cosmic-ext-bg/issues/32
+    # cosmic-ext-bg = {
+    #   url = "github:olafkfreund/cosmic-ext-bg";
+    #   inputs.nixpkgs.follows = "nixpkgs";
+    # };
 
-    # COSMIC RDP Server - Remote desktop for COSMIC Desktop (Samsung only)
-    # Note: no nixpkgs.follows - these crane-based Rust builds require
-    # their own tested nixpkgs to avoid cargo vendor hash mismatches.
-    # cosmic-comp-rdp's flake.lock is updated separately to track mesa versions.
-    cosmic-ext-rdp-server.url = "github:olafkfreund/cosmic-ext-rdp-server";
-    cosmic-portal-rdp.url = "github:olafkfreund/xdg-desktop-portal-cosmic";
-    cosmic-comp-rdp.url = "github:olafkfreund/cosmic-ext-comp-rdp";
+    # COSMIC RDP Server - Disabled: removed from active config (Samsung only)
+    # cosmic-ext-rdp-server.url = "github:olafkfreund/cosmic-ext-rdp-server";
+    # cosmic-portal-rdp.url = "github:olafkfreund/xdg-desktop-portal-cosmic";
+    # cosmic-comp-rdp.url = "github:olafkfreund/cosmic-ext-comp-rdp";
   };
 
   outputs =
@@ -243,8 +242,8 @@
         })
         # COSMIC Connect - KDE Connect alternative for COSMIC Desktop
         inputs.cosmic-ext-connect.overlays.default
-        # COSMIC Notifications NG - Enhanced notifications with images, links, progress
-        inputs.cosmic-ext-notifications.overlays.default
+        # COSMIC Notifications NG - Disabled: removed from active config
+        # inputs.cosmic-ext-notifications.overlays.default
         # COSMIC BG NG - Disabled pending upstream fix for startup race condition
         # See: https://github.com/olafkfreund/cosmic-ext-bg/issues/32
         # inputs.cosmic-ext-bg.overlays.default
@@ -501,7 +500,7 @@
               inputs.lanzaboote.nixosModules.lanzaboote
               nix-index-database.nixosModules.nix-index
               inputs.cosmic-ext-connect.nixosModules.default
-              inputs.cosmic-ext-notifications.nixosModules.default
+              # inputs.cosmic-ext-notifications.nixosModules.default  # Disabled: removed from active config
               # inputs.cosmic-ext-bg.nixosModules.default  # Disabled: https://github.com/olafkfreund/cosmic-ext-bg/issues/32
               # cosmic-ext-applet-radio: local module workaround for upstream mkPackageOption 'description' arg bug
               ./modules/services/cosmic-ext-radio-applet
@@ -510,27 +509,28 @@
             ++ stylixModule
             # COSMIC RDP Server stack (Samsung only) - replaces cosmic-comp and
             # xdg-desktop-portal-cosmic with RDP-capable forks
-            ++ nixpkgs.lib.optionals (host == "samsung") [
-              inputs.cosmic-ext-rdp-server.nixosModules.default
-              inputs.cosmic-portal-rdp.nixosModules.default
-              inputs.cosmic-comp-rdp.nixosModules.default
-              {
-                nixpkgs.overlays = [
-                  inputs.cosmic-ext-rdp-server.overlays.default
-                  inputs.cosmic-portal-rdp.overlays.default
-                  inputs.cosmic-comp-rdp.overlays.default
-                  # Fix: cosmic-comp-rdp overlay lacks meta.platforms, which
-                  # cosmic-ext-ctl inherits via cosmic-comp.meta.platforms
-                  (_final: prev: {
-                    cosmic-comp = prev.cosmic-comp.overrideAttrs (old: {
-                      meta = (old.meta or { }) // {
-                        platforms = old.meta.platforms or prev.lib.platforms.linux;
-                      };
-                    });
-                  })
-                ];
-              }
-            ]
+            # COSMIC RDP Server stack (Samsung only) - Disabled: removed from active config
+            # ++ nixpkgs.lib.optionals (host == "samsung") [
+            #   inputs.cosmic-ext-rdp-server.nixosModules.default
+            #   inputs.cosmic-portal-rdp.nixosModules.default
+            #   inputs.cosmic-comp-rdp.nixosModules.default
+            #   {
+            #     nixpkgs.overlays = [
+            #       inputs.cosmic-ext-rdp-server.overlays.default
+            #       inputs.cosmic-portal-rdp.overlays.default
+            #       inputs.cosmic-comp-rdp.overlays.default
+            #       # Fix: cosmic-comp-rdp overlay lacks meta.platforms, which
+            #       # cosmic-ext-ctl inherits via cosmic-comp.meta.platforms
+            #       (_final: prev: {
+            #         cosmic-comp = prev.cosmic-comp.overrideAttrs (old: {
+            #           meta = (old.meta or { }) // {
+            #             platforms = old.meta.platforms or prev.lib.platforms.linux;
+            #           };
+            #         });
+            #       })
+            #     ];
+            #   }
+            # ]
             ++ [
               {
                 home-manager = {

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -104,11 +104,11 @@ in
     openFirewall = true;
   };
 
-  # COSMIC Notifications NG - Enhanced notifications with rich content support
-  services.cosmic-ext-notifications = {
-    enable = true;
-    settings.max_image_size = 32;
-  };
+  # COSMIC Notifications NG - Disabled: removed from active config
+  # services.cosmic-ext-notifications = {
+  #   enable = true;
+  #   settings.max_image_size = 32;
+  # };
 
   # COSMIC BG - Disabled pending upstream fix for startup race condition
   # See: https://github.com/olafkfreund/cosmic-ext-bg/issues/32

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -10,30 +10,28 @@ let
 in
 {
   # Use laptop template and add Razer-specific modules
-  imports =
-    hostTypes.laptop.imports
-    ++ [
-      # Hardware-specific imports
-      ./nixos/hardware-configuration.nix
-      ./nixos/screens.nix
-      ./nixos/power.nix
-      ./nixos/boot.nix
-      # ./nixos/secure-boot.nix # Secure Boot enabled with lanzaboote
-      ./nixos/nvidia.nix
-      ../common/nixos/i18n.nix
-      ../common/nixos/hosts.nix
-      ../common/nixos/envvar.nix
-      ./nixos/cpu.nix
-      ./nixos/laptop.nix
-      ./nixos/memory.nix
-      ./themes/stylix.nix # Re-enabled after upstream cache fix
+  imports = hostTypes.laptop.imports ++ [
+    # Hardware-specific imports
+    ./nixos/hardware-configuration.nix
+    ./nixos/screens.nix
+    ./nixos/power.nix
+    ./nixos/boot.nix
+    # ./nixos/secure-boot.nix # Secure Boot enabled with lanzaboote
+    ./nixos/nvidia.nix
+    ../common/nixos/i18n.nix
+    ../common/nixos/hosts.nix
+    ../common/nixos/envvar.nix
+    ./nixos/cpu.nix
+    ./nixos/laptop.nix
+    ./nixos/memory.nix
+    ./themes/stylix.nix # Re-enabled after upstream cache fix
 
-      # Razer-specific additional modules
-      ../../modules/development/default.nix
-      ../../modules/security/secrets.nix
-      ../../modules/secrets/api-keys.nix
-      ../../modules/containers/docker.nix
-    ];
+    # Razer-specific additional modules
+    ../../modules/development/default.nix
+    ../../modules/security/secrets.nix
+    ../../modules/secrets/api-keys.nix
+    ../../modules/containers/docker.nix
+  ];
 
   # Consolidated networking configuration
   networking = {
@@ -62,7 +60,10 @@ in
     useNetworkd = false;
 
     # Set custom nameservers as fallback
-    nameservers = [ "1.1.1.1" "8.8.8.8" ];
+    nameservers = [
+      "1.1.1.1"
+      "8.8.8.8"
+    ];
 
     # Firewall disabled to allow all network access including SSH
     firewall.enable = lib.mkForce false;
@@ -75,11 +76,11 @@ in
     openFirewall = true;
   };
 
-  # COSMIC Notifications NG - Enhanced notifications with rich content support
-  services.cosmic-ext-notifications = {
-    enable = true;
-    settings.max_image_size = 32;
-  };
+  # COSMIC Notifications NG - Disabled: removed from active config
+  # services.cosmic-ext-notifications = {
+  #   enable = true;
+  #   settings.max_image_size = 32;
+  # };
 
   # COSMIC BG - Disabled pending upstream fix for startup race condition
   # See: https://github.com/olafkfreund/cosmic-ext-bg/issues/32
@@ -279,7 +280,7 @@ in
 
     # COSMIC Package Updater Applet - NixOS update notifications
     desktop.cosmic-applet-package-updater = {
-      enable = true;
+      enable = false;
       autoCheck = true;
       checkIntervalMinutes = 60;
       nixosMode = "auto"; # Auto-detect flakes vs channels mode
@@ -389,11 +390,9 @@ in
   # Use standard NetworkManager for laptop - useNetworkd already set above
   networking.useHostResolvConf = false;
 
-  environment.sessionVariables =
-    vars.environmentVariables
-    // {
-      NH_FLAKE = vars.paths.flakeDir;
-    };
+  environment.sessionVariables = vars.environmentVariables // {
+    NH_FLAKE = vars.paths.flakeDir;
+  };
 
   # Enable secrets management
   modules.security.secrets = {
@@ -404,18 +403,23 @@ in
   users.users = lib.genAttrs hostUsers (username: {
     isNormalUser = true;
     description = "User ${username}";
-    extraGroups = [ "wheel" "networkmanager" ];
+    extraGroups = [
+      "wheel"
+      "networkmanager"
+    ];
     shell = pkgs.zsh;
     # Only use secret-managed password if the secret exists
-    hashedPasswordFile =
-      lib.mkIf
-        (config.modules.security.secrets.enable
-          && builtins.hasAttr "user-password-${username}" config.age.secrets)
-        config.age.secrets."user-password-${username}".path;
+    hashedPasswordFile = lib.mkIf
+      (
+        config.modules.security.secrets.enable
+        && builtins.hasAttr "user-password-${username}" config.age.secrets
+      )
+      config.age.secrets."user-password-${username}".path;
   });
 
   # System packages - consolidated from individual nixos modules
-  environment.systemPackages = with pkgs;
+  environment.systemPackages =
+    with pkgs;
     [
       # Qt theme control tools for Stylix
       libsForQt5.qt5ct
@@ -473,9 +477,9 @@ in
   nixpkgs.overlays = [
     (_final: prev: {
       gnome-shell = prev.gnome-shell.overrideAttrs (old: {
-        patches = builtins.filter
-          (patch: !lib.hasSuffix "shell_remove_dark_mode.patch" (toString patch))
-          (old.patches or [ ]);
+        patches = builtins.filter (patch: !lib.hasSuffix "shell_remove_dark_mode.patch" (toString patch)) (
+          old.patches or [ ]
+        );
       });
     })
   ];

--- a/hosts/samsung/configuration.nix
+++ b/hosts/samsung/configuration.nix
@@ -78,37 +78,37 @@ in
     openFirewall = true;
   };
 
-  # COSMIC Notifications NG - Enhanced notifications with rich content support
-  services.cosmic-ext-notifications = {
-    enable = true;
-    settings.max_image_size = 32;
-  };
+  # COSMIC Notifications NG - Disabled: removed from active config
+  # services.cosmic-ext-notifications = {
+  #   enable = true;
+  #   settings.max_image_size = 32;
+  # };
 
   # COSMIC BG - Disabled pending upstream fix for startup race condition
   # See: https://github.com/olafkfreund/cosmic-ext-bg/issues/32
   # services.cosmic-ext-bg.enable = true;
 
-  # COSMIC RDP Server - Remote desktop access via standard RDP clients
-  services.cosmic-comp.enable = true;
-  services.xdg-desktop-portal-cosmic.enable = true;
-  services.cosmic-ext-rdp-server = {
-    enable = true;
-    openFirewall = true;
-    settings.bind = "0.0.0.0:3389";
-    auth = {
-      enable = true;
-      username = "olafkfreund";
-      domain = ""; # Required: nullOr str default breaks TOML generation
-      passwordFile = config.age.secrets.rdp-password.path;
-    };
-  };
+  # COSMIC RDP Server - Disabled: removed from active config
+  # services.cosmic-comp.enable = true;
+  # services.xdg-desktop-portal-cosmic.enable = true;
+  # services.cosmic-ext-rdp-server = {
+  #   enable = true;
+  #   openFirewall = true;
+  #   settings.bind = "0.0.0.0:3389";
+  #   auth = {
+  #     enable = true;
+  #     username = "olafkfreund";
+  #     domain = ""; # Required: nullOr str default breaks TOML generation
+  #     passwordFile = config.age.secrets.rdp-password.path;
+  #   };
+  # };
 
-  # Agenix secret for RDP server password
-  age.secrets.rdp-password = {
-    file = ../../secrets/rdp-password.age;
-    mode = "0400";
-    owner = "olafkfreund";
-  };
+  # Agenix secret for RDP server password - disabled with RDP server
+  # age.secrets.rdp-password = {
+  #   file = ../../secrets/rdp-password.age;
+  #   mode = "0400";
+  #   owner = "olafkfreund";
+  # };
 
   # COSMIC Radio Applet - Internet radio player for COSMIC Desktop panel
   # Add to panel via: COSMIC Settings > Panel > Applets

--- a/modules/desktop/cosmic-applet-package-updater.nix
+++ b/modules/desktop/cosmic-applet-package-updater.nix
@@ -54,9 +54,11 @@ in
     # Main configuration when enabled
     (mkIf cfg.enable {
       # Install the COSMIC package updater applet
-      environment.systemPackages = [
-        inputs.cosmic-package-updater.packages.${pkgs.stdenv.hostPlatform.system}.default
-      ];
+      # Disabled: cosmic-package-updater input removed from flake
+      # environment.systemPackages = [
+      #   inputs.cosmic-package-updater.packages.${pkgs.stdenv.hostPlatform.system}.default
+      # ];
+      environment.systemPackages = [ ];
 
       # XDG desktop database needs to be updated for applet discovery
       # This is handled automatically by NixOS


### PR DESCRIPTION
## Summary
Comment out (not delete) the following COSMIC extension packages from all hosts and flake inputs:

| Package | Hosts affected |
|---|---|
| `cosmic-ext-notifications` | p620, razer, samsung |
| `cosmic-ext-bg` | all (formally disabled in flake) |
| `cosmic-ext-rdp-server` | samsung |
| `cosmic-portal-rdp` | samsung |
| `cosmic-comp-rdp` | samsung |
| `cosmic-package-updater` | module + flake input |

## Files Changed
- `flake.nix` — inputs, overlays, nixosModules all commented out
- `flake.lock` — removed input entries pruned automatically
- `hosts/p620/configuration.nix` — notifications service commented out
- `hosts/razer/configuration.nix` — notifications service commented out
- `hosts/samsung/configuration.nix` — notifications + full RDP stack commented out
- `modules/desktop/cosmic-applet-package-updater.nix` — package reference commented out

## Testing
- `nix build .#nixosConfigurations.razer` ✅
- `nix build .#nixosConfigurations.samsung` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)