### PR TITLE
chore(claude-code): update to version 2.1.104

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.100";
+    version = "2.1.104";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-Dkip2mnbcvks8SbZVBqXajaRi1SQEemN2IDiHxlaqbA=";
+      hash = "sha256-yUFU2t646V/sq/JVwfCPC+IIWycx3B+q+gjCccSP0vc=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 


### PR DESCRIPTION
## Summary

- Update claude-code from 2.1.100 to 2.1.104
- Source hash updated for new version
- Build tested and binary verified (`claude --version` → `2.1.104`)

## Test plan

- [x] Package builds successfully with `nix build`
- [x] Binary outputs correct version
- [ ] Deploy to hosts with `just quick-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)