### PR TITLE
feat(razer): enable lanzaboote (Secure Boot bootloader)

### DIFF
--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -16,7 +16,7 @@ in
     ./nixos/screens.nix
     ./nixos/power.nix
     ./nixos/boot.nix
-    # ./nixos/secure-boot.nix # Secure Boot enabled with lanzaboote
+    ./nixos/secure-boot.nix # Secure Boot enabled with lanzaboote (issue #376)
     ./nixos/nvidia.nix
     ../common/nixos/i18n.nix
     ../common/nixos/hosts.nix


### PR DESCRIPTION
## Summary

Uncomments the import of `hosts/razer/nixos/secure-boot.nix` so `boot.lanzaboote` takes over from systemd-boot. Secure Boot stays **DISABLED in firmware** after this deploy — the system boots identically via the lanzaboote-stub. Firmware activation is a separate manual step tracked in #376.

This is **Step 1 of issue #376**.

## What this changes

- `hosts/razer/configuration.nix:19` — uncomments the `./nixos/secure-boot.nix` import.

That single line activates everything the existing `secure-boot.nix` already declared:

- `boot.lanzaboote.enable = true` (with `pkiBundle = "/etc/secureboot"`)
- `boot.loader.systemd-boot.enable = lib.mkForce false`
- `boot.bootspec.enable = true`
- `sbctl` package becomes available (already gated on lanzaboote.enable)

## Pre-flight (already satisfied)

- ✅ PR #375 set `configurationLimit = 10` — boot menu retains 6.18.22 fallbacks (gens 2430-2434, 2438) so we can roll back from a SB problem.
- ✅ Razer is currently on kernel 7.0.1 + nvidia-open via systemd-initrd (PR #379), confirmed bootable.

## Test plan

- [x] Eval succeeds: `boot.lanzaboote.enable=true`, `boot.loader.systemd-boot.enable=false`, `boot.bootspec.enable=true`
- [ ] After merge: deploy via `nh os boot --hostname razer .`
- [ ] Reboot razer, verify it boots normally (Secure Boot still disabled in BIOS — should be transparent)
- [ ] `bootctl status` should report a lanzaboote-stub bootloader
- [ ] `sbctl status` should run (now installed); expect `Setup Mode: Disabled` (PK still present from firmware factory keys)

## Next steps (after this PR)

Tracked in #376 — `sbctl create-keys`, BIOS Setup Mode dance, `sbctl enroll-keys -m`, then enable Secure Boot in firmware.

Refs #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)