### PR TITLE
chore(claude-code): bump 2.1.121 → 2.1.123 (#381)

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.121";
+  version = "2.1.123";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-tLaEu8s6iAKexBnbwIgksvPGllagqiN0hg+VJfxnyY8=";
+      hash = "sha256-WngTm2eahqiKCsVHbHBqZMMQW/am1DW6EPOqP7Y1vbI=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-cbeOY2T5eiJ7F75A38wjdGH40rHRCURNJLQq8P3vrDE=";
+      hash = "sha256-glxSYDXR11/wvB7r8YyIf5jQfqSeqAvTEv9Bb+YaObM=";
     };
   };
 


### PR DESCRIPTION
## Summary
- Bump `claude-code-native` from 2.1.121 → 2.1.123 (skipping 2.1.122)
- Hashes refreshed via `./scripts/update-claude-code-native.sh 2.1.123`
- Closes #381

## Verification
- [x] `nix build .#claude-code-native` clean
- [x] `claude --version` reports `2.1.123 (Claude Code)`
- [x] Host matrix builds OK: p620 (78s), razer (77s), p510 (39s)

## claude-desktop deliberately NOT bumped
Latest upstream release `v2.0.5+claude1.5220.0` (2026-04-29) ships with open high-priority regression aaddrick/claude-desktop-debian#537 — *Cowork project creation fails silently*. The bug appeared the same day as the release (zero bake time) and `--doctor` still reports all-PASS, masking it. Holding the current pin (`f9841bd8`, claude binary 1.4758.0) until a fix lands upstream.

## Test plan
- [x] Pre-deploy: all three hosts toplevel-build green
- [ ] Post-deploy: `claude --version` reports `2.1.123` on p620, razer, p510
- [ ] Post-deploy: launch `claude` interactively and confirm no startup regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)