### PR TITLE
refactor(gnome): centralise gnome-shell patch overlay (#470)

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -595,19 +595,6 @@ in
   # Windows app integration - Re-enabled after upstream fix (v0.9.0)
   # programs.winboat.enable = true; # DISABLED: Go 1.26 cross-compilation broken with mingw32 GCC 15
 
-  # Fix broken GNOME Shell patch in nixpkgs (shell_remove_dark_mode.patch failing on 49.1)
-  nixpkgs.overlays = [
-    (_final: prev: {
-      gnome-shell = prev.gnome-shell.overrideAttrs (oldAttrs: {
-        patches = builtins.filter
-          (
-            patch: !(builtins.match ".*shell_remove_dark_mode.*" (toString patch) != null)
-          )
-          (oldAttrs.patches or [ ]);
-      });
-    })
-  ];
-
   # Package configurations
   nixpkgs.config = {
     allowBroken = true;

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -479,17 +479,6 @@ in
     "/etc/ssh/ssh_host_rsa_key" # Host key (RSA fallback)
   ];
 
-  # Override GNOME Shell to remove problematic dark mode patch
-  nixpkgs.overlays = [
-    (_final: prev: {
-      gnome-shell = prev.gnome-shell.overrideAttrs (old: {
-        patches = builtins.filter (patch: !lib.hasSuffix "shell_remove_dark_mode.patch" (toString patch)) (
-          old.patches or [ ]
-        );
-      });
-    })
-  ];
-
   nixpkgs.config = {
     allowBroken = true;
     permittedInsecurePackages = [

--- a/overlays/upstream-fixes.nix
+++ b/overlays/upstream-fixes.nix
@@ -5,6 +5,14 @@ _final: prev: {
     doInstallCheck = false;
   });
 
+  # gnome-shell's shell_remove_dark_mode.patch fails to apply on GNOME 49.1.
+  # Strip it until nixpkgs catches up. Keep the rest of nixpkgs' patches.
+  gnome-shell = prev.gnome-shell.overrideAttrs (oldAttrs: {
+    patches = builtins.filter
+      (patch: builtins.match ".*shell_remove_dark_mode.*" (toString patch) == null)
+      (oldAttrs.patches or [ ]);
+  });
+
   # nixpkgs-unstable ships nix-prefetch-git as `nix-prefetch-git-VERSION`,
   # breaking fetchCargoVendor which calls the binary by its short name.
   # Symlink the short name to the versioned binary.


### PR DESCRIPTION
Move the shell_remove_dark_mode.patch filter from two host configs into
overlays/upstream-fixes.nix where similar workarounds (azure-cli,
nix-prefetch-git) already live. razer used lib.hasSuffix and p620 used
builtins.match — consolidated to builtins.match. p510 now inherits the
fix too.

Closes #470

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
