### PR TITLE
chore(lint): replace statix with nixpkgs-lint-community for whole-tree linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           echo "Scanning for security issues..."
 
           # Check for hardcoded passwords (exclude safe patterns and archived code)
+          # shellcheck disable=SC2016 # backslash-dollar is intentional regex literal, not parameter expansion
           if grep -r 'password\s*=\s*"[^"]\+"' . --include="*.nix" --exclude-dir=".git" --exclude-dir="archive" \
             | grep -v 'hashedPassword\|passwordFile\|password\s*=\s*""\|password\s*=\s*"nixos"\|onepassword\|secrets\|age\.secrets\|\$__file\|lib/live-images.nix\|modules/installer'; then
             echo "FAIL: Potential hardcoded passwords found"
@@ -109,7 +110,7 @@ jobs:
           echo "Checking documentation..."
 
           # Check if README exists and has minimum content
-          if [ -f "README.md" ] && [ $(wc -l < README.md) -gt 50 ]; then
+          if [ -f "README.md" ] && [ "$(wc -l < README.md)" -gt 50 ]; then
             echo "PASS: README.md is present and substantial"
           else
             echo "WARNING: README.md is missing or too short"
@@ -155,10 +156,10 @@ jobs:
 
       - name: Nix linting check
         run: |
-          echo "Linting Nix code..."
+          echo "Linting Nix code with nixpkgs-lint-community (tree-sitter)..."
 
-          nix shell nixpkgs#statix -c bash -c '
-            if statix check . ; then
+          nix shell nixpkgs#nixpkgs-lint-community -c bash -c '
+            if nixpkgs-lint . ; then
               echo "PASS: No linting issues found"
             else
               echo "WARNING: Linting issues detected"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,21 +18,21 @@ repos:
         files: '\.nix$'
         description: Format Nix files using nixpkgs-fmt
 
-      - id: statix
-        name: Lint Nix files
-        entry: statix check
+      - id: nixpkgs-lint
+        name: Lint Nix files (nixpkgs-lint-community, tree-sitter)
+        entry: nixpkgs-lint
         language: system
         files: '\.nix$'
-        pass_filenames: false
-        description: Lint Nix files for common issues
+        pass_filenames: true
+        description: Fast semantic linter for Nix; runs only on changed files
 
       - id: deadnix
         name: Check for dead Nix code
-        entry: deadnix --fail
+        entry: bash -c 'for f in "$@"; do deadnix --fail "$f" || exit 1; done' --
         language: system
         files: '\.nix$'
-        pass_filenames: false
-        description: Check for dead/unused Nix code
+        pass_filenames: true
+        description: Check changed Nix files for dead/unused code
 
       # =============================================================================
       # Shell Script Formatting and Linting

--- a/Justfile
+++ b/Justfile
@@ -144,10 +144,10 @@ format-all:
     pre-commit run prettier --all-files || true
     @echo "✅ All files formatted!"
 
-# Lint all files using pre-commit
+# Lint all files (whole-tree nixpkgs-lint-community + per-file deadnix)
 lint-all:
     @echo "🔍 Linting all files..."
-    pre-commit run statix --all-files || true
+    nixpkgs-lint . || true
     pre-commit run deadnix --all-files || true
     pre-commit run shellcheck --all-files || true
     pre-commit run markdownlint --all-files || true

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -5,14 +5,14 @@
 }:
 with lib; {
   # Syntax and style validation
-  statix-lint =
-    pkgs.runCommand "statix-validation"
+  nixpkgs-lint-check =
+    pkgs.runCommand "nixpkgs-lint-validation"
       {
         src = cleanSource ../.;
       } ''
-      echo "Running statix lint checks..."
-      ${pkgs.statix}/bin/statix check $src --format=stderr || {
-        echo "Statix found linting issues (warnings allowed)"
+      echo "Running nixpkgs-lint-community (tree-sitter) checks..."
+      ${pkgs.nixpkgs-lint-community}/bin/nixpkgs-lint $src || {
+        echo "nixpkgs-lint found linting issues (warnings allowed)"
       }
       touch $out
     '';

--- a/tools/dev.nix
+++ b/tools/dev.nix
@@ -18,7 +18,8 @@ pkgs.mkShell {
     commitizen # Conventional commits
 
     # Quality assurance
-    statix # Advanced linting
+    nixpkgs-lint-community # Primary linter (tree-sitter, fast, whole-tree-safe)
+    statix # Secondary linter (rule-based, run per-file: `statix check FILE`)
     deadnix # Dead code detection
     nixpkgs-fmt # Code formatting
     typos # Spell checking
@@ -51,7 +52,8 @@ pkgs.mkShell {
     echo ""
     echo "🔧 Development Tools:"
     echo "  nixd                - Start LSP server"
-    echo "  statix check        - Lint all Nix files"
+    echo "  nixpkgs-lint .      - Fast tree-sitter lint (whole tree)"
+    echo "  statix check FILE   - Rule-based lint (single file)"
     echo "  deadnix             - Check for dead code"
     echo "  nix-tree            - Visualize dependencies"
     echo "  nix-diff .#old .#new - Compare configurations"


### PR DESCRIPTION
## Summary

- Replaces `statix` (broken on this repo) with `nixpkgs-lint-community v0.3.0` in the pre-commit hook, CI, Justfile, and flake checks
- Keeps `statix` available in `tools/dev.nix` for opt-in single-file analysis (where it's fine)
- Permanent fix for the hang documented in PR #390 (where we had to use `--no-verify`)

## Why

`statix 0.5.8` (from nixpkgs; also the latest upstream — released Sept 2023, no new version in 2 years) has pathological behavior on this 141-module configuration when invoked whole-repo:

| Tool | Whole-tree time | RSS | Status |
|---|---|---|---|
| `statix check .` (current) | **25+ min** (timed out at 1h31m+ before manual kill) | **16+ GB** | ❌ unusable |
| `nixpkgs-lint .` (this PR) | **0.304s** | bounded | ✅ |

That's roughly **5000× faster**. Root cause appears to be quadratic/exponential interaction in statix's binding/scope analysis on deeply-nested recursive modules; likely related to upstream issues `oppiliappan/statix#142`, `#85`, `#63` (`collapsible_let_in` infinite recursion). No upstream fix has shipped.

The pre-commit hook is configured `pass_filenames: false`, so every commit triggers a whole-repo scan → every commit hangs. We discovered this while shipping #390 and were forced to commit with `--no-verify`.

## Provenance

This change is a cherry-pick of commit `fb4a4e091` from local branch `chore/sync-prior-session` — a prior Claude session already wrote the exact fix but never pushed it. I validated the cherry-pick against current `main`, ran the new linter end-to-end (0.304s), and confirmed it surfaces 1 legitimate pre-existing finding (out of scope for this PR; see follow-ups).

## What changed (5 files, +24/-21)

| File | Change |
|---|---|
| `.pre-commit-config.yaml` | `statix` hook → `nixpkgs-lint` hook (`pass_filenames: true`); `deadnix` defensively switched to per-file invocation |
| `.github/workflows/ci.yml` | Lint step swapped to `nixpkgs-lint`; also fixes two pre-existing shellcheck nits the actionlint hook surfaced on touch (SC2016 disable directive, SC2046 quote fix) |
| `Justfile` | `lint-all` recipe uses `nixpkgs-lint .` directly |
| `checks/default.nix` | Flake check `statix-lint` → `nixpkgs-lint-check` (still warning-only) |
| `tools/dev.nix` | Adds `nixpkgs-lint-community` as primary linter; keeps `statix` for per-file opt-in |

## Test plan

- [x] `nixpkgs-lint .` whole-tree — completes in 0.304s real (vs `statix` which never finishes); 1 pre-existing finding only (`modules/services/cosmic-ext-radio-applet/default.nix:24` — `makeWrapper` should be in `nativeBuildInputs`; out of scope here)
- [x] Cherry-pick applies cleanly to current `main` (one auto-merge in `Justfile`)
- [x] All references to `statix` post-change verified — only IDE/editor integrations (`vscode.nix`, `windsurf.nix`, `nixd.nix`, `lsp-servers.nix`), system package install (`modules/development/{pre-commit,nix}.nix`), and explicit per-file opt-in (`tools/dev.nix`) remain
- [ ] CI `lint-check` (post-push)

## Follow-ups (separate PRs)

1. `tools/default.nix:281` still has a `statix check --format=stderr` whole-repo invocation in a script utility. Same hang risk if that script is run. Migrate to `nixpkgs-lint` in a separate change to keep this PR's scope tight.
2. Fix the pre-existing `cosmic-ext-radio-applet` `buildInputs` → `nativeBuildInputs` lint that `nixpkgs-lint` will start surfacing on every CI run.
3. Two unrelated commits also live on `chore/sync-prior-session` (NotebookLM dev profile, `update-commit-deploy` auto-switch) — not in this PR; user to triage separately.

## Notes

- This PR unblocks normal pre-commit hook flow. After merge, future commits no longer need `--no-verify`.
- Why not a simple `statix` version bump? `0.5.8` *is* the latest upstream; no fix exists yet.
- Why not just disable the `collapsible_let_in` lint via `.statix.toml`? Insufficient evidence that's the only trigger; the timing data shows `nixpkgs-lint` is structurally orders of magnitude faster regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)