### PR TITLE
theme(unify-2): wallpaper into baseTheme, drop host.theme.wallpaper

### DIFF
--- a/hosts/common/shared-variables.nix
+++ b/hosts/common/shared-variables.nix
@@ -38,9 +38,13 @@
     QT_QPA_PLATFORMTHEME = "qt5ct";
   };
 
-  # Base theme structure (95% common - only wallpaper differs)
+  # Base theme structure (100% common — single wallpaper across hosts).
+  # If per-host wallpaper divergence is ever needed again, re-introduce
+  # `host.theme.wallpaper` in modules/desktop/stylix-theme.nix as an
+  # override that defaults to baseTheme.wallpaper.
   baseTheme = {
     scheme = "gruvbox-dark-medium";
+    wallpaper = ../../assets/wallpapers/orange-desert.jpg;
     cursor = {
       name = "Bibata-Modern-Classic";
       size = 16;

--- a/hosts/p510/themes/stylix.nix
+++ b/hosts/p510/themes/stylix.nix
@@ -1,10 +1,9 @@
 { lib, ... }: {
-  # System-level Stylix configuration is shared across hosts via
+  # System-level Stylix configuration is fully shared via
   # modules/desktop/stylix-theme.nix. p510 is a headless server so the
-  # GNOME target is overridden back to false.
+  # GNOME target is overridden back to false. (Phase 3 will replace this
+  # mkForce with a `host.class = "headless-rdp"` gate.)
   imports = [ ../../../modules/desktop/stylix-theme.nix ];
-
-  host.theme.wallpaper = ../../../assets/wallpapers/orange-desert.jpg;
 
   # Headless server — no GNOME session to theme.
   stylix.targets.gnome.enable = lib.mkForce false;

--- a/hosts/p620/themes/stylix.nix
+++ b/hosts/p620/themes/stylix.nix
@@ -1,7 +1,7 @@
 _: {
-  # System-level Stylix configuration is shared across hosts via
-  # modules/desktop/stylix-theme.nix. Only the per-host wallpaper differs.
+  # System-level Stylix configuration is fully shared via
+  # modules/desktop/stylix-theme.nix. Wallpaper now lives in baseTheme
+  # (hosts/common/shared-variables.nix). This file remains as the
+  # per-host attach point for any future host-specific theming overrides.
   imports = [ ../../../modules/desktop/stylix-theme.nix ];
-
-  host.theme.wallpaper = ../../../assets/wallpapers/orange-desert.jpg;
 }

--- a/hosts/razer/themes/stylix.nix
+++ b/hosts/razer/themes/stylix.nix
@@ -1,7 +1,7 @@
 _: {
-  # System-level Stylix configuration is shared across hosts via
-  # modules/desktop/stylix-theme.nix. Only the per-host wallpaper differs.
+  # System-level Stylix configuration is fully shared via
+  # modules/desktop/stylix-theme.nix. Wallpaper now lives in baseTheme
+  # (hosts/common/shared-variables.nix). This file remains as the
+  # per-host attach point for any future host-specific theming overrides.
   imports = [ ../../../modules/desktop/stylix-theme.nix ];
-
-  host.theme.wallpaper = ../../../assets/wallpapers/orange-desert.jpg;
 }

--- a/modules/desktop/stylix-theme.nix
+++ b/modules/desktop/stylix-theme.nix
@@ -7,14 +7,6 @@ let
   vars = import ../../hosts/common/shared-variables.nix;
 in
 {
-  options.host.theme.wallpaper = lib.mkOption {
-    type = lib.types.path;
-    description = ''
-      Per-host wallpaper image. Set in the importing host module
-      (e.g. `host.theme.wallpaper = ./orange-desert.jpg;`).
-    '';
-  };
-
   config = {
     stylix = {
       enable = true;
@@ -23,7 +15,7 @@ in
       autoEnable = true;
       base16Scheme =
         "${pkgs.base16-schemes}/share/themes/${vars.baseTheme.scheme}.yaml";
-      image = config.host.theme.wallpaper;
+      image = vars.baseTheme.wallpaper;
 
       fonts = {
         monospace = {


### PR DESCRIPTION
## Summary

Closes #440. Phase 2 of the GNOME+Stylix unification work.

All 3 hosts already pointed at the same wallpaper after Phase 1's consolidation. The \`host.theme.wallpaper\` mkOption was ceremony for no current value, and the user wants "all hosts the same theme."

## Changes

- \`hosts/common/shared-variables.nix\`: add \`wallpaper = ../../assets/wallpapers/orange-desert.jpg;\` to the \`baseTheme\` block
- \`modules/desktop/stylix-theme.nix\`: read \`vars.baseTheme.wallpaper\` instead of \`config.host.theme.wallpaper\`; delete the mkOption
- \`hosts/{p620,razer,p510}/themes/stylix.nix\`: drop the per-host \`host.theme.wallpaper = ...;\` line

The per-host \`stylix.nix\` files survive as the canonical attach point for any future host-specific theming overrides — they're now ~5-line stubs.

## Verification

✅ All 3 host drvs **byte-identical** to pre-change — pure file-content relocation, no semantic difference at the closure level:

- p620: \`b6v2wbgkgv0fnc2nclpqljgj02xi7w4k\` (unchanged)
- razer: \`jhz9ah8hgf6znv8cxv1lyh4l0d4gik7a\` (unchanged)
- p510: \`f15va8kpzs0gcdgzhd3qf64zx6g7ilf2\` (unchanged)

## Test plan

- [ ] Merge to main
- [ ] \`nh os switch\` on p620 — wallpaper unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)