### PR TITLE
feat(terminals): add Warp terminal to razer and p620

### DIFF
--- a/Users/common/features-impl.nix
+++ b/Users/common/features-impl.nix
@@ -18,6 +18,7 @@ in
       wezterm.enable = cfg.terminals.wezterm;
       kitty.enable = cfg.terminals.kitty;
       ghostty.enable = cfg.terminals.ghostty;
+      warp.enable = cfg.terminals.warp;
     })
 
     # Editor implementations

--- a/Users/common/features.nix
+++ b/Users/common/features.nix
@@ -8,6 +8,7 @@ with lib; {
       wezterm = mkEnableOption "Enable Wezterm terminal";
       kitty = mkEnableOption "Enable Kitty terminal";
       ghostty = mkEnableOption "Enable Ghostty terminal";
+      warp = mkEnableOption "Enable Warp terminal";
     };
 
     editors = {

--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -78,6 +78,7 @@
       wezterm = true;
       kitty = true;
       ghostty = true;
+      warp = true;
     };
 
     editors = {

--- a/Users/olafkfreund/razer_home.nix
+++ b/Users/olafkfreund/razer_home.nix
@@ -64,6 +64,7 @@ in
       wezterm = true;
       kitty = false;
       ghostty = false;
+      warp = true;
     };
 
     editors = {

--- a/home/desktop/terminals/default.nix
+++ b/home/desktop/terminals/default.nix
@@ -103,6 +103,7 @@ in
   imports = [
     ./ghostty
     ./wezterm
+    ./warp
   ];
 
   # Backward compatibility options for individual terminals

--- a/home/desktop/terminals/warp/default.nix
+++ b/home/desktop/terminals/warp/default.nix
@@ -1,0 +1,24 @@
+{ pkgs
+, config
+, lib
+, ...
+}:
+with lib; let
+  cfg = config.warp;
+in
+{
+  options.warp = {
+    enable = mkEnableOption "Warp terminal emulator";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.warp-terminal ];
+
+    # Register Warp's .desktop as an associated terminal handler. We deliberately
+    # do NOT override the default terminal cascade in
+    # home/desktop/terminals/default.nix (which prefers kitty → foot → alacritty).
+    xdg.mimeApps.associations.added = {
+      "x-scheme-handler/terminal" = "dev.warp.Warp.desktop";
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Adds [Warp](https://www.warp.dev/) terminal as an opt-in option in the existing `features.terminals.*` Home Manager system, enabled on `p620` and `razer`.

## Why

User-facing change: an additional modern terminal (AI features, command blocks) available alongside the existing kitty/foot/alacritty/wezterm/ghostty cascade.

## What changed (6 files, +29 lines)

| File | Change |
|---|---|
| `Users/common/features.nix` | Adds `terminals.warp` enable option |
| `Users/common/features-impl.nix` | Wires `warp.enable = cfg.terminals.warp` |
| `Users/olafkfreund/p620_home.nix` | `terminals.warp = true` |
| `Users/olafkfreund/razer_home.nix` | `terminals.warp = true` (kept independent of `kitty=false`/`ghostty=false`) |
| `home/desktop/terminals/default.nix` | Imports `./warp` |
| `home/desktop/terminals/warp/default.nix` | New HM submodule: enables `pkgs.warp-terminal`, registers `dev.warp.Warp.desktop` as an associated terminal handler |

## Design notes

- No `programs.warp-terminal` HM module exists upstream — using `home.packages` directly
- The default `xdg.mimeApps.defaultApplications` cascade (kitty → foot → alacritty) is **not** overridden; warp is just an associated handler
- `pkgs.warp-terminal` is unfree; `allowUnfree` is already set repo-wide

## Test plan

- [x] `nix build .#nixosConfigurations.razer.config.system.build.toplevel` — passes (1:16 real)
- [x] `warp-terminal-0.2026.04.15.08.45.stable_04` confirmed in razer's closure
- [x] `nixosConfigurations.razer.config.home-manager.users.olafkfreund.warp.enable` evaluates to `true`
- [ ] `just quick-deploy razer` — to be run by maintainer
- [ ] `just quick-deploy p620` — to be run by maintainer

## Notes

Branch was rebased onto current `main` after PR #390 (Obsidian) and #391 (statix→nixpkgs-lint) merged, so pre-commit hooks ran cleanly (nixpkgs-lint, deadnix, formatters all passed).

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)