### PR TITLE
fix(base-user): drop vim from user packages (collides with home-manager vimAlias)

### DIFF
--- a/modules/common/base-user.nix
+++ b/modules/common/base-user.nix
@@ -9,7 +9,11 @@ let inherit (lib) mkDefault; in {
     description = mkDefault "Olaf K-Freund";
     extraGroups = [ "wheel" "video" "scanner" "lp" ];
     shell = mkDefault pkgs.zsh; # Changed to mkDefault to allow host configs to override
-    packages = with pkgs; [ vim wally-cli ];
+    # vim deliberately not here: it would collide with the
+    # programs.neovim.{viAlias,vimAlias} symlinks in home-manager-path
+    # (nixpkgs#451). The vim package is still in environment.systemPackages
+    # via modules/nixos/packages/core.nix for sudo / root / other users.
+    packages = with pkgs; [ wally-cli ];
   };
 
   # Common shell setup


### PR DESCRIPTION
## Summary

Closes #451. \`nh os build\` was warning:

\`\`\`
user-environment> pkgs.buildEnv warning: colliding subpath (ignored):
  /nix/store/.../vim-9.2.0340/bin/vi
  and /nix/store/.../home-manager-path/bin/vi
\`\`\`

Two sources provided vi/vim into the same per-user \`pkgs.buildEnv\`:

| Source | Path |
|---|---|
| \`users.users.<x>.packages = [ pkgs.vim ... ]\` | \`/etc/profiles/per-user/<x>/bin/vim\` |
| \`programs.neovim.{viAlias,vimAlias} = true\` | \`~/.nix-profile/bin/vim → nvim\` |

## Fix

Drop \`vim\` from \`modules/common/base-user.nix:12\`. The home-manager neovim aliases are intentional and become the canonical winner.

\`vim\` stays available system-wide via \`environment.systemPackages\` (modules/nixos/packages/core.nix:13) — \`sudo vim\`, root, and other user accounts still get real vim.

## Verification

- ✅ All 3 hosts evaluate cleanly
- ✅ Drvs change (expected — user-environment package set differs):
  - p620: \`3lvh0wgan0f2k5vhvz72adlkvg47jm9j\`
  - razer: \`k8w6x27rw961kswrgj1i5flycjpiyn4h\`
  - p510: \`wd90slzjmxwryw99pzwqipxcg1acipfs\`

## Test plan

- [ ] Merge to main
- [ ] \`nh os switch\` on p620 — collision warning should be gone
- [ ] Verify \`vim\` (your user) launches neovim, \`sudo vim\` launches real vim

🤖 Generated with [Claude Code](https://claude.com/claude-code)