### PR TITLE
fix(claude-desktop): pin aaddrick to v1.3.30+claude1.2278.0 (avoid #408 regression)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,16 +132,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1776303575,
-        "narHash": "sha256-M52nBx8J19tIwXaqqqtcEJR4bkuSxVfYw4boeX7l/60=",
+        "lastModified": 1776130753,
+        "narHash": "sha256-CWrwYni9qluaBppQfi2sR/e/uLS+xljt6k2EioPQ54M=",
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "214d5e92d458a57ec73d8de2ac6041b0095caa7a",
+        "rev": "89208a596a3e876a74f865fb5267996f666f4a09",
         "type": "github"
       },
       "original": {
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
+        "rev": "89208a596a3e876a74f865fb5267996f666f4a09",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -72,7 +72,10 @@
     # Additional tools
     lan-mouse.url = "github:feschber/lan-mouse";
     zjstatus.url = "github:dj95/zjstatus";
-    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian";
+    # Pinned to v1.3.30+claude1.2278.0 — v1.3.31+claude1.2773.0 has a
+    # regression (upstream #408) where _svcLaunched guard never clears,
+    # breaking Cowork VM daemon respawn after any failure/crash.
+    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/89208a596a3e876a74f865fb5267996f666f4a09";
 
     # Terminal YouTube browser
     yt-x = {


### PR DESCRIPTION
## Summary
Pin \`claude-desktop-linux\` flake input to aaddrick commit \`89208a5\` (tag \`v1.3.30+claude1.2278.0\`, 2026-04-14) to work around upstream regression #408 in \`v1.3.31+claude1.2773.0\`.

## Symptom
After the k3d3 → aaddrick swap + socat fix, Cowork workspaces still failed with:
> Failed to start Claude's workspace
> VM service not running. The service failed to start.

\`~/.config/Claude/logs/cowork_vm_node.log\` showed the daemon starting, copying \`smol-bin.x64.vhdx\`, then silently dying 5 seconds later — no stderr captured anywhere.

## Root cause (upstream bug)
Per aaddrick/claude-desktop-debian#408, v1.3.31 has a one-shot \`_svcLaunched\` boolean guard in Patch 6 (inside app.asar) that never clears. After the first daemon startup failure, the app never respawns it. Every subsequent attempt loops on ENOENT connecting to a socket that was never created. Full app restart, OS reboot, and state wipe all fail to recover.

## Fix
Pin to the previous release (v1.3.30+claude1.2278.0) until aaddrick ships the Patch 6 rewrite (rate-limited spawn + stale-socket cleanup) discussed in #408.

## Verified
- \`just test-host p620\` ✅
- \`nixos-rebuild switch\` ✅
- Closure now contains \`claude-desktop-1.2278.0\` instead of \`1.2773.0\`

## Follow-up
Watch aaddrick/claude-desktop-debian#408 for the upstream fix; remove the pin (revert this commit's \`flake.nix\` edit and run \`nix flake update claude-desktop-linux\`) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)