### PR TITLE
chore(gitignore): ignore Claude Code ScheduleWakeup lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,12 @@ result-*
 *.swo
 *~
 
+# Claude Code runtime artifacts (the .claude/ tree itself is tracked,
+# but ScheduleWakeup writes a transient JSON lockfile here that must not be
+# committed — otherwise nhs/update-commit-deploy aborts on dirty tree.)
+.claude/scheduled_tasks.lock
+.claude/*.lock
+
 # OS generated files
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary

The `.claude/` tree is intentionally tracked (commands, agents, skills),
but Claude Code's `ScheduleWakeup` runtime writes a transient
`.claude/scheduled_tasks.lock` JSON file. Without an ignore rule, that
lockfile shows as untracked and trips the working-tree-clean pre-flight
check in `scripts/update-commit-deploy.sh`, aborting `nhs` deploys.

This adds two ignore patterns: the specific lockfile name, and a
defensive `.claude/*.lock` glob in case the runtime introduces other
lockfiles in the same directory.

## Test plan

- [x] `git status` no longer shows `.claude/scheduled_tasks.lock` as untracked
- [ ] `nhs p620` passes pre-flight (verified by user post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)