### PR TITLE
fix(themes): restore stylix.nix wallpaper paths missed in PR #432

### DIFF
--- a/hosts/p510/themes/stylix.nix
+++ b/hosts/p510/themes/stylix.nix
@@ -4,7 +4,7 @@
   # GNOME target is overridden back to false.
   imports = [ ../../../modules/desktop/stylix-theme.nix ];
 
-  host.theme.wallpaper = ./orange-desert.jpg;
+  host.theme.wallpaper = ../../../assets/wallpapers/orange-desert.jpg;
 
   # Headless server — no GNOME session to theme.
   stylix.targets.gnome.enable = lib.mkForce false;

--- a/hosts/p620/themes/stylix.nix
+++ b/hosts/p620/themes/stylix.nix
@@ -3,5 +3,5 @@ _: {
   # modules/desktop/stylix-theme.nix. Only the per-host wallpaper differs.
   imports = [ ../../../modules/desktop/stylix-theme.nix ];
 
-  host.theme.wallpaper = ./orange-desert.jpg;
+  host.theme.wallpaper = ../../../assets/wallpapers/orange-desert.jpg;
 }

--- a/hosts/razer/themes/stylix.nix
+++ b/hosts/razer/themes/stylix.nix
@@ -3,5 +3,5 @@ _: {
   # modules/desktop/stylix-theme.nix. Only the per-host wallpaper differs.
   imports = [ ../../../modules/desktop/stylix-theme.nix ];
 
-  host.theme.wallpaper = ./orange-desert.jpg;
+  host.theme.wallpaper = ../../../assets/wallpapers/orange-desert.jpg;
 }


### PR DESCRIPTION
## Summary

**Critical fix.** PR #432 moved \`orange-desert.jpg\` from per-host \`themes/\` dirs to \`assets/wallpapers/\` but the corresponding \`stylix.nix\` path updates were not staged — only the binary moves landed in main. As a result, all 3 hosts currently fail to evaluate:

\`\`\`
error: Path 'hosts/p620/themes/orange-desert.jpg' does not exist
in Git repository "/home/olafkfreund/.config/nixos"
\`\`\`

This PR applies the 3-line fix that should have been in #432:

- \`hosts/p620/themes/stylix.nix\`: \`./orange-desert.jpg\` → \`../../../assets/wallpapers/orange-desert.jpg\`
- \`hosts/razer/themes/stylix.nix\`: same
- \`hosts/p510/themes/stylix.nix\`: same

## Verification

After this fix, all 3 hosts evaluate to the same drvs as pre-Phase-1:
- p620: \`f8ya5hgvi676fb5g8f4sq7wh3jjxmnb2\`
- razer: \`6lhbjc0i6axd9sm6xjqn9wr1jnq184sz\`
- p510: \`a76w0dgh8pgcxm5p4py25i0p9lh5rgl8\`

## Root cause

The Phase 1 commit was assembled by mixing \`git mv\`/\`git rm\` (which auto-stage) with Edit-tool file modifications (which don't). The commit captured only the staged binary moves. Lesson: always \`git add\` explicitly when mixing tooling-driven edits with git index changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)