### PR TITLE
chore(claude-code): update to version 2.1.100

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.97";
+    version = "2.1.100";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-Wd+OiD7dCSW8tzQH+XTQE4w5EGt0S45kU/8j4xVLmoo=";
+      hash = "sha256-Dkip2mnbcvks8SbZVBqXajaRi1SQEemN2IDiHxlaqbA=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 


### PR DESCRIPTION
## Summary
- Update claude-code from 2.1.97 to 2.1.100
- Source hash updated, npmDepsHash unchanged (vendored deps)
- Build tested and binary verified (`claude --version` → 2.1.100)

## Test plan
- [x] `nix build .#packages.x86_64-linux.claude-code` succeeds
- [x] Binary outputs correct version
- [ ] CI host configuration checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)