### PR TITLE
refactor(phase-5): extract inline overlays from flake.nix into overlays/ (#408)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -293,73 +293,7 @@
         })
         # Custom package: citrix-workspace - Citrix Workspace with USB support and local tarball management
         (import ./overlays/citrix-workspace.nix)
-        # Fix CMake version compatibility issues for packages requiring CMake < 3.5
-        (_final: prev: {
-          clblast = prev.clblast.overrideAttrs (oldAttrs: {
-            cmakeFlags =
-              (oldAttrs.cmakeFlags or [ ])
-              ++ [
-                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
-              ];
-          });
-          cld2 = prev.cld2.overrideAttrs (oldAttrs: {
-            cmakeFlags =
-              (oldAttrs.cmakeFlags or [ ])
-              ++ [
-                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
-              ];
-          });
-          ctranslate2 = prev.ctranslate2.overrideAttrs (oldAttrs: {
-            cmakeFlags =
-              (oldAttrs.cmakeFlags or [ ])
-              ++ [
-                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
-              ];
-          });
-          rofi-file-browser-extended = prev.rofi-file-browser-extended.overrideAttrs (oldAttrs: {
-            cmakeFlags =
-              (oldAttrs.cmakeFlags or [ ])
-              ++ [
-                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
-              ];
-          });
-          birdtray = prev.birdtray.overrideAttrs (oldAttrs: {
-            cmakeFlags =
-              (oldAttrs.cmakeFlags or [ ])
-              ++ [
-                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
-              ];
-          });
-          allegro = prev.allegro.overrideAttrs (oldAttrs: {
-            cmakeFlags =
-              (oldAttrs.cmakeFlags or [ ])
-              ++ [
-                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
-              ];
-          });
-          # Skip ltrace tests that fail on newer kernels
-          ltrace = prev.ltrace.overrideAttrs (_oldAttrs: {
-            doCheck = false;
-          });
-          # Skip mu tests - test_index_move has timing-dependent assertion that fails in sandbox
-          mu = prev.mu.overrideAttrs (_oldAttrs: {
-            doCheck = false;
-          });
-          # Fix cxxopts missing icu dependency
-          cxxopts = prev.cxxopts.overrideAttrs (oldAttrs: {
-            buildInputs = (oldAttrs.buildInputs or [ ]) ++ [ prev.icu ];
-            propagatedBuildInputs = (oldAttrs.propagatedBuildInputs or [ ]) ++ [ prev.icu ];
-          });
-          # Fix pamixer missing cxxopts dependency
-          pamixer = prev.pamixer.overrideAttrs (oldAttrs: {
-            buildInputs = (oldAttrs.buildInputs or [ ]) ++ [ prev.cxxopts prev.icu ];
-          });
-          # khard/lbdb: sphinx-argparse 0.5.2 incompatible with Sphinx 9.x
-          # lbdb temporarily removed from home/shell/mail/default.nix
-          # Note: COSMIC cargo vendor dedup overlays removed — the nix-prefetch-git
-          # symlink overlay above already resolves fetchCargoVendor producing
-          # duplicate git source entries for cosmic-applets and cosmic-settings-daemon.
-        })
+        (import ./overlays/cmake-compat.nix)
         # Fix azure-cli k8s-extension: pinned kubernetes==24.2.0 and oras==0.2.25
         # are not satisfied by newer versions in nixpkgs-unstable
         (_final: prev: {

--- a/flake.nix
+++ b/flake.nix
@@ -225,78 +225,7 @@
         };
       };
 
-      # Import custom packages and overlays
-      overlays = [
-        (final: _prev: {
-          customPkgs = import ./pkgs {
-            pkgs = final;
-          };
-        })
-        (_final: prev: {
-          zjstatus = inputs.zjstatus.packages.${prev.stdenv.hostPlatform.system}.default;
-        })
-        # Claude Desktop from aaddrick/claude-desktop-debian (FHS variant;
-        # bubblewrap-sandboxed Cowork / Local Agent Mode).
-        #
-        # No overlay patches needed at v2.0.5+:
-        #   - v2.0.0 (2026-04-20) refactored build.sh into scripts/ and fixed
-        #     the Nix-sandbox chmod issue (PRs #432, #438).
-        #   - v2.0.5+ strips CRLF from cowork-plugin-shim.sh during staging
-        #     (PRs #499, #505), retiring our previous postInstall workaround.
-        #
-        # See /update-claude-code for the bump workflow. If a future bump
-        # reintroduces a Nix-incompatible step, re-add the overrideAttrs
-        # block here.
-        (_final: prev: {
-          claude-desktop-linux = inputs.claude-desktop-linux.packages.${prev.stdenv.hostPlatform.system}.claude-desktop-fhs;
-        })
-        # COSMIC applets from flakes
-        (_final: prev: {
-          cosmic-ext-applet-music-player = inputs.cosmic-music-player.packages.${prev.stdenv.hostPlatform.system}.default;
-          cosmic-applet-spotify = inputs.cosmic-applet-spotify.packages.${prev.stdenv.hostPlatform.system}.default;
-          inherit (inputs.cosmic-ext-radio-applet.packages.${prev.stdenv.hostPlatform.system}) cosmic-ext-applet-radio;
-          cosmic-ext-web-apps = inputs.cosmic-ext-web-apps.packages.${prev.stdenv.hostPlatform.system}.default;
-        })
-        # COSMIC Connect - KDE Connect alternative for COSMIC Desktop
-        inputs.cosmic-ext-connect.overlays.default
-        # COSMIC Notifications NG - Disabled: removed from active config
-        # inputs.cosmic-ext-notifications.overlays.default
-        # COSMIC BG NG - Disabled pending upstream fix for startup race condition
-        # See: https://github.com/olafkfreund/cosmic-ext-bg/issues/32
-        # inputs.cosmic-ext-bg.overlays.default
-        # Custom package: glim - GitLab CI/CD TUI
-        (final: _prev: {
-          glim = final.callPackage ./overlays/glim { };
-        })
-        # Custom package: intune-portal - Microsoft Intune Company Portal with version control
-        (final: _prev: {
-          intune-portal = final.callPackage ./pkgs/intune-portal { };
-        })
-        # Custom package: zsh-ai-cmd - AI-powered shell command suggestions using Anthropic Claude
-        (final: _prev: {
-          zsh-ai-cmd = final.callPackage ./pkgs/zsh-ai-cmd { };
-        })
-        # Custom package: claude-code-native - Native binary alternative to npm-based claude-code
-        (final: _prev: {
-          claude-code-native = final.callPackage ./pkgs/claude-code-native { };
-        })
-        # Custom package: warp-terminal — track latest stable independently of nixpkgs.
-        # Bumped by .github/workflows/update-warp-terminal.yml (daily). Replaces the
-        # nixpkgs attribute by the same name so consumers (notably
-        # home/desktop/terminals/warp/default.nix) get our version transparently.
-        (final: _prev: {
-          warp-terminal = final.callPackage ./pkgs/warp-terminal { };
-        })
-        # Custom package: gemini-cli - Google Gemini AI CLI tool
-        (final: _prev: {
-          gemini-cli = final.callPackage ./home/development/gemini-cli { };
-        })
-        # Custom package: citrix-workspace - Citrix Workspace with USB support and local tarball management
-        (import ./overlays/citrix-workspace.nix)
-        (import ./overlays/cmake-compat.nix)
-        (import ./overlays/python-compat.nix)
-        (import ./overlays/upstream-fixes.nix)
-      ];
+      overlays = import ./overlays { inherit inputs; };
 
       makeNixosSystem = host:
         let

--- a/flake.nix
+++ b/flake.nix
@@ -294,71 +294,7 @@
         # Custom package: citrix-workspace - Citrix Workspace with USB support and local tarball management
         (import ./overlays/citrix-workspace.nix)
         (import ./overlays/cmake-compat.nix)
-        # Fix azure-cli k8s-extension: pinned kubernetes==24.2.0 and oras==0.2.25
-        # are not satisfied by newer versions in nixpkgs-unstable
-        (_final: prev: {
-          azure-cli-extensions = prev.azure-cli-extensions // {
-            k8s-extension = prev.azure-cli-extensions.k8s-extension.overridePythonAttrs (oldAttrs: {
-              pythonRelaxDeps = (oldAttrs.pythonRelaxDeps or [ ]) ++ [
-                "kubernetes"
-                "oras"
-              ];
-              nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++ [
-                prev.python3Packages.pythonRelaxDepsHook
-              ];
-            });
-          };
-        })
-        # Fix azure-mgmt-network: msrest not declared as runtime dependency
-        # (nixpkgs-unstable regression caught by pythonRuntimeDepsCheckHook)
-        (_final: prev: {
-          python312 = prev.python312.override {
-            packageOverrides = _pyFinal: pyPrev: {
-              azure-mgmt-network = pyPrev.azure-mgmt-network.overridePythonAttrs (oldAttrs: {
-                dependencies = (oldAttrs.dependencies or [ ]) ++ [
-                  pyPrev.msrest
-                ];
-              });
-            };
-          };
-        })
-        # Fix python3.11 doc build failure (Sphinx 9.1.0 + docutils 0.22.4 incompatibility)
-        # Skip building the broken doc output - it's a passthru attribute that some packages pull in
-        (_final: prev: {
-          python311 = prev.python311.overrideAttrs (oldAttrs: {
-            passthru = (oldAttrs.passthru or { }) // {
-              doc = prev.emptyDirectory;
-            };
-          });
-        })
-        # Fix sse-starlette: disable flaky timing tests and add missing starlette dependency
-        # (nixpkgs-unstable regression - applied globally so all consumers get the fix)
-        (_final: prev: {
-          python312Packages = prev.python312Packages // {
-            sse-starlette = prev.python312Packages.sse-starlette.overridePythonAttrs (old: {
-              doCheck = false;
-              pythonImportsCheck = [ ];
-              dependencies = (old.dependencies or [ ]) ++ [ prev.python312Packages.starlette ];
-            });
-          };
-        })
-        # Fix python3.13 package test failures in nixpkgs-unstable:
-        # - plotly: pytest 9 deprecation of py.path.local breaks test collection
-        # - wandb: flaky async spinner test (MockDynamicTextPrinter.captured_text empty)
-        # Both affect newelle → llama-index-core → spacy → wandb/plotly chain
-        # Must use packageOverrides to propagate through Python's scope-based resolution
-        (_final: prev: {
-          python313 = prev.python313.override {
-            packageOverrides = _pyFinal: pyPrev: {
-              plotly = pyPrev.plotly.overridePythonAttrs (_old: {
-                doCheck = false;
-              });
-              wandb = pyPrev.wandb.overridePythonAttrs (_old: {
-                doCheck = false;
-              });
-            };
-          };
-        })
+        (import ./overlays/python-compat.nix)
         # Fix azure-cli: azure-mgmt-web missing v2024_11_01 subpackage breaks installCheck
         # (nixpkgs-unstable regression - azure-cli 2.81.0 expects newer azure-mgmt-web)
         (_final: prev: {
@@ -381,22 +317,6 @@
                 fi
               '';
           });
-        })
-        # Fix python312Packages.sse-starlette missing starlette in propagatedBuildInputs
-        # nixpkgs regression: sse-starlette-3.2.0 fails runtime dep check without starlette
-        # Also disable flaky tests (consolidated with earlier overlay)
-        (_final: prev: {
-          python312Packages = prev.python312Packages.overrideScope (
-            _pySelf: pyPrev: {
-              sse-starlette = pyPrev.sse-starlette.overrideAttrs (oldAttrs: {
-                doCheck = false;
-                pythonImportsCheck = [ ];
-                propagatedBuildInputs = (oldAttrs.propagatedBuildInputs or [ ]) ++ [
-                  prev.python312Packages.starlette
-                ];
-              });
-            }
-          );
         })
       ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -295,29 +295,7 @@
         (import ./overlays/citrix-workspace.nix)
         (import ./overlays/cmake-compat.nix)
         (import ./overlays/python-compat.nix)
-        # Fix azure-cli: azure-mgmt-web missing v2024_11_01 subpackage breaks installCheck
-        # (nixpkgs-unstable regression - azure-cli 2.81.0 expects newer azure-mgmt-web)
-        (_final: prev: {
-          azure-cli = prev.azure-cli.overrideAttrs (_old: {
-            doInstallCheck = false;
-          });
-        })
-        # Fix nix-prefetch-git binary name (nixpkgs-unstable regression: binary named
-        # "nix-prefetch-git-VERSION" instead of "nix-prefetch-git", breaking fetchCargoVendor)
-        (_final: prev: {
-          nix-prefetch-git = prev.nix-prefetch-git.overrideAttrs (_oldAttrs: {
-            postFixup =
-              let
-                versionedName = prev.nix-prefetch-git.name;
-              in
-              ''
-                if [ ! -e "$out/bin/nix-prefetch-git" ] && [ -e "$out/bin/${versionedName}" ];
-                then
-                ln -s "${versionedName}" "$out/bin/nix-prefetch-git"
-                fi
-              '';
-          });
-        })
+        (import ./overlays/upstream-fixes.nix)
       ];
 
       makeNixosSystem = host:

--- a/overlays/cmake-compat.nix
+++ b/overlays/cmake-compat.nix
@@ -1,0 +1,34 @@
+_final: prev:
+let
+  mkCmakePolicyFix = pkgName:
+    prev.${pkgName}.overrideAttrs (oldAttrs: {
+      cmakeFlags = (oldAttrs.cmakeFlags or [ ]) ++ [
+        "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+      ];
+    });
+in
+{
+  clblast = mkCmakePolicyFix "clblast";
+  cld2 = mkCmakePolicyFix "cld2";
+  ctranslate2 = mkCmakePolicyFix "ctranslate2";
+  rofi-file-browser-extended = mkCmakePolicyFix "rofi-file-browser-extended";
+  birdtray = mkCmakePolicyFix "birdtray";
+  allegro = mkCmakePolicyFix "allegro";
+
+  ltrace = prev.ltrace.overrideAttrs (_oldAttrs: {
+    doCheck = false;
+  });
+
+  mu = prev.mu.overrideAttrs (_oldAttrs: {
+    doCheck = false;
+  });
+
+  cxxopts = prev.cxxopts.overrideAttrs (oldAttrs: {
+    buildInputs = (oldAttrs.buildInputs or [ ]) ++ [ prev.icu ];
+    propagatedBuildInputs = (oldAttrs.propagatedBuildInputs or [ ]) ++ [ prev.icu ];
+  });
+
+  pamixer = prev.pamixer.overrideAttrs (oldAttrs: {
+    buildInputs = (oldAttrs.buildInputs or [ ]) ++ [ prev.cxxopts prev.icu ];
+  });
+}

--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -1,0 +1,8 @@
+final: _prev: {
+  glim = final.callPackage ./glim { };
+  intune-portal = final.callPackage ../pkgs/intune-portal { };
+  zsh-ai-cmd = final.callPackage ../pkgs/zsh-ai-cmd { };
+  claude-code-native = final.callPackage ../pkgs/claude-code-native { };
+  warp-terminal = final.callPackage ../pkgs/warp-terminal { };
+  gemini-cli = final.callPackage ../home/development/gemini-cli { };
+}

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,0 +1,31 @@
+{ inputs }:
+[
+  (final: _prev: {
+    customPkgs = import ../pkgs { pkgs = final; };
+  })
+
+  (_final: prev: {
+    zjstatus = inputs.zjstatus.packages.${prev.stdenv.hostPlatform.system}.default;
+  })
+
+  # Claude Desktop (FHS variant from aaddrick/claude-desktop-debian).
+  # See /update-claude-code for the bump workflow.
+  (_final: prev: {
+    claude-desktop-linux = inputs.claude-desktop-linux.packages.${prev.stdenv.hostPlatform.system}.claude-desktop-fhs;
+  })
+
+  (_final: prev: {
+    cosmic-ext-applet-music-player = inputs.cosmic-music-player.packages.${prev.stdenv.hostPlatform.system}.default;
+    cosmic-applet-spotify = inputs.cosmic-applet-spotify.packages.${prev.stdenv.hostPlatform.system}.default;
+    inherit (inputs.cosmic-ext-radio-applet.packages.${prev.stdenv.hostPlatform.system}) cosmic-ext-applet-radio;
+    cosmic-ext-web-apps = inputs.cosmic-ext-web-apps.packages.${prev.stdenv.hostPlatform.system}.default;
+  })
+
+  inputs.cosmic-ext-connect.overlays.default
+
+  (import ./custom-packages.nix)
+  (import ./citrix-workspace.nix)
+  (import ./cmake-compat.nix)
+  (import ./python-compat.nix)
+  (import ./upstream-fixes.nix)
+]

--- a/overlays/python-compat.nix
+++ b/overlays/python-compat.nix
@@ -1,0 +1,56 @@
+_final: prev: {
+  azure-cli-extensions = prev.azure-cli-extensions // {
+    k8s-extension = prev.azure-cli-extensions.k8s-extension.overridePythonAttrs (oldAttrs: {
+      pythonRelaxDeps = (oldAttrs.pythonRelaxDeps or [ ]) ++ [
+        "kubernetes"
+        "oras"
+      ];
+      nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++ [
+        prev.python3Packages.pythonRelaxDepsHook
+      ];
+    });
+  };
+
+  python311 = prev.python311.overrideAttrs (oldAttrs: {
+    passthru = (oldAttrs.passthru or { }) // {
+      doc = prev.emptyDirectory;
+    };
+  });
+
+  python312 = prev.python312.override {
+    packageOverrides = _pyFinal: pyPrev: {
+      azure-mgmt-network = pyPrev.azure-mgmt-network.overridePythonAttrs (oldAttrs: {
+        dependencies = (oldAttrs.dependencies or [ ]) ++ [
+          pyPrev.msrest
+        ];
+      });
+    };
+  };
+
+  python312Packages = (prev.python312Packages // {
+    sse-starlette = prev.python312Packages.sse-starlette.overridePythonAttrs (old: {
+      doCheck = false;
+      pythonImportsCheck = [ ];
+      dependencies = (old.dependencies or [ ]) ++ [ prev.python312Packages.starlette ];
+    });
+  }).overrideScope (_pySelf: pyPrev: {
+    sse-starlette = pyPrev.sse-starlette.overrideAttrs (oldAttrs: {
+      doCheck = false;
+      pythonImportsCheck = [ ];
+      propagatedBuildInputs = (oldAttrs.propagatedBuildInputs or [ ]) ++ [
+        prev.python312Packages.starlette
+      ];
+    });
+  });
+
+  python313 = prev.python313.override {
+    packageOverrides = _pyFinal: pyPrev: {
+      plotly = pyPrev.plotly.overridePythonAttrs (_old: {
+        doCheck = false;
+      });
+      wandb = pyPrev.wandb.overridePythonAttrs (_old: {
+        doCheck = false;
+      });
+    };
+  };
+}

--- a/overlays/upstream-fixes.nix
+++ b/overlays/upstream-fixes.nix
@@ -1,0 +1,23 @@
+_final: prev: {
+  # azure-cli 2.81.0 expects azure-mgmt-web v2024_11_01 which isn't packaged yet;
+  # disable installCheck until nixpkgs catches up.
+  azure-cli = prev.azure-cli.overrideAttrs (_old: {
+    doInstallCheck = false;
+  });
+
+  # nixpkgs-unstable ships nix-prefetch-git as `nix-prefetch-git-VERSION`,
+  # breaking fetchCargoVendor which calls the binary by its short name.
+  # Symlink the short name to the versioned binary.
+  nix-prefetch-git = prev.nix-prefetch-git.overrideAttrs (_oldAttrs: {
+    postFixup =
+      let
+        versionedName = prev.nix-prefetch-git.name;
+      in
+      ''
+        if [ ! -e "$out/bin/nix-prefetch-git" ] && [ -e "$out/bin/${versionedName}" ];
+        then
+        ln -s "${versionedName}" "$out/bin/nix-prefetch-git"
+        fi
+      '';
+  });
+}


### PR DESCRIPTION
Closes #408. Part of #403. Stacked on top of #415 (Phase 4) — review/merge that one first.

## Summary

`flake.nix` lines 229–467 held 18+ inline overlay definitions mixing 5 categories. Extracted to focused files under `overlays/`. The 6 packages that repeated the same `CMAKE_POLICY_VERSION_MINIMUM=3.5` `overrideAttrs` block now use a one-line helper. The two `sse-starlette` overlay entries are consolidated into one.

**`flake.nix`: 729 → 490 lines (−239 lines / -33%).**

**Net: 6 files changed, +153 / −240 (−87 lines total).**

## Verification — zero behaviour change

`nix eval` of `system.build.toplevel.drvPath` produced byte-identical results for all 3 hosts after **each** of the 4 commits (verified at every step, not just at the end):

| Host | drvPath unchanged | systemPackages unchanged |
|---|---|---|
| p620 | ✓ | ✓ (714) |
| p510 | ✓ | ✓ (483) |
| razer | ✓ | ✓ (619) |

The sse-starlette consolidation worked — keeping closures byte-identical proves the chained `(prev.python312Packages // {...}).overrideScope (...)` is semantically equivalent to the two original `// {...}` and `.overrideScope` overlays.

## Commits

| Commit | What | Lines |
|---|---|---|
| `5940fbc7b` | Extract `overlays/cmake-compat.nix`. Six identical CMake-policy fixes collapse to a `mkCmakePolicyFix` helper. Same file holds related upstream fixes (ltrace/mu doCheck=false, cxxopts/pamixer dep additions). | flake.nix -67 / new file +33 |
| `a621eafbe` | Extract `overlays/python-compat.nix`. Five Python overlays moved (azure-cli-extensions k8s, python311 doc, python312 azure-mgmt-network, python312 sse-starlette CONSOLIDATED, python313 plotly+wandb). | flake.nix -81 / new file +56 |
| `c156c3a94` | Extract `overlays/upstream-fixes.nix`. Two non-Python upstream-fix overlays (azure-cli installCheck, nix-prefetch-git symlink). | flake.nix -23 / new file +23 |
| `4b1d39f2e` | Extract `overlays/custom-packages.nix` (6 callPackages) and create `overlays/default.nix` as the collector. `flake.nix`'s `overlays = [ ~70 entries ];` becomes one line: `overlays = import ./overlays { inherit inputs; };`. | flake.nix -69 / new files +40 |

## Final structure

```
overlays/
├── default.nix          # NEW — collector (foundational + flake-input pass-throughs + imports)
├── cmake-compat.nix     # NEW — 6 CMake fixes (helper) + ltrace/mu/cxxopts/pamixer
├── python-compat.nix    # NEW — 5 Python compat overlays
├── upstream-fixes.nix   # NEW — azure-cli + nix-prefetch-git
├── custom-packages.nix  # NEW — 6 custom callPackages
├── citrix-workspace.nix # KEPT — unchanged
└── glim/default.nix     # KEPT — package derivation, not an overlay
```

`flake.nix` overlays consumer is now one line.

## Verified by parallel agent before any edits

Pre-flight verification agent catalogued every overlay entry in flake.nix, identified categories, confirmed all 7 custom packages have live consumers (glim in p620_home.nix, citrix-workspace in razer/p620, gemini-cli per-host, etc.), and noted the duplicate sse-starlette entries (now consolidated).

## Test plan

- [x] `nix eval` drvPath byte-identical for p620, p510, razer after each of the 4 commits
- [x] `nix eval` package list byte-identical for all 3 hosts (p620: 714, p510: 483, razer: 619)
- [x] All pre-commit hooks pass (no `--no-verify`)
- [x] sse-starlette consolidation verified safe via drvPath check
- [ ] Optional: `nix build .#nixosConfigurations.razer.config.system.build.vm` to smoke-test in QEMU
- [ ] `just test-host p620 p510 razer` (left to merge gate)
- [ ] Smoke deploy on Razer first, then P620