### PR TITLE
chore(warp): bump warp-terminal to 0.2026.04.29.08.57.stable_01

### DIFF
--- a/pkgs/warp-terminal/versions.json
+++ b/pkgs/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "linux_x86_64": {
-    "hash": "sha256-N93S9SPPW9UhR3C3wlHpwvumnkj7Dx16x4TmKGxd/bc=",
-    "version": "0.2026.04.27.15.32.stable_03"
+    "hash": "sha256-93IBcHfExMduG2idnpCif6hD3vO+/tsQGF7FlgS6meE=",
+    "version": "0.2026.04.29.08.57.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-09/GiuV4Tqal9qzvX4+GhhtbqrDNc1X5w/4j6vkd3Xo=",
-    "version": "0.2026.04.27.15.32.stable_03"
+    "hash": "sha256-2XGgK20SLFiSBix/WXuW0yCkp46HzBtWJD+5I+H9js8=",
+    "version": "0.2026.04.29.08.57.stable_01"
   }
 }


### PR DESCRIPTION
## Summary

Closes #455. Routine bump via \`scripts/update-warp-terminal.sh\` (also wired as \`passthru.updateScript\`).

| | Before | After |
|---|---|---|
| Version | \`0.2026.04.27.15.32.stable_03\` | \`0.2026.04.29.08.57.stable_01\` |

Both linux_x86_64 and linux_aarch64 hashes refreshed from upstream.

## Verification

- ✅ \`nix build .#...pkgs.warp-terminal\` succeeds
- ✅ \`$out/bin/warp-terminal\` present
- ✅ \`pkgs.warp-terminal.version\` reports new value

## Test plan

- [ ] Merge to main
- [ ] \`nh os switch\` on p620; launch warp; check About → version

🤖 Generated with [Claude Code](https://claude.com/claude-code)