### PR TITLE
chore(razer): keep 10 systemd-boot generations instead of 5

### DIFF
--- a/hosts/razer/nixos/boot.nix
+++ b/hosts/razer/nixos/boot.nix
@@ -2,7 +2,7 @@
   # Boot optimizations
   boot.loader.systemd-boot = {
     enable = true;
-    configurationLimit = 5; # Keep 5 generations for easy rollback
+    configurationLimit = 10; # Keep 10 generations so known-good kernels stay selectable in the boot menu
     editor = false; # Disable bootloader editing for security
   };
   boot.loader.efi.canTouchEfiVariables = true;


### PR DESCRIPTION
## Summary

- Raise `boot.loader.systemd-boot.configurationLimit` from `5` to `10` in `hosts/razer/nixos/boot.nix`.
- The previous limit pruned known-good kernel entries (e.g. 6.18.22) within a few deploys, leaving the boot menu with only the most recent kernels — bad when a fresh kernel regresses.
- With limit=10, the systemd-boot installer keeps the latest 10 generations selectable in the boot menu on every `nixos-rebuild boot`. Older `.conf` files that were previously pruned are re-emitted on the next deploy as long as their store paths still exist.

## Test plan

- [x] File edited and verified: `hosts/razer/nixos/boot.nix:5` shows `configurationLimit = 10;`
- [ ] After merge, run `nh os boot --hostname razer --target-host razer .` (or `nixos-rebuild boot --flake .#razer` locally on razer) and confirm `bootctl list` shows entries for ~10 generations including a 6.18.22 generation.
- [ ] Reboot razer; menu lists known-good 6.18.22 kernel as a fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)