### PR TITLE
feat: --no-deploy flag for split build/deploy + fix markdownlint on p620

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -6,7 +6,12 @@
     "tables": false
   },
   "MD033": {
-    "allowed_elements": ["kbd", "br", "details", "summary"]
+    "allowed_elements": [
+      "kbd",
+      "br",
+      "details",
+      "summary"
+    ]
   },
   "MD041": false,
   "MD024": {
@@ -14,5 +19,8 @@
   },
   "MD029": {
     "style": "ordered"
+  },
+  "MD060": {
+    "style": "leading_and_trailing"
   }
 }

--- a/Justfile
+++ b/Justfile
@@ -41,6 +41,11 @@ update-flake:
 update-commit-deploy HOST="$(hostname)" SCOPE="nixpkgs":
     ./scripts/update-commit-deploy.sh {{HOST}} {{SCOPE}}
 
+# Stage 1 of split deploy: bump lock + build + commit + PR-merge, no switch.
+# Use when the target host is offline; later `nhs HOST` does the deploy.
+update-commit HOST="$(hostname)" SCOPE="nixpkgs":
+    ./scripts/update-commit-deploy.sh {{HOST}} {{SCOPE}} --no-deploy
+
 # Preview updates with detailed package changes (before building)
 preview-updates HOST="$(hostname)":
     @echo "🔍 Previewing updates for {{HOST}}..."

--- a/docs/UPDATE-DEPLOY.md
+++ b/docs/UPDATE-DEPLOY.md
@@ -65,20 +65,25 @@ Both invoke the same script: `scripts/update-commit-deploy.sh`.
 
 - **Never orphan a lock.** Commit + push happen BEFORE switch. If push fails, abort before any deploy.
 - **Dirty-tree safety.** Refuses to run if unrelated dirty files exist — forces you to clean up first.
-- **Build-first.** Test-build must succeed before any commit. Build failure = lock stays dirty, nothing committed, nothing deployed.
+- **Build-first.** Test-build must succeed before any commit. Build failure = lock stays dirty, nothing committed,
+  nothing deployed.
 - **Freshness-aware.** If the lock is unchanged but the target host is behind, deploys anyway.
 - **Fails loud.** Every failure path prints a clear remediation hint and rolls back to a sane state.
 
 ## Remote host requirements
 
 - SSH alias in `~/.ssh/config` (or fully-qualified name)
-- `~/.config/nixos` on the remote is a git clone of this repo with no local edits (the script's freshness check only reads `/run/current-system`; the actual deploy is handled by `nh os switch --target-host`, which ships the closure over SSH from your local machine)
-- Passwordless sudo for your user OR `nh`'s elevation strategy kicks in (we already have `NOPASSWD: ALL` on p620/razer/p510)
+- `~/.config/nixos` on the remote is a git clone of this repo with no local edits (the script's freshness check only
+  reads `/run/current-system`; the actual deploy is handled by `nh os switch --target-host`, which ships the closure
+  over SSH from your local machine)
+- Passwordless sudo for your user OR `nh`'s elevation strategy kicks in (we already have `NOPASSWD: ALL` on
+  p620/razer/p510)
 - SSH key loaded in `ssh-agent` (no password prompts)
 
 ## The `nhs` shortcut
 
-`nhs` is a zsh function defined in `home/shell/zsh.nix`. It wraps `just update-commit-deploy` so the muscle-memory alias works the same way from any directory:
+`nhs` is a zsh function defined in `home/shell/zsh.nix`. It wraps `just update-commit-deploy` so the muscle-memory
+alias works the same way from any directory:
 
 ```zsh
 nhs() {
@@ -86,7 +91,8 @@ nhs() {
 }
 ```
 
-Before 2026-04-21 `nhs` was `alias nhs="nh os switch"` — a raw `nh` invocation. The new form adds lock commit + freshness check + push safety.
+Before 2026-04-21 `nhs` was `alias nhs="nh os switch"` — a raw `nh` invocation. The new form adds lock commit +
+freshness check + push safety.
 
 ## Examples
 
@@ -112,11 +118,39 @@ $ nhs razer home-manager
 $ nhs $(hostname) all
 ```
 
+## Split deploy: build now, deploy later (`nhsb` / `--no-deploy`)
+
+If the target host is offline (e.g. razer is off-network), you can still bump
+the lock and pre-build its closure on this machine, then deploy when the host
+comes back. Two stages:
+
+```bash
+# Stage 1 (now, target offline): bump lock + build + commit + PR-merge.
+# Skips the SSH reachability check and the final `nh os switch`.
+nhsb razer                  # or: just update-commit razer
+
+# Stage 2 (later, target online): cache-hit build + copy + activate.
+nhs razer
+```
+
+Why this works: Nix is content-addressed, so the closure built in stage 1 lives
+in your local `/nix/store`. In stage 2, `nh os switch` re-evaluates and finds
+every derivation already built — no rebuild, only `nix copy` over SSH and
+activation.
+
+Stage 1 still commits `flake.lock` to `main` via the same PR-merge flow as the
+full command, so your tree is clean afterwards and you can deploy other hosts
+in between without dirty-lock drift.
+
+If the lock is unchanged when you run `nhsb`, it exits "nothing to prebuild"
+without doing wasted work — there's no point pre-building a closure for an
+unreachable host when nothing changed.
+
 ## Files
 
-- `scripts/update-commit-deploy.sh` — the script
-- `Justfile` — `update-commit-deploy` recipe
-- `home/shell/zsh.nix` — `nhs` function
+- `scripts/update-commit-deploy.sh` — the script (`--no-deploy` flag for stage 1)
+- `Justfile` — `update-commit-deploy` and `update-commit` recipes
+- `home/shell/zsh.nix` — `nhs` and `nhsb` functions
 
 ## Related
 

--- a/home/shell/zsh.nix
+++ b/home/shell/zsh.nix
@@ -599,6 +599,18 @@ with lib; {
         nhs() {
           (cd ~/.config/nixos && just update-commit-deploy "$@")
         }
+
+        # nhsb: stage 1 of split deploy — build + commit + PR-merge without
+        # switching. Use when the target is offline (e.g. razer is off-network).
+        # Later run `nhs HOST` to deploy — build will be a cache hit, only
+        # copy + activate over SSH remains.
+        #
+        # Usage:
+        #   nhsb razer            # bump nixpkgs, build razer, commit, no deploy
+        #   nhsb razer all        # update all inputs, prebuild razer, no deploy
+        nhsb() {
+          (cd ~/.config/nixos && just update-commit "$@")
+        }
       '';
 
       # Optimized Oh My Zsh configuration with essential plugins only

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -182,6 +182,7 @@ in
       devshell = true; # Temporarily disabled due to patch issue
       python = true;
       nodejs = true;
+      precommit = true; # Activates modules/development/pre-commit.nix — installs markdownlint, statix, taplo, yamllint, ruff, etc. system-wide.
     };
 
     gnome-remote-desktop = {

--- a/scripts/update-commit-deploy.sh
+++ b/scripts/update-commit-deploy.sh
@@ -35,8 +35,27 @@
 
 set -euo pipefail
 
-HOST="${1:-$(hostname)}"
-SCOPE="${2:-nixpkgs}"
+# --- Argument parsing -------------------------------------------------------
+# Positional args: HOST [SCOPE]. Flag --no-deploy can appear anywhere.
+# --no-deploy: run update + build + commit + PR-merge but skip the final
+# `nh os switch`. Use this to prepare a deploy while the target host is
+# offline; later run `nhs HOST` (or this same script without --no-deploy)
+# when it's reachable — the build will be a cache hit, only copy+activate
+# remains. See docs/UPDATE-DEPLOY.md.
+NO_DEPLOY=0
+positional=()
+for arg in "$@"; do
+  case "$arg" in
+    --no-deploy) NO_DEPLOY=1 ;;
+    --*)
+      printf "!! unknown flag: %s\n" "$arg" >&2
+      exit 2
+      ;;
+    *) positional+=("$arg") ;;
+  esac
+done
+HOST="${positional[0]:-$(hostname)}"
+SCOPE="${positional[1]:-nixpkgs}"
 
 # Resolve repo root from script location.
 cd "$(dirname "$0")/.."
@@ -74,11 +93,15 @@ if [ "$HOST" = "$(hostname)" ]; then
   MODE=local
 else
   MODE=remote
-  log "pre-flight: SSH reachability check for remote host '$HOST'"
-  if ! ssh -o ConnectTimeout=5 -o BatchMode=yes "$HOST" true 2>/dev/null; then
-    err "cannot reach '$HOST' via SSH. Fix DNS / SSH config / host availability and retry."
+  if [ $NO_DEPLOY -eq 0 ]; then
+    log "pre-flight: SSH reachability check for remote host '$HOST'"
+    if ! ssh -o ConnectTimeout=5 -o BatchMode=yes "$HOST" true 2>/dev/null; then
+      err "cannot reach '$HOST' via SSH. Fix DNS / SSH config / host availability and retry."
+    fi
+    ok "SSH to $HOST works"
+  else
+    log "skipping SSH reachability check (--no-deploy: target may be offline)"
   fi
-  ok "SSH to $HOST works"
 fi
 
 # --- 2. Snapshot pre-update state -------------------------------------------
@@ -134,6 +157,14 @@ fi
 # --- 6. Nothing-to-do exit --------------------------------------------------
 if [ $LOCK_CHANGED -eq 0 ] && [ $HOST_STALE -eq 0 ]; then
   ok "no lock changes AND ${HOST} already on ${expected##*/} — nothing to do."
+  exit 0
+fi
+
+# In --no-deploy mode the deploy isn't happening, so HOST_STALE alone isn't
+# reason to do work — only the lock matters. (Without this, an unreachable
+# host short-circuits to HOST_STALE=1, which would trigger a wasted build.)
+if [ $NO_DEPLOY -eq 1 ] && [ $LOCK_CHANGED -eq 0 ]; then
+  ok "no lock changes — nothing to prebuild (--no-deploy)."
   exit 0
 fi
 
@@ -272,6 +303,16 @@ ELEV=(--elevation-strategy passwordless)
 # was invoked from). Intentionally NOT routing builds through p620, because
 # you might run this from razer while traveling with no network to p620.
 # If you want p620 to do the heavy lifting, run `nhs` from p620.
+
+# --no-deploy: lock is committed and closure is built+cached locally. Skip
+# the activation step and tell the user how to finish later. The cached
+# closure means stage 2 is a fast copy+activate (no rebuild).
+if [ $NO_DEPLOY -eq 1 ]; then
+  ok "prebuild complete. lock is on origin/main; closure cached in local /nix/store."
+  log "to deploy when ${HOST} is reachable, run:  nhs ${HOST}"
+  log "  (build will be a cache hit; only copy + activate over SSH remains)"
+  exit 0
+fi
 
 case "$MODE" in
   local)


### PR DESCRIPTION
Two related changes:

## 1. fix(p620): activate pre-commit toolchain so markdownlint works

`modules/development/pre-commit.nix` is gated on `features.development.precommit`, which was unset on p620.
Result: every commit touching `.md` failed with `Executable 'markdownlint' not found`.
Flipping the flag activates markdownlint-cli + statix, deadnix, taplo, yamllint, ruff, typos, actionlint, prettier, stylua system-wide.

## 2. feat(update-commit-deploy): `--no-deploy` flag for split build/deploy

Two-stage workflow for offline targets — bump lock + build + commit + PR-merge in stage 1, deploy in stage 2 once the host is reachable. The cached closure makes stage 2 a fast copy + activate.

```bash
nhsb razer    # stage 1 — host can be offline
nhs razer     # stage 2 — cache-hit build + activate over SSH
```

Adds:
- `scripts/update-commit-deploy.sh`: `--no-deploy` flag (gates SSH reachability check, gates deploy block, no-deploy-aware "nothing to prebuild" exit).
- `Justfile`: sibling `update-commit` recipe.
- `home/shell/zsh.nix`: sibling `nhsb` function.
- `docs/UPDATE-DEPLOY.md`: split-deploy section + four wrapped pre-existing long lines that the previously-broken markdownlint hook had been masking.
- `.markdownlint.json`: declares MD060 table-style as `leading_and_trailing` (matches existing tables).

## Test plan

- [x] `bash -n scripts/update-commit-deploy.sh` clean
- [x] Unknown flag rejected with clear error and exit 2
- [x] `markdownlint docs/UPDATE-DEPLOY.md` clean
- [x] `which markdownlint` resolves to system path after p620 rebuild
- [x] Both commits pass full pre-commit suite (markdownlint included)
- [ ] Run `nhsb razer` to verify end-to-end (deferred — needs razer offline scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)