### PR TITLE
theme(unify-3): introduce host.class enum, gate stylix gnome target

### DIFF
--- a/hosts/common/nixos/host-class.nix
+++ b/hosts/common/nixos/host-class.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+let inherit (lib) mkOption types;
+in {
+  options.host.class = mkOption {
+    type = types.enum [ "workstation" "laptop" "headless-rdp" ];
+    description = ''
+      The role this host plays. Modules consume this to gate decisions
+      that should track host purpose rather than be set per-host.
+
+      - workstation: full desktop, AC-only, no battery extensions
+      - laptop:      full desktop, battery-aware, mobile features
+      - headless-rdp: no interactive session; remote-only
+    '';
+    # No default — every host must declare its class explicitly. This
+    # is intentional; getting it wrong silently is worse than a build
+    # failure.
+  };
+}

--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -22,6 +22,7 @@ in
       ./nixos/recyclarr.nix # Recyclarr Trash Guides sync
       ../common/nixos/i18n.nix
       ../common/nixos/envvar.nix
+      ../common/nixos/host-class.nix
       ./nixos/cpu.nix
       ./nixos/memory.nix
       ../common/nixos/hosts.nix
@@ -37,6 +38,8 @@ in
       ./themes/stylix.nix # Re-enabled after upstream cache fix
       # ../../home/desktop/gnome/default.nix # Home Manager module - can't import here
     ];
+
+  host.class = "headless-rdp";
 
   # Basic networking configuration (detailed config in ./nixos/network.nix)
   networking = {

--- a/hosts/p510/themes/stylix.nix
+++ b/hosts/p510/themes/stylix.nix
@@ -1,10 +1,6 @@
-{ lib, ... }: {
+_: {
   # System-level Stylix configuration is fully shared via
-  # modules/desktop/stylix-theme.nix. p510 is a headless server so the
-  # GNOME target is overridden back to false. (Phase 3 will replace this
-  # mkForce with a `host.class = "headless-rdp"` gate.)
+  # modules/desktop/stylix-theme.nix. The GNOME target is now gated by
+  # host.class in that module (headless-rdp → false), so no override needed.
   imports = [ ../../../modules/desktop/stylix-theme.nix ];
-
-  # Headless server — no GNOME session to theme.
-  stylix.targets.gnome.enable = lib.mkForce false;
 }

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -22,6 +22,7 @@ in
     ../common/nixos/i18n.nix
     ../common/nixos/hosts.nix
     ../common/nixos/envvar.nix
+    ../common/nixos/host-class.nix
     ./nixos/cpu.nix
     ./nixos/memory.nix
     ./nixos/load.nix
@@ -35,6 +36,8 @@ in
     ../../modules/scrcpy/default.nix
     ../../modules/system/logging.nix
   ];
+  host.class = "workstation";
+
   # Consolidated networking configuration
   networking = {
     # Set hostname from variables

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -22,6 +22,7 @@ in
     ../common/nixos/i18n.nix
     ../common/nixos/hosts.nix
     ../common/nixos/envvar.nix
+    ../common/nixos/host-class.nix
     ./nixos/cpu.nix
     ./nixos/laptop.nix
     ./nixos/memory.nix
@@ -33,6 +34,8 @@ in
     ../../modules/secrets/api-keys.nix
     ../../modules/containers/docker.nix
   ];
+
+  host.class = "laptop";
 
   # Consolidated networking configuration
   networking = {

--- a/modules/desktop/stylix-theme.nix
+++ b/modules/desktop/stylix-theme.nix
@@ -57,7 +57,7 @@ in
         # ships a generated GTK theme package. COSMIC stores its own theme in
         # ~/.config/cosmic/com.system76.CosmicTheme.* and ignores these
         # gsettings keys, so the two desktops stay isolated.
-        gnome.enable = true;
+        gnome.enable = config.host.class != "headless-rdp";
 
         qt = {
           enable = true;


### PR DESCRIPTION
## Summary

Closes #441. Phase 3 of the GNOME+Stylix unification work.

p510's headless status used to be expressed via \`lib.mkForce false\` in \`hosts/p510/themes/stylix.nix:9\` — a manually-maintained negation that fought the central module. With a class enum gating the same decision in one place, the override becomes redundant.

## Changes

- New \`hosts/common/nixos/host-class.nix\` declaring \`host.class = "workstation" | "laptop" | "headless-rdp"\` (enum, no default — every host must declare explicitly)
- \`hosts/{p620,razer,p510}/configuration.nix\`: import host-class.nix + set the class
- \`modules/desktop/stylix-theme.nix\`: \`stylix.targets.gnome.enable\` now reads \`config.host.class != "headless-rdp"\` instead of being unconditionally \`true\`
- \`hosts/p510/themes/stylix.nix\`: removed the now-redundant \`mkForce false\`; file matches p620/razer pattern

## Out of scope

Many other \`mkForce\` sites in p510 (terminals, editors, network, memory, home-manager \`features.desktop\`). Each addresses a different concern; gating them on \`host.class\` is a separate exercise not part of GNOME-stylix unification.

## Verification

✅ **All 3 host drvs byte-identical to post-Phase-2** — pure refactor, gold-standard confirmation:

- p620: \`b6v2wbgkgv0fnc2nclpqljgj02xi7w4k\` (unchanged)
- razer: \`jhz9ah8hgf6znv8cxv1lyh4l0d4gik7a\` (unchanged)
- p510: \`f15va8kpzs0gcdgzhd3qf64zx6g7ilf2\` (unchanged)

✅ Class + gating evaluate as expected:

| Host | host.class | stylix.targets.gnome.enable |
|---|---|---|
| p620 | workstation | true |
| razer | laptop | true |
| p510 | headless-rdp | false |

## Future use

\`host.class\` is now available to gate other host-role decisions cleanly. Phase 4 (display manager) and Phase 5 (shared profile) will both benefit from this enum being declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)