### PR TITLE
feat(razer): add shim+MOK module to bypass Razer's locked Setup Mode

### DIFF
--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -17,6 +17,7 @@ in
     ./nixos/power.nix
     ./nixos/boot.nix
     ./nixos/secure-boot.nix # Secure Boot enabled with lanzaboote (issue #376)
+    ./nixos/shim.nix # Microsoft-signed shim + MOK enrollment for Razer's locked PK (issue #376)
     ./nixos/nvidia.nix
     ../common/nixos/i18n.nix
     ../common/nixos/hosts.nix

--- a/hosts/razer/nixos/shim.nix
+++ b/hosts/razer/nixos/shim.nix
@@ -1,0 +1,95 @@
+{ config, lib, pkgs, ... }:
+# Shim integration for razer.
+#
+# Razer's firmware has the Razer "Platform Key" set as PK and won't expose a
+# "Reset Secure Boot keys" / "Setup Mode" option in BIOS — we cannot enroll
+# our own db key directly via sbctl enroll-keys. (Confirmed across multiple
+# 2021+ Razer Blade models; see issue #376 for the research.)
+#
+# Workaround: chain through Ubuntu's Microsoft-dualsigned shim. Razer's `db`
+# already trusts the "Microsoft Corporation UEFI CA 2011" (verified via
+# /sys/firmware/efi/efivars/db-*), which signs Ubuntu's shim. shim ships a
+# UEFI app called MokManager (mmx64.efi) that lets us enroll our own key as
+# a Machine Owner Key WITHOUT touching Setup Mode.
+#
+# Architecture after install:
+#   firmware → /EFI/BOOT/BOOTX64.EFI (= shim, Microsoft-signed)
+#            → /EFI/BOOT/grubx64.efi (= lanzaboote-stub, signed by our db key,
+#              trusted via the MOK we enroll once via mokutil + reboot)
+#            → /EFI/Linux/nixos-generation-N.efi (UKI, signed by our db key)
+#            → kernel + initrd
+#
+# Reference: working setup posted by user "Mareo" on
+# https://github.com/nix-community/lanzaboote/issues/165
+let
+  # Ubuntu's shim-signed package — ships shim signed by both Microsoft (via the
+  # 3rd Party UEFI CA — what our firmware trusts) and Canonical, plus mmx64.efi
+  # (MokManager).
+  #
+  # Pin to a specific .deb on launchpad: launchpad URLs are immutable per file,
+  # so this hash is stable forever. Bump only after verifying a newer version
+  # also boots on this hardware.
+  shimUbuntu = pkgs.stdenvNoCC.mkDerivation {
+    pname = "shim-ubuntu-signed";
+    version = "1.59+15.8-0ubuntu2";
+
+    src = pkgs.fetchurl {
+      url = "https://launchpad.net/ubuntu/+archive/primary/+files/shim-signed_1.59+15.8-0ubuntu2_amd64.deb";
+      hash = "sha256-+O1xzi2RowS21euEmX+EbzMbVUV4vALb/njhOtisgak=";
+    };
+
+    nativeBuildInputs = [ pkgs.dpkg ];
+
+    unpackPhase = "dpkg-deb -x $src .";
+
+    installPhase = ''
+      mkdir -p $out
+      # Use the dualsigned variant — has both Microsoft and Canonical sigs
+      # for maximum firmware compatibility. Singletons are also available
+      # at shimx64.efi.signed.latest if dualsigned ever gets dropped.
+      cp usr/lib/shim/shimx64.efi.dualsigned $out/shimx64.efi
+      cp usr/lib/shim/mmx64.efi              $out/mmx64.efi
+    '';
+
+    meta = {
+      description = "Ubuntu's Microsoft+Canonical dualsigned shim and MokManager UEFI binaries";
+      homepage = "https://launchpad.net/ubuntu/+source/shim-signed";
+      license = lib.licenses.bsd2;
+      platforms = [ "x86_64-linux" ];
+    };
+  };
+in
+{
+  config = lib.mkIf config.boot.lanzaboote.enable {
+    # Wrap lanzaboote's bootloader installer so every nixos-rebuild boot/switch
+    # also stages shim. We override system.build.installBootLoader rather than
+    # using activation scripts because activation only runs on `switch`, not
+    # on `boot` — and we need shim staged on /boot before any reboot.
+    #
+    # Reads boot.lanzaboote.installCommand (the partial lzbt invocation) and
+    # invokes it with our $@ args, then performs the shim staging atomically.
+    system.build.installBootLoader = lib.mkForce (pkgs.writeShellScript "install-bootloader-with-shim" ''
+      set -euo pipefail
+
+      # Step 1: lanzaboote's standard install. Writes signed BOOTX64.EFI
+      # (= lanzaboote-stub) and per-generation UKIs in /EFI/Linux/.
+      ${config.boot.lanzaboote.installCommand} "$@"
+
+      # Step 2: shim swap. Move lanzaboote-stub aside as grubx64.efi (the
+      # hardcoded name shim chainloads by default — even though we're chain-
+      # loading lanzaboote, not grub, the historical name sticks). Then
+      # overwrite BOOTX64.EFI with Microsoft-signed shim.
+      cp -f /boot/EFI/BOOT/BOOTX64.EFI /boot/EFI/BOOT/grubx64.efi
+      install -m 0755 ${shimUbuntu}/shimx64.efi /boot/EFI/BOOT/BOOTX64.EFI
+
+      # MokManager — required to enroll our MOK at first SB-enabled boot.
+      install -m 0755 ${shimUbuntu}/mmx64.efi /boot/EFI/BOOT/mmx64.efi
+
+      echo "shim-install: BOOTX64.EFI=shim (Ubuntu dualsigned 1.59+15.8); grubx64.efi=lanzaboote-stub"
+    '');
+
+    # Also add mokutil to system PATH so user can `mokutil --import` etc.
+    # without a nix shell.
+    environment.systemPackages = [ pkgs.mokutil ];
+  };
+}


### PR DESCRIPTION
## Summary

Razer Blade BIOS (multiple 2021+ models, including this one) **hides Secure Boot key management** — no "Reset Secure Boot keys" / "Setup Mode" / "Custom mode" options are exposed in firmware. Confirmed across multiple [Razer Insider forum threads](https://insider.razer.com/razer-support-45/secure-boot-violation-on-razer-blade-15-2021-rz09-0367-no-option-to-restore-factory-keys-86744). Standard sbctl enroll-keys requires Setup Mode and is therefore impossible on this hardware.

**Workaround**: chain through Microsoft-signed shim. Razer's `db` already trusts `Microsoft Corporation UEFI CA 2011` (verified by reading `/sys/firmware/efi/efivars/db-d719b2cb-…`), which signs Ubuntu's `shim-signed` package. shim ships `mmx64.efi` (MokManager), a UEFI application that lets us enroll our own db key as a Machine Owner Key **without** touching Setup Mode or PK.

## Architecture (after install)

```
firmware (PK = Razer, db trusts MS UEFI CA 2011)
    ↓ (Microsoft signature)
/EFI/BOOT/BOOTX64.EFI  = shim (Ubuntu dualsigned)
    ↓ (our MOK, enrolled via mokutil + MokManager — Phase 5)
/EFI/BOOT/grubx64.efi  = lanzaboote-stub (signed by our /var/lib/sbctl key)
    ↓
/EFI/Linux/nixos-generation-N.efi  = UKI (signed)
    ↓
kernel + initrd
```

## Implementation details

- New `shim-ubuntu-signed` derivation extracts `shimx64.efi.dualsigned` and `mmx64.efi` from Ubuntu's `shim-signed_1.59+15.8-0ubuntu2_amd64.deb` on Launchpad. Pinned by SRI hash. Dualsigned variant has both Microsoft and Canonical signatures for max firmware compatibility.
- `system.build.installBootLoader` is overridden via `lib.mkForce` with a wrapper that:
  1. Runs the original `boot.lanzaboote.installCommand "$@"` (writes signed BOOTX64.EFI = lanzaboote-stub + UKIs)
  2. Atomically swaps: `BOOTX64.EFI` ← shim, `grubx64.efi` ← old BOOTX64.EFI (lanzaboote-stub)
  3. Stages `mmx64.efi` for MokManager invocation
- We override `installBootLoader` rather than use activation scripts so it runs on `nixos-rebuild boot` as well as `switch`.
- `mokutil` added to system PATH for Phase 5 enrollment.

## What does NOT change in this PR

- **Secure Boot stays disabled in firmware.** With SB off, shim chainloads lanzaboote-stub identically to a no-shim setup. The next reboot will boot fine.
- No firmware variables are touched. No `efibootmgr` invocation.
- MOK is **not** enrolled yet. That's Phase 5 (manual `mokutil --import` followed by user-confirmed MokManager UEFI dialog at next boot).

## Test plan

- [x] `nh os build --hostname razer .` succeeds (2m47s)
- [x] Closure diff: +mokutil, +shim-ubuntu-signed, +install-bootloader-with-shim, -bootinstall (+1.82 MiB)
- [ ] After merge: `nh os boot --hostname razer .` — verify `/boot/EFI/BOOT/BOOTX64.EFI` becomes the shim binary (size ~924KB), `grubx64.efi` becomes lanzaboote-stub
- [ ] Reboot. Should boot identically to current state since SB is still disabled.

## Next steps (Phase 5 + 6, separate manual)

1. `mokutil --import /var/lib/sbctl/keys/db/db.der` (after `openssl x509 -outform DER` conversion). Set one-shot password.
2. Reboot. MokManager pops up at boot, asks to confirm enrollment with the password.
3. Reboot. SB still off but our key is now in `MokListRT`.
4. **Toggle Secure Boot ON in BIOS.** (User confirmed this toggle is available.)
5. Reboot. shim verifies grubx64.efi via MOK → grubx64.efi (lanzaboote-stub) verifies UKI via embedded db cert → boot proceeds under SB.

Refs #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)