### PR TITLE
feat(claude-code): migrate to native binary + add release watcher

### DIFF
--- a/.claude/commands/update-claude-code.md
+++ b/.claude/commands/update-claude-code.md
@@ -1,414 +1,186 @@
-# Update Claude Code to Latest Version
+# Update Claude Code (native binary)
 
-You are a NixOS package update specialist. Update the claude-code package to the latest version following NixOS best practices.
+Update the `claude-code-native` package to a given version (or `latest` /
+`stable` channel). This tracks Anthropic's official GCS distribution, not
+the npm registry — so it's **immune to the npm-side packaging refactors**
+(e.g. the 2.1.113 optionalDependencies split) that break `buildNpmPackage`.
 
-## Task Overview
+The npm-based `home/development/claude-code/` derivation is **deprecated**
+and may be removed in a follow-up chore.
 
-Update the Claude Code package derivation with proper hash calculation, testing, and GitHub workflow integration.
+## When to invoke
+
+- When the claude-code watcher opens a "new version available" issue
+  (label: `claude-code-update`).
+- On explicit request: `/update-claude-code 2.1.114` or `/update-claude-code latest`.
 
 ## Prerequisites
 
-- [ ] Check for existing issues: `/check_tasks`
-- [ ] Ensure clean git state: `git status`
-- [ ] Review current version: `claude --version`
+- [ ] `git status` clean (no unrelated dirty files that would land in the PR)
+- [ ] `gh auth status` OK
+- [ ] Current `claude --version` (for the commit body): `claude --version`
 
-## Step 1: Research Latest Version
-
-```bash
-# Use WebSearch to find latest release
-```
-
-**Search for:**
-
-1. NPM package page: <https://www.npmjs.com/package/@anthropic-ai/claude-code>
-2. GitHub releases: <https://github.com/anthropics/claude-code/releases>
-3. Changelog: Check for breaking changes
-
-**Record:**
-
-- Latest version number: `X.X.X`
-- Release date
-- Notable changes from changelog
-- Breaking changes (if any)
-
-## Step 2: Read Current Package Configuration
+## Step 1 — Pick the version
 
 ```bash
-# Read the current derivation
-cat home/development/claude-code/default.nix
+# Show both channels, do nothing
+./scripts/update-claude-code-native.sh
+# → Channels:
+#     stable  = 2.1.98
+#     latest  = 2.1.114
 ```
 
-**Note current:**
+If the user passed an arg to the command, use that. Otherwise default to
+**`latest`** — that's the channel this infra tracks per policy decision
+2026-04-18. If you have a reason to pick `stable` instead, tell the user
+before doing it.
 
-- Version number
-- npmDepsHash value
-- Any custom patches or modifications
+## Step 2 — Fetch hashes and preview Nix snippet
 
-## Step 3: Update Package Derivation
+```bash
+./scripts/update-claude-code-native.sh <version>   # e.g. 2.1.114 or latest
+```
 
-### Update Version Number
+The script:
+- Resolves `latest`/`stable` → concrete version
+- Prefetches both Linux binaries (x86_64 + aarch64) via `nix store prefetch-file`
+- Prints SRI hashes and a ready-to-paste Nix snippet
+- **Does NOT edit any file** — it's read-only
 
-Edit `home/development/claude-code/default.nix`:
+Capture the script output. You need exactly three values:
+- `version`
+- x86_64-linux `hash`
+- aarch64-linux `hash`
+
+## Step 3 — Edit `pkgs/claude-code-native/default.nix`
+
+Update three lines:
 
 ```nix
-{
-  lib,
-  buildNpmPackage,
-  fetchFromGitHub,
+  version = "<NEW_VERSION>";
   ...
-}:
-buildNpmPackage rec {
-  pname = "claude-code";
-  version = "X.X.X";  # <-- Update this
-
-  src = fetchFromGitHub {
-    owner = "anthropics";
-    repo = "claude-code";
-    rev = "v${version}";
-    hash = "sha256-AAAA...";  # May need update
+  sources = {
+    x86_64-linux = {
+      url = "${gcs_bucket}/${version}/linux-x64/claude";
+      hash = "<NEW_X64_HASH>";
+    };
+    aarch64-linux = {
+      url = "${gcs_bucket}/${version}/linux-arm64/claude";
+      hash = "<NEW_ARM64_HASH>";
+    };
   };
-
-  npmDepsHash = "sha256-TEMP...";  # <-- Will update next
-
-  # ... rest of derivation
-}
 ```
 
-### Calculate New npmDepsHash
+**Do NOT change anything else** in the derivation.
+
+## Step 4 — Build and sanity-check
 
 ```bash
-# Method 1: Set empty hash and get correct one from error
-# Edit default.nix and set: npmDepsHash = "";
+nix build --no-link --print-out-paths .#claude-code-native
+# Take the printed path, verify:
+$(nix build --no-link --print-out-paths .#claude-code-native)/bin/claude --version
+# → 2.1.114 (Claude Code)
 
-# Try to build
-nix-build -A packages.x86_64-linux.claude-code 2>&1 | grep "got:" | awk '{print $2}'
-
-# Method 2: Use nix-prefetch-url
-cd /tmp
-git clone https://github.com/anthropics/claude-code --branch vX.X.X --depth 1
-cd claude-code
-nix hash convert --to sri $(nix-prefetch-url --unpack "file://$(npm pack)")
-
-# Method 3: Use prefetch-npm-deps (if available)
-nix run nixpkgs#prefetch-npm-deps home/development/claude-code/package-lock.json
+ldd $(nix build --no-link --print-out-paths .#claude-code-native)/bin/claude \
+  | grep -E "not found|missing" && echo "MISSING LIBS" || echo "libs OK"
 ```
 
-### Update the Hash
+If `--version` mismatches the target, abort and re-check the hash.
 
-Edit `home/development/claude-code/default.nix` with correct hash:
+## Step 5 — Full host build matrix
 
-```nix
-npmDepsHash = "sha256-ACTUAL_HASH_HERE";
+```bash
+# Parallel. Any failure → stop; fix before proceeding.
+just quick-test   # builds all 3 host closures
+# OR individually:
+nix build --no-link .#nixosConfigurations.p620.config.system.build.toplevel
+nix build --no-link .#nixosConfigurations.razer.config.system.build.toplevel
+nix build --no-link .#nixosConfigurations.p510.config.system.build.toplevel
 ```
 
-## Step 4: Test the Update
-
-### Syntax Check
+## Step 6 — Issue → branch → commit → PR
 
 ```bash
-just check-syntax
-```
+# Check for an existing auto-opened watcher issue first.
+gh issue list -l claude-code-update --search "$VERSION" --state open
 
-### Build Test
+# If an issue exists, reference it as $ISSUE. If not, create one:
+gh issue create \
+  --label claude-code-update \
+  --title "chore(claude-code): update to $VERSION" \
+  --body "Bump claude-code-native from <OLD> to $VERSION.
 
-```bash
-# Test on primary host
-just test-host p620
+Source: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/$VERSION/manifest.json
+Release notes: https://github.com/anthropics/claude-code/releases/tag/v$VERSION"
 
-# If successful, test on other hosts
-just quick-test
-```
+# Standard issue-driven flow
+git checkout -b chore/<ISSUE>-claude-code-$VERSION
+git add pkgs/claude-code-native/default.nix
+git commit -m "chore(claude-code): update to $VERSION (#$ISSUE)
 
-### Verify Binary Works
+Bump claude-code-native from <OLD> to $VERSION via the GCS
+distribution channel (\`latest\`).
 
-```bash
-# Build and test the package
-result/bin/claude --version
+- x86_64-linux hash refreshed
+- aarch64-linux hash refreshed
+- Verified: claude --version = $VERSION
+- Built all 3 host closures
 
-# Should show: X.X.X
-```
+Closes #$ISSUE
 
-## Step 5: Create GitHub Issue
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 
-Use the `/new_task` command:
-
-```bash
-/new_task
-```
-
-**Issue details:**
-
-- **Type:** chore
-- **Priority:** medium
-- **Title:** "Update Claude Code to version X.X.X"
-- **Description:**
-
-  ```
-  Update claude-code package from vOLD to vNEW
-
-  Changes:
-  - Updated version from OLD → NEW
-  - Recalculated npmDepsHash
-  - Tested on all hosts
-
-  Breaking changes: [None/List them]
-
-  Release notes: [Link to changelog]
-  ```
-
-## Step 6: Create Branch and Commit
-
-```bash
-# Get issue number from /new_task output
-ISSUE_NUM=123
-
-# Create feature branch
-git checkout -b chore/${ISSUE_NUM}-update-claude-code-X.X.X
-
-# Stage changes
-git add home/development/claude-code/default.nix
-
-# Commit with detailed message
-git commit -m "chore(claude-code): update to version X.X.X (#${ISSUE_NUM})
-
-Update Claude Code package derivation:
-- Version: OLD → X.X.X
-- npmDepsHash: recalculated for new version
-- Source hash: [updated/unchanged]
-
-Changes in this release:
-- [Notable feature 1]
-- [Notable feature 2]
-- [Bug fixes]
-
-Testing:
-- Built successfully on all hosts
-- Binary verified: claude --version shows X.X.X
-- No breaking changes detected
-
-Closes #${ISSUE_NUM}"
-
-# Push branch
-git push -u origin chore/${ISSUE_NUM}-update-claude-code-X.X.X
-```
-
-## Step 7: Create Pull Request
-
-```bash
-# Create PR with GitHub CLI
-gh pr create --fill --base main
-
-# Or use web interface with pre-filled template
-```
-
-**PR Template:**
-
-````markdown
-## Summary
-
-Update Claude Code to version X.X.X
-
-## Changes
-
-- ✅ Updated version from OLD → X.X.X
-- ✅ Recalculated npmDepsHash
-- ✅ Tested on all hosts (p620, razer, p510, samsung)
-- ✅ Verified binary functionality
-
-## Testing Evidence
-
-```bash
-# Build successful
-just test-host p620 ✅
-
-# Version check
-$ result/bin/claude --version
-claude-code X.X.X ✅
-
-# All hosts tested
-just quick-test ✅
-```
-````
-
-## Release Notes
-
-[Link to release notes]
-
-**Notable changes:**
-
-- Feature 1
-- Feature 2
-- Bug fixes
-
-**Breaking changes:** None
-
-## Checklist
-
-- [x] Version updated in default.nix
-- [x] npmDepsHash recalculated
-- [x] Build tested on all hosts
-- [x] Binary verified functional
-- [x] GitHub issue created
-- [x] Commit message follows conventional commits
-- [x] No anti-patterns introduced (checked against @docs/NIXOS-ANTI-PATTERNS.md)
-
-Closes #${ISSUE_NUM}
-
-````
-
-## Step 8: Code Review
-
-Run code review before merging:
-
-```bash
-/review
-````
-
-**Review focus:**
-
-- Package derivation follows @docs/PATTERNS.md
-- No anti-patterns from @docs/NIXOS-ANTI-PATTERNS.md
-- Hash calculations are correct
-- Testing was comprehensive
-
-## Step 9: Merge and Deploy
-
-```bash
-# After PR approval
-gh pr merge ${ISSUE_NUM} --squash --delete-branch
-
-# Deploy to hosts
-just quick-deploy p620
-just quick-deploy razer
-just quick-deploy p510
-just quick-deploy samsung
-```
-
-## Step 10: Verify Deployment
-
-```bash
-# Check version on each host
-ssh p620 "claude --version"
-ssh razer "claude --version"
-ssh p510 "claude --version"
-ssh samsung "claude --version"
-
-# All should show: X.X.X
-```
-
-## Success Criteria
-
-- [ ] Latest version identified from npm/GitHub
-- [ ] npmDepsHash calculated correctly
-- [ ] Build succeeds on all hosts
-- [ ] Binary verified functional
-- [ ] GitHub issue created and linked
-- [ ] Branch created following naming convention
-- [ ] Commit message follows conventional commits
-- [ ] PR created with comprehensive description
-- [ ] Code review passed
-- [ ] PR merged to main
-- [ ] Deployed to all hosts
-- [ ] Version verified on all hosts
-
-## Rollback Procedure
-
-If issues occur after deployment:
-
-```bash
-# Revert the commit
-git revert COMMIT_HASH
-
-# Or rollback system generation
-sudo nixos-rebuild switch --rollback
-
-# Report issue on GitHub
-gh issue create --title "Claude Code X.X.X causing issues" --body "Description of issue..."
-```
-
-## Common Issues
-
-### Hash Mismatch
-
-```bash
-# Clear cache and retry
-nix-collect-garbage -d
-nix-store --verify --check-contents
-
-# Recalculate hash
-nix-prefetch-url --unpack "URL"
-```
-
-### Build Failure
-
-```bash
-# Check build logs
-nix-build -A packages.x86_64-linux.claude-code --show-trace
-
-# Check for missing dependencies
-nix-build -A packages.x86_64-linux.claude-code --keep-failed
-
-# Review failed build directory
-cd /tmp/nix-build-*
-cat build.log
-```
-
-### Binary Not Working
-
-```bash
-# Test in nix-shell
-nix-shell -p packages.x86_64-linux.claude-code
-claude --version
-
-# Check for missing runtime dependencies
-ldd result/bin/claude
-```
-
-## Documentation References
-
-- @docs/PATTERNS.md - Package writing patterns
-- @docs/NIXOS-ANTI-PATTERNS.md - Avoid these
-- @docs/GITHUB-WORKFLOW.md - PR workflow
-- @home/development/claude-code/default.nix - Current derivation
-
-## Notes
-
-- Always test on all hosts before deploying
-- Document breaking changes in commit message
-- Update roadmap if significant features added
-- Keep old generation for rollback capability
-- Monitor for issues after deployment (24h)
-
-## Example Complete Workflow
-
-```bash
-# 1. Research
-# Use WebSearch for latest version
-
-# 2. Update
-vim home/development/claude-code/default.nix
-# Update version and calculate hash
-
-# 3. Test
-just test-host p620
-
-# 4. GitHub workflow
-/new_task
-git checkout -b chore/123-update-claude-code-X.X.X
-git add home/development/claude-code/default.nix
-git commit -m "chore(claude-code): update to X.X.X (#123)"
-git push -u origin chore/123-update-claude-code-X.X.X
+git push -u origin chore/<ISSUE>-claude-code-$VERSION
 gh pr create --fill
+gh pr merge --squash --delete-branch
+```
 
-# 5. Review and merge
-/review
-gh pr merge 123 --squash
+If pre-commit hook hangs on statix (established precedent), use
+`git commit --no-verify` — this project has that as a known workaround.
 
-# 6. Deploy
-just deploy-all-parallel
+## Step 7 — Deploy
 
-# 7. Verify
-for host in p620 razer p510 samsung; do
-  ssh $host "claude --version"
+```bash
+# Local host (p620)
+sudo nixos-rebuild switch --flake ~/.config/nixos#p620
+
+# Remote hosts (SSH aliases in ~/.ssh/config)
+ssh razer 'cd ~/.config/nixos && git pull && sudo nixos-rebuild switch --flake .#razer'
+ssh p510  'cd ~/.config/nixos && git pull && sudo nixos-rebuild switch --flake .#p510'
+
+# Verify each
+for h in "" razer p510; do
+  out=$( [ -z "$h" ] && claude --version || ssh "$h" claude --version )
+  echo "${h:-local}: $out"
 done
 ```
+
+## Rollback
+
+```bash
+# Option A: revert the commit, re-deploy
+git revert <COMMIT_SHA>
+git push
+
+# Option B: NixOS generation rollback (no git change)
+sudo nixos-rebuild switch --rollback
+```
+
+## Anti-patterns to avoid
+
+- ❌ Do NOT use `buildNpmPackage` — that's the deprecated path. Upstream
+  npm packaging changes (e.g. 2.1.113) will silently break your build.
+- ❌ Do NOT hand-compute hashes with `nix-prefetch-url` — use the script
+  (`nix store prefetch-file` is the modern, authenticated route).
+- ❌ Do NOT commit without running `claude --version` on the built binary.
+  A wrong hash produces a valid but stale binary.
+- ❌ Do NOT skip host builds. The 2 minutes you save loses 2 hours if
+  razer's NVIDIA stack regresses against the new binary.
+
+## Related files
+
+- `pkgs/claude-code-native/default.nix` — the package
+- `scripts/update-claude-code-native.sh` — the prefetch helper
+- `home/default.nix` — `programs.claude-code.package = pkgs.claude-code-native;`
+- `.github/workflows/claude-code-watch.yml` — hourly watcher that opens
+  issues when `/latest` advances

--- a/.github/workflows/claude-code-watch.yml
+++ b/.github/workflows/claude-code-watch.yml
@@ -1,0 +1,112 @@
+# Poll Anthropic's GCS distribution for a new claude-code `latest` channel
+# version. When it advances past the version we have pinned in
+# pkgs/claude-code-native/default.nix, open a single tracking issue so we
+# can review the release (manifest, GitHub notes, any breaking changes)
+# before running /update-claude-code.
+#
+# Policy: we track `latest`, not `stable` (see 2026-04-18 decision). The
+# `latest` channel ships multiple times per day — this workflow dedups by
+# version number in the issue title, so at most one open issue per new
+# version.
+#
+# Related: .claude/commands/update-claude-code.md describes the bump flow.
+
+name: claude-code watch
+
+on:
+  schedule:
+    # Every hour. `latest` can advance multiple times per day; hourly is
+    # a reasonable floor. Slip is harmless — dedup handles it.
+    - cron: "0 * * * *"
+  workflow_dispatch:    # manual trigger for testing
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve upstream + pinned versions
+        id: v
+        run: |
+          set -euo pipefail
+          GCS="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+
+          upstream=$(curl -fsSL --max-time 20 "$GCS/latest")
+          pinned=$(sed -nE 's/^[[:space:]]*version = "([^"]+)";.*$/\1/p' \
+            pkgs/claude-code-native/default.nix | head -1)
+
+          if [ -z "$upstream" ] || [ -z "$pinned" ]; then
+            echo "Could not determine versions (upstream=$upstream, pinned=$pinned)" >&2
+            exit 1
+          fi
+
+          echo "upstream=$upstream" >>"$GITHUB_OUTPUT"
+          echo "pinned=$pinned"     >>"$GITHUB_OUTPUT"
+          echo "upstream=$upstream  pinned=$pinned"
+
+      - name: Exit if already up to date
+        if: steps.v.outputs.upstream == steps.v.outputs.pinned
+        run: echo "pinned == upstream (${{ steps.v.outputs.pinned }}) — nothing to do"
+
+      - name: Dedup — skip if an issue for this version already exists
+        if: steps.v.outputs.upstream != steps.v.outputs.pinned
+        id: dedup
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPSTREAM: ${{ steps.v.outputs.upstream }}
+        run: |
+          set -euo pipefail
+          # Match by title substring — covers both open and closed-but-same-version.
+          existing=$(gh issue list \
+            --label claude-code-update \
+            --state all \
+            --search "in:title \"claude-code: update to $UPSTREAM\"" \
+            --json number,title \
+            --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Issue #$existing already tracks $UPSTREAM — skipping"
+            echo "skip=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Open tracking issue
+        if: steps.v.outputs.upstream != steps.v.outputs.pinned && steps.dedup.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPSTREAM: ${{ steps.v.outputs.upstream }}
+          PINNED:   ${{ steps.v.outputs.pinned }}
+        run: |
+          set -euo pipefail
+          GCS="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+
+          # Best-effort manifest fetch for build date (may fail; harmless)
+          build_date=$(curl -fsSL --max-time 10 "$GCS/$UPSTREAM/manifest.json" 2>/dev/null \
+            | jq -r '.buildDate // "(unknown)"' 2>/dev/null || echo "(unknown)")
+
+          gh issue create \
+            --label claude-code-update \
+            --title "chore(claude-code): update to $UPSTREAM" \
+            --body "Anthropic has published **claude-code $UPSTREAM** on the \`latest\` channel.
+
+- Currently pinned: **$PINNED**
+- Upstream latest:  **$UPSTREAM**
+- Upstream build date: $build_date
+
+Links:
+- Manifest: ${GCS}/${UPSTREAM}/manifest.json
+- Release notes (if any): https://github.com/anthropics/claude-code/releases/tag/v$UPSTREAM
+- npm page: https://www.npmjs.com/package/@anthropic-ai/claude-code/v/$UPSTREAM
+
+## To act on this
+
+Run \`/update-claude-code $UPSTREAM\` in Claude Code. The slash command
+will fetch hashes, edit \`pkgs/claude-code-native/default.nix\`, build,
+test, and open the PR.
+
+This issue will auto-close when that PR merges."

--- a/home/default.nix
+++ b/home/default.nix
@@ -13,15 +13,21 @@
     ./files.nix
   ];
 
-  # Enable Claude Code via home-manager's built-in module
-  # Options for package:
-  #   - inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.claude-code  # Our npm package (latest: 2.1.19)
-  #   - pkgs.claude-code-native  # Native binary (faster startup, version: 2.1.19)
-  #   - pkgs.claude-code  # nixpkgs version (may be older)
+  # Enable Claude Code via home-manager's built-in module.
+  #
+  # Using pkgs.claude-code-native: pre-built binaries from Anthropic's GCS
+  # bucket (no Node.js runtime, faster startup, immune to npm-side
+  # repackaging like the 2.1.113 optionalDependencies refactor).
+  # Tracks the `latest` channel. Update with:
+  #   ./scripts/update-claude-code-native.sh <version>
+  #
+  # Alternatives (kept for reference, not used):
+  #   - pkgs.claude-code  # nixpkgs version, often lags
+  #   - inputs.self.packages.${system}.claude-code  # legacy npm package,
+  #     stuck at 2.1.112 due to upstream packaging change
   programs.claude-code = {
     enable = true;
-    # Use our npm package for the latest version
-    package = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
+    package = pkgs.claude-code-native;
   };
 
   home.packages = [

--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.20";
+  version = "2.1.114";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-+dNpj1N4pIbbLU7qXID5XCzrQQ+86p/8VwO1qslXT8w=";
+      hash = "sha256-Er1LCRbesGvhf/x7LwSF4UC/ALLbPct4Rp1mcj1zwn8=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-64gBx6SoUBshwjXzZnTxcyjmXnls+KYZazv5ojrhb5k=";
+      hash = "sha256-lVa3TiyRLn3K75DJH9DdUJU2T4qdcTmN48XGaWErgoo=";
     };
   };
 

--- a/scripts/update-claude-code-native.sh
+++ b/scripts/update-claude-code-native.sh
@@ -1,197 +1,93 @@
 #!/usr/bin/env bash
-# Update script for claude-code-native package
-# Usage: ./scripts/update-claude-code-native.sh [version]
+# Update claude-code-native package to a given version.
+# Usage:
+#   ./scripts/update-claude-code-native.sh            # prints channels, does nothing
+#   ./scripts/update-claude-code-native.sh <version>  # prints Nix snippet for that version
+#   ./scripts/update-claude-code-native.sh latest     # resolves and uses the /latest channel
+#   ./scripts/update-claude-code-native.sh stable     # resolves and uses the /stable channel
 #
-# This script fetches the latest version and calculates hashes for the native binary.
-# If no version is specified, it uses the stable version.
+# Read-only: prints version + hashes. Does NOT edit default.nix — paste the
+# output yourself or pipe through sed.
 
-set -euo pipefail
+set -u
+# NB: intentionally no `set -e` — curl on a miss should not abort the whole
+# script; we handle failure explicitly. Also no `pipefail` — jq-less is fine.
 
-GCS_BUCKET="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
-PKG_DIR="$(dirname "$0")/../pkgs/claude-code-native"
+GCS="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+PKG_FILE="$(dirname "$0")/../pkgs/claude-code-native/default.nix"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-info() {
-  echo -e "${GREEN}[INFO]${NC} $1"
-}
-
-warn() {
-  echo -e "${YELLOW}[WARN]${NC} $1"
-}
-
-error() {
-  echo -e "${RED}[ERROR]${NC} $1"
+die() {
+  echo "error: $*" >&2
   exit 1
 }
+log() { echo ">> $*" >&2; }
 
-# Get stable version from distribution channel
-get_stable_version() {
-  info "Fetching stable version..."
-  curl -fsSL "$GCS_BUCKET/stable" 2>/dev/null || error "Failed to fetch stable version"
+resolve_channel() {
+  local ch="$1"
+  curl -fsSL --max-time 10 "$GCS/$ch" 2>/dev/null \
+    || die "could not resolve channel '$ch' (404 or network)"
 }
 
-# Get latest version from distribution channel
-get_latest_version() {
-  info "Fetching latest version..."
-  curl -fsSL "$GCS_BUCKET/latest" 2>/dev/null || error "Failed to fetch latest version"
+prefetch_hash() {
+  # Returns SRI hash, or empty string on failure (stderr shows why).
+  local url="$1" platform="$2"
+  local json
+  if ! json=$(nix store prefetch-file --json --hash-type sha256 "$url" 2>&1); then
+    log "prefetch failed for $platform: $json"
+    return 1
+  fi
+  printf '%s' "$json" | jq -r '.hash' 2>/dev/null \
+    || {
+      log "jq failed parsing prefetch output for $platform"
+      return 1
+    }
 }
 
-# Get manifest for a version
-get_manifest() {
-  local version="$1"
-  info "Fetching manifest for version $version..."
-  curl -fsSL "$GCS_BUCKET/$version/manifest.json" 2>/dev/null || error "Failed to fetch manifest"
-}
+# Banner + channel summary (always, for context).
+echo "Channels:"
+echo "  stable  = $(resolve_channel stable)"
+echo "  latest  = $(resolve_channel latest)"
+echo
 
-# Calculate SRI hash for a URL
-calculate_hash() {
-  local url="$1"
-  local platform="$2"
+version="${1-}"
+if [ -z "$version" ]; then
+  log "no version given. Rerun with a version number, 'latest', or 'stable'."
+  exit 0
+fi
 
-  info "Downloading $platform binary..."
+# Shorthand: `latest` / `stable` → resolve to actual version.
+case "$version" in
+  latest | stable) version=$(resolve_channel "$version") ;;
+esac
 
-  # Create temp file
-  local tmpfile
-  tmpfile=$(mktemp)
-  trap 'rm -f "$tmpfile"' RETURN
+log "resolving hashes for $version ..."
 
-  if curl -fsSL "$url" -o "$tmpfile" 2>/dev/null; then
-    # Calculate SRI hash
-    local hash
-    hash=$(nix hash file --sri "$tmpfile" 2>/dev/null)
-    local size
-    size=$(stat -c %s "$tmpfile" 2>/dev/null || stat -f %z "$tmpfile" 2>/dev/null)
-    echo "$hash|$size"
-  else
-    warn "Failed to download $platform binary"
-    echo ""
-  fi
-}
+x64_hash=$(prefetch_hash "$GCS/$version/linux-x64/claude" x86_64-linux) \
+  || die "could not hash linux-x64 binary for $version"
+arm64_hash=$(prefetch_hash "$GCS/$version/linux-arm64/claude" aarch64-linux) \
+  || die "could not hash linux-arm64 binary for $version"
 
-# Main update logic
-main() {
-  local version="${1:-}"
+current=$(sed -nE 's/^[[:space:]]*version = "([^"]+)";.*$/\1/p' "$PKG_FILE" | head -1)
 
-  echo -e "${BLUE}=========================================="
-  echo "Claude Code Native Binary Update Tool"
-  echo -e "==========================================${NC}"
-  echo ""
+cat <<EOF
+Current pinned: $current
+Target:         $version
 
-  # Show available versions
-  local stable_ver latest_ver
-  stable_ver=$(get_stable_version)
-  latest_ver=$(get_latest_version)
+Paste into $PKG_FILE:
 
-  echo ""
-  echo "Available versions:"
-  echo "  Stable: $stable_ver"
-  echo "  Latest: $latest_ver"
-  echo ""
+  version = "$version";
+  ...
+  sources = {
+    x86_64-linux = {
+      url = "\${gcs_bucket}/\${version}/linux-x64/claude";
+      hash = "$x64_hash";
+    };
+    aarch64-linux = {
+      url = "\${gcs_bucket}/\${version}/linux-arm64/claude";
+      hash = "$arm64_hash";
+    };
+  };
 
-  # Use provided version or default to stable
-  if [ -z "$version" ]; then
-    version="$stable_ver"
-    info "Using stable version: $version"
-  else
-    info "Using specified version: $version"
-  fi
-
-  echo ""
-
-  # Get manifest to verify version exists
-  local manifest
-  manifest=$(get_manifest "$version")
-  if [ -z "$manifest" ]; then
-    error "Version $version not found"
-  fi
-
-  # Extract checksums from manifest (for verification)
-  local x64_manifest_checksum arm64_manifest_checksum
-  x64_manifest_checksum=$(echo "$manifest" | jq -r '.platforms["linux-x64"].checksum // empty' 2>/dev/null)
-  arm64_manifest_checksum=$(echo "$manifest" | jq -r '.platforms["linux-arm64"].checksum // empty' 2>/dev/null)
-
-  echo "Manifest checksums (SHA256):"
-  echo "  linux-x64:   ${x64_manifest_checksum:-NOT AVAILABLE}"
-  echo "  linux-arm64: ${arm64_manifest_checksum:-NOT AVAILABLE}"
-  echo ""
-
-  # Calculate SRI hashes
-  local x64_url="${GCS_BUCKET}/${version}/linux-x64/claude"
-  local arm64_url="${GCS_BUCKET}/${version}/linux-arm64/claude"
-
-  local x64_result arm64_result
-  x64_result=$(calculate_hash "$x64_url" "x86_64-linux")
-  arm64_result=$(calculate_hash "$arm64_url" "aarch64-linux")
-
-  # Parse results
-  local x64_hash x64_size arm64_hash arm64_size
-  x64_hash=$(echo "$x64_result" | cut -d'|' -f1)
-  x64_size=$(echo "$x64_result" | cut -d'|' -f2)
-  arm64_hash=$(echo "$arm64_result" | cut -d'|' -f1)
-  arm64_size=$(echo "$arm64_result" | cut -d'|' -f2)
-
-  echo ""
-  echo -e "${GREEN}=========================================="
-  echo "Update Results"
-  echo -e "==========================================${NC}"
-  echo ""
-  echo "Version: $version"
-  echo ""
-
-  if [ -n "$x64_hash" ]; then
-    echo "x86_64-linux:"
-    echo "  URL:  $x64_url"
-    echo "  Hash: $x64_hash"
-    echo "  Size: $x64_size bytes"
-  else
-    echo "x86_64-linux: NOT AVAILABLE"
-  fi
-  echo ""
-
-  if [ -n "$arm64_hash" ]; then
-    echo "aarch64-linux:"
-    echo "  URL:  $arm64_url"
-    echo "  Hash: $arm64_hash"
-    echo "  Size: $arm64_size bytes"
-  else
-    echo "aarch64-linux: NOT AVAILABLE"
-  fi
-  echo ""
-
-  # Generate Nix snippet
-  if [ -n "$x64_hash" ] || [ -n "$arm64_hash" ]; then
-    echo -e "${BLUE}=========================================="
-    echo "Nix Expression Update"
-    echo -e "==========================================${NC}"
-    echo ""
-    echo "Update pkgs/claude-code-native/default.nix with:"
-    echo ""
-    echo "  version = \"$version\";"
-    echo ""
-    echo "  sources = {"
-    if [ -n "$x64_hash" ]; then
-      echo "    x86_64-linux = {"
-      echo "      url = \"\${gcs_bucket}/\${version}/linux-x64/claude\";"
-      echo "      hash = \"$x64_hash\";"
-      echo "    };"
-    fi
-    if [ -n "$arm64_hash" ]; then
-      echo "    aarch64-linux = {"
-      echo "      url = \"\${gcs_bucket}/\${version}/linux-arm64/claude\";"
-      echo "      hash = \"$arm64_hash\";"
-      echo "    };"
-    fi
-    echo "  };"
-    echo ""
-  else
-    error "No binaries found for version $version"
-  fi
-}
-
-main "$@"
+Next:
+  nix build .#claude-code-native && result/bin/claude --version
+EOF


### PR DESCRIPTION
## Summary
- Switch `programs.claude-code.package` to `pkgs.claude-code-native` (GCS-distributed pre-built binary).
- Bump `claude-code-native` 2.1.20 → 2.1.114.
- Rewrite `scripts/update-claude-code-native.sh` to fix a silent-exit bug and use `nix store prefetch-file`.
- Rewrite `.claude/commands/update-claude-code.md` to document the new workflow.
- Add `.github/workflows/claude-code-watch.yml` — hourly cron that opens a tracking issue when the `/latest` channel advances.

## Why

Upstream claude-code 2.1.113 moved to a platform-specific pre-built binary model (`optionalDependencies`). `buildNpmPackage` + vendored `package-lock.json` can't build this. nixpkgs master is blocked on the same issue.

`claude-code-native` (already in the repo) fetches from Anthropic's GCS bucket directly. Immune to future npm-side refactors.

## Test plan
- [x] `nix build .#claude-code-native` → `claude --version` = 2.1.114
- [x] `nix build .#nixosConfigurations.p620.config.system.build.toplevel` ✅
- [x] `nix build .#nixosConfigurations.razer.config.system.build.toplevel` ✅
- [x] `nix build .#nixosConfigurations.p510.config.system.build.toplevel` ✅
- [x] `./scripts/update-claude-code-native.sh` with no args, `latest`, `2.1.114` ✅
- [ ] Deploy p620 and verify `claude --version`
- [ ] Deploy razer, p510 when reachable
- [ ] Watcher workflow fires correctly (will verify after merge on first scheduled run)

## Not in this PR
Leaving `home/development/claude-code/` in place for now. Follow-up chore to remove it after a week of stability.

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)