### PR TITLE
chore(flake): bump nixpkgs 4bd9165 → b12141e, home-manager + nur

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -808,11 +808,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776661682,
-        "narHash": "sha256-X32LTSDqUdVqMy85WYdRgyt0I75wc4Lhi9j+lrCDR8w=",
+        "lastModified": 1776701552,
+        "narHash": "sha256-CCRzOEFg6JwCdZIR5dLD0ypah5/e2JQVuWQ/l3rYrPY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4bfce11ea820df0359f73736fd59c7e8f53641a6",
+        "rev": "c81775b640d4507339d127f5adb4105f6015edf2",
         "type": "github"
       },
       "original": {
@@ -1182,11 +1182,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {
@@ -1214,11 +1214,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {
@@ -1354,11 +1354,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {
@@ -1390,11 +1390,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1776679267,
-        "narHash": "sha256-SW3OGbLSo4w0Uh6wHfD5gYnvMRYwvKLW3EBX+TBHcA4=",
+        "lastModified": 1776714245,
+        "narHash": "sha256-YIGmC6rumRIgDYTf0Sx5rSrfRxv6XXOAPbqSyHFJ49w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dd785f4fd2fdb039e8fe6c72a729912a0debc4ce",
+        "rev": "89328aa9113694352542d6b2abeabaa325db0af2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
Bumps nixpkgs to `b12141e` (2026-04-18) + home-manager + nur to 2026-04-20 tips. First real nixpkgs cascade since 2026-04-14 lock.

## What changes
- COSMIC suite: 1.0.8 → **1.0.10** (all 22 cosmic-* packages)
- vscode: 1.115 → **1.116**
- cursor: 3.0.16 → 3.1.15
- mesa: 26.0.4 → 26.0.5
- nvidia-x11: 6.18.22 → 6.18.23
- ROCm stack: 7.2.1 → 7.2.2
- Home Manager module: 2026-03-13 → 2026-04-14
- ~80 other routine upstream updates

## Test plan
- [x] p620 already running this state (gen 1901)
- [x] Identical system closure hash as gen 1899 which ran successfully overnight
- [ ] razer/p510: will build when you're ready (per standing policy not touching them from this session)

## Why this exists
Yesterday's gen 1899 used this lock locally (dirty, uncommitted). Gen 1900 accidentally reverted to origin/main's older lock — surprise downgrade. This PR syncs git with reality.

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)