### PR TITLE
fix(home/desktop): drop wasistlos (removed upstream from nixpkgs)

### DIFF
--- a/home/desktop/com.nix
+++ b/home/desktop/com.nix
@@ -13,7 +13,8 @@
     # pkgs.fractal
     pkgs.vesktop # Re-enabled: upstream build fixed in nixpkgs
     # pkgs.telegram-desktop
-    pkgs.wasistlos
+    # wasistlos removed upstream (unmaintained); karere is in p620/razer
+    # system packages instead, so no replacement needed here.
     # pkgs.ferdium  # Removed: no longer needed
     pkgs.zoom-us
     pkgs.libcamera


### PR DESCRIPTION
## Summary

\`nh os build\` on p620 fails with:

\`\`\`
error: 'wasistlos' has been removed because it was unmaintained and
archived upstream. Consider using 'karere' instead
\`\`\`

\`wasistlos\` was a GTK4 WhatsApp client; nixpkgs replaced it with \`karere\`.

\`karere\` is already in the system packages on p620 (\`hosts/p620/configuration.nix:469\`) and razer (\`hosts/razer/configuration.nix:440\`) — the only hosts that ever ran wasistlos. So dropping the home-profile reference is sufficient; no replacement needed here.

## Verification

- ✅ All 3 hosts (p620, razer, p510) evaluate cleanly
- ✅ p620 builds end-to-end
- ✅ p510 builds end-to-end
- ⚠️ Razer has a separate, unrelated build dependency failure in its closure (not introduced by this change; will be diagnosed separately)

## Test plan

- [ ] Merge to main
- [ ] \`nh os switch\` on p620 — should now succeed
- [ ] Confirm karere still works (system-level package, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)