### PR TITLE
chore(claude-desktop): bump 1.4758.0 → 1.5354.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,17 +132,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1777081066,
-        "narHash": "sha256-4zGmWbUnOJ1VBd8eB8R2mxm8oBh5HFZX648aWYkiLSs=",
+        "lastModified": 1777513221,
+        "narHash": "sha256-DgAIB8w7lm3KFVmt++TZ5O9DdhWXmJNHK6hBIp7ITus=",
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "f9841bd81e79e1d42970a0b5b92b8d8e35a6b6d9",
+        "rev": "dc762a35a02782415fcaa84f0d7ed9d2a6064215",
         "type": "github"
       },
       "original": {
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "f9841bd81e79e1d42970a0b5b92b8d8e35a6b6d9",
+        "rev": "dc762a35a02782415fcaa84f0d7ed9d2a6064215",
         "type": "github"
       }
     },
@@ -1217,11 +1217,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1776949667,
+        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -73,13 +73,13 @@
     # Additional tools
     lan-mouse.url = "github:feschber/lan-mouse";
     zjstatus.url = "github:dj95/zjstatus";
-    # = tag v2.0.5+claude1.4758.0 (2026-04-25). Wrapper at v2.0.5 includes
+    # = tag v2.0.5+claude1.5354.0 (2026-04-30). Wrapper at v2.0.5 includes
     # upstream's own CRLF-strip fix for cowork-plugin-shim.sh (PRs #499,
     # #505) — our overlay's postInstall workaround is now unneeded; the
     # overlay below simplifies to a direct FHS pass-through.
-    # claude binary at 1.4758.0.
+    # claude binary at 1.5354.0.
     # Bump via /update-claude-code.
-    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/f9841bd81e79e1d42970a0b5b92b8d8e35a6b6d9";
+    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/dc762a35a02782415fcaa84f0d7ed9d2a6064215";
 
     # Terminal YouTube browser
     yt-x = {


### PR DESCRIPTION
## Summary

Bumps the embedded Claude binary in `claude-desktop`:

|  | Pin | Tag | Date |
|---|---|---|---|
| Was | `f9841bd8` | `v2.0.5+claude1.4758.0` | 2026-04-25 |
| New | `dc762a35` | `v2.0.5+claude1.5354.0` | 2026-04-30 |

Wrapper version unchanged at v2.0.5 — only the embedded Claude binary advances. Our overlay remains a clean FHS pass-through (the CRLF-strip + chmod fixes are already in upstream PRs #432/#499/#505, all included from v2.0.0+).

## Risk assessment

| Concern | Status |
|---|---|
| Issue #431 (electron missing +x on NixOS) | ✅ Not affecting us — fix landed in v2.0.0 (PR #432); our pin is post-v2.0.0. Verified `electron` binary is `r-x` (executable). |
| Issue #429 (build.sh patches warn-and-continue) | ✅ N/A — our overlay no longer applies any sed patch (clean pass-through since v2.0.5+). |
| `_svcLaunched` cowork regressions | ✅ Not in open issue list against this tag. |
| `pty.node` is Linux ELF (not Windows binary) | ✅ Verified ELF 64-bit |
| Inner package version | ✅ `claude-desktop-1.5354.0` (matches target) |

## Test plan

- [x] `nix build .#nixosConfigurations.razer.pkgs.claude-desktop-linux` — clean
- [x] Inner package: `claude-desktop-1.5354.0`
- [x] `electron` binary has `+x`
- [x] `pty.node` is Linux ELF
- [x] Host matrix:
  - [x] p620 toplevel — clean (1:24)
  - [x] razer toplevel — clean (1:23)
  - [x] p510 toplevel — clean (1:27, package in closure even though UI not deployed there)

## Deploy notes (idiot-proofing per `/update-claude-code` Section B)

- claude-desktop is **probably running** on razer/p620 right now. `nixos-rebuild switch` activates the new generation but the existing Electron process keeps running from the OLD store path until killed.
- After deploy, run: `pkill -f "claude-desktop-1\.[0-9]"` then relaunch from app menu. **Warn the user first** — in-flight chat state is lost.
- If launch fails (rare with this small bump, more likely on major jumps): `rm -rf ~/.config/Claude/vm_bundles/` and relaunch (upstream issue #408).

## Rollback

`sudo nixos-rebuild switch --rollback` per host, OR `git revert HEAD` and redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)