### PR TITLE
fix(lazyvim): load blink.cmp from nixpkgs to restore Rust matcher

### DIFF
--- a/home/shell/lazyvim/default.nix
+++ b/home/shell/lazyvim/default.nix
@@ -1,6 +1,12 @@
-_: {
+{ pkgs, ... }: {
   home.file.".config/nvim" = {
     source = ./lazyvim;
     recursive = true;
   };
+
+  # Expose the Nix-built blink.cmp (with prebuilt Rust fuzzy matcher) at a
+  # stable path so lazy.nvim can load it via `dir = ...` and skip the broken
+  # release-binary download.
+  home.file.".local/share/nix-vim-plugins/blink.cmp".source =
+    pkgs.vimPlugins.blink-cmp;
 }

--- a/home/shell/lazyvim/lazyvim/lua/plugins/blink.lua
+++ b/home/shell/lazyvim/lazyvim/lua/plugins/blink.lua
@@ -6,12 +6,12 @@ return {
       "rafamadriz/friendly-snippets",
       "folke/lazydev.nvim",
     },
-    -- Pin to 1.x releases so lazy.nvim picks up upstream's prebuilt Rust
-    -- matcher binary (linux-x86_64.gz asset on each release). Using `false`
-    -- (main HEAD) means no prebuilt is available, and since this is
-    -- Nix-managed nvim — no cargo in the runtime — blink falls back to the
-    -- Lua matcher and emits a loud warning on every startup.
-    version = "1.*",
+    -- Use the Nix-built plugin (vimPlugins.blink-cmp), which ships the
+    -- prebuilt libblink_cmp_fuzzy.so. The path is materialized by
+    -- home/shell/lazyvim/default.nix. Avoids lazy.nvim's release-binary
+    -- download (which fails in this env) and the Lua-fallback warning.
+    dir = vim.fn.expand("~/.local/share/nix-vim-plugins/blink.cmp"),
+    build = false,
     opts = {
       keymap = {
         preset = "enter",


### PR DESCRIPTION
## Summary
- lazy.nvim's blink.cmp v1.* spec was failing to download the prebuilt Rust matcher binary, falling back to the Lua matcher and warning on every Neovim startup
- Symlink \`pkgs.vimPlugins.blink-cmp\` (1.10.2, already builds \`libblink_cmp_fuzzy.so\`) into \`~/.local/share/nix-vim-plugins/blink.cmp\` via home-manager
- Switch the lazy spec to \`dir = ...\` + \`build = false\` so lazy loads the Nix-built plugin directly — no network, no fallback

## Test plan
- [x] \`nix flake check --no-build\` passes
- [x] pre-commit hooks (format, lint, dead-code, flake check, spell) pass
- [ ] After deploy: \`:Lazy sync\` in Neovim picks up the new \`dir\` and the "No fuzzy matching library found" warning is gone
- [ ] \`:lua print(require('blink.cmp.fuzzy').implementation())\` reports \`rust\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)