### PR TITLE
chore(packages): drop termshark + wireshark (unblocks build)

### DIFF
--- a/Users/olafkfreund/p510_home.nix
+++ b/Users/olafkfreund/p510_home.nix
@@ -119,7 +119,6 @@
     netcat
     socat
     nmap
-    wireshark
     tcpdump
 
     # Performance analysis for server optimization

--- a/home/profiles/developer/default.nix
+++ b/home/profiles/developer/default.nix
@@ -147,7 +147,6 @@
     # Network development tools
     netcat
     socat
-    wireshark
 
     # Documentation and writing
     pandoc

--- a/hosts/p510/nixos/microvm/nixvm.nix
+++ b/hosts/p510/nixos/microvm/nixvm.nix
@@ -215,7 +215,6 @@ in
     gparted
     ethtool
     tcpdump
-    wireshark
 
     # Graphics tools
     gimp

--- a/modules/development/shell.nix
+++ b/modules/development/shell.nix
@@ -28,7 +28,6 @@ in
         pkgs.crossplane-cli
         pkgs.just
         pkgs.atac
-        pkgs.termshark
       ]
       ++ cfg.packages;
   };

--- a/modules/packages/sets.nix
+++ b/modules/packages/sets.nix
@@ -216,7 +216,6 @@
   # Network tools
   network = with pkgs; [
     nmap
-    wireshark
     tcpdump
     iperf3
     mtr


### PR DESCRIPTION
## Summary

Closes #453. \`nh os build\` was failing on a wireshark-cli source hash mismatch (GitLab archive instability via fetchFromGitLab):

\`\`\`
error: hash mismatch in fixed-output derivation '/nix/store/.../source.drv':
         specified: sha256-U30OJ8m+L/EVLN7NrqWNl77IMaO2cnw2N5uWzLVJE30=
            got:    sha256-Zvrwxjp4LK2J3QnxmPxKKrU01YHQvPyp54UWzeGNCjA=
\`\`\`

Cascading failure: \`wireshark-cli\` → \`termshark\` → \`system-path\`.

User decided neither tool is actually needed. Dropping the references rather than chasing the upstream hash issue.

## Changes

Removed from 5 files:
- \`modules/development/shell.nix\` — \`pkgs.termshark\`
- \`modules/packages/sets.nix\` — \`wireshark\` (network set)
- \`home/profiles/developer/default.nix\` — \`wireshark\`
- \`Users/olafkfreund/p510_home.nix\` — \`wireshark\`
- \`hosts/p510/nixos/microvm/nixvm.nix\` — \`wireshark\`

## Verification

- ✅ \`grep -rnE "termshark|wireshark" --include="*.nix" hosts/ modules/ home/ Users/\` returns 0 hits
- ✅ All 3 hosts evaluate cleanly:
  - p620: \`hhrys6xl3d7vphws2gqn8rd67knpvp9w\`
  - razer: \`y2rlgl78z74010spw5ddbf2fy6idv66j\`
  - p510: \`8b2f06xacpp92nlxbba655c9jqnfnfj0\`

## Test plan

- [ ] Merge to main
- [ ] \`nh os build\` should now complete without the wireshark/termshark errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)