### PR TITLE
feat(claude-code): three-layer settings architecture (managed + init-template) (#398)

### DIFF
--- a/home/development/claude-code-lsp.nix
+++ b/home/development/claude-code-lsp.nix
@@ -5,64 +5,27 @@
 }:
 with lib; let
   cfg = config.programs.claudeCode.lsp;
-  hooksCfg = config.programs.claudeCode.hooks;
 
-  # PARR Protocol Reminder Hook - Enforces structured reasoning for every task
-  parrReminderScript = pkgs.writeShellScript "parr-reminder.sh" ''
-        #!/usr/bin/env bash
-        cat << 'PARR_EOF'
-    <system-reminder>
-    ## MANDATORY: Follow PARR Protocol for This Task
-
-    You MUST structure your response using these phases:
-
-    ### 🎯 PLAN (Before ANY action)
-    - State the goal in one sentence
-    - List steps with verification criteria
-    - Identify approach, assumptions, and risks
-
-    ### ⚡ ACT (Execute ONE step at a time)
-    - Announce what you're doing
-    - Execute exactly ONE step
-    - Show output and verify checkpoint
-    - NEVER chain commands without checking results
-
-    ### 🔍 REFLECT (After EACH step)
-    - Did it work? Compare expected vs actual
-    - Any side effects?
-    - Is the plan still valid?
-
-    ### 🔄 REVISE (When needed)
-    - If something failed, diagnose root cause
-    - Update plan with new information
-    - Consider alternative approaches
-
-    ### ✅ COMPLETE (When done)
-    - Summarize what was achieved
-    - List files changed
-    - Note any follow-up needed
-
-    CRITICAL RULES:
-    - NEVER skip the PLAN phase
-    - NEVER execute multiple steps without reflection
-    - STOP immediately if something unexpected happens
-    - Ask for clarification if stuck after 2 attempts
-    </system-reminder>
-    PARR_EOF
-  '';
-
-  # Build hooks configuration based on enabled options
-  hooksConfig = {
-    hooks = { }
-      // optionalAttrs hooksCfg.enableParrProtocol {
-      UserPromptSubmit = [{
-        hooks = [{
+  # Init-template content for ~/.claude/settings.json. Written ONCE on
+  # activation if the file is missing; never overwritten thereafter so
+  # `claude plugin install`, permission prompts, and other runtime
+  # mutations stick. The PARR hook used to live here too — it now lives
+  # in /etc/claude-code/managed-settings.json (managed scope) so users
+  # cannot disable it by editing this file. See issue #398.
+  userSettingsTemplate = pkgs.writeText "claude-user-settings.json"
+    (builtins.toJSON (
+      {
+        statusLine = {
           type = "command";
-          command = toString parrReminderScript;
-        }];
-      }];
-    };
-  };
+          command = "${config.home.homeDirectory}/.claude/statusline-gruvbox.sh";
+        };
+      }
+      // lib.optionalAttrs cfg.enableNixLsp {
+        enabledPlugins = {
+          "nix-lsp@nixos-lsp-marketplace" = true;
+        };
+      }
+    ));
 
   # Marketplace configuration for Nix LSP
   marketplaceJson = pkgs.writeTextFile {
@@ -155,19 +118,10 @@ in
       };
     };
 
-    hooks = {
-      enableParrProtocol = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Enable PARR (Plan, Act, Reflect, Revise) protocol enforcement.
-          When enabled, Claude Code will receive a system reminder on every
-          user prompt submission to follow the structured reasoning protocol.
-          This ensures consistent, high-quality responses with proper planning
-          and verification for every task.
-        '';
-      };
-    };
+    # NOTE: programs.claudeCode.hooks.enableParrProtocol was removed in
+    # issue #398. The PARR hook moved to managed scope; configure via
+    # modules.programs.claude-code-managed.parrProtocol.enable in your
+    # NixOS configuration.
   };
 
   config = mkMerge [
@@ -186,68 +140,80 @@ in
           # Plugin README
           ".claude/plugins/custom-marketplace/plugins/nix-lsp/README.md".source = pluginReadme;
 
-          # Ensure the plugin is enabled in settings.json
-          # Note: This includes LSP settings, statusLine, and hooks configuration
-          ".claude/settings.json" = mkIf cfg.enableNixLsp {
-            text = builtins.toJSON ({
-              enabledPlugins = {
-                "nix-lsp@nixos-lsp-marketplace" = true;
-              };
-              # Claude Code status line with gruvbox theme
-              statusLine = {
-                type = "command";
-                command = "${config.home.homeDirectory}/.claude/statusline-gruvbox.sh";
-              };
-            } // hooksConfig);
-            onChange = ''
-              # Merge with existing settings if they exist
-              if [ -f "$HOME/.claude/settings.json.backup" ]; then
-                ${pkgs.jq}/bin/jq -s '.[0] * .[1]' \
-                  "$HOME/.claude/settings.json.backup" \
-                  "$HOME/.claude/settings.json" \
-                  > "$HOME/.claude/settings.json.tmp" && \
-                mv "$HOME/.claude/settings.json.tmp" "$HOME/.claude/settings.json"
-              fi
-            '';
-          };
+          # NOTE: ~/.claude/settings.json is NOT a home.file anymore.
+          # Claude Code mutates it at runtime (`claude plugin install`,
+          # permission prompts, statusline UI) so a nix-store symlink would
+          # break with EACCES. See issue #398 and the activation script
+          # claudeUserSettingsInit below for the init-template pattern.
         };
 
         activation = {
-          # Add shell command to install the marketplace and plugin on first activation
-          # This uses a script that only runs if the marketplace isn't already installed
-          claudeCodeLspSetup = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-            # Check if Claude Code is available
-            if command -v claude &>/dev/null; then
-              $DRY_RUN_CMD echo "Setting up Claude Code LSP plugins..."
+          # Seed ~/.claude/settings.json from a Nix-rendered template ONLY
+          # if the file doesn't already exist as a regular (non-symlink)
+          # file. This makes the user-scope settings file writable so
+          # Claude Code can mutate it at runtime, while still giving us
+          # declarative defaults on a fresh setup.
+          #
+          # Migration handling: if the file is a symlink (e.g. legacy
+          # nix-store symlink from before #398), unlink it first and seed
+          # the template. Existing user-edited content (regular file) is
+          # preserved untouched.
+          claudeUserSettingsInit = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+            target="$HOME/.claude/settings.json"
+            mkdir -p "$HOME/.claude"
 
-              # Function to check if marketplace exists
-              marketplace_exists() {
-                claude plugin marketplace list 2>/dev/null | grep -q "nixos-lsp-marketplace"
-              }
-
-              # Function to check if plugin is installed
-              plugin_installed() {
-                claude plugin marketplace list 2>/dev/null | grep -q "nix-lsp@nixos-lsp-marketplace" || \
-                [ -f "$HOME/.claude/plugins/installed_plugins.json" ] && \
-                grep -q "nix-lsp@nixos-lsp-marketplace" "$HOME/.claude/plugins/installed_plugins.json"
-              }
-
-              # Add marketplace if it doesn't exist
-              if ! marketplace_exists; then
-                $DRY_RUN_CMD echo "Adding nixos-lsp-marketplace..."
-                $DRY_RUN_CMD claude plugin marketplace add "${cfg.customMarketplacePath}" 2>/dev/null || true
-              fi
-
-              # Install plugin if not already installed
-              if ! plugin_installed; then
-                $DRY_RUN_CMD echo "Installing nix-lsp plugin..."
-                $DRY_RUN_CMD claude plugin install nix-lsp@nixos-lsp-marketplace 2>/dev/null || true
-              fi
-
-              $DRY_RUN_CMD echo "Claude Code LSP setup complete!"
-            else
-              $DRY_RUN_CMD echo "Claude Code not found, skipping LSP setup"
+            if [ -L "$target" ]; then
+              # Legacy symlink (likely into /nix/store) — remove it so we
+              # can write a real file. The pre-existing target was always
+              # the same Nix-rendered content, nothing user-authored is
+              # lost.
+              $DRY_RUN_CMD rm -f "$target"
             fi
+
+            if [ ! -e "$target" ]; then
+              $DRY_RUN_CMD install -m 0644 ${userSettingsTemplate} "$target"
+              $DRY_RUN_CMD echo "Seeded $target from Nix template"
+            fi
+          '';
+
+          # Install Claude Code's nix-lsp plugin on first activation. Now
+          # that ~/.claude/settings.json is writable (see #398), this can
+          # actually succeed; it used to silently fail with EACCES, hidden
+          # by the 2>/dev/null swallow. Errors now surface to the user
+          # except for the "claude not installed yet" path, which is
+          # legitimately optional.
+          #
+          # Runs after claudeUserSettingsInit so the settings file exists
+          # before `claude plugin install` tries to write to it.
+          claudeCodeLspSetup = lib.hm.dag.entryAfter [ "claudeUserSettingsInit" ] ''
+            if ! command -v claude >/dev/null 2>&1; then
+              $DRY_RUN_CMD echo "Claude Code not found, skipping LSP setup"
+              exit 0
+            fi
+
+            $DRY_RUN_CMD echo "Setting up Claude Code LSP plugins..."
+
+            marketplace_exists() {
+              claude plugin marketplace list | grep -q "nixos-lsp-marketplace"
+            }
+
+            plugin_installed() {
+              claude plugin marketplace list | grep -q "nix-lsp@nixos-lsp-marketplace" \
+                || ( [ -f "$HOME/.claude/plugins/installed_plugins.json" ] \
+                     && grep -q "nix-lsp@nixos-lsp-marketplace" "$HOME/.claude/plugins/installed_plugins.json" )
+            }
+
+            if ! marketplace_exists; then
+              $DRY_RUN_CMD echo "Adding nixos-lsp-marketplace..."
+              $DRY_RUN_CMD claude plugin marketplace add "${cfg.customMarketplacePath}"
+            fi
+
+            if ! plugin_installed; then
+              $DRY_RUN_CMD echo "Installing nix-lsp plugin..."
+              $DRY_RUN_CMD claude plugin install nix-lsp@nixos-lsp-marketplace
+            fi
+
+            $DRY_RUN_CMD echo "Claude Code LSP setup complete!"
           '';
 
           # MCP server configuration is now handled by claude-code-mcp.nix module

--- a/home/development/claude-code-mcp.nix
+++ b/home/development/claude-code-mcp.nix
@@ -1,6 +1,17 @@
 # Claude Code MCP Configuration
-# Automatically generates settings.local.json for MCP servers
-# Follows docs/NIXOS-ANTI-PATTERNS.md security patterns
+#
+# Renders ~/.claude/settings.local.json with the per-host MCP server set.
+# As of issue #398 this file is *seeded* (init-template) rather than
+# managed as a nix-store symlink — Claude Code mutates it at runtime
+# (`claude mcp add`, accepted permissions) and a read-only symlink would
+# break with EACCES.
+#
+# Tradeoff: once Claude Code or the user edits the file, subsequent
+# `nixos-rebuild switch` runs will NOT push new declarative MCP servers
+# into it. To resync to the Nix-declared set, delete the file and
+# re-activate (e.g. `home-manager switch` or any `nixos-rebuild switch`).
+#
+# Follows docs/NIXOS-ANTI-PATTERNS.md security patterns.
 { config, lib, pkgs, osConfig, ... }:
 let
   # Access system-level MCP configuration via osConfig
@@ -13,209 +24,221 @@ let
 
   # Helper function to create shell script wrappers
   mkWrapper = name: script: pkgs.writeShellScript name script;
+
+  mcpSettingsTemplate = pkgs.writeText "claude-mcp-settings.local.json"
+    (builtins.toJSON {
+      mcpServers =
+        # Always enabled MCP servers
+        {
+          # Playwright MCP for browser automation
+          playwright = {
+            command = "${pkgs.nodejs}/bin/npx";
+            args = [ "-y" "@playwright/mcp@latest" ];
+            env = {
+              PLAYWRIGHT_BROWSERS_PATH = "${pkgs.playwright-driver.browsers}";
+              PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
+            };
+            description = "Browser automation using Playwright - AI-powered web testing, form filling, and DOM interaction";
+          };
+
+          # BrowserMCP for privacy-focused browser automation
+          browsermcp = {
+            command = "${pkgs.nodejs}/bin/npx";
+            args = [ "@browsermcp/mcp@latest" ];
+            description = "Browser automation with privacy - AI-powered web automation (requires Chrome extension)";
+          };
+
+          # Context7 for up-to-date library documentation
+          context7 = {
+            type = "stdio";
+            command = "${pkgs.nodejs}/bin/npx";
+            args = [ "-y" "@upstash/context7-mcp@latest" ];
+            description = "Up-to-date library documentation - prevents coding hallucinations with current docs";
+          };
+
+          # Sequential Thinking for systematic problem-solving
+          sequential-thinking = {
+            command = "${pkgs.nodejs}/bin/npx";
+            args = [ "-y" "@modelcontextprotocol/server-sequential-thinking" ];
+            description = "Dynamic and reflective problem-solving through systematic thinking - helps break down complex problems into steps";
+          };
+
+          # NotebookLM MCP for Google NotebookLM interaction
+          notebooklm = {
+            command = "${pkgs.uv}/bin/uvx";
+            args = [ "--from" "notebooklm-mcp-cli" "notebooklm-mcp" ];
+            description = "Google NotebookLM interaction - create notebooks, add sources, generate audio/video overviews, query content via AI";
+          };
+
+          # Terraform MCP for Infrastructure as Code
+          terraform = {
+            command = if pkgs ? terraform-mcp-server then "${pkgs.terraform-mcp-server}/bin/terraform-mcp-server" else "${pkgs.writeShellScript "terraform-mcp-placeholder" "echo 'Terraform MCP not available'"}";
+            args = [ ];
+            description = "Terraform Infrastructure as Code - manage and query terraform configurations";
+          };
+        }
+        # Obsidian MCP - conditional configuration based on implementation
+        // (lib.optionalAttrs obsidianEnabled {
+          "obsidian-rest" =
+            if mcpCfg.obsidian.implementation == "zero-dependency"
+            then {
+              command = if pkgs ? obsidian-mcp then "${pkgs.obsidian-mcp}/bin/obsidian-mcp" else "${pkgs.writeShellScript "obsidian-mcp-placeholder" "echo 'Obsidian MCP not available'"}";
+              args = [ mcpCfg.obsidian.vaultPath ];
+              description = "Obsidian vault knowledge base (zero-dependency, read-only)";
+            }
+            else {
+              command = "${mkWrapper "obsidian-mcp-rest-wrapper" ''
+                export OBSIDIAN_API_KEY_FILE=${mcpCfg.obsidian.restApi.apiKeyFile}
+                export OBSIDIAN_HOST=${mcpCfg.obsidian.restApi.host}
+                export OBSIDIAN_PORT=${toString mcpCfg.obsidian.restApi.port}
+                export VERIFY_SSL=${if mcpCfg.obsidian.restApi.verifySsl then "true" else "false"}
+                ${if pkgs ? obsidian-mcp-rest then ''
+                  exec ${pkgs.obsidian-mcp-rest}/bin/obsidian-mcp-rest "$@"
+                '' else ''
+                  echo "Obsidian MCP REST not available" >&2
+                  exit 1
+                ''}
+              ''}";
+              args = [ ];
+              description = "Obsidian vault with full CRUD via REST API plugin - requires Local REST API plugin installed";
+            };
+        })
+        # GitHub MCP server (if GitHub token available)
+        // (lib.optionalAttrs (osConfig.age.secrets."api-github-token" or null != null) {
+          github = {
+            command = "${mkWrapper "github-mcp-wrapper" ''
+              export GITHUB_TOKEN_FILE=${osConfig.age.secrets."api-github-token".path}
+              exec ${pkgs.github-mcp-server}/bin/github-mcp-server "$@"
+            ''}";
+            args = [ ];
+            description = "GitHub repository integration - PR automation, issue management, repository queries";
+          };
+        })
+        # LinkedIn MCP server (if LinkedIn cookie available)
+        // (lib.optionalAttrs linkedinEnabled {
+          linkedin = {
+            command = "${mkWrapper "linkedin-mcp-wrapper" ''
+              export LINKEDIN_COOKIE_FILE=${osConfig.age.secrets."api-linkedin-cookie".path}
+              exec ${pkgs.docker}/bin/docker run --rm -i \
+                --read-only \
+                --security-opt=no-new-privileges \
+                --cap-drop=ALL \
+                -e LINKEDIN_COOKIE="$(cat $LINKEDIN_COOKIE_FILE)" \
+                stickerdaniel/linkedin-mcp-server:latest "$@"
+            ''}";
+            args = [ ];
+            description = "LinkedIn professional networking and job search";
+          };
+        })
+        # WhatsApp MCP server
+        // (lib.optionalAttrs whatsappEnabled {
+          whatsapp = {
+            command = "${mkWrapper "whatsapp-mcp-wrapper" ''
+              # Ensure WhatsApp bridge service is running
+              if ! systemctl is-active --quiet whatsapp-bridge; then
+                echo "ERROR: WhatsApp bridge service is not running" >&2
+                echo "Start service: systemctl start whatsapp-bridge" >&2
+                echo "View QR code for authentication: journalctl -u whatsapp-bridge -f" >&2
+                exit 1
+              fi
+
+              # Launch MCP server
+              exec ${pkgs.customPkgs.whatsapp-mcp.whatsappMcpServer}/bin/whatsapp-mcp-server "$@"
+            ''}";
+            args = [ ];
+            description = "WhatsApp messaging integration - AI-assisted WhatsApp send/receive, message history queries (requires bridge service + QR auth)";
+          };
+        })
+        # Atlassian MCP server (Jira and Confluence)
+        // (lib.optionalAttrs atlassianEnabled (
+          let
+            mode = mcpCfg.atlassian.mode or "cloud";
+            jiraEnabled = mcpCfg.atlassian.jira.enable or false;
+            confluenceEnabled = mcpCfg.atlassian.confluence.enable or false;
+          in
+          {
+            atlassian = {
+              command = "${mkWrapper "atlassian-mcp-wrapper" (
+                if mode == "cloud" then ''
+                  ${lib.optionalString jiraEnabled ''
+                    export JIRA_URL="${mcpCfg.atlassian.jira.url}"
+                    export JIRA_USERNAME="${mcpCfg.atlassian.jira.username}"
+                    export JIRA_TOKEN_FILE="${mcpCfg.atlassian.jira.tokenFile}"
+                  ''}
+                  ${lib.optionalString confluenceEnabled ''
+                    export CONFLUENCE_URL="${mcpCfg.atlassian.confluence.url}"
+                    export CONFLUENCE_USERNAME="${mcpCfg.atlassian.confluence.username}"
+                    export CONFLUENCE_TOKEN_FILE="${mcpCfg.atlassian.confluence.tokenFile}"
+                  ''}
+                  export ATLASSIAN_MODE="cloud"
+                  exec ${pkgs.customPkgs.atlassian-mcp}/bin/atlassian-mcp "$@"
+                '' else ''
+                  ${lib.optionalString jiraEnabled ''
+                    export JIRA_URL="${mcpCfg.atlassian.jira.url}"
+                    export JIRA_PAT_FILE="${mcpCfg.atlassian.jira.patFile}"
+                  ''}
+                  ${lib.optionalString confluenceEnabled ''
+                    export CONFLUENCE_URL="${mcpCfg.atlassian.confluence.url}"
+                    export CONFLUENCE_PAT_FILE="${mcpCfg.atlassian.confluence.patFile}"
+                  ''}
+                  export ATLASSIAN_MODE="self-hosted"
+                  exec ${pkgs.customPkgs.atlassian-mcp}/bin/atlassian-mcp "$@"
+                ''
+              )}";
+              args = [ ];
+              description = "Atlassian Jira and Confluence integration - issue tracking, project management, and documentation (${mode} mode)";
+            };
+          }
+        ))
+        # Grafana MCP server (if enabled in servers configuration)
+        // (lib.optionalAttrs (mcpCfg.servers.grafana or false) {
+          grafana = {
+            command = if pkgs ? mcp-grafana then "${pkgs.mcp-grafana}/bin/mcp-grafana" else "${pkgs.writeShellScript "grafana-mcp-placeholder" "echo 'Grafana MCP not available'"}";
+            args = [
+              "--url"
+              "http://p620:3001" # P620 is the monitoring server
+              "--token"
+              "\${GRAFANA_API_TOKEN}"
+            ];
+            description = "Grafana dashboard and metrics integration - query monitoring data from P620";
+          };
+        });
+    });
 in
 {
   config = lib.mkIf enabled {
-    # Claude Code MCP configuration file
-    # Location: ~/.claude/settings.local.json
-    home.file.".claude/settings.local.json" = {
-      text = builtins.toJSON {
-        mcpServers =
-          # Always enabled MCP servers
-          {
-            # Playwright MCP for browser automation
-            playwright = {
-              command = "${pkgs.nodejs}/bin/npx";
-              args = [ "-y" "@playwright/mcp@latest" ];
-              env = {
-                PLAYWRIGHT_BROWSERS_PATH = "${pkgs.playwright-driver.browsers}";
-                PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
-              };
-              description = "Browser automation using Playwright - AI-powered web testing, form filling, and DOM interaction";
-            };
+    # Seed ~/.claude/settings.local.json from a Nix-rendered template
+    # ONLY if the file is missing or a legacy nix-store symlink. After
+    # that, Claude Code owns it (claude mcp add etc.). To resync to the
+    # Nix-declared MCP set, delete the file and re-activate. See #398.
+    home.activation.claudeMcpSettingsInit = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      target="$HOME/.claude/settings.local.json"
+      mkdir -p "$HOME/.claude"
 
-            # BrowserMCP for privacy-focused browser automation
-            browsermcp = {
-              command = "${pkgs.nodejs}/bin/npx";
-              args = [ "@browsermcp/mcp@latest" ];
-              description = "Browser automation with privacy - AI-powered web automation (requires Chrome extension)";
-            };
+      if [ -L "$target" ]; then
+        $DRY_RUN_CMD rm -f "$target"
+      fi
 
-            # Context7 for up-to-date library documentation
-            context7 = {
-              type = "stdio";
-              command = "${pkgs.nodejs}/bin/npx";
-              args = [ "-y" "@upstash/context7-mcp@latest" ];
-              description = "Up-to-date library documentation - prevents coding hallucinations with current docs";
-            };
+      if [ ! -e "$target" ]; then
+        $DRY_RUN_CMD install -m 0644 ${mcpSettingsTemplate} "$target"
+        $DRY_RUN_CMD echo "Seeded $target from Nix template"
+      fi
+    '';
 
-            # Sequential Thinking for systematic problem-solving
-            sequential-thinking = {
-              command = "${pkgs.nodejs}/bin/npx";
-              args = [ "-y" "@modelcontextprotocol/server-sequential-thinking" ];
-              description = "Dynamic and reflective problem-solving through systematic thinking - helps break down complex problems into steps";
-            };
-
-            # NotebookLM MCP for Google NotebookLM interaction
-            notebooklm = {
-              command = "${pkgs.uv}/bin/uvx";
-              args = [ "--from" "notebooklm-mcp-cli" "notebooklm-mcp" ];
-              description = "Google NotebookLM interaction - create notebooks, add sources, generate audio/video overviews, query content via AI";
-            };
-
-            # Terraform MCP for Infrastructure as Code
-            terraform = {
-              command = if pkgs ? terraform-mcp-server then "${pkgs.terraform-mcp-server}/bin/terraform-mcp-server" else "${pkgs.writeShellScript "terraform-mcp-placeholder" "echo 'Terraform MCP not available'"}";
-              args = [ ];
-              description = "Terraform Infrastructure as Code - manage and query terraform configurations";
-            };
-          }
-          # Obsidian MCP - conditional configuration based on implementation
-          // (lib.optionalAttrs obsidianEnabled {
-            "obsidian-rest" =
-              if mcpCfg.obsidian.implementation == "zero-dependency"
-              then {
-                command = if pkgs ? obsidian-mcp then "${pkgs.obsidian-mcp}/bin/obsidian-mcp" else "${pkgs.writeShellScript "obsidian-mcp-placeholder" "echo 'Obsidian MCP not available'"}";
-                args = [ mcpCfg.obsidian.vaultPath ];
-                description = "Obsidian vault knowledge base (zero-dependency, read-only)";
-              }
-              else {
-                command = "${mkWrapper "obsidian-mcp-rest-wrapper" ''
-                  export OBSIDIAN_API_KEY_FILE=${mcpCfg.obsidian.restApi.apiKeyFile}
-                  export OBSIDIAN_HOST=${mcpCfg.obsidian.restApi.host}
-                  export OBSIDIAN_PORT=${toString mcpCfg.obsidian.restApi.port}
-                  export VERIFY_SSL=${if mcpCfg.obsidian.restApi.verifySsl then "true" else "false"}
-                  ${if pkgs ? obsidian-mcp-rest then ''
-                    exec ${pkgs.obsidian-mcp-rest}/bin/obsidian-mcp-rest "$@"
-                  '' else ''
-                    echo "Obsidian MCP REST not available" >&2
-                    exit 1
-                  ''}
-                ''}";
-                args = [ ];
-                description = "Obsidian vault with full CRUD via REST API plugin - requires Local REST API plugin installed";
-              };
-          })
-          # GitHub MCP server (if GitHub token available)
-          // (lib.optionalAttrs (osConfig.age.secrets."api-github-token" or null != null) {
-            github = {
-              command = "${mkWrapper "github-mcp-wrapper" ''
-                export GITHUB_TOKEN_FILE=${osConfig.age.secrets."api-github-token".path}
-                exec ${pkgs.github-mcp-server}/bin/github-mcp-server "$@"
-              ''}";
-              args = [ ];
-              description = "GitHub repository integration - PR automation, issue management, repository queries";
-            };
-          })
-          # LinkedIn MCP server (if LinkedIn cookie available)
-          // (lib.optionalAttrs linkedinEnabled {
-            linkedin = {
-              command = "${mkWrapper "linkedin-mcp-wrapper" ''
-                export LINKEDIN_COOKIE_FILE=${osConfig.age.secrets."api-linkedin-cookie".path}
-                exec ${pkgs.docker}/bin/docker run --rm -i \
-                  --read-only \
-                  --security-opt=no-new-privileges \
-                  --cap-drop=ALL \
-                  -e LINKEDIN_COOKIE="$(cat $LINKEDIN_COOKIE_FILE)" \
-                  stickerdaniel/linkedin-mcp-server:latest "$@"
-              ''}";
-              args = [ ];
-              description = "LinkedIn professional networking and job search";
-            };
-          })
-          # WhatsApp MCP server
-          // (lib.optionalAttrs whatsappEnabled {
-            whatsapp = {
-              command = "${mkWrapper "whatsapp-mcp-wrapper" ''
-                # Ensure WhatsApp bridge service is running
-                if ! systemctl is-active --quiet whatsapp-bridge; then
-                  echo "ERROR: WhatsApp bridge service is not running" >&2
-                  echo "Start service: systemctl start whatsapp-bridge" >&2
-                  echo "View QR code for authentication: journalctl -u whatsapp-bridge -f" >&2
-                  exit 1
-                fi
-
-                # Launch MCP server
-                exec ${pkgs.customPkgs.whatsapp-mcp.whatsappMcpServer}/bin/whatsapp-mcp-server "$@"
-              ''}";
-              args = [ ];
-              description = "WhatsApp messaging integration - AI-assisted WhatsApp send/receive, message history queries (requires bridge service + QR auth)";
-            };
-          })
-          # Atlassian MCP server (Jira and Confluence)
-          // (lib.optionalAttrs atlassianEnabled (
-            let
-              mode = mcpCfg.atlassian.mode or "cloud";
-              jiraEnabled = mcpCfg.atlassian.jira.enable or false;
-              confluenceEnabled = mcpCfg.atlassian.confluence.enable or false;
-            in
-            {
-              atlassian = {
-                command = "${mkWrapper "atlassian-mcp-wrapper" (
-                  if mode == "cloud" then ''
-                    ${lib.optionalString jiraEnabled ''
-                      export JIRA_URL="${mcpCfg.atlassian.jira.url}"
-                      export JIRA_USERNAME="${mcpCfg.atlassian.jira.username}"
-                      export JIRA_TOKEN_FILE="${mcpCfg.atlassian.jira.tokenFile}"
-                    ''}
-                    ${lib.optionalString confluenceEnabled ''
-                      export CONFLUENCE_URL="${mcpCfg.atlassian.confluence.url}"
-                      export CONFLUENCE_USERNAME="${mcpCfg.atlassian.confluence.username}"
-                      export CONFLUENCE_TOKEN_FILE="${mcpCfg.atlassian.confluence.tokenFile}"
-                    ''}
-                    export ATLASSIAN_MODE="cloud"
-                    exec ${pkgs.customPkgs.atlassian-mcp}/bin/atlassian-mcp "$@"
-                  '' else ''
-                    ${lib.optionalString jiraEnabled ''
-                      export JIRA_URL="${mcpCfg.atlassian.jira.url}"
-                      export JIRA_PAT_FILE="${mcpCfg.atlassian.jira.patFile}"
-                    ''}
-                    ${lib.optionalString confluenceEnabled ''
-                      export CONFLUENCE_URL="${mcpCfg.atlassian.confluence.url}"
-                      export CONFLUENCE_PAT_FILE="${mcpCfg.atlassian.confluence.patFile}"
-                    ''}
-                    export ATLASSIAN_MODE="self-hosted"
-                    exec ${pkgs.customPkgs.atlassian-mcp}/bin/atlassian-mcp "$@"
-                  ''
-                )}";
-                args = [ ];
-                description = "Atlassian Jira and Confluence integration - issue tracking, project management, and documentation (${mode} mode)";
-              };
-            }
-          ))
-          # Grafana MCP server (if enabled in servers configuration)
-          // (lib.optionalAttrs (mcpCfg.servers.grafana or false) {
-            grafana = {
-              command = if pkgs ? mcp-grafana then "${pkgs.mcp-grafana}/bin/mcp-grafana" else "${pkgs.writeShellScript "grafana-mcp-placeholder" "echo 'Grafana MCP not available'"}";
-              args = [
-                "--url"
-                "http://p620:3001" # P620 is the monitoring server
-                "--token"
-                "\${GRAFANA_API_TOKEN}"
-              ];
-              description = "Grafana dashboard and metrics integration - query monitoring data from P620";
-            };
-          });
-      };
-
-      # Generate JSON configuration with proper formatting
-      onChange = ''
-        echo "Claude Code MCP configuration updated at ~/.claude/settings.local.json"
-        echo "Restart Claude Code for changes to take effect"
-      '';
-    };
-
-    # Documentation for Claude Code MCP setup
+    # Documentation file: Claude Code never reads it, never writes it,
+    # so a nix-store symlink is fine.
     home.file.".claude/MCP-README.md".text = ''
       # Claude Code MCP Configuration
 
-      This configuration file is automatically generated by NixOS.
-      Do not edit ~/.claude/settings.local.json manually unless you want custom overrides.
+      As of issue #398 ~/.claude/settings.local.json is SEEDED ONCE from
+      this Nix module and then owned by Claude Code (so `claude mcp add`
+      and runtime permission prompts work). To resync to the Nix-declared
+      MCP servers, delete the file and re-run `nixos-rebuild switch`.
 
       ## Configuration Location
 
       Source: ${config.home.homeDirectory}/.config/nixos/home/development/claude-code-mcp.nix
-      Generated: ~/.claude/settings.local.json
+      Generated: ~/.claude/settings.local.json (seed-only after #398)
 
       ## Enabled MCP Servers
 
@@ -287,10 +310,6 @@ in
       - Requires: whatsapp-bridge service running
       - Authentication: QR code scan (expires ~20 days)
       - View QR: journalctl -u whatsapp-bridge -f
-      - Examples:
-        - "Send a message to John saying I'll be late"
-        - "Find messages from Sarah containing 'meeting'"
-        - "Send document.pdf to the team group"
       ''}
 
       ${lib.optionalString atlassianEnabled ''
@@ -298,22 +317,11 @@ in
       ${lib.optionalString (mcpCfg.atlassian.jira.enable or false) ''
       - **Jira Integration**:
         - URL: ${mcpCfg.atlassian.jira.url or "Not configured"}
-        - JQL search with natural language
-        - Issue creation, updates, and transitions
-        - Project management automation
       ''}
       ${lib.optionalString (mcpCfg.atlassian.confluence.enable or false) ''
       - **Confluence Integration**:
         - URL: ${mcpCfg.atlassian.confluence.url or "Not configured"}
-        - CQL search for documentation
-        - Page creation, updates, and comments
-        - Content discovery and management
       ''}
-      - Examples:
-        - "Find all issues assigned to me in project PROJ"
-        - "Create a bug ticket for the login issue"
-        - "Search Confluence for API documentation"
-        - "Update issue PROJ-123 status to In Progress"
       ''}
 
       ${lib.optionalString (mcpCfg.servers.grafana or false) ''
@@ -323,40 +331,21 @@ in
       - Requires GRAFANA_API_TOKEN environment variable
       ''}
 
-      ## Applying Changes
+      ## Resync after manual edits
 
-      After modifying the configuration in NixOS:
-      1. Rebuild your system: `just deploy` or `just quick-deploy HOST`
-      2. Restart Claude Code (or reload configuration)
-      3. MCP servers will be available in Claude Code
+      To replace whatever is currently at ~/.claude/settings.local.json
+      with the Nix-declared baseline:
 
-      ## Troubleshooting
-
-      Check configuration:
-      - cat ~/.claude/settings.local.json
-      - Verify JSON syntax is valid
-
-      Test MCP servers manually:
-      - Run the command directly from terminal
-      - Check for any error messages
-
-      Service status (WhatsApp):
-      - systemctl status whatsapp-bridge
-      - journalctl -u whatsapp-bridge -f
+      ```
+      rm ~/.claude/settings.local.json
+      home-manager switch  # or nixos-rebuild switch
+      ```
 
       ## Security Notes
 
       - API keys and tokens loaded at runtime (not in Nix store)
       - Secrets managed via agenix
       - Shell wrappers generated with proper paths
-      - Follows docs/NIXOS-ANTI-PATTERNS.md security patterns
-
-      ## Customization
-
-      To add custom MCP servers:
-      1. DO NOT edit settings.local.json directly (will be overwritten)
-      2. Instead, edit this Nix module: ${config.home.homeDirectory}/.config/nixos/home/development/claude-code-mcp.nix
-      3. Rebuild system to apply changes
     '';
   };
 }

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -318,6 +318,15 @@ in
     user = vars.username;
   };
 
+  # Claude Code managed-settings.json — read-only baseline (issue #398).
+  # PARR hook lives here (highest precedence, cannot be disabled by the
+  # user via `claude` CLI). User-scope ~/.claude/settings.json remains
+  # writable for plugin installs and runtime mutations.
+  modules.programs.claude-code-managed = {
+    enable = true;
+    parrProtocol.enable = true;
+  };
+
   # Enable NixOS package monitoring tools
   tools.nixpkgs-monitors = {
     enable = true;

--- a/modules/programs/claude-code-managed.nix
+++ b/modules/programs/claude-code-managed.nix
@@ -1,0 +1,126 @@
+# Claude Code managed-settings.json
+#
+# Renders /etc/claude-code/managed-settings.json — Claude Code's highest-
+# precedence config layer. The CLI reads this file but NEVER writes to it,
+# making the read-only nix-store backing both safe and correct.
+#
+# Use this for settings the user must not be able to disable from the CLI
+# (PARR hooks, baseline permissions, apiKeyHelper). User-scope preferences
+# like statusLine and enabledPlugins should NOT live here — see the init-
+# template pattern in home/development/claude-code-lsp.nix instead.
+#
+# Reference: https://code.claude.com/docs/en/settings.md
+# Tracked in issue #398.
+{ config
+, lib
+, pkgs
+, ...
+}:
+let
+  cfg = config.modules.programs.claude-code-managed;
+
+  # PARR Protocol Reminder Hook — kept identical to the script in
+  # home/development/claude-code-lsp.nix so behaviour is unchanged when we
+  # move the hook from user scope to managed scope.
+  parrReminderScript = pkgs.writeShellScript "parr-reminder.sh" ''
+        #!/usr/bin/env bash
+        cat << 'PARR_EOF'
+    <system-reminder>
+    ## MANDATORY: Follow PARR Protocol for This Task
+
+    You MUST structure your response using these phases:
+
+    ### 🎯 PLAN (Before ANY action)
+    - State the goal in one sentence
+    - List steps with verification criteria
+    - Identify approach, assumptions, and risks
+
+    ### ⚡ ACT (Execute ONE step at a time)
+    - Announce what you're doing
+    - Execute exactly ONE step
+    - Show output and verify checkpoint
+    - NEVER chain commands without checking results
+
+    ### 🔍 REFLECT (After EACH step)
+    - Did it work? Compare expected vs actual
+    - Any side effects?
+    - Is the plan still valid?
+
+    ### 🔄 REVISE (When needed)
+    - If something failed, diagnose root cause
+    - Update plan with new information
+    - Consider alternative approaches
+
+    ### ✅ COMPLETE (When done)
+    - Summarize what was achieved
+    - List files changed
+    - Note any follow-up needed
+
+    CRITICAL RULES:
+    - NEVER skip the PLAN phase
+    - NEVER execute multiple steps without reflection
+    - STOP immediately if something unexpected happens
+    - Ask for clarification if stuck after 2 attempts
+    </system-reminder>
+    PARR_EOF
+  '';
+
+  # Hooks contributed by the parrProtocol convenience flag, merged with
+  # whatever the user supplies via cfg.settings.hooks.
+  parrHooks = lib.optionalAttrs cfg.parrProtocol.enable {
+    UserPromptSubmit = [{
+      hooks = [{
+        type = "command";
+        command = toString parrReminderScript;
+      }];
+    }];
+  };
+
+  mergedSettings = lib.recursiveUpdate
+    (cfg.settings // {
+      hooks = (cfg.settings.hooks or { }) // parrHooks;
+    })
+    { };
+
+  managedJson = pkgs.writeText "claude-code-managed-settings.json"
+    (builtins.toJSON mergedSettings);
+in
+{
+  options.modules.programs.claude-code-managed = {
+    enable = lib.mkEnableOption "Claude Code managed-settings.json (read-only baseline)";
+
+    settings = lib.mkOption {
+      type = lib.types.attrsOf lib.types.anything;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          permissions.deny = [ "Bash(rm -rf /*)" ];
+          apiKeyHelper = "/run/wrappers/bin/op-claude-key";
+        }
+      '';
+      description = ''
+        Settings to write into /etc/claude-code/managed-settings.json.
+        Claude Code reads this with highest precedence and never writes back.
+        Anything here is effectively unmodifiable from the CLI/UI.
+      '';
+    };
+
+    parrProtocol.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Inject the PARR (Plan, Act, Reflect, Revise) UserPromptSubmit hook.
+        Equivalent to the previous programs.claudeCode.hooks.enableParrProtocol
+        option, but enforced from managed scope so the user cannot disable it
+        by editing ~/.claude/settings.json.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.etc."claude-code/managed-settings.json" = {
+      source = managedJson;
+      mode = "0644";
+    };
+  };
+}

--- a/modules/programs/default.nix
+++ b/modules/programs/default.nix
@@ -12,6 +12,7 @@ _: {
     ./yt-x.nix # Terminal YouTube browser
     ./reddix.nix # Reddit TUI client
     ./chrome-pwa-icons.nix # Sync Chrome PWA icons into XDG hicolor (issue #397)
+    ./claude-code-managed.nix # Read-only Claude Code baseline at /etc/claude-code (issue #398)
     # ./streamcontroller.nix
     # ./thunar.nix
   ];


### PR DESCRIPTION
Background: ~/.claude/settings.json was rendered as a read-only
nix-store symlink, which meant `claude plugin install`, `claude mcp
add`, and runtime permission grants all failed with EACCES. Per Claude
Code's docs (https://code.claude.com/docs/en/settings.md) user-scope
settings are designed to be writable; managed scope at /etc/claude-code/
is the read-only baseline layer.

This rewires the repo to match Claude Code's intended layering:

* Layer 1 (NEW) — /etc/claude-code/managed-settings.json
  - Rendered by new module modules/programs/claude-code-managed.nix
  - Highest precedence, never written by Claude Code
  - PARR hook lives here now (cannot be disabled by editing
    ~/.claude/settings.json)

* Layer 2 — ~/.claude/settings.json
  - No longer a home.file symlink
  - Seeded from a Nix template via home.activation if missing
  - Migration: legacy nix-store symlinks are unlinked then reseeded
  - User-edited or Claude-mutated content is preserved across rebuilds

* Layer 3 — ~/.claude/settings.local.json
  - Same init-template treatment as Layer 2
  - 11 declared MCP servers seed once; `claude mcp add` works freely
    afterward
  - To resync to the Nix-declared baseline, delete the file and re-
    activate

Also tightens the existing claudeCodeLspSetup activation script: drops
the 2>/dev/null/|| true error swallowing that was hiding the same
EACCES failures, and orders it after the new claudeUserSettingsInit so
~/.claude/settings.json exists before `claude plugin install` runs.

Removes the programs.claudeCode.hooks.enableParrProtocol home-manager
option (replaced by modules.programs.claude-code-managed.parrProtocol.
enable, default true). PARR functionality is identical and now more
strongly enforced.

Enabled on razer initially. p620 to follow once verified.

Closes #398

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
