### PR TITLE
docs: refresh READMEs to match current architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,144 +1,260 @@
 # NixOS Configuration
 
-Multi-host NixOS configuration using flakes, template-based architecture, and Home Manager.
+Multi-host NixOS configuration using flakes, a single parameterised host
+template, Home Manager as a flake module, and Stylix-driven theming.
+
+Last verified: 2026-05-04 against `nixos-unstable` (NixOS 26.05).
 
 ## Hosts
 
-| Host | Type | Hardware | Purpose |
-|------|------|----------|---------|
-| p620 | workstation | AMD | Primary development |
-| p510 | server | Intel Xeon | Media server (Plex) |
-| razer | laptop | Intel/NVIDIA | Mobile development |
+| Host  | Class       | Hardware       | Role                              | Template            |
+|-------|-------------|----------------|-----------------------------------|---------------------|
+| p620  | workstation | AMD RX 7900    | Primary development, AI workloads | desktop/workstation |
+| p510  | workstation | Intel Xeon     | Headless media server (Plex)      | desktop/workstation |
+| razer | laptop      | Intel + NVIDIA | Mobile development, Secure Boot   | desktop/laptop      |
+
+DEX5550 and Samsung have been removed from the configuration. References
+in older docs are stale.
+
+## Architecture
+
+- Single parameterised host template at `hosts/templates/desktop.nix`
+  (selects between `workstation` and `laptop` profiles via the
+  `profile` argument). Surfaced through `lib/hostTypes.nix` as
+  `hostTypes.workstation` / `hostTypes.laptop`. The previous
+  `server`/`hybrid`/`base` templates were removed; P510 also uses the
+  workstation template (headless via `host.class = "workstation"` and
+  no display manager).
+- Hardware GPU profiles in `hosts/common/hardware-profiles/` (`amd`,
+  `nvidia`, `intel-integrated`).
+- Feature flags drive module enablement (see `lib/features.nix`).
+- Module tree under `modules/` is imported explicitly by the template;
+  there is no auto-discovery.
+- Overlays are split by purpose under `overlays/`:
+  `default.nix`, `custom-packages.nix`, `cmake-compat.nix`,
+  `python-compat.nix`, `upstream-fixes.nix`, `citrix-workspace.nix`.
+- Theming is centralised through Stylix (`base16` palette). Dependent
+  surfaces — GNOME Terminal, Zellij, COSMIC (full RON palette write,
+  30 fields) — derive their colours from
+  `config.lib.stylix.colors`. The standalone `nix-colors` input has
+  been removed.
+- Home Manager is loaded as a flake module from `flake.nix`. Do **not**
+  run `home-manager switch` directly; user environments are activated
+  by the system rebuild.
 
 ## Quick Start
 
 ```bash
-git clone https://github.com/olafkfreund/nixos_config.git
-cd nixos_config
-just validate        # Validate configuration
-just deploy          # Deploy to current host
-just HOST            # Deploy to specific host (p620/p510/razer)
+git clone https://github.com/olafkfreund/nixos_config.git ~/.config/nixos
+cd ~/.config/nixos
+just validate                 # Configuration validation
+just test-host p620           # Build a host without switching
+just <host>                   # Build and switch (p620 / p510 / razer)
 ```
 
-### Routine updates: one command does everything
+## Routine Update + Deploy
 
-For the common case — bump flake inputs, commit the new lock, build, and
-switch — use the idiot-proof recipe. It works for local AND remote hosts,
-refuses to run with a dirty working tree, commits before switching so the
-lock can never get orphaned, and handles the stale-host case (deploy even
-if the lock didn't move).
+The recommended flow for the common case (bump lock, commit, push,
+build, switch) — works for local and remote hosts, refuses to run with
+a dirty tree, and never orphans a lock:
 
 ```bash
-nhs                  # current host, nixpkgs scope (zsh shortcut)
-nhs razer            # remote deploy via SSH/nh
-nhs p510 all         # update all inputs
-nhs razer home-manager   # single-input scope
+nhs                           # current host, nixpkgs scope (zsh shortcut)
+nhs razer                     # remote deploy via SSH (nh --target-host)
+nhs p510 all                  # update all flake inputs, deploy p510
+nhs razer home-manager        # bump a single input
 
-# Same thing without the alias:
+# Without the alias:
 just update-commit-deploy [HOST] [SCOPE]
+
+# Pre-build for a currently offline host (commit + build now, deploy later):
+nhsb razer
 ```
 
-Full reference: **[docs/UPDATE-DEPLOY.md](./docs/UPDATE-DEPLOY.md)**.
+Full reference: [docs/UPDATE-DEPLOY.md](./docs/UPDATE-DEPLOY.md).
 
-## Directory Structure
+## Directory Layout
 
-```
-flake.nix                     Main configuration
-justfile                      Automation commands
-modules/                      Feature modules
+```text
+flake.nix                       Main flake (inputs, outputs, host wiring)
+Justfile                        Automation recipes (just --list)
+lib/                            Shared functions (hostTypes, features, secrets, live-images)
+modules/                        Feature modules (explicit imports only)
+overlays/                       Split nixpkgs overlays
 hosts/
-  templates/                  Host type templates (workstation/laptop/server)
-  p620/, p510/, razer/
-  common/
-home/profiles/                Home Manager profiles
-Users/                        Per-user configurations
-secrets/                      Agenix encrypted secrets
-docs/                         Documentation
+  templates/desktop.nix         Single parameterised template (workstation | laptop)
+  common/                       Shared host fragments + hardware-profiles
+  p620/  p510/  razer/          Per-host configurations
+home/                           Home Manager modules
+  profiles/                     Role-based profiles (developer, server-admin, ...)
+Users/<user>/<host>_home.nix    Per-user, per-host Home Manager entry
+secrets/                        agenix-encrypted secrets (.age)
+checks/                         flake checks (nix flake check)
+scripts/                        Operational scripts
+docs/                           Documentation
+assets/wallpapers/              Centralised wallpapers (consumed by Stylix)
 ```
 
-## Commands
+## Common Commands
 
 ```bash
 # Validation
-just check-syntax             # Syntax check
-just validate                 # Full validation
-just test-host HOST           # Test specific host
+just check-syntax               # Nix syntax pass
+just validate-quick             # Fast validation
+just validate                   # Full validation
+just test-host <host>           # Build a host without switching
 
 # Deployment
-just deploy                   # Deploy locally
-just HOST                     # Deploy to host
-just quick-deploy HOST        # Deploy only if changed
-just update-commit-deploy HOST [SCOPE]   # Full flow: update → commit → push → switch (docs/UPDATE-DEPLOY.md)
-nhs [HOST] [SCOPE]            # zsh shortcut for `just update-commit-deploy`
+just deploy                     # Local switch
+just <host>                     # Build + switch a specific host
+just quick-deploy <host>        # Deploy only if the closure changed
+just update-commit-deploy <host> [scope]   # See docs/UPDATE-DEPLOY.md
+nhs [host] [scope]              # zsh shortcut for the above
 
 # Maintenance
-just cleanup                  # Clean old generations
-just update-flake             # Update inputs (no commit)
-just secrets                  # Manage secrets
-
-# All commands
-just --list
+just cleanup                    # GC old generations
+just update-flake               # nix flake update (no commit)
+just secrets                    # Interactive secrets manager
+just --list                     # All recipes
 ```
 
-## Configuration
+## Feature Flags
 
-Hosts use feature flags:
+Hosts compose functionality through flags rather than direct service
+configuration. Example (from `hosts/p620/configuration.nix`):
 
 ```nix
 features = {
   development.enable = true;
   desktop.enable = true;
-  virtualization.enable = true;
+  virtualization = {
+    enable = true;
+    docker = true;
+  };
 };
 ```
 
-See `hosts/*/configuration.nix` for examples.
+Adding a new service: create a module under
+`modules/services/<name>.nix` exposing `features.<name>` options, then
+import it explicitly from the template or host. Do not place
+`services.* = { ... }` blocks directly in
+`hosts/*/configuration.nix`.
 
 ## Secrets
 
+Encrypted with agenix; decrypted at activation time only.
+
 ```bash
-just secrets                              # Interactive manager
-./scripts/manage-secrets.sh create NAME   # Create secret
-./scripts/manage-secrets.sh edit NAME     # Edit secret
-./scripts/manage-secrets.sh rekey         # Rekey all
+just secrets                                    # Interactive manager
+./scripts/manage-secrets.sh create <name>
+./scripts/manage-secrets.sh edit   <name>
+./scripts/manage-secrets.sh rekey
 ```
 
-Use runtime loading:
+Always reference secrets by path, never read them at evaluation time:
 
 ```nix
-# Correct
-services.myapp.passwordFile = config.age.secrets.password.path;
+# Correct — runtime load
+services.myapp.passwordFile = config.age.secrets.myapp-password.path;
 
-# Wrong - exposes secret in store
+# Wrong — embeds the secret in /nix/store
 services.myapp.password = builtins.readFile "/secrets/password";
 ```
 
-## Documentation
+Access control lives in `secrets.nix` (per-host and per-user public
+keys).
 
-- [docs/UPDATE-DEPLOY.md](./docs/UPDATE-DEPLOY.md) - `nhs` / `just update-commit-deploy` — idiot-proof update+deploy flow (local + remote)
-- [docs/PATTERNS.md](./docs/PATTERNS.md) - Best practices
-- [docs/NIXOS-ANTI-PATTERNS.md](./docs/NIXOS-ANTI-PATTERNS.md) - Common mistakes
-- [docs/GITHUB-WORKFLOW.md](./docs/GITHUB-WORKFLOW.md) - Development workflow
+## Razer: Secure Boot
 
-## Development
+razer boots via lanzaboote (`v1.0.0`) with `systemd-initrd`. Because
+the firmware ships a locked Setup Mode, MOK enrollment is handled by a
+shim+MOK module (`modules/razer/...`) that wraps `lzbt` and points
+`pkiBundle` at `/var/lib/sbctl` (the sbctl 0.18 default). Kernel is
+pinned to `linuxPackages_latest` to dodge the 6.18.24 + NVIDIA boot
+regression.
+
+## Live Installer
+
+A bootable installer image is produced for razer:
 
 ```bash
-gh issue develop N --checkout   # Create branch from issue
-just test-host HOST             # Test changes
-just validate                   # Validate
-git commit -m "type: description (#N)"
-gh pr create --fill             # Create PR
+nix build .#live-iso-razer
+just show-devices                 # Identify the USB target
+just flash-live razer /dev/sdX    # Destructive, double-check the device
+```
+
+Live images for other hosts have been removed from the flake; the same
+builder (`lib/live-images.nix`) can be re-instantiated if needed.
+
+## Theming
+
+- Source of truth: `config.lib.stylix.colors` (base16 scheme).
+- `assets/wallpapers/` contains all wallpapers; the active wallpaper is
+  selected by the per-host theme module.
+- COSMIC: a writer derivation produces the full RON palette (30
+  fields) from the base16 scheme; no hardcoded hex values remain.
+- GNOME Terminal: palette derived from Stylix base16.
+- Zellij: theme derived from Stylix.
+- GNOME profile: shared `home/profiles/desktop-user/profile.nix` and
+  the `desktop.gnome.profile` module unify the wiring; the
+  `desktop.displayManager` module unifies display-manager selection.
+- `host.class` (enum) is used to gate desktop-only Stylix targets so
+  headless hosts don't pull GNOME assets.
+
+## Removed Infrastructure
+
+The following are intentionally absent from the current configuration:
+
+- Prometheus / Grafana / Loki / Alertmanager monitoring stack — system
+  insight is now via `journalctl`, `systemctl`, and per-service logs.
+- DEX5550, Samsung, HP hosts.
+- `nix-colors` input (replaced by Stylix base16).
+- `termshark`, `wireshark`, `reddix`, `wasistlos`, `steampipe` modules
+  and the standalone `cosmic-applet-package-updater` chain.
+- `vim` from the base user package set (Home Manager `vimAlias`
+  handles it).
+- `cosmic-ext-applet-radio` as an upstream input — replaced by a local
+  module workaround for an upstream `mkPackageOption`/`description`
+  bug.
+
+## Development Workflow
+
+```bash
+gh issue develop <n> --checkout    # Branch from issue
+just test-host <host>              # Build the change
+just validate                      # Syntax + checks + flake check
+git commit -m "type(scope): summary (#n)"
+gh pr create --fill                # Open PR
+nhs <host>                         # After merge: lock-aware deploy
 ```
 
 ## Troubleshooting
 
 ```bash
-just check-syntax               # Syntax errors
-just diff HOST                  # Show changes
-just status                     # System health
-nix flake check --show-trace    # Detailed errors
+just check-syntax                  # Syntax errors
+just diff <host>                   # Pending closure delta
+nix flake check --show-trace       # Detailed evaluation errors
+journalctl -u <service> -f         # Follow service logs
+sudo nixos-rebuild switch --rollback   # Roll back to previous generation
 ```
+
+## Documentation
+
+- [docs/UPDATE-DEPLOY.md](./docs/UPDATE-DEPLOY.md) — `nhs` /
+  `just update-commit-deploy` reference (local + remote).
+- [docs/PATTERNS.md](./docs/PATTERNS.md) — NixOS patterns and best
+  practices (read before writing modules).
+- [docs/NIXOS-ANTI-PATTERNS.md](./docs/NIXOS-ANTI-PATTERNS.md) —
+  Anti-patterns and review checklist.
+- [docs/MCP-GUIDE.md](./docs/MCP-GUIDE.md) — MCP server integration.
+- [docs/guides/GITHUB-WORKFLOW.md](./docs/guides/GITHUB-WORKFLOW.md) —
+  Issue-driven development workflow.
+- [docs/guides/CACHE-STRATEGY.md](./docs/guides/CACHE-STRATEGY.md) —
+  Binary cache configuration.
+- [docs/guides/PACKAGE-SYSTEM-USAGE.md](./docs/guides/PACKAGE-SYSTEM-USAGE.md)
+  — Package categorisation.
+- [docs/README.md](./docs/README.md) — Full documentation index.
 
 ## License
 
-See repository for license information.
+See [LICENSE](./LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,229 +1,173 @@
 # NixOS Infrastructure Documentation
 
-Last Updated: 2026-01-25
+Last Updated: 2026-05-04
 
 ## Overview
 
-This directory contains comprehensive documentation for the NixOS infrastructure configuration. Documentation is organized by category for easy navigation.
+Documentation index for the NixOS configuration. Files are grouped by
+purpose. All docs are plain technical Markdown.
 
 ## Core Documentation
 
-Essential documentation for NixOS development and best practices.
+`PATTERNS.md`
+Comprehensive NixOS patterns and best practices. Module system, package
+writing conventions, security patterns, performance considerations.
+Read before writing modules or packages.
 
-**PATTERNS.md**
-- NixOS best practices and patterns
-- Module system usage
-- Package writing conventions
-- Security patterns
-- Performance optimization
-- Read this before writing any Nix code
+`NIXOS-ANTI-PATTERNS.md`
+Anti-patterns to avoid, review checklist, and community-aligned
+practices. Read before opening a PR.
 
-**NIXOS-ANTI-PATTERNS.md**
-- Critical anti-patterns to avoid
-- Common mistakes and their fixes
-- Code review checklist
-- Community standards alignment
-- Read this to avoid common pitfalls
+`UPDATE-DEPLOY.md`
+Reference for `just update-commit-deploy` and the `nhs` / `nhsb` zsh
+shortcuts. Idiot-proof flake-lock bump + commit + push + build + switch
+flow, including remote hosts and offline-host pre-builds.
 
-**MCP-GUIDE.md**
-- Model Context Protocol server integration
-- Available MCP servers and features
-- Setup and configuration
-- Service integrations (Atlassian, LinkedIn, WhatsApp, Obsidian)
-- Troubleshooting guide
+`MCP-GUIDE.md`
+Model Context Protocol server integration: enabled servers, setup, and
+troubleshooting.
 
 ## Guides
 
-Procedural guides for system setup, deployment, and workflows.
+Procedural guides for setup, deployment, and routine workflows.
 
-**guides/HOST_SETUP.md**
-- Host configuration procedures
-- Initial setup steps
-- Hardware-specific considerations
+`guides/HOST_SETUP.md`
+Procedure for adding a new host (directory layout, host SSH key,
+variables, secrets wiring).
 
-**guides/deployment-guide.md**
-- Deployment procedures
-- Build and test workflows
-- Production deployment strategy
+`guides/deployment-guide.md`
+Full deployment reference: smart deploy, parallel deploy, fast/cached
+modes, build-locally-deploy-remotely, emergency deploy.
 
-**guides/UPDATE-WORKFLOW.md**
-- System update procedures
-- Package update management
-- Testing and validation
+`guides/UPDATE-WORKFLOW.md`
+Update preview workflow with `nvd` (Nix Version Diff): preview-updates,
+new-package discovery, integrated `just update-workflow`.
 
-**guides/GITHUB-WORKFLOW.md**
-- Issue-driven development process
-- Branch management
-- Pull request procedures
-- Code review standards
+`guides/GITHUB-WORKFLOW.md`
+Issue-driven development workflow: branch naming, conventional commits,
+PR process, review standards.
 
-**guides/CACHE-STRATEGY.md**
-- Binary cache configuration
-- Cache optimization
-- Multi-tier caching setup
+`guides/CACHE-STRATEGY.md`
+Multi-tier binary cache strategy (local nix-serve on p620, official
+NixOS cache, Nix community cache).
 
-**guides/CACHIX-ANALYSIS.md**
-- Cachix integration analysis
-- Performance considerations
-- Setup procedures
+`guides/CACHIX-ANALYSIS.md`
+Cachix integration analysis and optional setup.
 
-**guides/PACKAGE-SYSTEM-USAGE.md**
-- Three-tier package architecture
-- Package categorization
-- System vs user packages
-- Conditional package loading
+`guides/PACKAGE-SYSTEM-USAGE.md`
+Package categorisation: system vs user, conditional package loading,
+template-driven defaults.
 
-**guides/GEMINI_CLI_FEATURE.md**
-- Gemini CLI integration
-- Features and capabilities
-- Configuration guide
+`guides/GEMINI_CLI_FEATURE.md`
+Gemini CLI integration and configuration.
 
 ## Applications
 
-Application-specific setup and configuration guides.
+Application-specific setup notes.
 
-**applications/CITRIX-WORKSPACE-SETUP.md**
-- Citrix Workspace installation
-- Configuration procedures
-- Troubleshooting
+`applications/CITRIX-WORKSPACE-SETUP.md`
+Citrix Workspace install and configuration. Requires manual tarball
+download (see `pkgs/citrix-workspace/fetch-citrix.sh`); the package is
+provided via overlay.
 
-**applications/WAYDROID-SETUP.md**
-- Waydroid Android container setup
-- Configuration and usage
-- Known issues
+`applications/WAYDROID-SETUP.md`
+Waydroid Android container setup.
 
-**applications/flaresolverr-deployment.md**
-- FlareSolverr proxy deployment
-- Configuration and integration
-- Usage guide
+`applications/flaresolverr-deployment.md`
+FlareSolverr proxy deployment.
 
-**applications/GITLAB-RUNNER-SETUP.md**
-- GitLab Runner configuration
-- NixOS integration
-- Job execution setup
+`applications/GITLAB-RUNNER-SETUP.md`
+GitLab Runner configuration on NixOS.
 
-**applications/VSCODE_EXTENSIONS.md**
-- VS Code extension management
-- NixOS configuration
-- Recommended extensions
+`applications/VSCODE_EXTENSIONS.md`
+Declarative VS Code extension management.
 
-**applications/screensharing_cosmic.md**
-- Screen sharing in COSMIC desktop
-- Wayland configuration
-- Troubleshooting guide
+`applications/screensharing_cosmic.md`
+Screen sharing under COSMIC desktop with Wayland.
 
-**applications/P620-BIOS-NUMA-Configuration.md**
-- P620 BIOS settings
-- NUMA configuration
-- Performance tuning
+`applications/P620-BIOS-NUMA-Configuration.md`
+P620 BIOS and NUMA tuning.
 
 ## Tooling
 
 Development tooling and Claude Code documentation.
 
-**tooling/CLAUDE-CODE-OPTIMIZATION.md**
-- Claude Code performance optimization
-- Configuration tuning
-- Best practices
+`tooling/CLAUDE-CODE-OPTIMIZATION.md`
+Claude Code performance and configuration tuning.
 
-**tooling/claude-code-update-2.0.54.md**
-- Claude Code 2.0.54 update notes
-- New features
-- Migration guide
+`tooling/claude-code-update-2.0.54.md`
+Update notes for Claude Code 2.0.54.
 
-**tooling/Claude-Powerline.md**
-- Powerline shell integration
-- Theme configuration
-- Claude Code integration
+`tooling/Claude-Powerline.md`
+Powerline integration for Claude Code.
 
-**tooling/Github-spec-kit.md**
-- GitHub specification toolkit
-- Template usage
-- Workflow automation
+`tooling/Github-spec-kit.md`
+GitHub spec-kit for Spec-Driven Development.
 
 ## NixOS Command System
 
-Command system documentation and reference guides.
+`Nixos/README.md`
+Command system overview.
 
-**Nixos/README.md**
-- Command system overview
-- Usage instructions
+`Nixos/COMMANDS-INDEX.md`
+Full command index by category.
 
-**Nixos/COMMANDS-INDEX.md**
-- Complete command index
-- Command categories
-- Quick reference
+`Nixos/Command-System-Overview.md`
+Architecture and extension model.
 
-**Nixos/Command-System-Overview.md**
-- Architecture overview
-- Command implementation
-- Extension guide
+`Nixos/Quick-Reference.md`
+Common commands at a glance.
 
-**Nixos/Quick-Reference.md**
-- Common commands
-- Quick lookup guide
-- Usage examples
-
-**Nixos/Update-Checker-Guide.md**
-- Update checking system
-- Automation procedures
-- Configuration guide
+`Nixos/Update-Checker-Guide.md`
+Automated update checking and configuration.
 
 ## Documentation Standards
 
-All documentation follows these standards:
+Format
 
-**Format:**
-- Markdown format (.md)
-- No emojis or decorative icons
-- Clear section headers
-- Code blocks for examples
-- Professional technical writing
+- Markdown (`.md`), CommonMark.
+- No emojis or decorative icons.
+- Code blocks for examples.
+- Concise technical prose.
 
-**Organization:**
-- Categorized by purpose
-- Logical folder structure
-- Consistent naming conventions
-- Cross-referenced where appropriate
+Organisation
 
-**Maintenance:**
-- Last Updated date at top of each file
-- Status indicator (Active, Deprecated, etc.)
-- Regular reviews for accuracy
-- Obsolete docs removed promptly
+- One topic per file.
+- Cross-reference using relative paths.
+- Filenames: `UPPERCASE-WITH-DASHES.md` for top-level, descriptive
+  lowercase for application notes.
+
+Maintenance
+
+- Top-of-file `Last Updated:` date.
+- Remove obsolete docs rather than letting them rot.
+- Reflect repository state (templates, hosts, modules) accurately.
 
 ## Contributing
 
-When adding new documentation:
+When adding documentation:
 
-1. Choose appropriate category folder
-2. Follow naming conventions (UPPERCASE-WITH-DASHES.md)
-3. Include Last Updated date
-4. No emojis or icons
-5. Update this README index
-6. Cross-reference related documentation
+1. Pick the right category folder.
+2. Add a `Last Updated:` line at the top.
+3. No emojis or icons.
+4. Update this index in the same change.
+5. Cross-reference related docs.
 
 ## Quick Navigation
 
-**New to NixOS?**
-Start with PATTERNS.md and NIXOS-ANTI-PATTERNS.md
+New to the repo
+Start with `PATTERNS.md`, then `NIXOS-ANTI-PATTERNS.md`, then the root
+`README.md`.
 
-**Setting up a host?**
-See guides/HOST_SETUP.md and guides/deployment-guide.md
+Deploying changes
+`UPDATE-DEPLOY.md` for the routine flow; `guides/deployment-guide.md`
+for advanced cases.
 
-**Working with AI tools?**
-See MCP-GUIDE.md and tooling/ folder
+Adding a host
+`guides/HOST_SETUP.md`.
 
-**Deploying applications?**
-See applications/ folder for specific guides
+Reviewing or contributing
+`guides/GITHUB-WORKFLOW.md` and `NIXOS-ANTI-PATTERNS.md`.
 
-**Need command reference?**
-See Nixos/COMMANDS-INDEX.md
-
-## Support
-
-For infrastructure questions or documentation issues:
-- Check relevant documentation first
-- Review PATTERNS.md for best practices
-- Consult NIXOS-ANTI-PATTERNS.md for common issues
-- Reference GitHub workflow for contribution process
+Command reference
+`Nixos/COMMANDS-INDEX.md` and `just --list`.

--- a/hosts/README.md
+++ b/hosts/README.md
@@ -1,30 +1,51 @@
-# Hosts Configurations
+# Host Configurations
 
-This directory contains system configurations for different machines. Each subdirectory represents
-a different host with its specific hardware configuration and system settings.
+System configurations for each machine. Every host imports the
+parameterised desktop template (`templates/desktop.nix`) via
+`lib/hostTypes.nix` and adds host-specific modules on top.
 
 ## Active Hosts
 
-- `p620/` - Configuration for the P620 workstation (AMD-based system, primary development)
-- `p510/` - Configuration for the P510 system (media server, includes MicroVM configurations)
-- `razer/` - Configuration for the Razer laptop
+- `p620/` — AMD RX 7900 workstation, primary development and AI host.
+  Workstation template; full COSMIC/GNOME desktop.
+- `p510/` — Intel Xeon system, headless media server (Plex, NZBGet,
+  FlareSolverr). Workstation template; no display manager. MicroVM
+  guest config lives in `p510/microvm.nix`.
+- `razer/` — Intel + NVIDIA laptop. Laptop template; lanzaboote Secure
+  Boot with shim+MOK.
+
+## Templates
+
+There is a single parameterised template:
+
+- `templates/desktop.nix` — accepts `profile = "workstation" | "laptop"`.
+  Adds thermald and `cpuFreqGovernor = "powersave"` for the laptop
+  profile. Surfaced through `lib/hostTypes.nix` as
+  `hostTypes.workstation` and `hostTypes.laptop`. The previous
+  `server`, `hybrid`, and `base` templates have been removed; headless
+  hosts use the workstation template with `host.class = "workstation"`
+  and no display manager.
 
 ## Host Directory Structure
 
 Each host typically contains:
 
-- `configuration.nix` - Main system configuration
-- `nixos/` - NixOS-specific configurations:
-  - `hardware-configuration.nix` - Generated hardware configuration
-  - `boot.nix` - Boot loader configuration
-  - `power.nix` - Power management settings
-  - `i18n.nix` - Internationalization settings
-  - `greetd.nix` - Login manager configuration
-  - Other system-specific configurations
-- `themes/` - Host-specific theme settings
-- `services/` - Host-specific services
-- `guests/` - MicroVM and container configurations (when applicable)
+- `configuration.nix` — Top-level host config; imports the template
+  plus host-specific modules.
+- `variables.nix` — Hostname, primary user, feature toggles.
+- `nixos/` — Host-local NixOS fragments:
+  - `hardware-configuration.nix` — Generated hardware config.
+  - `boot.nix`, `power.nix`, `cpu.nix`, `memory.nix`, etc.
+  - GPU vendor file (`amd.nix`, `nvidia.nix`, ...).
+- `themes/stylix.nix` — Host theme wiring (Stylix + base16 + wallpaper).
+- Optional host-only modules (e.g. `microvm.nix`, `flaresolverr.nix`).
 
-## Archive
+## Common Layer
 
-- `archive/` - Historical configurations for systems no longer in active use
+`common/` holds fragments shared across hosts:
+
+- `common/nixos/` — `i18n.nix`, `hosts.nix`, `envvar.nix`,
+  `host-class.nix`.
+- `common/hardware-profiles/` — GPU profiles (`amd-gpu.nix`,
+  `nvidia-gpu.nix`, `intel-integrated.nix`).
+- `common/shared-variables.nix` — User mappings consumed by `flake.nix`.

--- a/modules/README.md
+++ b/modules/README.md
@@ -1,42 +1,68 @@
 # NixOS Modules
 
-This directory contains modular NixOS configurations that can be imported by different host configurations. These modules provide reusable functionality across systems.
+Reusable NixOS modules consumed by host configurations. Imports are
+explicit — there is no auto-discovery or `default.nix` re-export. The
+host template (`hosts/templates/desktop.nix`) imports the top-level
+category modules (`core.nix`, `desktop.nix`, `development.nix`,
+`virtualization.nix`, `performance.nix`, `email.nix`, `cloud.nix`,
+`programs.nix`); per-host configs add the rest as needed.
 
-## Module Categories
+## Top-Level Aggregators
 
-- `ai/` - AI-related tools and configurations (ollama, chatgpt)
-- `cloud/` - Cloud provider tooling (AWS, Azure, Google Cloud)
-- `containers/` - Container runtime configurations
-- `desktop/` - Desktop environment modules
-- `development/` - Development tool modules
-- `fonts/` - Font configurations
-- `hardware/` - Hardware-specific modules
-- `helpers/` - Helper functions and utilities
-- `intune-portal/` - Microsoft Intune portal configurations
-- `laptop-related/` - Laptop-specific configurations
-- `nix/` - Nix package manager configurations
-- `nix-index/` - Nix index database configuration
-- `obsidian/` - Obsidian note-taking app configuration
-- `office/` - Office applications
-- `overlays/` - Nixpkgs overlays
-- `pkgs/` - Custom package definitions
-- `playmouth/` - Boot splash screen configurations
-- `programs/` - Various program configurations
-- `security/` - Security-related configurations
-- `services/` - System service configurations
-- `spell/` - Spell checking tools
-- `ssh/` - SSH configurations
-- `system-scripts/` - System maintenance scripts
-- `system-tweaks/` - Performance and behavior tweaks
-- `system-utils/` - System utilities
-- `virt/` - Virtualization tools (libvirt, incus, podman)
-- `webcam/` - Webcam utilities
+- `core.nix` — Baseline system services, networking, users.
+- `desktop.nix` — Desktop environments and session.
+- `development.nix` — Language toolchains and editors.
+- `virtualization.nix` — VM, container, libvirt wiring.
+- `performance.nix` — Tuning knobs.
+- `email.nix` — Mail clients and SMTP relays.
+- `cloud.nix` — Cloud CLIs (consolidated from per-provider wrappers).
+- `programs.nix` — Miscellaneous programs.
 
-## Usage
+## Category Subdirectories
 
-These modules are imported by host configurations in the `hosts/` directory. The main entry point is `default.nix` which imports common modules needed by most systems.
+- `ai/` — AI tooling (Ollama, providers).
+- `cloud/` — Cloud provider packages (single `packages.nix` after the
+  wrapper consolidation).
+- `common/` — Cross-cutting defaults (e.g. `ai-defaults.nix`).
+- `containers/` — Container runtimes (Docker, Podman).
+- `desktop/` — Desktop environments and the unified
+  `desktop.displayManager` module.
+- `development/` — Language toolchains, editors, language servers.
+- `email/`, `office/`, `obsidian/`, `spell/`, `fonts/`, `funny/` —
+  User-facing application bundles.
+- `helpers/` — Internal helper functions (entry: `helpers/default.nix`).
+- `installer/` — Live ISO support modules.
+- `microvms/` — microvm.nix guest definitions.
+- `networking/` — Network stack and Tailscale wiring.
+- `nix/` — Nix daemon and binary cache configuration.
+- `nix-index/` — `nix-index-database` integration.
+- `overlays/` — Module-side overlay registration.
+- `packages/` — Curated package sets.
+- `pkgs/` — Custom package derivations.
+- `programs/` — Per-program modules (terminals, browsers, utilities).
+- `scrcpy/`, `webcam/`, `windows/`, `scripts/` — Discrete utilities.
+- `secrets/` — agenix-managed secret declarations
+  (`api-keys.nix`, etc.).
+- `security/` — Security modules (`secrets.nix` wrapper, hardening).
+- `services/` — Long-running services (one file per service).
+- `storage/` — Filesystem and storage configuration.
+- `system/` — System-level concerns (logging, etc.).
+- `system-utils/` — System utility bundles.
+- `virt/` — libvirt, incus, qemu helpers.
 
-For specialized system types, separate entry points exist:
+## Templates
 
-- `server.nix` - For server systems
-- `laptops.nix` - For laptop systems
+- `TEMPLATE.nix` — Skeleton for a new feature module.
+- `SYSTEMD_SERVICE_TEMPLATE.nix` — Skeleton for a hardened systemd
+  service module.
+
+## Conventions
+
+- One service per file under `services/`.
+- Module options live under `features.<name>` or
+  `services.<name>` and gate the actual configuration with `mkIf cfg.enable`.
+- Hosts compose features through flags rather than inlining
+  `services.* = { ... }` blocks. See `docs/PATTERNS.md`.
+- Systemd units must use `DynamicUser`, `ProtectSystem = "strict"`,
+  `NoNewPrivileges`, and the rest of the hardening checklist in
+  `docs/NIXOS-ANTI-PATTERNS.md`.


### PR DESCRIPTION
## Summary

Refresh the top-level README and the `hosts/`, `modules/`, and `docs/` indexes so they describe the repository as it actually exists today, after the recent refactor and theming phases. No emojis or icons; technical tone throughout.

### What changed

- **README.md** — full rewrite. Documents the three active hosts (`p620`, `p510`, `razer`), the single parameterised `hosts/templates/desktop.nix` template (workstation/laptop), the removed server/hybrid/base templates, Stylix-driven theming with the COSMIC RON writer, razer lanzaboote secure boot with shim+MOK, the `nhs` / `nhsb` deploy flow, the split overlay layout, and the fact that the live ISO is now razer-only. Lists removed infrastructure (Prometheus/Grafana/Loki, DEX5550, Samsung, `nix-colors`, `termshark`, `wireshark`, `reddix`, `wasistlos`, `steampipe`).
- **docs/README.md** — refreshed index. Every entry matches a file actually on disk; cross-references verified. `Last Updated` bumped.
- **hosts/README.md** — drops the `archive/` reference, corrects the p510 description, documents the single template and `host.class`.
- **modules/README.md** — replaces the stale category list (referenced non-existent `hardware/`, `intune-portal/`, `playmouth/`, `system-tweaks/`, etc., and a non-existent `default.nix`/`server.nix`/`laptops.nix`) with the actual top-level aggregator files and current category tree, plus the explicit-imports convention.

### Out of scope

- `flake.lock` was already dirty in the working tree from a prior session; not included in this PR.
- `CLAUDE.md` was not touched — large, separate concern.

## Test plan

- [x] All README cross-references resolve to existing files in the repo.
- [x] `pre-commit` (markdownlint, codespell, etc.) passes for the staged files.
- [ ] No code changes; no build or runtime testing required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)