### PR TITLE
chore(flake): bump nixpkgs to 0726a0ec

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1376,11 +1376,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Auto-generated lock bump from `nhs p620 nixpkgs`. The push from
`scripts/update-commit-deploy.sh` was rejected by the `main` branch
protection rule ("Changes must be made through a pull request"), so
the commit is being landed via PR instead.

- Scope: `nixpkgs`
- From: `b12141ef`
- To:   `0726a0ec` (current `nixos-unstable` HEAD per `/check-nixos-issues` audit earlier this session)
- Build verification: full p620 toplevel built locally (1h33m, included
  large source builds: chromium-derivative + ROCm closures
  hipblaslt-7.2.2 / rocblas-7.2.2 / rocsolver-7.2.2 / rocsparse-7.2.2
  which are now reachable from cache.nixos.org).

## Test plan

- [x] `flake.lock` only — no other files changed
- [x] p620 system-path build succeeded (the `>> build succeeded` step in `nhs`)
- [ ] Deploy via `nh os switch` after merge — build artifact already in store, activation will be fast
- [ ] Follow-up: fix `scripts/update-commit-deploy.sh` to use the PR flow instead of direct push (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)