### PR TITLE
fix(razer): NVMe boot race on kernel 7.0.x + TLP i915 freq out of range (#464)

### DIFF
--- a/hosts/razer/nixos/boot.nix
+++ b/hosts/razer/nixos/boot.nix
@@ -13,8 +13,19 @@
     "intel_idle.max_cstate=2" # Limit C-states for better responsiveness when needed
     "i915.enable_fbc=1" # Enable framebuffer compression
     "i915.enable_guc=2" # Enable graphics microcontroller
-    "nvme.noacpi=1" # Try if having NVMe issues
-    "pcie_aspm=default" # PCIe Active State Power Management
+    # NVMe boot-race mitigations for kernel 7.0.x (issue #464):
+    #   - pcie_aspm=off prevents L1 substates from delaying PCIe link training
+    #     during the concurrent reset of two NVMe controllers (Samsung +
+    #     Kingston). =default proved insufficient on 7.0.3 — Kingston's 8s
+    #     D3 entry latency lost the race and triggered "Device not ready".
+    #   - nvme_core.io_timeout=60 doubles the wait for CSTS.RDY so a slow
+    #     controller becomes benign rather than fatal.
+    # Removed: nvme.noacpi=1 — historically a Razer suspend workaround, but
+    # actively harmful on 7.0.x because it suppresses the ACPI _PS0/_PR3
+    # notifications the new pci_dev_wait() needs to know D3cold→D0 finished
+    # before the NVMe driver issues its reset sequence.
+    "pcie_aspm=off"
+    "nvme_core.io_timeout=60"
     "button.lid_init_state=open" # Lid open state on boot
     "mitigations=off" # Disable all CPU mitigations for performance (use with caution)
   ];

--- a/hosts/razer/nixos/cpu.nix
+++ b/hosts/razer/nixos/cpu.nix
@@ -23,12 +23,18 @@ _: {
       CPU_MIN_PERF_ON_BAT = 0;
       CPU_MAX_PERF_ON_BAT = 80; # Limit max performance on battery
 
-      # Optimize for 10th gen Intel
-      INTEL_GPU_MIN_FREQ_ON_AC = 300;
-      INTEL_GPU_MIN_FREQ_ON_BAT = 300;
-      INTEL_GPU_MAX_FREQ_ON_AC = 1350;
+      # i915 frequency bounds for the iGPU (UHD Graphics on Comet Lake).
+      # Values must lie within the hardware-reported min and max from
+      # /sys/class/drm/card*/gt_min_freq_mhz and gt_max_freq_mhz; on
+      # kernel 7.0.3 these are 350 and 1200 respectively (verified live).
+      # Pre-#464 the file had 300 and 1350, which TLP rejected as
+      # "frequency invalid or out of range" on 7.0.x — the failure
+      # cascaded to nixos-rebuild exiting with status 4.
+      INTEL_GPU_MIN_FREQ_ON_AC = 350;
+      INTEL_GPU_MIN_FREQ_ON_BAT = 350;
+      INTEL_GPU_MAX_FREQ_ON_AC = 1200;
       INTEL_GPU_MAX_FREQ_ON_BAT = 1100;
-      INTEL_GPU_BOOST_FREQ_ON_AC = 1350;
+      INTEL_GPU_BOOST_FREQ_ON_AC = 1200;
       INTEL_GPU_BOOST_FREQ_ON_BAT = 900;
     };
   };

--- a/hosts/razer/nixos/power.nix
+++ b/hosts/razer/nixos/power.nix
@@ -61,8 +61,9 @@
   # Disable USB autosuspend to prevent keyboard/mouse from turning off
   boot.kernelParams = [
     "mem_sleep_default=deep" # Prefer deep sleep modes
-    "nvme.noacpi=1" # Avoid ACPI conflicts with NVMe
     "usbcore.autosuspend=-1" # Disable USB autosuspend globally
+    # Note: nvme.noacpi=1 was removed in issue #464 — see boot.nix for
+    # rationale. NVMe-related kernel params are now consolidated in boot.nix.
   ];
 
   # Fix systemd sleep targets


### PR DESCRIPTION
Two related fallouts from the 2026-05-04 nixpkgs bump (kernel 7.0.1
→ 7.0.3):

A. NVMe "Device not ready" boot race
=====================================

Kernel 7.0-rc1 changed pci_scan_child_bus_extend() to interleave PCI
probe across buses, so razer's two NVMe controllers (Samsung @ 04:00.0,
Kingston @ 05:00.0) now enter nvme_reset_work concurrently. 7.0.x also
tightened pci_dev_wait() to require ACPI _PS0/_PR3 notifications before
D3cold→D0 transitions. Current `nvme.noacpi=1` (set twice — boot.nix:16
+ power.nix:64) suppresses exactly those notifications, so the NVMe
driver starts its reset sequence while PCIe links may still be in L1
substates. Kingston's documented 8s D3 entry latency loses the race and
triggers "Device not ready" on transient boots that get rolled back via
the systemd-boot menu.

Diagnosis confirmed by debugger + search-specialist research agents,
referencing drivers/nvme/host/core.c::nvme_dev_not_ready() and
drivers/pci/pci.c::pci_dev_wait(). The device-renumbering observed
between boots (nvme0/nvme1 swap depending on probe order) is a symptom
of the same race; UUID-based mounts saved us from data loss.

Fix:
  - Drop nvme.noacpi=1 from both boot.nix:16 and power.nix:64
  - Switch pcie_aspm=default → pcie_aspm=off (eliminates L1 substate
    delays during boot; ~0.5W battery cost acceptable)
  - Add nvme_core.io_timeout=60 (belt-and-braces: doubles ctrl-ready
    wait, makes a slow controller benign instead of fatal)
  - Consolidate all NVMe-related kernelParams into boot.nix; power.nix
    keeps only sleep/suspend params

B. TLP activation status 4
==========================

Today's nixos-rebuild switch failed (status 4) with:
  tlp[]: Error in configuration at INTEL_GPU_MIN_FREQ_ON_AC="300":
         frequency invalid or out of range

Verified live on running kernel 7.0.3 system that i915 hardware bounds
on this Comet Lake UHD iGPU are 350 MHz and 1200 MHz. The old 300 and
1350 values were outside that range.

Fix:
  INTEL_GPU_MIN_FREQ_ON_AC  300  → 350
  INTEL_GPU_MIN_FREQ_ON_BAT 300  → 350
  INTEL_GPU_MAX_FREQ_ON_AC  1350 → 1200
  INTEL_GPU_BOOST_FREQ_ON_AC 1350 → 1200
  (others unchanged)

Validation:
  - just test-host razer succeeds
  - Evaluated cmdline contains pcie_aspm=off + nvme_core.io_timeout=60
    and no nvme.noacpi=1
  - Comment trail in each file points at #464 for future maintainers

Closes #464

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
