### PR TITLE
chore(claude-code): update to version 2.1.109

### DIFF
--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.108";
+    version = "2.1.109";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-viCymGDX1wgEPu35o2uxQi5QlOfeQny8vKQGiwDg2bg=";
+      hash = "sha256-BEm50FshQbpRx6UmKnxi5oxzCYuH5PyXteGlF6qvcSg=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 

--- a/home/development/claude-code/default.nix
+++ b/home/development/claude-code/default.nix
@@ -9,11 +9,11 @@
 let
   claudeCode = buildNpmPackage rec {
     pname = "claude-code";
-    version = "2.1.104";
+    version = "2.1.108";
 
     src = fetchurl {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-      hash = "sha256-yUFU2t646V/sq/JVwfCPC+IIWycx3B+q+gjCccSP0vc=";
+      hash = "sha256-viCymGDX1wgEPu35o2uxQi5QlOfeQny8vKQGiwDg2bg=";
       curlOptsList = [ "--http1.1" ]; # Force HTTP/1.1 to avoid HTTP/2 protocol errors
     };
 

--- a/modules/desktop/cosmic-applet-package-updater.nix
+++ b/modules/desktop/cosmic-applet-package-updater.nix
@@ -1,7 +1,5 @@
 { config
 , lib
-, pkgs
-, inputs
 , ...
 }:
 with lib; let

--- a/modules/virt/virt.nix
+++ b/modules/virt/virt.nix
@@ -56,25 +56,27 @@ in
     };
 
     # Make sure the problematic libvirt drop-in isn't picked up anymore
-    systemd.tmpfiles.rules = [
-      "r /etc/ssh/ssh_config.d/30-libvirt-ssh-proxy.conf"
-      "L+ /var/lib/qemu/firmware - - - - ${pkgs.qemu}/share/qemu/firmware"
-    ];
-    systemd.services.libvirtd.restartIfChanged = false;
-    # Fix virt-secret-init-encryption crash on hosts without working TPM2
-    # systemd-creds encrypt fails with assertion error when TPM2 is unavailable.
-    # Generate a raw 256-bit key file directly instead.
-    systemd.services.virt-secret-init-encryption.serviceConfig.ExecStart = lib.mkForce
-      (
-        let
-          script = pkgs.writeShellScript "virt-secret-init-encryption" ''
-            umask 0077
-            mkdir -p /var/lib/libvirt/secrets
-            dd if=/dev/random of=/var/lib/libvirt/secrets/secrets-encryption-key bs=32 count=1 status=none
-          '';
-        in
-        "${script}"
-      );
+    systemd = {
+      tmpfiles.rules = [
+        "r /etc/ssh/ssh_config.d/30-libvirt-ssh-proxy.conf"
+        "L+ /var/lib/qemu/firmware - - - - ${pkgs.qemu}/share/qemu/firmware"
+      ];
+      services.libvirtd.restartIfChanged = false;
+      # Fix virt-secret-init-encryption crash on hosts without working TPM2
+      # systemd-creds encrypt fails with assertion error when TPM2 is unavailable.
+      # Generate a raw 256-bit key file directly instead.
+      services.virt-secret-init-encryption.serviceConfig.ExecStart = lib.mkForce
+        (
+          let
+            script = pkgs.writeShellScript "virt-secret-init-encryption" ''
+              umask 0077
+              mkdir -p /var/lib/libvirt/secrets
+              dd if=/dev/random of=/var/lib/libvirt/secrets/secrets-encryption-key bs=32 count=1 status=none
+            '';
+          in
+          "${script}"
+        );
+    };
     boot.kernelParams = [
       "cgroup_enable=cpuset"
       "cgroup_memory=1"


### PR DESCRIPTION
## Summary

- Bump `claude-code` package from 2.1.107 → **2.1.108**
- Fix two pre-existing pre-commit lint violations that were blocking commits

## Changes

### `home/development/claude-code/default.nix`
- `version`: `2.1.107` → `2.1.108`
- Source `hash`: recalculated → `sha256-viCymGDX1wgEPu35o2uxQi5QlOfeQny8vKQGiwDg2bg=`
- `npmDepsHash`: unchanged (deps vendored, trivial lockfile)

### `modules/virt/virt.nix` (lint cleanup)
- Merged three sibling `systemd.*` assignments into a single `systemd = { ... }` attrset (statix W20: repeated keys in attribute set)

### `modules/desktop/cosmic-applet-package-updater.nix` (lint cleanup)
- Removed unused `pkgs` and `inputs` lambda args (deadnix: unused declarations)

## Testing

- [x] `nix build` of `claude-code` derivation succeeds
- [x] Built binary reports `2.1.108 (Claude Code)`
- [x] `statix check` clean on both modified lint-fix files
- [x] `deadnix` clean on cosmic-applet file
- [x] Pre-commit hooks pass on both commits

## Test Plan

- [ ] Deploy to p620 and verify `claude --version` = 2.1.108
- [ ] Deploy to other hosts (razer, p510, samsung) after merge