### PR TITLE
fix(blueman): apply withApplet=false workaround for nixpkgs#514705

### DIFF
--- a/modules/services/bluetooth/bluetooth.nix
+++ b/modules/services/bluetooth/bluetooth.nix
@@ -9,7 +9,15 @@ _: {
     };
   };
 
-  services.blueman.enable = true;
+  services.blueman = {
+    enable = true;
+    # Workaround for upstream nixpkgs#514705: the blueman NixOS module
+    # ships a systemd unit definition that conflicts with the unit shipped
+    # by the blueman package itself, causing `bad-setting` and silent
+    # applet failure. Disabling the module-side unit lets users still
+    # launch the applet manually (the package ships its own working unit).
+    withApplet = false;
+  };
 
   # Removed duplicate mpris-proxy service definition
   # The service is already enabled via home.media.mpd configuration


### PR DESCRIPTION
## Summary

Closes #437. Fixes a silent service failure surfaced via the \`/check-nixos-issues\` audit.

## Live evidence on p620 (before this fix)

\`\`\`
$ systemctl --user status blueman-applet
○ blueman-applet.service - Blueman tray applet
     Loaded: bad-setting (Reason: Unit blueman-applet.service has a bad unit file setting.)
     Active: inactive (dead)
\`\`\`

## Root cause

Upstream nixpkgs#514705 — the \`services.blueman\` NixOS module ships a systemd unit definition that conflicts with the unit shipped by the \`blueman\` package itself, putting the applet unit in \`bad-setting\` state.

## Fix

Apply the upstream-recommended workaround in \`modules/services/bluetooth/bluetooth.nix\`:

\`\`\`nix
services.blueman = {
  enable = true;
  withApplet = false;  # workaround for nixpkgs#514705
};
\`\`\`

The blueman *package* stays installed via \`modules/nixos/packages/host-specific/laptop-packages.nix:14\` — only the broken module-side autostart unit is disabled. Users can still launch the applet manually if needed.

## Verification

- ✅ All 3 hosts evaluate cleanly
- ✅ Drv hashes change (expected — systemd unit set differs):
  - p620: \`mfsa9pxr3sqcpkpi2zq0987kvg8immak\`
  - razer: \`lh1ki46cli72nm8ykqf2nr6y98z9ppgc\`
  - p510: \`5wzw1mwi8fpgf3ky3wali7akx77zjlvi\`
- 📷 **Post-deploy verification**: \`systemctl --user status blueman-applet\` should no longer report \`bad-setting\`

## References

- Upstream: https://github.com/NixOS/nixpkgs/issues/514705
- Audit found this via \`/check-nixos-issues\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)