### PR TITLE
fix(claude-desktop): add socat for Cowork/Local Agent Mode

### DIFF
--- a/modules/ai/default.nix
+++ b/modules/ai/default.nix
@@ -20,7 +20,9 @@ in
     ]
     ++ optionals cfg.claude-desktop [
       pkgs.customPkgs.claude-desktop
-      pkgs.bubblewrap # required by Claude Desktop's Cowork/Local Agent Mode
+      # Claude Desktop's Cowork/Local Agent Mode runtime deps (aaddrick --doctor)
+      pkgs.bubblewrap # namespace sandbox (default backend)
+      pkgs.socat # Unix-socket relay the cowork daemon uses for IPC
     ];
   };
 }


### PR DESCRIPTION
## Summary
Add \`socat\` to the Claude Desktop feature module so the Cowork VM service daemon can start.

## Symptom
Clicking a Cowork workspace threw:
> VM service not running. The service failed to start. Restarting Claude or your computer sometimes resolves this. If it persists, you can reinstall the workspace.

## Diagnosis
\`claude-desktop --doctor\` showed everything else OK:
\`\`\`
Cowork Mode
[PASS] bubblewrap: found
[PASS] KVM: accessible
[PASS] vsock: module loaded
[PASS] QEMU: found
       socat: not found      <-- missing
[PASS] virtiofsd: found
       Cowork isolation: bubblewrap (namespace sandbox)
\`\`\`

aaddrick's cowork-vm-service daemon uses socat as a Unix-socket relay for IPC between the Electron process and the sandboxed Claude Code subprocess.

## Fix
\`modules/ai/default.nix\`: add \`pkgs.socat\` alongside \`pkgs.bubblewrap\` when \`features.ai.claude-desktop\` is enabled.

## Verified on p620 (post-deploy)
\`\`\`
$ which socat
/run/current-system/sw/bin/socat
$ claude-desktop --doctor | grep -E 'socat|Cowork isolation'
[PASS] socat: found
       Cowork isolation: bubblewrap (namespace sandbox)
\`\`\`

## Rollback
\`git revert\` + redeploy; single-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)