### PR TITLE
fix: remove cosmic-osd polkit workaround - fixed in COSMIC 1.0

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -160,7 +160,6 @@ in
       useCosmicGreeter = false;
       defaultSession = false;
       installAllApps = false;
-      disableOsd = true;
     };
 
     # Remote Desktop support using GNOME Remote Desktop (native RDP support)

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -327,7 +327,6 @@ in
       useCosmicGreeter = true; # Using COSMIC Greeter as display manager
       defaultSession = true; # Set COSMIC as default session
       installAllApps = true;
-      disableOsd = true; # Workaround for polkit agent crashes in COSMIC beta
     };
 
     # COSMIC Package Updater Applet - NixOS update notifications

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -275,7 +275,6 @@ in
       useCosmicGreeter = true; # Using COSMIC Greeter as display manager
       defaultSession = true;
       installAllApps = true;
-      disableOsd = true; # Workaround for polkit agent crashes in COSMIC beta
     };
 
     # COSMIC Package Updater Applet - NixOS update notifications

--- a/hosts/samsung/configuration.nix
+++ b/hosts/samsung/configuration.nix
@@ -294,7 +294,6 @@ in
       useCosmicGreeter = true; # Using COSMIC Greeter as display manager
       defaultSession = true; # Set COSMIC as default session
       installAllApps = true; # Install full Cosmic app suite
-      disableOsd = true; # Workaround for polkit agent crashes in COSMIC beta
     };
 
 

--- a/modules/desktop/cosmic.nix
+++ b/modules/desktop/cosmic.nix
@@ -28,12 +28,6 @@ in
       description = "Install all COSMIC applications and extensions";
     };
 
-    disableOsd = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Disable cosmic-osd (on-screen display) to work around polkit agent crashes";
-    };
-
     enableTailscaleApplet = mkOption {
       type = types.bool;
       default = true;
@@ -246,8 +240,6 @@ in
         NIXOS_OZONE_WL = "1";
         MOZ_ENABLE_WAYLAND = "1";
         QT_QPA_PLATFORM = "wayland";
-        # Disable cosmic-osd if requested (workaround for polkit crashes)
-        COSMIC_DISABLE_OSD = mkIf cfg.disableOsd "1";
       };
 
       # Set environment variable to suppress KDE hint warnings in cosmic-notifications
@@ -317,27 +309,6 @@ in
             echo "Setting Tailscale operator privileges for $user"
             ${pkgs.tailscale}/bin/tailscale set --operator="$user" 2>/dev/null || true
           done
-        '';
-      };
-
-      # Workaround for cosmic-osd polkit agent crashes
-      user.services.cosmic-osd-blocker = mkIf cfg.disableOsd {
-        description = "Block cosmic-osd from starting (workaround for polkit crashes)";
-        wantedBy = [ "cosmic-session.target" ];
-        before = [ "cosmic-session.target" ];
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-        };
-        # Create a dummy cosmic-osd that does nothing
-        script = ''
-          mkdir -p $HOME/.local/bin
-          cat > $HOME/.local/bin/cosmic-osd << 'EOF'
-          #!/bin/sh
-          # Dummy cosmic-osd to prevent crashes - does nothing
-          exit 0
-          EOF
-          chmod +x $HOME/.local/bin/cosmic-osd
         '';
       };
 


### PR DESCRIPTION
## Summary
Remove the `disableOsd` workaround that was blocking `cosmic-osd` from starting to prevent polkit agent crashes in COSMIC beta.

## Why It's Safe to Remove
- COSMIC reached **stable 1.0.9** (no longer beta)
- The crash was fixed in `cosmic-osd`: it now handles polkit agent conflicts gracefully with a log warning instead of panicking (SIGABRT)
- No open crash-related polkit issues remain upstream
- Ref: https://github.com/pop-os/cosmic-osd/issues/114

## What Was Removed
- `disableOsd` option from `modules/desktop/cosmic.nix`
- `COSMIC_DISABLE_OSD=1` environment variable
- `cosmic-osd-blocker` systemd user service (wrote a dummy binary to `~/.local/bin/cosmic-osd`)
- `disableOsd = true` from p620, razer, samsung, p510

## Testing
- `nix eval .#nixosConfigurations.razer` ✅ no errors
- `nix eval .#nixosConfigurations.p620` ✅ (building in background)

🤖 Generated with [Claude Code](https://claude.com/claude-code)