### PR TITLE
refactor(lazyvim): clean up bootstrap, add right-click keymap, host-aware nixd

### DIFF
--- a/home/shell/lazyvim/lazyvim/init.lua
+++ b/home/shell/lazyvim/lazyvim/init.lua
@@ -1,3 +1,2 @@
 -- bootstrap lazy.nvim, LazyVim and your plugins
 require("config.lazy")
--- require("config.profiles")

--- a/home/shell/lazyvim/lazyvim/lua/config/keymaps.lua
+++ b/home/shell/lazyvim/lazyvim/lua/config/keymaps.lua
@@ -6,3 +6,10 @@
 vim.keymap.set("n", "<leader>?C", function()
   vim.cmd.edit(vim.fn.stdpath("config") .. "/AI-CHEATSHEET.md")
 end, { desc = "Open AI cheatsheet" })
+
+-- Right-click context menu via nvchad/menu (mouse + NvimTree).
+vim.keymap.set("n", "<RightMouse>", function()
+  vim.cmd.exec('"normal! \\<RightMouse>"')
+  local opts = vim.bo.ft == "NvimTree" and "nvimtree" or "default"
+  require("menu").open(opts, { mouse = true })
+end, { desc = "Open right-click menu" })

--- a/home/shell/lazyvim/lazyvim/lua/config/lazy.lua
+++ b/home/shell/lazyvim/lazyvim/lua/config/lazy.lua
@@ -7,14 +7,6 @@ if not (vim.uv or vim.loop).fs_stat(lazypath) then
 end
 vim.opt.rtp:prepend(lazypath)
 
--- mouse users + nvimtree users!
-vim.keymap.set("n", "<RightMouse>", function()
-  vim.cmd.exec('"normal! \\<RightMouse>"')
-
-  local options = vim.bo.ft == "NvimTree" and "nvimtree" or "default"
-  require("menu").open(options, { mouse = true })
-end, {})
-
 require("lazy").setup({
   spec = {
     -- add LazyVim and import its plugins

--- a/home/shell/lazyvim/lazyvim/lua/plugins/nix.lua
+++ b/home/shell/lazyvim/lazyvim/lua/plugins/nix.lua
@@ -17,17 +17,18 @@ return {
                 command = { "alejandra" },
                 timeout_ms = 5000,
               },
-              options = {
-                enable = true,
-                target = { "all" },
-                offline = true,
-                nixos = {
-                  expr = '(builtins.getFlake ("git+file://" + toString /home/olafkfreund/.config/nixos)).nixosConfigurations.p620.options',
-                },
-                home_manager = {
-                  expr = '(builtins.getFlake ("git+file://" + toString /home/olafkfreund/.config/nixos)).homeConfigurations."olafkfreund@p620".options',
-                },
-              },
+              options = (function()
+                local host = vim.fn.hostname()
+                local flake = '(builtins.getFlake ("git+file://" + toString /home/olafkfreund/.config/nixos))'
+                return {
+                  enable = true,
+                  target = { "all" },
+                  offline = true,
+                  nixos = {
+                    expr = flake .. ".nixosConfigurations." .. host .. ".options",
+                  },
+                }
+              end)(),
               diagnostics = {
                 enable = true,
                 ignored = {},


### PR DESCRIPTION
## Summary

Three small refactors that had been sitting in the working tree:

1. **`init.lua`** — drop a commented-out `require("config.profiles")` line.
2. **`config/lazy.lua` → `config/keymaps.lua`** — move the `<RightMouse>` keymap out of the `lazy.nvim` bootstrap file (where it didn't belong) into `keymaps.lua`. Adds a `desc` so which-key shows it.
3. **`plugins/nix.lua`** — parameterize nixd's `options.nixos.expr` to use `vim.fn.hostname()` instead of hardcoding `p620`. The LSP now resolves *this host's* configuration on razer / p510 / p620 without manual editing. Drops the `home_manager.expr` branch — home-manager is loaded as a NixOS module here, not exposed as a separate `homeConfigurations` flake output.

## Test plan

- [x] No NixOS closure changes — these only affect Neovim's runtime config inside the lazyvim module
- [ ] On next `nvim` startup: right-click in NvimTree opens menu (was working before, still works after move)
- [ ] On p620, razer, p510: opening a `.nix` file in the flake → nixd resolves options correctly (the host-aware expr is what makes razer/p510 work without P620-specific paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)