### PR TITLE
fix: restore COSMIC logout/shutdown/reboot buttons

### DIFF
--- a/Users/common/base-home.nix
+++ b/Users/common/base-home.nix
@@ -1,4 +1,5 @@
 { pkgs ? { }
+, lib
 , username ? "olafkfreund"
 , # Default fallback
   ...
@@ -20,6 +21,16 @@
       OBSIDIAN_VAULT_PATH = "\${HOME}/Documents/Caliti";
     };
     stateVersion = "26.05";
+
+    # One-time cleanup: remove dummy cosmic-osd left by the now-removed
+    # cosmic-osd-blocker workaround (fixed in COSMIC 1.0, PR #296).
+    # Safe to keep permanently - idempotent, does nothing if file is absent.
+    activation.removeCosmicOsdDummy = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      if [ -f "$HOME/.local/bin/cosmic-osd" ]; then
+        $DRY_RUN_CMD rm "$HOME/.local/bin/cosmic-osd"
+        echo "Removed leftover dummy cosmic-osd from ~/.local/bin/"
+      fi
+    '';
 
     # Common packages for all users
     packages = with pkgs; [

--- a/modules/desktop/cosmic.nix
+++ b/modules/desktop/cosmic.nix
@@ -312,19 +312,6 @@ in
         '';
       };
 
-      # Fix for COSMIC logout button black screen issue
-      # Ensures proper session cleanup via systemd-logind
-      user.services.cosmic-session-cleanup = {
-        description = "COSMIC session cleanup on logout";
-        wantedBy = [ "graphical-session.target" ];
-        partOf = [ "graphical-session.target" ];
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-          ExecStop = "${pkgs.systemd}/bin/loginctl terminate-session $XDG_SESSION_ID";
-        };
-      };
-
       services = {
         # Filter out harmless KDE notification hint warnings from logs
         systemd-journald.environment = {


### PR DESCRIPTION
## Problem
The logout, shutdown, and reboot buttons in COSMIC did nothing silently.

## Root Cause
The `cosmic-osd-blocker` workaround (removed in #296) left a dummy `~/.local/bin/cosmic-osd` script on disk. COSMIC routes **all** power actions through `cosmic-osd`:

```
[Shutdown] → cosmic-applet-power → cosmic-osd shutdown → logind PowerOff()
[Reboot]   → cosmic-applet-power → cosmic-osd restart  → logind Reboot()
[Logout]   → cosmic-applet-power → cosmic-osd log-out  → cosmic-session exit
```

The dummy script intercepted all three and silently exited (`exit 0`).

## Fixes

### 1. Home Manager activation script (`Users/common/base-home.nix`)
Automatically removes `~/.local/bin/cosmic-osd` on all hosts at next `nixos-rebuild switch`. Idempotent — safe if file doesn't exist.

### 2. Remove `cosmic-session-cleanup` service (`modules/desktop/cosmic.nix`)
The `ExecStop` used `$XDG_SESSION_ID` which is not available in the systemd user environment. Failed silently on every logout and was redundant (cosmic-session handles its own teardown).

## Testing
- `nix eval .#nixosConfigurations.razer` ✅ clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)