### PR TITLE
fix(razer): pass key flags + hardcoded paths to lzbt in shim wrapper

### DIFF
--- a/hosts/razer/nixos/shim.nix
+++ b/hosts/razer/nixos/shim.nix
@@ -73,7 +73,19 @@ in
 
       # Step 1: lanzaboote's standard install. Writes signed BOOTX64.EFI
       # (= lanzaboote-stub) and per-generation UKIs in /EFI/Linux/.
-      ${config.boot.lanzaboote.installCommand} "$@"
+      #
+      # boot.lanzaboote.installCommand is the *partial* lzbt invocation —
+      # the lanzaboote module's own bootinstall script appends --public-key
+      # and --private-key flags from publicKeyFile/privateKeyFile config
+      # before forwarding the toplevel/boot args. We replicate that here.
+      # Match upstream bootinstall.sh: hardcoded `/boot` + glob over all
+      # system profiles (lanzaboote needs to see them all to install one
+      # UKI per generation).
+      ${config.boot.lanzaboote.installCommand} \
+        --public-key ${config.boot.lanzaboote.publicKeyFile} \
+        --private-key ${config.boot.lanzaboote.privateKeyFile} \
+        /boot \
+        /nix/var/nix/profiles/system-*-link
 
       # Step 2: shim swap. Move lanzaboote-stub aside as grubx64.efi (the
       # hardcoded name shim chainloads by default — even though we're chain-


### PR DESCRIPTION
## Summary

PR #385's `system.build.installBootLoader` wrapper invoked `${installCommand} "\$@"` and lzbt 1.0.0 panicked twice during deploy:

1. **`Failed to obtain public key`** — `boot.lanzaboote.installCommand` is only the *partial* lzbt invocation. The lanzaboote module's own bootinstall script appends `--public-key` and `--private-key` from `publicKeyFile` / `privateKeyFile` config separately. Our wrapper missed those flags.

2. **`Installing Lanzaboote to /nix/store/...`** — `nixos-rebuild` passes the new toplevel as `$1` to `installBootLoader`, but upstream's bootinstall.sh ignores that and hardcodes `/boot /nix/var/nix/profiles/system-*-link` so lzbt sees ALL profile generations to write one UKI per gen. Our wrapper used `"$@"` and lzbt treated the single toplevel arg as the install destination.

This PR replicates upstream's invocation faithfully.

## Verified result on razer

```
/boot/EFI/BOOT/BOOTX64.EFI  968,696 bytes  (= shim, dualsigned)
/boot/EFI/BOOT/grubx64.efi  156,336 bytes  (= lanzaboote-stub, signed by our key)
/boot/EFI/BOOT/mmx64.efi    856,280 bytes  (= MokManager)
```

All three valid PE32+ EFI applications. Boot chain on next reboot:

```
firmware → BOOTX64.EFI (shim) → grubx64.efi (lanzaboote-stub) → UKI → kernel
```

Secure Boot still disabled in firmware — shim chainloads identically to non-shim setup with SB off, so reboot is safe.

Refs #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)