### PR TITLE
fix(razer/shim): use archive.ubuntu.com mirror to survive launchpad DDoS

### DIFF
--- a/hosts/razer/nixos/shim.nix
+++ b/hosts/razer/nixos/shim.nix
@@ -26,15 +26,20 @@ let
   # 3rd Party UEFI CA — what our firmware trusts) and Canonical, plus mmx64.efi
   # (MokManager).
   #
-  # Pin to a specific .deb on launchpad: launchpad URLs are immutable per file,
-  # so this hash is stable forever. Bump only after verifying a newer version
-  # also boots on this hardware.
+  # Pin to a specific .deb. Same file, same sha256 across mirrors; archive.ubuntu.com
+  # listed first because it's the distributed CDN (resilient to attacks on
+  # launchpad.net's centralised infra — e.g. May 2026 313-Team DDoS), with launchpad
+  # as fallback in case a mirror prunes the version. Both URLs serve byte-identical
+  # files; the hash check is the integrity gate either way.
   shimUbuntu = pkgs.stdenvNoCC.mkDerivation {
     pname = "shim-ubuntu-signed";
     version = "1.59+15.8-0ubuntu2";
 
     src = pkgs.fetchurl {
-      url = "https://launchpad.net/ubuntu/+archive/primary/+files/shim-signed_1.59+15.8-0ubuntu2_amd64.deb";
+      urls = [
+        "http://archive.ubuntu.com/ubuntu/pool/main/s/shim-signed/shim-signed_1.59+15.8-0ubuntu2_amd64.deb"
+        "https://launchpad.net/ubuntu/+archive/primary/+files/shim-signed_1.59+15.8-0ubuntu2_amd64.deb"
+      ];
       hash = "sha256-+O1xzi2RowS21euEmX+EbzMbVUV4vALb/njhOtisgak=";
     };
 


### PR DESCRIPTION
## Summary

Razer's lanzaboote-shim build (\`hosts/razer/nixos/shim.nix\`) fetches the Ubuntu shim-signed .deb from launchpad.net. **Launchpad has been under sustained DDoS since ~30 April 2026** (claimed by 313 Team), making the build hang on \`curl: (28) Failed to connect to launchpad.net port 443\` and fail with \`error: Build failed due to failed dependency\`.

\`archive.ubuntu.com\` serves the byte-identical .deb from the distributed mirror network, which the attack hasn't taken down. Switching \`fetchurl\` to a \`urls = [...]\` list with archive.ubuntu.com first and launchpad second:
- Resilient under launchpad outages
- Falls back to launchpad if a mirror ever prunes the version
- Hash unchanged (\`sha256-+O1xzi2Ro...\`) — fetchurl verifies integrity regardless of source

## Verification

- ✅ Hash from \`archive.ubuntu.com\` mirror matches the pinned hash exactly:
  \`\`\`
  $ nix hash file --type sha256 --sri shim-signed_1.59+15.8-0ubuntu2_amd64.deb
  sha256-+O1xzi2RowS21euEmX+EbzMbVUV4vALb/njhOtisgak=
  \`\`\`
- ✅ \`nh os build\` for razer completes successfully (1:28, no shim-fetch retries)
- ✅ Output: \`/nix/store/3pb87jrck...-nixos-system-razer-26.05.20260427.1c3fe55\`

## Context

Related news (May 1, 2026): [Pro-Iran group turns Ubuntu DDoS into shakedown — The Register](https://www.theregister.com/2026/05/01/canonical_confirms_ubuntu_infrastructure_under/)

Affected services: launchpad.net, snap store, login.ubuntu.com, livepatch API, MAAS. Apt repos + ISO mirrors stayed online (distributed CDN).

## Test plan

- [ ] Merge to main
- [ ] \`nh os switch\` on razer (only host using shim)
- [ ] Confirm boot-into-secure-boot still works (shim binary unchanged, only download path changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)