### PR TITLE
fix(p620,razer): disable obsidian to unblock electron-39 lock bump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1376,11 +1376,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {

--- a/home/development/productivity.nix
+++ b/home/development/productivity.nix
@@ -9,7 +9,7 @@ with lib; let
   cfg = {
     # Note-taking and knowledge management
     notes = {
-      obsidian = true; # Knowledge management
+      obsidian = false; # disabled — see #370 (electron-39 build broken upstream)
       logseq = false; # Block-based notes
       zettlr = false; # Academic writing
       notable = false; # Markdown notes

--- a/home/profiles/developer/default.nix
+++ b/home/profiles/developer/default.nix
@@ -55,7 +55,7 @@
     desktop = {
       enable = true; # Full desktop environment for development
       zathura = true; # PDF viewer for documentation
-      obsidian = true; # Note-taking and project documentation
+      obsidian = false; # disabled — see #370 (electron-39 build broken upstream)
       flameshot = true; # Screenshots for documentation
       kooha = true; # Screen recording for demos
       remotedesktop = true; # Remote development access

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -251,18 +251,9 @@ in
       # Enable MCP (Model Context Protocol) servers for AI integration
       mcp = {
         enable = true;
-        # Enable Obsidian MCP server for knowledge base access
-        obsidian = {
-          enable = true;
-          implementation = "rest-api"; # Use REST API mode for full CRUD operations
-          vaultPath = "/home/olafkfreund/Documents/Caliti"; # Used for zero-dependency mode
-          restApi = {
-            apiKeyFile = config.age.secrets."obsidian-api-key".path;
-            host = "localhost";
-            port = 27123;
-            verifySsl = true;
-          };
-        };
+        # Obsidian MCP server — disabled while pkgs.obsidian is unavailable (see #370).
+        # Re-enable with the surrounding hosts/p620/configuration.nix obsidian = true flip.
+        obsidian.enable = false;
         # Enable Atlassian MCP server for Jira and Confluence integration
         atlassian = {
           enable = true;
@@ -313,7 +304,7 @@ in
     programs = {
       lazygit = true;
       thunderbird = false;
-      obsidian = true;
+      obsidian = false; # disabled — see #370 (electron-39 build broken upstream)
       office = true;
       webcam = true;
       print = true;

--- a/hosts/p620/nixos-options.nix
+++ b/hosts/p620/nixos-options.nix
@@ -23,7 +23,7 @@
   programs = {
     lazygit.enable = lib.mkForce true;
     thunderbird.enable = lib.mkForce false;
-    obsidian.enable = lib.mkForce true;
+    obsidian.enable = lib.mkForce false; # disabled — see #370 (electron-39 build broken upstream)
     office.enable = lib.mkForce true;
     webcam.enable = lib.mkForce true; # OBS Virtual Camera support
   };

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -212,18 +212,9 @@ in
       # Enable MCP (Model Context Protocol) servers for AI integration
       mcp = {
         enable = true;
-        # Enable Obsidian MCP server for knowledge base access
-        obsidian = {
-          enable = true;
-          implementation = "rest-api"; # Use REST API mode for full CRUD operations
-          vaultPath = "/home/olafkfreund/Documents/Caliti"; # Used for zero-dependency mode
-          restApi = {
-            apiKeyFile = config.age.secrets."obsidian-api-key".path;
-            host = "localhost";
-            port = 27123;
-            verifySsl = true;
-          };
-        };
+        # Obsidian MCP server — disabled while pkgs.obsidian is unavailable (see #370).
+        # Re-enable with the surrounding hosts/razer/configuration.nix obsidian = true flip.
+        obsidian.enable = false;
         # Enable Atlassian MCP server for Jira and Confluence integration
         atlassian = {
           enable = true;
@@ -264,7 +255,7 @@ in
     programs = {
       lazygit = true;
       thunderbird = false;
-      obsidian = true;
+      obsidian = false; # disabled — see #370 (electron-39 build broken upstream)
       office = true;
       webcam = true; # OBS Virtual Camera support
       print = true;

--- a/hosts/razer/nixos-options.nix
+++ b/hosts/razer/nixos-options.nix
@@ -22,7 +22,7 @@
   # Git tools
   programs.lazygit.enable = lib.mkForce true;
   programs.thunderbird.enable = lib.mkForce false;
-  programs.obsidian.enable = lib.mkForce true;
+  programs.obsidian.enable = lib.mkForce false; # disabled — see #370 (electron-39 build broken upstream)
   programs.office.enable = lib.mkForce true;
   programs.webcam.enable = lib.mkForce true;
 


### PR DESCRIPTION
## Summary

Lock-bump `nixpkgs 0726a0e → 1c3fe55a` was blocked by `electron-unwrapped-39.8.9` — our local overlay's patch had stale 39.8.7-shaped context after upstream electron bumped 39.8.7 → 39.8.9 (added pdfium + libaom entries after angle in `electron/patches/config.json`).

Smallest cut: disable obsidian on p620 + razer (only consumer of `pkgs.electron_39`). Removes electron-39 from the closure entirely; our overlay and the upstream patch shape become irrelevant.

## What changed

| File | Change |
|---|---|
| `flake.lock` | nixpkgs `0726a0e → 1c3fe55a` (bumped lock now builds) |
| `hosts/p620/configuration.nix` | `programs.obsidian = false`; `mcp.obsidian.enable = false` |
| `hosts/razer/configuration.nix` | same |
| `hosts/p620/nixos-options.nix` | `programs.obsidian.enable = lib.mkForce false` |
| `hosts/razer/nixos-options.nix` | same |
| `home/development/productivity.nix` | `notes.obsidian = false` (was unconditionally true) |
| `home/profiles/developer/default.nix` | `features.desktop.obsidian = false` |

7 files, +15 / -33 lines.

## Verified

- ✅ `nix build .#nixosConfigurations.p620.config.system.build.toplevel` succeeds (was failing before)
- ✅ razer + p510 build clean
- ✅ `electron_39` not in any host's closure
- ✅ Closure path: `/nix/store/yha2b3dgblwgqga6d2m109qbbh6vjyl9-nixos-system-p620-26.05.20260427.1c3fe55`

## Test plan

- [x] All three hosts build against bumped lock
- [ ] After merge, run `nhs p620 nixpkgs` (or `just quick-deploy p620`)
- [ ] Confirm Obsidian launcher no longer appears in app menu (or appears but errors out — XDG entries left dangling intentionally as low-cost cleanup deferral)
- [ ] Verify `~/Documents/R3_vault/` markdown files still editable via `nvim` + `obsidian.nvim`
- [ ] Verify `obsidian-mcp` (zero-dep filesystem reader) still works for Claude Code
- [ ] Note: `obsidian-mcp-rest` (calls running Obsidian's REST API) will be inert until Obsidian is re-enabled — expected

## Out of scope (deferred)

- Cleaning up the two leftover `obsidian-wayland.desktop` / `obsidian.desktop` XDG entries (text files pointing to missing binaries — harmless)
- Removing the `electron_39` overlay block in `flake.nix:482-503` and `overlays/39-angle-patchdir-fixed.patch` (kept for if Obsidian is re-enabled before nixpkgs stabilizes)
- Removing the `obsidian-api-key` agenix secret (kept; harmless when unused)

Closes #371. Tracks #370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)