### PR TITLE
feat(claude-desktop): bump to latest main + patch Nix build + add watcher

### DIFF
--- a/.claude/commands/update-claude-code.md
+++ b/.claude/commands/update-claude-code.md
@@ -1,186 +1,239 @@
-# Update Claude Code (native binary)
+# Update Claude Code / Claude Desktop
 
-Update the `claude-code-native` package to a given version (or `latest` /
-`stable` channel). This tracks Anthropic's official GCS distribution, not
-the npm registry — so it's **immune to the npm-side packaging refactors**
-(e.g. the 2.1.113 optionalDependencies split) that break `buildNpmPackage`.
+Two packages, two sources, two workflows — both start here. Default to
+**claude-code** if the user's message doesn't disambiguate.
 
-The npm-based `home/development/claude-code/` derivation is **deprecated**
-and may be removed in a follow-up chore.
+| Package | Source | Enabled on | Update target |
+|---|---|---|---|
+| `claude-code` (CLI) | Anthropic GCS binary channel | p620, razer, p510 | `pkgs/claude-code-native/default.nix` |
+| `claude-desktop` (Electron app) | `aaddrick/claude-desktop-debian` flake input | **razer + p620 only** (NOT p510 — headless server) | `flake.nix` input URL |
 
-## When to invoke
+Which package? Ask yourself:
 
-- When the claude-code watcher opens a "new version available" issue
-  (label: `claude-code-update`).
-- On explicit request: `/update-claude-code 2.1.114` or `/update-claude-code latest`.
+- User said "claude-code", `claude`, "CLI" → **claude-code** section.
+- User said "claude-desktop", "desktop", "GUI" → **claude-desktop** section.
+- User passed a version like `2.1.114` → claude-code (matches 2.x).
+- User passed a version like `v1.3.32` → claude-desktop (matches the aaddrick tag format).
 
-## Prerequisites
+If still ambiguous, **ask**. Do NOT bump both blindly — each has its own risk surface.
 
-- [ ] `git status` clean (no unrelated dirty files that would land in the PR)
+---
+
+## A. Update `claude-code` (the CLI)
+
+Tracks Anthropic's GCS distribution, not npm. Immune to npm-side refactors
+like the 2.1.113 optionalDependencies split.
+
+### Prerequisites
+
+- [ ] `git status` clean (or know what's dirty and why)
 - [ ] `gh auth status` OK
-- [ ] Current `claude --version` (for the commit body): `claude --version`
+- [ ] Current `claude --version` captured for the commit body
 
-## Step 1 — Pick the version
+### Steps
 
-```bash
-# Show both channels, do nothing
-./scripts/update-claude-code-native.sh
-# → Channels:
-#     stable  = 2.1.98
-#     latest  = 2.1.114
-```
+1. **Pick the version.**
+   ```bash
+   ./scripts/update-claude-code-native.sh           # just show channels
+   ./scripts/update-claude-code-native.sh latest    # shorthand
+   ./scripts/update-claude-code-native.sh 2.1.114   # explicit
+   ```
+   Default is `latest`. The script prints SRI hashes + a ready-to-paste Nix
+   snippet. It does NOT edit files.
 
-If the user passed an arg to the command, use that. Otherwise default to
-**`latest`** — that's the channel this infra tracks per policy decision
-2026-04-18. If you have a reason to pick `stable` instead, tell the user
-before doing it.
+2. **Edit `pkgs/claude-code-native/default.nix`** — three lines only:
+   ```nix
+   version = "<NEW>";
+   ...
+   sources.x86_64-linux.hash = "<NEW_X64_HASH>";
+   sources.aarch64-linux.hash = "<NEW_ARM64_HASH>";
+   ```
+   Nothing else.
 
-## Step 2 — Fetch hashes and preview Nix snippet
+3. **Build + sanity.**
+   ```bash
+   OUT=$(nix build --no-link --print-out-paths .#claude-code-native)
+   $OUT/bin/claude --version          # must match target
+   ldd $OUT/bin/claude | grep -i "not found" && echo "MISSING LIBS" || echo "libs OK"
+   ```
 
-```bash
-./scripts/update-claude-code-native.sh <version>   # e.g. 2.1.114 or latest
-```
+4. **Host matrix.** Any failure → stop.
+   ```bash
+   for h in p620 razer p510; do
+     nix build --no-link .#nixosConfigurations.$h.config.system.build.toplevel
+   done
+   ```
 
-The script:
-- Resolves `latest`/`stable` → concrete version
-- Prefetches both Linux binaries (x86_64 + aarch64) via `nix store prefetch-file`
-- Prints SRI hashes and a ready-to-paste Nix snippet
-- **Does NOT edit any file** — it's read-only
+5. **Issue / branch / commit / PR.** If watcher `claude-code-update` issue
+   exists, reference it as `$ISSUE`. Otherwise create one. Use
+   `git commit --no-verify` (pre-commit statix hook hangs — established
+   workaround).
 
-Capture the script output. You need exactly three values:
-- `version`
-- x86_64-linux `hash`
-- aarch64-linux `hash`
+6. **Deploy.** p620 = local; razer/p510 = via SSH.
 
-## Step 3 — Edit `pkgs/claude-code-native/default.nix`
+### Rollback
 
-Update three lines:
+- `sudo nixos-rebuild switch --rollback` (per-host) OR `git revert`.
 
-```nix
-  version = "<NEW_VERSION>";
-  ...
-  sources = {
-    x86_64-linux = {
-      url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "<NEW_X64_HASH>";
-    };
-    aarch64-linux = {
-      url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "<NEW_ARM64_HASH>";
-    };
-  };
-```
+---
 
-**Do NOT change anything else** in the derivation.
+## B. Update `claude-desktop` (the Electron app)
 
-## Step 4 — Build and sanity-check
+Tracks `aaddrick/claude-desktop-debian` via a flake input (commit SHA, not
+tag — Nix's `github:` fetcher resolves tags to commits anyway).
 
-```bash
-nix build --no-link --print-out-paths .#claude-code-native
-# Take the printed path, verify:
-$(nix build --no-link --print-out-paths .#claude-code-native)/bin/claude --version
-# → 2.1.114 (Claude Code)
+**Runs on razer + p620 only.** p510 is headless — don't test anything UI-ish
+there.
 
-ldd $(nix build --no-link --print-out-paths .#claude-code-native)/bin/claude \
-  | grep -E "not found|missing" && echo "MISSING LIBS" || echo "libs OK"
-```
+### Prerequisites (same as A, plus:)
 
-If `--version` mismatches the target, abort and re-check the hash.
+- [ ] Check upstream release notes for breaking changes
+- [ ] Check upstream issue tracker for active regressions (especially
+      cowork / `_svcLaunched` / sandbox / node-pty)
+- [ ] If running claude-desktop right now, backup `~/.config/Claude`:
+      ```bash
+      cp -a ~/.config/Claude ~/.config/Claude.bak-$(date +%Y%m%d)
+      ```
 
-## Step 5 — Full host build matrix
+### Steps
 
-```bash
-# Parallel. Any failure → stop; fix before proceeding.
-just quick-test   # builds all 3 host closures
-# OR individually:
-nix build --no-link .#nixosConfigurations.p620.config.system.build.toplevel
-nix build --no-link .#nixosConfigurations.razer.config.system.build.toplevel
-nix build --no-link .#nixosConfigurations.p510.config.system.build.toplevel
-```
+1. **Inspect upstream.** Read BEFORE bumping:
+   ```bash
+   # Latest releases
+   gh api repos/aaddrick/claude-desktop-debian/releases --jq '.[:5] | .[] | {tag: .tag_name, published: .published_at, body_lines: (.body | split("\n") | .[0:5])}'
 
-## Step 6 — Issue → branch → commit → PR
+   # Open issues labeled regression / critical
+   gh issue list -R aaddrick/claude-desktop-debian --label "bug" --state open --limit 10
 
-```bash
-# Check for an existing auto-opened watcher issue first.
-gh issue list -l claude-code-update --search "$VERSION" --state open
+   # Commits between our pin and the candidate target
+   OURS=$(jq -r '.nodes."claude-desktop-linux".locked.rev' flake.lock)
+   TARGET=<tag-or-commit>
+   gh api "repos/aaddrick/claude-desktop-debian/compare/$OURS...$TARGET" \
+     --jq '.commits[] | "\(.sha[0:8]) \(.commit.message | split("\n")[0])"'
+   ```
 
-# If an issue exists, reference it as $ISSUE. If not, create one:
-gh issue create \
-  --label claude-code-update \
-  --title "chore(claude-code): update to $VERSION" \
-  --body "Bump claude-code-native from <OLD> to $VERSION.
+   **Red flags to stop on:**
+   - `_svcLaunched` still in open issues → Cowork daemon recovery broken
+   - Recent `build.sh` changes → our overlay's sed pattern may miss
+   - New `optionalDependencies` changes in claude npm → may require overlay rework
 
-Source: https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/$VERSION/manifest.json
-Release notes: https://github.com/anthropics/claude-code/releases/tag/v$VERSION"
+2. **Resolve target → commit SHA.**
+   ```bash
+   TAG=v1.3.32+claude1.3109.0                       # pick from releases list
+   TARGET=$(gh api "repos/aaddrick/claude-desktop-debian/git/ref/tags/$TAG" --jq '.object.sha')
+   echo "Will pin to: $TARGET"
+   ```
+   Or, if tracking `main` HEAD (for post-release fixes):
+   ```bash
+   TARGET=$(gh api repos/aaddrick/claude-desktop-debian/commits/main --jq '.sha')
+   ```
 
-# Standard issue-driven flow
-git checkout -b chore/<ISSUE>-claude-code-$VERSION
-git add pkgs/claude-code-native/default.nix
-git commit -m "chore(claude-code): update to $VERSION (#$ISSUE)
+3. **Edit `flake.nix`** — update the input URL AND its comment so future-you
+   knows what tag this SHA corresponds to:
+   ```nix
+   # = tag v1.3.32+claude1.3109.0 (2026-04-17) [or: main @ 4cc6cc21 (2026-04-19)]
+   claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/<TARGET>";
+   ```
 
-Bump claude-code-native from <OLD> to $VERSION via the GCS
-distribution channel (\`latest\`).
+4. **Lock + sanity-eval.**
+   ```bash
+   nix flake lock --update-input claude-desktop-linux
+   # Confirm the resolved rev
+   jq -r '.nodes."claude-desktop-linux".locked | "rev: \(.rev[0:10])\ndate: \(.lastModified | todate)"' flake.lock
+   ```
 
-- x86_64-linux hash refreshed
-- aarch64-linux hash refreshed
-- Verified: claude --version = $VERSION
-- Built all 3 host closures
+5. **Verify our overlay's sed pattern still matches upstream build.sh.**
+   ```bash
+   SRC=$(nix build --print-out-paths --no-link ".#inputs.claude-desktop-linux.outPath" 2>/dev/null \
+         || jq -r '.nodes."claude-desktop-linux".locked | "github:\(.owner)/\(.repo)/\(.rev)"' flake.lock \
+         | xargs -I{} nix eval --raw "{}" --apply 'x: x' 2>/dev/null)
+   grep -c 'Copying node-pty native binaries to unpacked directory' "$SRC/build.sh"
+   # Must be exactly 1. If 0, upstream finally removed it → remove our sed.
+   # If >1, sed may match more than intended → investigate.
+   ```
 
-Closes #$ISSUE
+6. **Build + verify the asar is correctly packed.**
+   ```bash
+   # Build the FHS wrapper (exposed via nixosConfigurations.razer.pkgs)
+   FHS=$(nix build --no-link --print-out-paths '.#nixosConfigurations.razer.pkgs.claude-desktop-linux')
+   INNER=$(nix-store -qR "$FHS" | grep -E "claude-desktop-1\.[0-9]" | head -1)
+   echo "Inner: $(basename $INNER)"
 
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+   # Linux pty.node is an ELF and present in .unpacked/
+   PTY="$INNER/lib/claude-desktop/electron/resources/app.asar.unpacked/node_modules/node-pty/build/Release/pty.node"
+   file "$PTY" | grep -q ELF && echo "OK: pty.node is ELF" || echo "FAIL: not ELF"
+   ```
 
-git push -u origin chore/<ISSUE>-claude-code-$VERSION
-gh pr create --fill
-gh pr merge --squash --delete-branch
-```
+7. **Host matrix.** claude-desktop only runs on razer + p620; p510 still
+   needs to BUILD (it's in the closure via overlay) but won't install UI.
+   ```bash
+   for h in p620 razer p510; do
+     nix build --no-link .#nixosConfigurations.$h.config.system.build.toplevel
+   done
+   ```
 
-If pre-commit hook hangs on statix (established precedent), use
-`git commit --no-verify` — this project has that as a known workaround.
+8. **Issue / branch / commit / PR.** Same pattern as claude-code.
+   Branch naming: `feat/<N>-claude-desktop-<tag>`.
 
-## Step 7 — Deploy
+9. **Deploy — razer first** (primary claude-desktop host):
+   ```bash
+   ssh razer 'cd ~/.config/nixos && git pull && sudo nixos-rebuild switch --flake .#razer'
+   # Verify on razer:
+   ssh razer 'pgrep -af "claude-desktop-1\.[0-9]"'
+   ```
+   Then p620 (user confirmation on timing — desktop requires quit-and-relaunch
+   to pick up the new binary; see "Idiot-proofing" below).
 
-```bash
-# Local host (p620)
-sudo nixos-rebuild switch --flake ~/.config/nixos#p620
+### Idiot-proofing (READ BEFORE DEPLOY)
 
-# Remote hosts (SSH aliases in ~/.ssh/config)
-ssh razer 'cd ~/.config/nixos && git pull && sudo nixos-rebuild switch --flake .#razer'
-ssh p510  'cd ~/.config/nixos && git pull && sudo nixos-rebuild switch --flake .#p510'
+- **claude-desktop is usually RUNNING** when you deploy. `nixos-rebuild
+  switch` activates the new generation but the existing Electron processes
+  keep running from the OLD store path until killed.
+- To use the new version: `pkill -f claude-desktop` then relaunch from app
+  menu. Warn the user before doing this — they'll lose in-flight state.
+- Always check the post-deploy process tree:
+  ```bash
+  ssh razer 'pgrep -af "claude-desktop-1\.[0-9]" | head -3'
+  # Should show the NEW inner hash. If OLD hash → user hasn't restarted.
+  ```
+- `~/.config/Claude/vm_bundles/` state is version-sensitive. After a major
+  bump (e.g. claude binary 1.2278→1.3109, ~800 version advance), a stale
+  bundle can cause "VM service not running" — see upstream issue #408.
+  First thing to try after a failed launch: `rm -rf ~/.config/Claude/vm_bundles/`
+  and relaunch.
 
-# Verify each
-for h in "" razer p510; do
-  out=$( [ -z "$h" ] && claude --version || ssh "$h" claude --version )
-  echo "${h:-local}: $out"
-done
-```
+### Rollback
 
-## Rollback
+- `sudo nixos-rebuild switch --rollback` OR `git revert` + redeploy.
 
-```bash
-# Option A: revert the commit, re-deploy
-git revert <COMMIT_SHA>
-git push
-
-# Option B: NixOS generation rollback (no git change)
-sudo nixos-rebuild switch --rollback
-```
+---
 
 ## Anti-patterns to avoid
 
-- ❌ Do NOT use `buildNpmPackage` — that's the deprecated path. Upstream
-  npm packaging changes (e.g. 2.1.113) will silently break your build.
-- ❌ Do NOT hand-compute hashes with `nix-prefetch-url` — use the script
-  (`nix store prefetch-file` is the modern, authenticated route).
-- ❌ Do NOT commit without running `claude --version` on the built binary.
-  A wrong hash produces a valid but stale binary.
-- ❌ Do NOT skip host builds. The 2 minutes you save loses 2 hours if
-  razer's NVIDIA stack regresses against the new binary.
+- ❌ Do NOT bump both packages in one PR. Each has different release cadence
+  and risk surface.
+- ❌ Do NOT assume "upstream fixed our overlay's bug → remove overlay". Verify
+  the specific fix landed in a reachable tag AND that no NEW bug replaces it
+  (e.g. v1.3.32 fixed the asar manifest, but introduced the read-only
+  `.unpacked/` cp regression we now patch).
+- ❌ Do NOT deploy to razer while the user has claude-desktop running unless
+  they've explicitly OK'd the pkill. Loss of in-flight state is user-facing.
+- ❌ Do NOT skip the 'grep -c "Copying node-pty native binaries"' check in
+  step B5 — if upstream removes that block, our sed becomes a silent no-op
+  and a subtly-broken build could land.
 
 ## Related files
 
-- `pkgs/claude-code-native/default.nix` — the package
-- `scripts/update-claude-code-native.sh` — the prefetch helper
+- `pkgs/claude-code-native/default.nix` — claude-code package
+- `scripts/update-claude-code-native.sh` — claude-code prefetch helper
+- `flake.nix` — `inputs.claude-desktop-linux` (pin) + claude-desktop overlay
 - `home/default.nix` — `programs.claude-code.package = pkgs.claude-code-native;`
-- `.github/workflows/claude-code-watch.yml` — hourly watcher that opens
-  issues when `/latest` advances
+- `.github/workflows/claude-code-watch.yml` — watcher for claude-code
+- `.github/workflows/claude-desktop-watch.yml` — watcher for claude-desktop
+
+## Watchers
+
+Both workflows run hourly. They compare upstream HEAD against the version
+pinned in the repo. When drift is detected they open a deduped issue with
+the appropriate label (`claude-code-update` or `claude-desktop-update`).
+This command handles both — just follow the relevant section.

--- a/.github/workflows/claude-desktop-watch.yml
+++ b/.github/workflows/claude-desktop-watch.yml
@@ -1,0 +1,146 @@
+# Poll aaddrick/claude-desktop-debian for a new release. When the latest
+# release tag's commit differs from the commit we pinned in flake.lock,
+# open a single tracking issue so the release notes can be reviewed
+# BEFORE running /update-claude-code.
+#
+# We compare by COMMIT SHA, not tag name, because upstream retags in
+# place when re-releasing with the same wrapper version + new claude
+# binary (e.g. v1.3.31+claude1.2773.0 → v1.3.31+claude1.3109.0). A
+# commit-level compare catches both new versions AND retags.
+#
+# Dedup: one issue per {upstream-commit, pinned-commit} pair. An already-
+# open tracking issue silences subsequent runs for that same drift.
+#
+# Related:
+#   .claude/commands/update-claude-code.md — bump workflow
+#   .github/workflows/claude-code-watch.yml — sibling for the CLI
+
+name: claude-desktop watch
+
+on:
+  schedule:
+    - cron: "17 * * * *"    # hourly at :17, offset from claude-code-watch
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve latest upstream release + pinned commit
+        id: v
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Latest release on aaddrick/claude-desktop-debian (any kind,
+          # including pre-releases — upstream uses semver tags like
+          # v1.3.32+claude1.3109.0 and doesn't mark pre-releases).
+          latest_tag=$(gh api repos/aaddrick/claude-desktop-debian/releases \
+            --jq '.[0].tag_name')
+          latest_commit=$(gh api "repos/aaddrick/claude-desktop-debian/git/ref/tags/$latest_tag" \
+            --jq '.object.sha' 2>/dev/null \
+            || gh api "repos/aaddrick/claude-desktop-debian/commits/$latest_tag" \
+            --jq '.sha')
+
+          # What we have pinned
+          pinned_commit=$(jq -r '.nodes."claude-desktop-linux".locked.rev' flake.lock)
+          pinned_date=$(jq -r '.nodes."claude-desktop-linux".locked.lastModified' flake.lock \
+            | xargs -I{} date -u -d @{} +%Y-%m-%dT%H:%M:%SZ)
+
+          if [ -z "$latest_tag" ] || [ -z "$latest_commit" ] || [ -z "$pinned_commit" ]; then
+            echo "Could not determine versions (tag=$latest_tag commit=$latest_commit pin=$pinned_commit)" >&2
+            exit 1
+          fi
+
+          echo "latest_tag=$latest_tag"       >>"$GITHUB_OUTPUT"
+          echo "latest_commit=$latest_commit" >>"$GITHUB_OUTPUT"
+          echo "pinned_commit=$pinned_commit" >>"$GITHUB_OUTPUT"
+          echo "pinned_date=$pinned_date"     >>"$GITHUB_OUTPUT"
+          echo "latest=$latest_tag ($latest_commit) pinned=$pinned_commit"
+
+      - name: Exit if no drift
+        if: steps.v.outputs.latest_commit == steps.v.outputs.pinned_commit
+        run: echo "pinned == latest ($pinned_commit) — nothing to do"
+
+      - name: Dedup — skip if an issue for this upstream commit already exists
+        if: steps.v.outputs.latest_commit != steps.v.outputs.pinned_commit
+        id: dedup
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.v.outputs.latest_tag }}
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list \
+            --label claude-desktop-update \
+            --state all \
+            --search "in:title \"claude-desktop: update to $TAG\"" \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Issue #$existing already tracks $TAG — skipping"
+            echo "skip=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch release notes for context
+        if: steps.v.outputs.latest_commit != steps.v.outputs.pinned_commit && steps.dedup.outputs.skip != 'true'
+        id: notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.v.outputs.latest_tag }}
+        run: |
+          set -euo pipefail
+          notes=$(gh release view "$TAG" -R aaddrick/claude-desktop-debian \
+            --json body --jq '.body // ""' 2>/dev/null | head -40)
+          # Multi-line output via heredoc syntax
+          {
+            echo 'body<<EOF'
+            echo "$notes"
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Open tracking issue
+        if: steps.v.outputs.latest_commit != steps.v.outputs.pinned_commit && steps.dedup.outputs.skip != 'true'
+        env:
+          GH_TOKEN:      ${{ secrets.GITHUB_TOKEN }}
+          TAG:           ${{ steps.v.outputs.latest_tag }}
+          LATEST_COMMIT: ${{ steps.v.outputs.latest_commit }}
+          PINNED_COMMIT: ${{ steps.v.outputs.pinned_commit }}
+          PINNED_DATE:   ${{ steps.v.outputs.pinned_date }}
+          NOTES:         ${{ steps.notes.outputs.body }}
+        run: |
+          set -euo pipefail
+          gh issue create \
+            --label claude-desktop-update \
+            --title "chore(claude-desktop): update to $TAG" \
+            --body "Upstream \`aaddrick/claude-desktop-debian\` has a new release: **$TAG**.
+
+- Currently pinned commit: \`${PINNED_COMMIT:0:10}\` (locked $PINNED_DATE)
+- Latest release commit:   \`${LATEST_COMMIT:0:10}\` (tag \`$TAG\`)
+
+### Release notes
+
+$NOTES
+
+### Links
+
+- Release: https://github.com/aaddrick/claude-desktop-debian/releases/tag/$TAG
+- Compare: https://github.com/aaddrick/claude-desktop-debian/compare/${PINNED_COMMIT}...${LATEST_COMMIT}
+- Open issues (regression watch): https://github.com/aaddrick/claude-desktop-debian/issues?q=is%3Aissue+is%3Aopen+label%3Abug
+
+### To act on this
+
+Run \`/update-claude-code\` in Claude Code and follow the **B. Update
+claude-desktop** section. **Read the release notes first** — upstream
+occasionally ships regressions (e.g. v1.3.31 broke Cowork daemon recovery)
+and our overlay may need a patch rev.
+
+This issue will auto-close when that PR merges."

--- a/flake.lock
+++ b/flake.lock
@@ -132,17 +132,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1776130753,
-        "narHash": "sha256-CWrwYni9qluaBppQfi2sR/e/uLS+xljt6k2EioPQ54M=",
+        "lastModified": 1776580440,
+        "narHash": "sha256-RbyLmh3dO+WVsLk1AP9BB8McN3yxMRgbqjrTAuUCfKw=",
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "89208a596a3e876a74f865fb5267996f666f4a09",
+        "rev": "4cc6cc2183fec7160963a774944d77b6a8c12c2d",
         "type": "github"
       },
       "original": {
         "owner": "aaddrick",
+        "ref": "4cc6cc2183",
         "repo": "claude-desktop-debian",
-        "rev": "89208a596a3e876a74f865fb5267996f666f4a09",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -72,10 +72,12 @@
     # Additional tools
     lan-mouse.url = "github:feschber/lan-mouse";
     zjstatus.url = "github:dj95/zjstatus";
-    # Pinned to v1.3.30+claude1.2278.0 — v1.3.31+claude1.2773.0 has a
-    # regression (upstream #408) where _svcLaunched guard never clears,
-    # breaking Cowork VM daemon respawn after any failure/crash.
-    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/89208a596a3e876a74f865fb5267996f666f4a09";
+    # = main @ 4cc6cc2183 (2026-04-19), includes post-v1.3.32 fixes: AppArmor
+    # bwrap probe diagnosis, cowork daemon recovery backport (#408), bwrap
+    # home-dir ordering, SDK binary routing. Upstream commit 3150477 fixed
+    # the node-pty asar-manifest bug that our overlay previously patched; no
+    # overlay is needed from v1.3.32 on. Bump via /update-claude-code.
+    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/4cc6cc2183";
 
     # Terminal YouTube browser
     yt-x = {
@@ -231,58 +233,42 @@
         (_final: prev: {
           zjstatus = inputs.zjstatus.packages.${prev.stdenv.hostPlatform.system}.default;
         })
-        # Claude Desktop from aaddrick/claude-desktop-debian (FHS variant; tracks latest
-        # upstream version with Cowork/Local Agent Mode via bubblewrap sandbox).
+        # Claude Desktop from aaddrick/claude-desktop-debian (FHS variant;
+        # bubblewrap-sandboxed Cowork / Local Agent Mode).
+        #
+        # Upstream v1.3.32+ fixed the node-pty asar-manifest bug in 3150477, so
+        # we no longer need the full asar-repack overlay. However, they kept a
+        # legacy "copy node-pty natives to .unpacked/" cp step in build.sh that
+        # races the new `asar pack --unpack "**/*.node"` path: asar creates
+        # .unpacked/ read-only, then the legacy cp fails in Nix sandbox with
+        # "Permission denied". We patch it out in postPatch.
+        # See /update-claude-code for the bump workflow.
         (_final: prev:
           let
             system = prev.stdenv.hostPlatform.system;
             upstream = inputs.claude-desktop-linux.packages.${system};
-            # Upstream ships Windows node-pty binaries packed inside app.asar,
-            # shadowing the Linux ELF pty.node in app.asar.unpacked/. Electron
-            # then tries to dlopen the Windows DLL from the packed asar and fails
-            # with "Failed to load native module: pty.node". Fix by re-packing
-            # app.asar with the Linux pty.node swapped in, stripping Windows-only
-            # binaries, and marking *.node entries as unpacked so Electron
-            # redirects lookups to app.asar.unpacked/ at runtime.
-            # Upstream tracking: https://github.com/aaddrick/claude-desktop-debian/issues/401
+            # A standalone derivation producing a patched build.sh. The
+            # original comes from the flake input's root. We strip the
+            # legacy cp-to-.unpacked/ block that `finalize_app_asar()`
+            # leaves in place — redundant since upstream's
+            # `asar pack --unpack "**/*.node"` already placed the .node
+            # files, AND failing in Nix sandbox because .unpacked/ is
+            # read-only post-pack. Upstream commit 3150477 acknowledged
+            # this step as "redundant but harmless" — for Nix, not harmless.
+            patchedBuildSh = prev.runCommand "claude-desktop-build-sh-patched" { } ''
+              cp ${inputs.claude-desktop-linux}/build.sh $out
+              chmod +w $out
+              sed -i '/Copying node-pty native binaries to unpacked directory/,/node-pty native binaries copied/c\		echo "skipped legacy .unpacked/ cp (handled by --unpack; Nix patch)"' $out
+            '';
             claude-desktop-patched = upstream.claude-desktop.overrideAttrs (old: {
-              nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ prev.asar ];
-              postInstall = (old.postInstall or "") + ''
-                ASAR_DIR=$out/lib/claude-desktop/electron/resources
-                WORK=$(mktemp -d)
-                asar extract "$ASAR_DIR/app.asar" "$WORK/extracted"
-
-                # Replace Windows pty.node (PE32) with Linux pty.node (ELF) from .unpacked/
-                cp -f "$ASAR_DIR/app.asar.unpacked/node_modules/node-pty/build/Release/pty.node" \
-                      "$WORK/extracted/node_modules/node-pty/build/Release/pty.node"
-
-                # Strip Windows-only companion binaries (unused on Linux, cleanup)
-                rm -f "$WORK/extracted/node_modules/node-pty/build/Release/conpty.node" \
-                      "$WORK/extracted/node_modules/node-pty/build/Release/conpty_console_list.node" \
-                      "$WORK/extracted/node_modules/node-pty/build/Release/winpty-agent.exe" \
-                      "$WORK/extracted/node_modules/node-pty/build/Release/winpty.dll"
-
-                # Provide prebuilds/linux-x64/ path (node-pty fallback when
-                # process.versions.modules is empty in Electron -> "//" lookup)
-                mkdir -p "$WORK/extracted/node_modules/node-pty/prebuilds/linux-x64"
-                ln -sf ../../build/Release/pty.node \
-                  "$WORK/extracted/node_modules/node-pty/prebuilds/linux-x64/node.napi.node"
-                ln -sf ../../build/Release/pty.node \
-                  "$WORK/extracted/node_modules/node-pty/prebuilds/linux-x64/electron.napi.node"
-
-                # Repack: --unpack "*.node" marks every *.node entry as unpacked
-                # in the asar header, so Electron redirects to app.asar.unpacked/
-                chmod -R u+w "$ASAR_DIR"
-                rm -rf "$ASAR_DIR/app.asar" "$ASAR_DIR/app.asar.unpacked"
-                asar pack "$WORK/extracted" "$ASAR_DIR/app.asar" --unpack "*.node"
-
-                # Sanity: Linux ELF must be in the post-repack .unpacked/ tree
-                PTY_OUT="$ASAR_DIR/app.asar.unpacked/node_modules/node-pty/build/Release/pty.node"
-                [ -f "$PTY_OUT" ] || { echo "ERROR: Linux pty.node missing after repack"; exit 1; }
-                file "$PTY_OUT" | grep -q ELF || { echo "ERROR: $PTY_OUT is not ELF"; exit 1; }
-
-                rm -rf "$WORK"
-              '';
+              # Replace the reference to upstream's build.sh with our patched one.
+              # Upstream's cleanSourceWith(src = ./..) evaluates to the input's
+              # raw outPath for this repo's filter set, so the string match is
+              # deterministic as long as upstream keeps that pattern.
+              buildPhase = prev.lib.replaceStrings
+                [ "bash ${inputs.claude-desktop-linux}/build.sh" ]
+                [ "bash ${patchedBuildSh}" ]
+                old.buildPhase;
             });
           in
           {


### PR DESCRIPTION
## Summary
- Bump `claude-desktop-linux` flake input from `89208a596a` (v1.3.30+claude1.2278.0) → `4cc6cc2183` (main @ 2026-04-19). ~30 commits forward, includes v1.3.32's node-pty asar fix plus post-v1.3.32 bugfixes.
- Shrink the claude-desktop overlay from 60 lines → minimal build.sh sed (upstream fixed the asar issue; we only patch their leftover-but-Nix-breaking cp step).
- Rewrite `/update-claude-code` to cover BOTH packages (claude-code CLI + claude-desktop GUI) with disambiguation, idiot-proofing, and rollback.
- Add `.github/workflows/claude-desktop-watch.yml` — hourly cron, opens tracking issue when aaddrick's latest release commit differs from our pin.

## Verified
- [x] Inner `claude-desktop-1.3109.0` builds with the Nix build.sh patch
- [x] `.unpacked/.../pty.node` is Linux ELF 64-bit (upstream's fix + our patch both in effect)
- [x] All 3 host closures build: p620, razer, p510
- [x] Update script sanity: `./scripts/update-claude-code-native.sh` still works
- [ ] Deploy p620 and verify (next step in this PR's workflow)

## Scope
- **Installed on:** razer + p620. p510 is headless (no GUI) but still builds the closure.
- **Deploy scope:** p620 only. razer stays for user to deploy when ready.

## Risks
- Our `build.sh` sed pattern must match one line that upstream may change. Step B5 of `/update-claude-code` adds a pre-bump check (`grep -c "Copying node-pty native binaries to unpacked directory"` must be `1`).
- Claude binary jump 1.2278.0 → 1.3109.0 (~830 versions). `~/.config/Claude/vm_bundles/` state may be incompatible; doc notes `rm -rf vm_bundles/` as the first recovery step if launches fail.

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)