### PR TITLE
fix(razer): switch to linuxPackages_latest (7.0.1) to dodge 6.18.24 + nvidia boot regression

### DIFF
--- a/hosts/razer/nixos/boot.nix
+++ b/hosts/razer/nixos/boot.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }: {
+{ config, pkgs, ... }: {
   # Boot optimizations
   boot.loader.systemd-boot = {
     enable = true;
@@ -23,8 +23,13 @@
   boot.initrd.compressor = "zstd";
   boot.initrd.compressorArgs = [ "-19" "-T0" ];
 
-  # Use kernel 6.18 for NVIDIA driver compatibility and newer hardware support
-  boot.kernelPackages = pkgs.linuxPackages_6_18;
+  # Kernel: trying linuxPackages_latest (7.0.1) on razer because 6.18.24 has a
+  # boot regression with nvidia-open-595.58.03 + RTX 3080 Laptop (Ampere) — gen
+  # 2443 was built with 6.18.24 + nvidia-open and failed to boot. 6.18.22 is
+  # known-good (gen 2438, currently running). 6.17/6.19 are EOL'd in nixpkgs.
+  # If 7.0.1 also fails to boot, fall back to pinning 6.18.22 via a separate
+  # nixpkgs flake input. See: https://github.com/nixos/nixpkgs/issues/493618
+  boot.kernelPackages = pkgs.linuxPackages_latest;
 
   boot.plymouth.enable = true;
   boot.kernel.sysctl."vm.nr_hugepages" = 1024;
@@ -33,7 +38,7 @@
   # };
   # OBS Virtual Cam Support - v4l2loopback setup
   boot.kernelModules = [ "v4l2loopback" ];
-  boot.extraModulePackages = with pkgs.linuxPackages_6_18; [ v4l2loopback ];
+  boot.extraModulePackages = with config.boot.kernelPackages; [ v4l2loopback ];
   boot.extraModprobeConfig = ''
     options v4l2loopback devices=3 video_nr=1,2,10 card_label="OBS Virtual Cam 1","OBS Virtual Cam 2","COSMIC Camera" exclusive_caps=1,1,1
   '';


### PR DESCRIPTION
## Summary

Gen 2443 with kernel 6.18.24 + nvidia-open-595.58.03 fails to boot on razer (RTX 3080 Laptop / Ampere). Gen 2438 (kernel 6.18.22, same driver series) boots fine. nixpkgs has dropped 6.17 and 6.19 as EOL.

This switches razer to `linuxPackages_latest` (currently **7.0.1**) as a one-shot test. nvidia-open-7.0.1-595.58.03 is a cache.nixos.org hit, so Hydra has already validated the combo at build time. Whether it actually **boots** on this hardware is what we need to verify by deploying.

If it fails: fall-back to pinning 6.18.22 via a second `nixpkgs-kernel` flake input (heavier, but known-good).

## Changes

- `hosts/razer/nixos/boot.nix:32` — `pkgs.linuxPackages_6_18` → `pkgs.linuxPackages_latest`
- `hosts/razer/nixos/boot.nix:41` — `with pkgs.linuxPackages_6_18` → `with config.boot.kernelPackages` so v4l2loopback tracks the chosen kernel rather than being hardcoded
- Added `config` to the module's argument list

## Test plan

- [x] `nh os build --hostname razer .` succeeds (2m54s, 30 builds, 0 failures)
- [x] nvidia-open-7.0.1-595.58.03 resolves (cache hit)
- [ ] `nh os boot --hostname razer .` writes new gen as default
- [ ] Reboot razer; `uname -r` reports 7.0.1; nvidia.ko loads; display/Wayland work

If verification step fails: revert this PR and apply the 6.18.22-pin alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)