### PR TITLE
chore(claude-code): bump 2.1.119 → 2.1.121

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.119";
+  version = "2.1.121";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-zKQwU/BilJSVWWsRtv0bWc95ECrbE7rL5mmX5vrkHko=";
+      hash = "sha256-tLaEu8s6iAKexBnbwIgksvPGllagqiN0hg+VJfxnyY8=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-OCqnPqSwf9jWmOMVm1754bhzn651BbqN3Si4pqYoGc4=";
+      hash = "sha256-cbeOY2T5eiJ7F75A38wjdGH40rHRCURNJLQq8P3vrDE=";
     };
   };
 


### PR DESCRIPTION
## Summary

Routine bump of the `claude-code` CLI binary. Tracks Anthropic's latest channel.

| | |
|---|---|
| Previous | `2.1.119` |
| New | `2.1.121` |
| Files changed | 1 (3 lines: version + 2 hashes) |

## Verification

- ✅ `nix build .#claude-code-native` succeeds
- ✅ `result/bin/claude --version` → `2.1.121 (Claude Code)`
- ✅ `ldd`: no missing libs
- ✅ Host matrix: p620 / razer / p510 all build clean

Closes #368

## Test plan

- [ ] CI green (allow ambient `module-structure-validation` red — see PR #367 for context)
- [ ] After merge, deploy with `just quick-deploy p620` (and `razer`/`p510` as needed)
- [ ] Run `claude --version` to confirm runtime matches package version

🤖 Generated with [Claude Code](https://claude.com/claude-code)