### PR TITLE
chore: rescue useful commits from PR #304 (razer tailscale + virt creds)

### DIFF
--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -72,7 +72,13 @@ in
   # Tailscale VPN using built-in NixOS service
   services.tailscale = {
     enable = true;
-    useRoutingFeatures = "client"; # Accept routes from other nodes
+    # "none": do not accept subnet routes. razer is directly on 192.168.1.0/24,
+    # and p510 advertises that same /24 as a subnet route. With accept-routes on,
+    # razer's routing table 52 sent LAN-destined replies back through tailscale0,
+    # causing asymmetric routing that broke TCP/ICMP to LAN peers (e.g. p620).
+    # Note: flipping this flag in Nix does not rewrite tailscale's persisted
+    # prefs; run `sudo tailscale set --accept-routes=false` once after switch.
+    useRoutingFeatures = "none";
     openFirewall = true;
   };
 

--- a/modules/virt/virt.nix
+++ b/modules/virt/virt.nix
@@ -62,16 +62,26 @@ in
         "L+ /var/lib/qemu/firmware - - - - ${pkgs.qemu}/share/qemu/firmware"
       ];
       services.libvirtd.restartIfChanged = false;
-      # Fix virt-secret-init-encryption crash on hosts without working TPM2
-      # systemd-creds encrypt fails with assertion error when TPM2 is unavailable.
-      # Generate a raw 256-bit key file directly instead.
+      # Fix virt-secret-init-encryption on hosts without working TPM2.
+      # Upstream runs `systemd-creds encrypt` which defaults to TPM2+host and
+      # fails when TPM2 is unavailable/broken. Force --with-key=host so the
+      # key is encrypted with /var/lib/systemd/credential.secret only.
+      # The libvirtd unit uses LoadCredentialEncrypted= which requires this
+      # file to be in systemd-creds encrypted format (not raw bytes).
       services.virt-secret-init-encryption.serviceConfig.ExecStart = lib.mkForce
         (
           let
             script = pkgs.writeShellScript "virt-secret-init-encryption" ''
+              set -eu
               umask 0077
               mkdir -p /var/lib/libvirt/secrets
-              dd if=/dev/random of=/var/lib/libvirt/secrets/secrets-encryption-key bs=32 count=1 status=none
+              out=/var/lib/libvirt/secrets/secrets-encryption-key
+              if [ ! -s "$out" ] || ! ${pkgs.systemd}/bin/systemd-creds --with-key=host decrypt --name=secrets-encryption-key "$out" /dev/null >/dev/null 2>&1; then
+                tmp=$(${pkgs.coreutils}/bin/mktemp)
+                ${pkgs.coreutils}/bin/dd if=/dev/random of="$tmp" bs=32 count=1 status=none
+                ${pkgs.systemd}/bin/systemd-creds --with-key=host encrypt --name=secrets-encryption-key "$tmp" "$out"
+                ${pkgs.coreutils}/bin/rm -f "$tmp"
+              fi
             '';
           in
           "${script}"


### PR DESCRIPTION
## Summary
PR #304 (open since 2026-04-15, conflicted) has 3 commits. This PR lands the two still-useful ones on a clean base and closes #304.

- Obsolete: commit \`94142f61\` — local repackage of claude-desktop v1.3.30. Superseded by PR #325 which migrated to the aaddrick flake input at v1.3.32+claude1.3109.0.
- Cherry-picked: \`bdeae4b8\` → razer: \`services.tailscale.useRoutingFeatures = \"none\"\` (fixes razer↔p620 LAN routing asymmetry).
- Cherry-picked: \`8ac21618\` → libvirt: replace raw-bytes key workaround with \`systemd-creds --with-key=host\` encryption.

## Post-deploy manual step (razer only)

After the razer rebuild, tailscale's persisted prefs still carry the old accept-routes=true. Run **once**:
\`\`\`
sudo tailscale set --accept-routes=false
\`\`\`

## Test plan
- [x] \`nix build .#nixosConfigurations.razer.config.system.build.toplevel\` ✅
- [x] \`nix build .#nixosConfigurations.p620.config.system.build.toplevel\` ✅
- [ ] User-driven: \`just update-commit-deploy razer\` when ready (will trigger deploy since razer will become stale after merge)

Closes #334 and supersedes #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)