### PR TITLE
fix(razer): point lanzaboote pkiBundle at /var/lib/sbctl (sbctl 0.18 default)

### DIFF
--- a/hosts/razer/nixos/secure-boot.nix
+++ b/hosts/razer/nixos/secure-boot.nix
@@ -6,10 +6,13 @@
     # Enable bootspec for lanzaboote (required for Secure Boot)
     bootspec.enable = true;
 
-    # Enable Lanzaboote for Secure Boot
+    # Enable Lanzaboote for Secure Boot.
+    # pkiBundle path changed from /etc/secureboot to /var/lib/sbctl in
+    # sbctl 0.14+ (lanzaboote v1.0.0 ships sbctl 0.18). Keys live at
+    # /var/lib/sbctl/keys/{db,KEK,PK}/*.{key,pem}.
     lanzaboote = {
       enable = true;
-      pkiBundle = "/etc/secureboot";
+      pkiBundle = "/var/lib/sbctl";
     };
 
     # Bootloader configuration


### PR DESCRIPTION
## Summary

Lanzaboote v1.0.0 (#383) ships sbctl 0.18, which moved its default key directory from `/etc/secureboot/` to `/var/lib/sbctl/`. Our `pkiBundle` was pinned to the old location and lanzaboote refused to install:

```
Failed to install generation 2438: Get stub name: Failed to read public key from /etc/secureboot/keys/db/db.pem: No such file or directory (os error 2)
```

After this change, install succeeds. `/boot/EFI/BOOT/BOOTX64.EFI` is now the lanzaboote-stub and `/boot/EFI/Linux/nixos-generation-*.efi` are signed UKIs (verified via `sbctl verify`). Secure Boot is still **disabled in firmware** — this only changes the bootloader path.

## Test plan

- [x] `sbctl verify` after install: BOOTX64.EFI + all UKIs signed
- [x] ESP usage: 298/511 MB after install
- [ ] After merge: reboot razer; verify lanzaboote-stub loads gen 2448 (Linux 7.0.1) cleanly
- [ ] `bootctl status` reports `Current Boot Loader: systemd-stub` or similar (not systemd-boot)

Refs #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)