### PR TITLE
theme(unify-4): unify display manager wiring under desktop.displayManager

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -213,23 +213,19 @@ in
   # Enable X server (NVIDIA drivers configured in nvidia.nix)
   services.xserver = {
     enable = true;
-    displayManager = {
-      xserverArgs = [
-        "-nolisten tcp"
-        "-dpi 96"
-      ];
-      # Disable LightDM to prevent conflicts with COSMIC Greeter
-      lightdm.enable = lib.mkForce false;
-    };
+    displayManager.xserverArgs = [
+      "-nolisten tcp"
+      "-dpi 96"
+    ];
   };
 
-  # Display manager - GDM for headless GNOME desktop (COSMIC not used on this server)
-  services.displayManager.gdm.enable = true;
-
-  # Enable auto-login for headless RDP access (override cosmic-remote-desktop module)
-  services.displayManager.autoLogin = {
-    enable = lib.mkOverride 0 true; # Highest priority override (overrides module's mkForce)
-    user = "olafkfreund";
+  # Display manager: GDM for headless GNOME RDP access
+  desktop.displayManager = {
+    backend = "gdm";
+    autoLogin = {
+      enable = true;
+      user = "olafkfreund";
+    };
   };
 
   # Desktop manager configuration - Full GNOME for headless RDP access

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -410,14 +410,10 @@ in
     # X server configuration
     xserver = {
       enable = true;
-      displayManager = {
-        xserverArgs = [
-          "-nolisten tcp"
-          "-dpi 96"
-        ];
-        # Disable LightDM to prevent conflicts with COSMIC Greeter
-        lightdm.enable = lib.mkForce false;
-      };
+      displayManager.xserverArgs = [
+        "-nolisten tcp"
+        "-dpi 96"
+      ];
       videoDrivers = [ "${vars.gpu}gpu" ]; # Correct way to set the video driver
     };
 

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -350,14 +350,10 @@ in
     # X server and desktop environment
     xserver = {
       enable = true;
-      displayManager = {
-        xserverArgs = [
-          "-nolisten tcp"
-          "-dpi 96"
-        ];
-        # Explicitly disable LightDM - using COSMIC Greeter instead
-        lightdm.enable = lib.mkForce false;
-      };
+      displayManager.xserverArgs = [
+        "-nolisten tcp"
+        "-dpi 96"
+      ];
       videoDrivers = [ vars.gpu ];
     };
 

--- a/modules/desktop/cosmic.nix
+++ b/modules/desktop/cosmic.nix
@@ -102,18 +102,13 @@ in
     # Enable COSMIC Desktop Environment and display manager configuration
     services = {
       desktopManager.cosmic.enable = true;
-
-      # Enable cosmic-greeter display manager
-      # NixOS's displayManager.cosmic-greeter handles all the complexity:
-      #   - Creates cosmic-greeter user automatically
-      #   - Configures greetd with cosmic-greeter-start command
-      #   - Sets up proper environment variables (XCURSOR_THEME, etc.)
-      #   - Manages all dependencies and services
-      displayManager = {
-        cosmic-greeter.enable = cfg.useCosmicGreeter;
-        defaultSession = mkIf cfg.defaultSession "cosmic";
-      };
+      displayManager.defaultSession = mkIf cfg.defaultSession "cosmic";
     };
+
+    # Delegate DM backend to the unified display-manager module.
+    # cosmic-greeter handles all complexity (cosmic-greeter user, greetd
+    # wiring, XCURSOR_THEME, etc.) via services.displayManager.cosmic-greeter.
+    desktop.displayManager.backend = mkIf cfg.useCosmicGreeter "cosmic-greeter";
 
     # Wrap cosmic-comp at the package level for libEGL.so.1 loading.
     # The four core apps are wrapped via symlinkJoin in systemPackages

--- a/modules/desktop/default.nix
+++ b/modules/desktop/default.nix
@@ -1,5 +1,6 @@
 { pkgs, ... }: {
   imports = [
+    ./display-manager.nix
     ./gnome-remote-desktop.nix
     ./cosmic-remote-desktop.nix
   ];

--- a/modules/desktop/display-manager.nix
+++ b/modules/desktop/display-manager.nix
@@ -1,0 +1,60 @@
+{ config, lib, ... }:
+let
+  inherit (lib) mkEnableOption mkIf mkOption types;
+  cfg = config.desktop.displayManager;
+in
+{
+  options.desktop.displayManager = {
+    backend = mkOption {
+      type = types.enum [ "gdm" "cosmic-greeter" "none" ];
+      default = "none";
+      description = ''
+        Which display manager runs at boot.
+
+        - gdm: GDM (used by the headless RDP host for auto-login GNOME)
+        - cosmic-greeter: COSMIC's own greeter (used by hosts with COSMIC)
+        - none: no DM enabled (e.g. host uses start* command directly)
+
+        This option exists to keep the wiring in one place and prevent
+        lightdm from sneaking back in (nixpkgs enables it by default
+        when xserver is enabled).
+      '';
+    };
+
+    autoLogin = {
+      enable = mkEnableOption "auto-login at boot (recommended only for headless RDP hosts)";
+      user = mkOption {
+        type = types.str;
+        default = "";
+        description = "User to auto-login as. Required when autoLogin.enable = true.";
+      };
+    };
+  };
+
+  config = {
+    assertions = [
+      {
+        assertion = !cfg.autoLogin.enable || cfg.autoLogin.user != "";
+        message = "desktop.displayManager.autoLogin.user must be set when autoLogin.enable = true";
+      }
+    ];
+
+    services = {
+      # Always disable lightdm — nixpkgs enables it as the X11 default;
+      # we don't use it on any host.
+      xserver.displayManager.lightdm.enable = lib.mkForce false;
+
+      displayManager = {
+        gdm.enable = cfg.backend == "gdm";
+        cosmic-greeter.enable = cfg.backend == "cosmic-greeter";
+
+        autoLogin = mkIf cfg.autoLogin.enable {
+          # mkOverride 0 to win over the cosmic-remote-desktop /
+          # gnome-remote-desktop modules' lib.mkForce false (priority 50).
+          enable = lib.mkOverride 0 true;
+          user = cfg.autoLogin.user;
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Closes #442. Phase 4 of the GNOME+Stylix unification work.

Display manager config was scattered across 3 hosts and \`modules/desktop/cosmic.nix\`. This PR consolidates everything into a single \`modules/desktop/display-manager.nix\` module exposing one enum + autoLogin block.

## Changes

**New**: \`modules/desktop/display-manager.nix\`
- \`desktop.displayManager.backend = "gdm" | "cosmic-greeter" | "none"\` (default \`"none"\` so hosts without an explicit choice don't hard fail; assertion catches autoLogin without a user set)
- \`desktop.displayManager.autoLogin = { enable; user; }\`
- Always disables lightdm via \`mkForce\` (nixpkgs enables it as the X11 default; we don't use it on any host)
- \`autoLogin\` uses \`mkOverride 0\` to beat \`cosmic-remote-desktop\`/\`gnome-remote-desktop\` modules' \`mkForce false\`

**Wiring**:
- \`modules/desktop/cosmic.nix\`: sets \`desktop.displayManager.backend = mkIf cfg.useCosmicGreeter "cosmic-greeter"\` instead of touching \`cosmic-greeter.enable\` directly
- \`modules/desktop/default.nix\`: imports the new module
- \`hosts/{p620,razer}/configuration.nix\`: deleted the redundant \`lightdm.enable = mkForce false\`
- \`hosts/p510/configuration.nix\`: replaced 3 scattered DM directives with one \`desktop.displayManager\` block

## Verification

✅ **All 3 host drvs byte-identical to post-Phase-3** — pure refactor:

- p620: \`b6v2wbgkgv0fnc2nclpqljgj02xi7w4k\` (unchanged)
- razer: \`jhz9ah8hgf6znv8cxv1lyh4l0d4gik7a\` (unchanged)
- p510: \`f15va8kpzs0gcdgzhd3qf64zx6g7ilf2\` (unchanged)

✅ Sanity evals (per host):

| | p620 | razer | p510 |
|---|---|---|---|
| backend | "cosmic-greeter" | "cosmic-greeter" | "gdm" |
| gdm.enable | false | false | true |
| cosmic-greeter.enable | true | true | false |
| lightdm.enable | false | false | false |

✅ p510 autoLogin: \`{ enable = true; user = "olafkfreund"; }\`

## Test plan

This is the highest-risk phase of the unification work because DM misconfig = no login. Drv equality means no semantic change at the closure level, but to be safe:

- [ ] Merge to main
- [ ] **Deploy p510 first** (least disruptive — RDP-only, easy to roll back via SSH if anything goes wrong)
- [ ] Confirm \`systemctl status gdm\` is active and autoLogin works for RDP
- [ ] Then deploy razer, confirm cosmic-greeter still appears at boot
- [ ] Then deploy p620

🤖 Generated with [Claude Code](https://claude.com/claude-code)