### PR TITLE
feat(nhs): rebind nhs to update-commit-deploy + docs + passwordless sudo fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -769,6 +769,8 @@ just perf-test
 
 ### Fast Deployment (Optimized)
 
+**For lock bumps + deploy in one idiot-proof command, see [docs/UPDATE-DEPLOY.md](./docs/UPDATE-DEPLOY.md).** TL;DR: `nhs [HOST] [SCOPE]` or `just update-commit-deploy [HOST] [SCOPE]` handles `nix flake update → test-build → commit + push → nh switch` atomically, works for local AND remote hosts, and refuses to run if the working tree is dirty.
+
 ```bash
 # Deploy to local system
 just deploy
@@ -777,6 +779,12 @@ just deploy
 just quick-deploy p620    # Deploy P620 only if configuration changed
 just quick-deploy razer   # Deploy Razer only if configuration changed
 just quick-deploy p510    # Deploy P510 only if configuration changed
+
+# RECOMMENDED for routine lock bumps: idiot-proof flow (see docs/UPDATE-DEPLOY.md)
+nhs                        # update+deploy current host, nixpkgs scope
+nhs razer                  # remote deploy via nh --target-host
+nhs p510 all               # update all inputs, deploy p510
+just update-commit-deploy razer home-manager  # single-input scope
 
 # Standard optimized deployment to specific hosts
 just p620    # AMD workstation with ROCm (optimized)

--- a/docs/UPDATE-DEPLOY.md
+++ b/docs/UPDATE-DEPLOY.md
@@ -1,0 +1,128 @@
+# NixOS Update & Deploy — `just update-commit-deploy` / `nhs`
+
+One command that does the full, idiot-proof update-and-deploy flow: bump the
+flake lock, commit it, push it, build, switch. Works for the local machine
+and for remote hosts over SSH.
+
+## TL;DR
+
+```bash
+nhs                 # update+deploy current host, nixpkgs scope
+nhs razer           # deploy razer (remote via SSH/nh)
+nhs p510 all        # update all inputs, deploy p510
+nhs razer home-manager  # bump one specific input
+```
+
+Or the explicit form:
+
+```bash
+just update-commit-deploy HOST [SCOPE]
+```
+
+Both invoke the same script: `scripts/update-commit-deploy.sh`.
+
+## What it does (in order)
+
+1. **Pre-flight**
+   - Must be on branch `main`
+   - Working tree must be clean — only `flake.lock` may be dirty
+   - If HOST is remote: check SSH reachability. Abort early if not.
+2. **Update** — `nix flake update <SCOPE>` (default `nixpkgs`; accepts `all` or any input name)
+3. **Freshness check** — cheap `nix eval --raw` to compute what the target's
+   closure should be, compared against its current `/run/current-system`.
+   If lock didn't change AND host already on latest → exit "nothing to do".
+4. **Show delta** — nixpkgs rev + list of all bumped flake inputs with dates
+5. **Build** the target host closure. Abort if build fails (no commit).
+6. **Commit + push** — only if the lock actually changed. Commits `flake.lock`
+   directly to `main` with an auto-generated message, then `git push`. Abort if push fails (no orphan drift).
+7. **Switch** via `nh os switch`:
+   - local: `nh os switch --hostname HOST .`
+   - remote: `nh os switch --hostname HOST --target-host HOST .`
+     (builds on the local machine and ships the closure over SSH)
+
+## State machine
+
+| Lock changed | Host stale | Outcome |
+|---|---|---|
+| no  | no  | exit "nothing to do" |
+| no  | yes | skip commit, still deploy (catch stale host up) |
+| yes | yes | commit + push + deploy (main path) |
+
+## Arguments
+
+| Position | Name | Default | Values |
+|---|---|---|---|
+| 1 | `HOST` | `$(hostname)` | any name in `flake.nix` `nixosConfigurations.*` |
+| 2 | `SCOPE` | `nixpkgs` | `all`, `nixpkgs`, or any specific input name |
+
+### Common scopes
+
+- `nixpkgs` — only the root nixpkgs input (default, most common)
+- `all` — update every input in the flake
+- `home-manager`, `claude-desktop-linux`, `sops-nix`, ... — any input name from `flake.nix`
+
+## Idiot-proofing guarantees
+
+- **Never orphan a lock.** Commit + push happen BEFORE switch. If push fails, abort before any deploy.
+- **Dirty-tree safety.** Refuses to run if unrelated dirty files exist — forces you to clean up first.
+- **Build-first.** Test-build must succeed before any commit. Build failure = lock stays dirty, nothing committed, nothing deployed.
+- **Freshness-aware.** If the lock is unchanged but the target host is behind, deploys anyway.
+- **Fails loud.** Every failure path prints a clear remediation hint and rolls back to a sane state.
+
+## Remote host requirements
+
+- SSH alias in `~/.ssh/config` (or fully-qualified name)
+- `~/.config/nixos` on the remote is a git clone of this repo with no local edits (the script's freshness check only reads `/run/current-system`; the actual deploy is handled by `nh os switch --target-host`, which ships the closure over SSH from your local machine)
+- Passwordless sudo for your user OR `nh`'s elevation strategy kicks in (we already have `NOPASSWD: ALL` on p620/razer/p510)
+- SSH key loaded in `ssh-agent` (no password prompts)
+
+## The `nhs` shortcut
+
+`nhs` is a zsh function defined in `home/shell/zsh.nix`. It wraps `just update-commit-deploy` so the muscle-memory alias works the same way from any directory:
+
+```zsh
+nhs() {
+  (cd ~/.config/nixos && just update-commit-deploy "$@")
+}
+```
+
+Before 2026-04-21 `nhs` was `alias nhs="nh os switch"` — a raw `nh` invocation. The new form adds lock commit + freshness check + push safety.
+
+## Examples
+
+```bash
+# Typical: bump nixpkgs, deploy to the current host
+$ nhs
+>> pre-flight: checking working tree state
+>> current nixpkgs pin: b12141ef61 (2026-04-18T21:33:21Z)
+>> nix flake update nixpkgs
+>> no lock changes — nothing to commit or deploy.
+
+# razer is behind — deploy without a lock bump
+$ nhs razer
+>> freshness check: evaluating expected closure for razer
+>> lock unchanged — but razer is stale (running ...); deploying current state
+>> building .#nixosConfigurations.razer.config.system.build.toplevel
+...
+
+# Pull in new home-manager + deploy to razer
+$ nhs razer home-manager
+
+# Update everything + deploy to current host
+$ nhs $(hostname) all
+```
+
+## Files
+
+- `scripts/update-commit-deploy.sh` — the script
+- `Justfile` — `update-commit-deploy` recipe
+- `home/shell/zsh.nix` — `nhs` function
+
+## Related
+
+- `just update` (`nh os update`) — plain nh update, no commit
+- `just update-flake` — `nix flake update` then `just deploy`, no commit
+- `just quick-deploy HOST` — smart-deploy-if-changed without touching the lock
+- `just deploy` — local-only switch via nh
+
+For everything else, see `just --list`.

--- a/home/shell/zsh.nix
+++ b/home/shell/zsh.nix
@@ -584,6 +584,21 @@ with lib; {
         # Modern tool configurations
         export BAT_THEME="gruvbox-dark"
         export EZA_COLORS="da=1;34:gm=1;34"
+
+        # nhs: idiot-proof NixOS update+switch.
+        # Wraps `just update-commit-deploy` so muscle-memory `nhs [HOST] [SCOPE]`
+        # now does the full flow: nix flake update → commit + push → build →
+        # switch (local OR remote via nh --target-host). Runs in a subshell so
+        # the user's cwd isn't affected. See docs/UPDATE-DEPLOY.md for details.
+        #
+        # Usage:
+        #   nhs                   # current host, nixpkgs scope
+        #   nhs razer             # remote deploy to razer
+        #   nhs p620 all          # update all inputs
+        #   nhs razer home-manager  # bump one specific input
+        nhs() {
+          (cd ~/.config/nixos && just update-commit-deploy "$@")
+        }
       '';
 
       # Optimized Oh My Zsh configuration with essential plugins only
@@ -623,8 +638,11 @@ with lib; {
         lr = "eza --icons=auto --color=auto --long --reverse --sort=modified --group-directories-first";
         lz = "eza --icons=auto --color=auto --long --sort=size --group-directories-first";
 
-        # NixOS management aliases
-        nhs = "nh os switch";
+        # NixOS management aliases.
+        # NOTE: `nhs` is deliberately NOT an alias here — it's defined as a
+        # zsh function in initContent below so it can wrap `just update-commit-deploy`
+        # (the idiot-proof update flow). The function preserves the "nhs HOST"
+        # muscle memory while adding lock-commit + freshness-aware deploy.
         nhu = "nh home switch";
 
         # Safe unique aliases

--- a/scripts/update-commit-deploy.sh
+++ b/scripts/update-commit-deploy.sh
@@ -212,10 +212,16 @@ fi
 #
 # We pass "." as the flake path (current dir). --hostname selects which
 # nixosConfigurations.<name> to build.
+# All our hosts (p620, razer, p510) are configured with NOPASSWD: ALL for
+# olafkfreund. Pass --elevation-strategy passwordless so nh never tries to
+# prompt for a sudo password on the remote — otherwise nh's default 'auto'
+# strategy can still block on a TTY prompt even with NOPASSWD configured.
+ELEV=(--elevation-strategy passwordless)
+
 case "$MODE" in
   local)
     log "nh os switch --hostname ${HOST} .  (local)"
-    if ! nh os switch --hostname "$HOST" .; then
+    if ! nh os switch "${ELEV[@]}" --hostname "$HOST" .; then
       err "local switch failed — commit is on origin/main. Investigate via \`journalctl -xe\` or rollback via \`nh os rollback\`."
     fi
     ;;
@@ -224,8 +230,8 @@ case "$MODE" in
     # locally (this machine, typically p620) and ship the closure rather
     # than burn remote CPU — faster and lets slow hosts (p510) off easy.
     # The --build-host flag is omitted so nh defaults to local build.
-    log "nh os switch --hostname ${HOST} --target-host ${HOST} .  (remote, build local)"
-    if ! nh os switch --hostname "$HOST" --target-host "$HOST" .; then
+    log "nh os switch --hostname ${HOST} --target-host ${HOST} .  (remote, build local, passwordless sudo)"
+    if ! nh os switch "${ELEV[@]}" --hostname "$HOST" --target-host "$HOST" .; then
       err "remote switch on ${HOST} failed — commit is on origin/main. SSH in and investigate: \`ssh ${HOST} 'journalctl -xe'\` or rollback via \`ssh ${HOST} 'nh os rollback'\`."
     fi
     ;;


### PR DESCRIPTION
## Summary
- \`nhs [HOST] [SCOPE]\` now runs the idiot-proof update flow (was raw \`nh os switch\`).
- \`--elevation-strategy passwordless\` added to nh calls — fixes the remote sudo prompt you were seeing on razer.
- New \`docs/UPDATE-DEPLOY.md\` covering everything; linked from CLAUDE.md's Fast Deployment section.

## Test plan
- [x] \`nix build .#nixosConfigurations.p620...\` builds clean (zsh.nix change doesn't break eval)
- [ ] After merge + rebuild on p620: \`nhs razer\` — should now proceed without any password prompt

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)