### PR TITLE
chore(lint): fix the four findings nixpkgs-lint surfaced after #391

### DIFF
--- a/modules/TEMPLATE.nix
+++ b/modules/TEMPLATE.nix
@@ -48,7 +48,7 @@ in
     ];
 
     # Warnings for deprecated options
-    warnings = optional (cfg.extraConfig != "") [
+    warnings = optionals (cfg.extraConfig != "") [
       "extraConfig option is deprecated, use settings instead"
     ];
   };

--- a/modules/desktop/cosmic.nix
+++ b/modules/desktop/cosmic.nix
@@ -139,7 +139,7 @@ in
           wrapCosmicApp = name: pkg: pkgs.symlinkJoin {
             name = "${name}-wrapped";
             paths = [ pkg ];
-            buildInputs = [ pkgs.makeWrapper ];
+            nativeBuildInputs = [ pkgs.makeWrapper ];
             postBuild = ''
               wrapProgram $out/bin/${name} \
                 --prefix LD_LIBRARY_PATH : "${waylandLibs}"

--- a/modules/services/cosmic-ext-radio-applet/default.nix
+++ b/modules/services/cosmic-ext-radio-applet/default.nix
@@ -21,7 +21,7 @@ let
   wrappedPackage = pkgs.symlinkJoin {
     name = "cosmic-ext-applet-radio-wrapped";
     paths = [ cfg.package ];
-    buildInputs = [ pkgs.makeWrapper ];
+    nativeBuildInputs = [ pkgs.makeWrapper ];
     postBuild = ''
       wrapProgram $out/bin/cosmic-ext-applet-radio \
         --prefix LD_LIBRARY_PATH : "${waylandLibs}"

--- a/tools/default.nix
+++ b/tools/default.nix
@@ -247,7 +247,7 @@
   # Development utilities
   dev-utils = pkgs.writeShellApplication {
     name = "nixos-dev-utils";
-    runtimeInputs = with pkgs; [ nix git nixpkgs-fmt statix deadnix ];
+    runtimeInputs = with pkgs; [ nix git nixpkgs-fmt nixpkgs-lint-community deadnix ];
     text = ''
       #!/bin/bash
 
@@ -277,8 +277,8 @@
           echo "✅ Formatting completed"
           ;;
         lint)
-          echo "Running linting checks..."
-          statix check --format=stderr || echo "Linting completed with warnings"
+          echo "Running linting checks (nixpkgs-lint, tree-sitter)..."
+          nixpkgs-lint . || echo "Linting completed with warnings"
           ;;
         check-dead)
           echo "Checking for dead code..."


### PR DESCRIPTION
## Summary

Now that `nixpkgs-lint-community` is the active whole-tree linter (PR #391), the tree showed up as **4 small pre-existing findings**. Fix them all so CI runs cleanly going forward.

| File | Finding | Fix |
|---|---|---|
| `tools/default.nix:281` | `dev-utils lint` subcommand still invoked `statix check` — same whole-repo hang as PR #391 | Swap to `nixpkgs-lint .`; update `runtimeInputs` (`statix` → `nixpkgs-lint-community`) |
| `modules/services/cosmic-ext-radio-applet/default.nix:24` | `pkgs.makeWrapper` in `buildInputs` (it's a build-time tool) | Move to `nativeBuildInputs` |
| `modules/desktop/cosmic.nix:142` | Same `makeWrapper` issue in the `wrapCosmicApp` helper used for cosmic-settings/term/edit/files | Move to `nativeBuildInputs` |
| `modules/TEMPLATE.nix:51` | `lib.optional (cond) [ "msg" ]` returns `[ [ "msg" ] ]` (nested list) when cond is true, which is wrong for `warnings` (expects a flat list of strings) | Switch to `lib.optionals` so the list flattens correctly |

## Verification

- ✅ `time nixpkgs-lint .` — **0.311s real, zero findings**
- ✅ `nix build .#nixosConfigurations.p620.config.system.build.toplevel` — passes (1:43; both `cosmic.nix` wrapper and `cosmic-ext-radio-applet` are in p620's closure)
- ✅ Pre-commit hooks ran cleanly in 1:23 (deadnix per-file, nixpkgs-lint whole-tree, formatters all Pass/Skip)

## Why include the bonus `TEMPLATE.nix` and `cosmic.nix` fixes?

PR #391 only mentioned the `cosmic-ext-radio-applet` finding because that was the only one I'd seen at the time. After that PR merged and I ran `nixpkgs-lint` on a clean tree, three more findings surfaced (one of them — `TEMPLATE.nix` — has a real semantic bug, not just style). Bundling them into one chore PR rather than four micro-PRs.

## Why the cosmic `lib.optional` matters

`lib.optional cond x` returns `[ x ]` if `cond`, else `[]`. The argument is wrapped in a list — so `lib.optional cond [ "msg" ]` returns `[ [ "msg" ] ]` when truthy, which is a list-of-list and would either crash or print weirdly when used as `warnings`. `lib.optionals cond xs` returns `xs` directly. The TEMPLATE was teaching the wrong pattern; this fixes it.

## What this unblocks

- `dev-utils lint` (`nix run .#dev-utils lint`) — now usable; previously hung on this repo
- CI `lint-check` job — fully green; no warning noise
- The TEMPLATE.nix copy-paste pattern others may follow — now teaches the right idiom

🤖 Generated with [Claude Code](https://claude.com/claude-code)