### PR TITLE
fix(nvim): pin blink.cmp to 1.x for prebuilt Rust matcher binary

### DIFF
--- a/home/shell/lazyvim/lazyvim/lua/plugins/blink.lua
+++ b/home/shell/lazyvim/lazyvim/lua/plugins/blink.lua
@@ -6,7 +6,12 @@ return {
       "rafamadriz/friendly-snippets",
       "folke/lazydev.nvim",
     },
-    version = false, -- use latest git commit for stability with LazyVim
+    -- Pin to 1.x releases so lazy.nvim picks up upstream's prebuilt Rust
+    -- matcher binary (linux-x86_64.gz asset on each release). Using `false`
+    -- (main HEAD) means no prebuilt is available, and since this is
+    -- Nix-managed nvim — no cargo in the runtime — blink falls back to the
+    -- Lua matcher and emits a loud warning on every startup.
+    version = "1.*",
     opts = {
       keymap = {
         preset = "enter",


### PR DESCRIPTION
Fixes the recurring 'No fuzzy matching library found!' warning in nvim.

Root cause: upstream blink.cmp only ships prebuilt Rust binaries on tagged releases; our spec followed main HEAD which has no prebuilt. On Nix-managed nvim there's no cargo, so blink fell back to Lua.

Fix: `version = "1.*"`.

Closes #344