### PR TITLE
chore(claude-code): bump native binary to 2.1.126

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.123";
+  version = "2.1.126";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-WngTm2eahqiKCsVHbHBqZMMQW/am1DW6EPOqP7Y1vbI=";
+      hash = "sha256-/OlpaNJ1Fh/2WkwZ/GQ078aXPZ9tNdw5kqK6BVPKwY4=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-glxSYDXR11/wvB7r8YyIf5jQfqSeqAvTEv9Bb+YaObM=";
+      hash = "sha256-iKbcphOkBVnzusipRqLsbmCocLkZONPfk9ysHexISMs=";
     };
   };
 


### PR DESCRIPTION
## Summary

Routine bump: \`claude-code-native\` 2.1.123 → 2.1.126.

Hashes obtained via \`./scripts/update-claude-code-native.sh latest\`.

## Verification

- ✅ Local build: \`nix build .#claude-code-native\` succeeds
- ✅ \`result/bin/claude --version\` → \`2.1.126 (Claude Code)\`
- ✅ \`ldd result/bin/claude\` → no missing libs
- ✅ All 3 hosts (p620, razer, p510) evaluate cleanly post-bump

## Test plan

- [ ] Merge to main
- [ ] \`nh os switch\` on p620 — confirm \`claude --version\` reports 2.1.126

🤖 Generated with [Claude Code](https://claude.com/claude-code)