### PR TITLE
chore(office): consolidate suite to libreoffice-fresh

### DIFF
--- a/modules/office/default.nix
+++ b/modules/office/default.nix
@@ -15,8 +15,7 @@ in
   };
   config = mkIf cfg.enable {
     environment.systemPackages = with pkgs; [
-      freeoffice
-      onlyoffice-desktopeditors
+      libreoffice-fresh
     ];
   };
 }


### PR DESCRIPTION
## Summary

Replace `freeoffice` + `onlyoffice-desktopeditors` with `libreoffice-fresh` on hosts that have `programs.office.enable = true` (p620 + razer). p510 unaffected (module disabled there).

Closes #360.

## Test plan

- [x] `git diff` confirms 1 file, +1/-2
- [x] `libreoffice-fresh-26.2.1.2-wrapped` narinfo verified in `cache.nixos.org` (no source build)
- [x] p620 + razer toplevel builds reached final activation scripts (initrd, boot.json) without errors before being interrupted
- [ ] Deploy verified post-merge — `nhs p620` then `nhs razer`, then launch LibreOffice

🤖 Generated with [Claude Code](https://claude.com/claude-code)