### PR TITLE
feat(spotify): switch to spicetify with Gruvbox + Xwayland decorations

### DIFF
--- a/Users/common/imports.nix
+++ b/Users/common/imports.nix
@@ -1,7 +1,7 @@
-{ ... }: {
+{ spicetify-nix, ... }: {
   # Common imports for all user configurations
   imports = [
-    # Note: spicetify-nix module disabled due to upstream issues
+    spicetify-nix.homeManagerModules.default
 
     # Internal modules
     ./base-home.nix

--- a/home/media/music.nix
+++ b/home/media/music.nix
@@ -1,16 +1,54 @@
-{ pkgs, ... }: {
+{ pkgs, spicetify-nix, ... }:
+let
+  spicePkgs = spicetify-nix.legacyPackages.${pkgs.system};
+in
+{
   home.packages = [
-    pkgs.spotify # Official Spotify client
-    pkgs.plexamp # Plex
-    pkgs.vlc # video player
-    pkgs.cava # audio visualizer
-    pkgs.castero # Podcasts - Re-enabled: Python 3.13.9 compatibility fixed (issue #35 closed)
-    pkgs.gnome-podcasts # Podcasts
+    # Spotify provided by programs.spicetify below
+    pkgs.plexamp
+    pkgs.vlc
+    pkgs.cava
+    pkgs.castero
+    pkgs.gnome-podcasts
     pkgs.hypnotix
-    pkgs.wiremix # Music streaming
+    pkgs.wiremix
     pkgs.parabolic
     pkgs.musicpod
-    pkgs.playerctl # Required dependency for our script
-    (pkgs.callPackage ../../pkgs/mpris-album-art { }) # Our album art script
+    pkgs.playerctl
+    (pkgs.callPackage ../../pkgs/mpris-album-art { })
   ];
+
+  # Opt out of stylix's auto-generated spicetify theme so the explicit
+  # Gruvbox choice below wins (same pattern as stylix.targets.firefox).
+  stylix.targets.spicetify.enable = false;
+
+  programs.spicetify = {
+    enable = true;
+    theme = spicePkgs.themes.text;
+    colorScheme = "Gruvbox";
+    # Force Xwayland so mutter draws server-side decorations.
+    wayland = false;
+    enabledExtensions = with spicePkgs.extensions; [
+      adblock
+      hidePodcasts
+      shuffle
+      fullAppDisplay
+    ];
+  };
+
+  # spicetify-nix's spotifyLaunchFlags only writes to config-xpui.ini and
+  # never reaches the runtime wrapper. Override the desktop entry instead
+  # so Chromium delegates decoration drawing to the compositor (combined
+  # with --ozone-platform=x11 from `wayland = false` above).
+  xdg.desktopEntries.spotify = {
+    name = "Spotify";
+    genericName = "Music Player";
+    exec = "spotify --enable-features=WaylandWindowDecorations %U";
+    icon = "spotify";
+    terminal = false;
+    type = "Application";
+    categories = [ "Audio" "Music" "Player" "AudioVideo" ];
+    mimeType = [ "x-scheme-handler/spotify" ];
+    settings.StartupWMClass = "Spotify";
+  };
 }


### PR DESCRIPTION
## Summary

- Re-enables the spicetify-nix home-manager module (was disabled with a stale "upstream issues" note that's no longer accurate)
- Replaces \`pkgs.spotify\` with the bundled \`text\` theme + \`Gruvbox\` color scheme — Spotify's inner UI now renders in monospace with Gruvbox accents
- Forces Xwayland (\`wayland = false\`) and passes \`--enable-features=WaylandWindowDecorations\` via \`xdg.desktopEntries\` so mutter draws GNOME-style server-side decorations instead of Chromium's grey-blue self-drawn frame
- Opts out of stylix's auto-generated spicetify theme so the explicit Gruvbox choice wins (matches existing \`stylix.targets.firefox.enable = false\` pattern)

## Why \`xdg.desktopEntries\` and not \`spotifyLaunchFlags\`?

\`programs.spicetify.spotifyLaunchFlags\` only writes \`spotify_launch_flags\` into spicetify's \`config-xpui.ini\` — that file is consumed by the imperative \`spicetify\` CLI for \`spicetify apply\`, but spicetify-nix never plumbs it to the runtime wrapper. So flags set there are silently dropped. Overriding the desktop entry is the only way to get extra Chromium flags onto the spotify launch line declaratively.

**Caveat:** launching \`spotify\` from a terminal won't pick up the new flag (the desktop file isn't in the path). Launching from GNOME Activities / dock does.

## Test plan

- [x] \`just test-host p620\` — builds clean
- [x] \`just quick-deploy p620\` — applied without errors
- [x] Wrapped binary resolves to \`spicetify-text\` derivation
- [x] \`/etc/profiles/per-user/olafkfreund/share/applications/spotify.desktop\` shows \`Exec=spotify --enable-features=WaylandWindowDecorations %U\`
- [x] After \`pkill spotify\` + relaunch from GNOME Activities, mutter draws the libadwaita-style header bar instead of Chromium's grey frame