### PR TITLE
fix(p620): pin AQC107 NIC to 1G + harden /mnt/media NFS mount

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -48,6 +48,9 @@ usig = "usig"
 # nd is a valid lsblk flag (-nd = no headings, no dependents)
 nd = "nd"
 
+# AER is the PCIe Advanced Error Reporting acronym
+AER = "AER"
+
 [default.extend-identifiers]
 # Santa Claus - not "Clause"
 Claus = "Claus"

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -19,6 +19,7 @@ in
     ./nixos/boot.nix
     ./nixos/amd.nix
     ./nixos/usb-power-fix.nix # Fix USB mouse freezing issues
+    ./nixos/aqc107-link-pin.nix # Pin Aquantia AQC107 to 1G to dodge AER flapping
     ../common/nixos/i18n.nix
     ../common/nixos/hosts.nix
     ../common/nixos/envvar.nix
@@ -482,12 +483,39 @@ in
   };
 
   # File systems
+  #
+  # /mnt/media is hosted on p510 over NFSv3. The previous default of
+  # `hard` mount semantics meant every process touching this path
+  # (file managers, COSMIC indexers, mpd, etc.) blocked indefinitely
+  # whenever the link to p510 hiccuped. The on-board AQC107 has been
+  # emitting bursts of corrected PCIe AER errors, which manifested as
+  # 50%+ IO-pressure stalls and a sluggish desktop.
+  #
+  # New options:
+  #   soft+timeo+retrans  - fail an RPC after 5 s × 3 instead of blocking forever
+  #   bg                  - background-mount on first attempt; don't stall boot
+  #   noauto+automount    - mount on first access, not at boot
+  #   idle-timeout        - auto-unmount after 5 min idle so a flap can't
+  #                         poison long-running sessions
+  #   rsize/wsize         - 1 MiB I/O units (matches what the server already serves)
+  #   noatime             - skip atime updates over the wire
+  #
+  # Read-mostly media share, so `soft` is acceptable here - data
+  # corruption from a half-finished write is not in scope.
   fileSystems."/mnt/media" = {
     device = "p510.lan:/mnt/media";
     fsType = "nfs";
     options = [
-      "x-systemd.automount"
       "noauto"
+      "x-systemd.automount"
+      "x-systemd.idle-timeout=300"
+      "soft"
+      "timeo=50"
+      "retrans=3"
+      "bg"
+      "noatime"
+      "rsize=1048576"
+      "wsize=1048576"
     ];
   };
 

--- a/hosts/p620/nixos/aqc107-link-pin.nix
+++ b/hosts/p620/nixos/aqc107-link-pin.nix
@@ -1,0 +1,26 @@
+# AQC107 (Aquantia/Marvell 10GbE) link-speed pin.
+#
+# The on-board AQC107 on this host has been emitting bursts of corrected
+# PCIe AER errors and currently negotiates at 1 Gb/s anyway. Forcing the
+# link to a fixed 1 Gb/s eliminates the auto-neg renegotiation that
+# correlates with the AER bursts and the IO-pressure stalls those cause
+# (NFS over `/mnt/media` blocks every consumer of the share, which the
+# kernel reports as IO pressure even with idle local disks).
+#
+# Remove this once the NIC is replaced or the cable/slot path is known
+# good.
+{ pkgs, ... }: {
+  systemd.services.aqc107-link-pin = {
+    description = "Pin AQC107 (enp1s0) to 1 Gb/s full duplex, autoneg off";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "network-pre.target" "sys-subsystem-net-devices-enp1s0.device" ];
+    bindsTo = [ "sys-subsystem-net-devices-enp1s0.device" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = "${pkgs.ethtool}/bin/ethtool -s enp1s0 speed 1000 duplex full autoneg off";
+      # ethtool returns 80 ("nothing changed") on no-op; treat as success.
+      SuccessExitStatus = [ 0 80 ];
+    };
+  };
+}


### PR DESCRIPTION
## Diagnosis

Live IO PSI on p620 was sitting at ~53% (`full avg10=52.71`) with idle local disks (`nvme0n1`, `sda`, `sdb` all 0 IOPS). CPU and memory PSI were both 0%, RAM was 28 G / 251 G with 0 swap used.

Root cause: the on-board **Aquantia AQC107** (`enp1s0`, `0000:01:00.0`) is emitting bursts of corrected PCIe AER errors — **37 in the last 24 h, in two clusters of ~18** — while still negotiating at **1 Gb/s on a 10 G card**, with `Queue[2] InErrors: 109` on the RX side.

Each burst stalls NFS RPCs to `p510.lan:/mnt/media`. The existing mount was `hard` with no idle-timeout, so anything touching the share — file managers, COSMIC indexers, mpd, syncthing — blocked indefinitely. The kernel reports those waits as IO pressure even though no block device is involved. The Wayland compositor (`cosmic-comp`) catches collateral damage, which is why the mouse felt sluggish.

COSMIC was **not** the cause: 1.87 GB total RSS across 25 `cosmic-*` processes after 27 h uptime, no drift signature. Each applet is ~35 MB by design.

## Changes

- **`hosts/p620/nixos/aqc107-link-pin.nix`** (new): systemd oneshot that runs `ethtool -s enp1s0 speed 1000 duplex full autoneg off`. Eliminates the 10 G auto-neg flap that correlates with the AER bursts. `SuccessExitStatus=0,80` so re-runs on `switch` don't fail spuriously when the link is already pinned. Bound to `enp1s0`'s device unit so it re-runs cleanly on hot-plug.
- **`hosts/p620/configuration.nix`**: `fileSystems."/mnt/media"` switched from `hard` to `soft,timeo=50,retrans=3,bg`, plus `x-systemd.idle-timeout=300` (auto-unmount when idle so a future flap can't poison long-running sessions) and explicit `rsize=1048576`/`wsize=1048576`/`noatime`. The share is read-mostly media, so `soft` semantics are acceptable here. Comment block documents the reasoning so future-me doesn't undo it without context.
- **`_typos.toml`**: adds `AER` to the allowlist (PCIe Advanced Error Reporting).

This is a **mitigation, not a fix**. The real fix is hardware: reseat or replace the AQC107, swap the cable to a known-good Cat6a, or move to a different NIC (Intel X550-T2, Mellanox ConnectX-3). Remove the link pin module once that's done.

## Test plan

- [x] `nix-instantiate --parse` passes for both touched files.
- [x] `nix build .#nixosConfigurations.p620.config.system.build.toplevel` succeeds.
- [x] Rendered `aqc107-link-pin.service` and the `/mnt/media` line in `/etc/fstab` inspected and look correct.
- [x] `pre-commit` (nixpkgs-lint, deadnix, typos, markdownlint, taplo, etc.) all green.
- [ ] Deploy with `nhs p620` and re-check `cat /proc/pressure/io` — IO `full avg10` should drop close to 0.
- [ ] `journalctl -u aqc107-link-pin.service` should show one `Started`/`Deactivated successfully` per boot.
- [ ] `ethtool enp1s0 | grep Speed` should report `1000Mb/s` with `Auto-negotiation: off`.
- [ ] Touch `/mnt/media` on demand (e.g. `ls /mnt/media`); confirm the automount mounts it; confirm it auto-unmounts after 5 min idle (`findmnt /mnt/media` returns nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)