### PR TITLE
fix(gnome): reconcile extension UUIDs and migrate fonts (#472)

### DIFF
--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -34,18 +34,10 @@ in
     };
     extensions = {
       enable = true;
+      # Shared extensions live in home/desktop/gnome/extensions.nix.
+      # Only profile-specific additions go here.
       packages = with pkgs.gnomeExtensions;
-        [
-          # Extensions shared by both interactive profiles
-          dash-to-dock
-          appindicator
-          caffeine
-          clipboard-indicator
-        ]
-        ++ optionals (gnomeProfile == "workstation") [
-          blur-my-shell
-        ]
-        ++ optionals (gnomeProfile == "laptop") [
+        optionals (gnomeProfile == "laptop") [
           battery-health-charging
         ];
     };

--- a/home/desktop/gnome/apps.nix
+++ b/home/desktop/gnome/apps.nix
@@ -81,7 +81,7 @@ in
         distroshelf # Manage Linux distributions
 
         # Fonts for better GNOME app experience
-        cantarell-fonts
+        adwaita-fonts # GNOME 48+ default; replaced cantarell-fonts
         source-sans-pro
         source-serif-pro
         dejavu_fonts

--- a/home/desktop/gnome/extensions.nix
+++ b/home/desktop/gnome/extensions.nix
@@ -14,27 +14,27 @@ in
       # Enable installed extensions
       "org/gnome/shell" = {
         disable-user-extensions = false;
+        # UUIDs verified against gnomeExtensions.<name>.passthru.extensionUuid.
+        # Each UUID must have a matching package in home.packages below or in
+        # cfg.extensions.packages (per-profile). Adding a UUID without its
+        # package makes gnome-shell silently skip it on session start.
         enabled-extensions = [
-          # Essential extensions UUIDs
           "user-theme@gnome-shell-extensions.gcampax.github.com"
           "dash-to-dock@micxgx.gmail.com"
           "appindicatorsupport@rgcjonas.gmail.com"
           "auto-accent-colour@Wartybix"
           "auto-move-windows@gnome-shell-extensions.gcampax.github.com"
-          "bring-out-submenu-of-power-offlogout-button@gnome-shell-extensions.gcampax.github.com"
+          "BringOutSubmenuOfPowerOffLogoutButton@pratap.fastmail.fm"
           "blur-my-shell@aunetx"
           "top-panel-logo@jmpegi.github.com"
           "workspace-indicator@gnome-shell-extensions.gcampax.github.com"
           "emoji-copy@felipeftn"
-          "Gnofi@aylur"
           "windowsNavigator@gnome-shell-extensions.gcampax.github.com"
           "caffeine@patapon.info"
           "clipboard-indicator@tudmotu.com"
-          "panel-osd@berend.de.schouwer.gmail.com"
           "tailscale-status@maxgallup.github.com"
-          "user-themes@gnome-shell-extensions.gcampax.github.com"
-          "bluetooth-battery@michalw.github.com"
-          "BringOutSubmenuOfPowerOffLogoutButton@pratap.fastmail.fm"
+          "Bluetooth-Battery-Meter@maniacx.github.com"
+          "dim-background-windows@stephane-13.github.com"
         ];
       };
 
@@ -115,11 +115,6 @@ in
         toogle-shortcut = "<Super>g";
       };
 
-      # Gnofi configuration
-      "org/gnome/shell/extensions/gnofi" = {
-        window-hotkey = "<Super>space ";
-      };
-
       # Clipboard Indicator configuration
       "org/gnome/shell/extensions/clipboard-indicator" = {
         cache-size = 50;
@@ -138,28 +133,34 @@ in
 
     # Note: Custom keybindings are defined in keybindings.nix to avoid conflicts
 
-    # Install GNOME Shell extensions and extension-specific packages
+    # Install every extension whose UUID is in enabled-extensions above.
+    # Profile-specific extras live in cfg.extensions.packages (see
+    # Users/<user>/profile.nix).
     home.packages = with pkgs;
       [
-        # Essential extensions (always installed when extensions are enabled)
         gnomeExtensions.user-themes
-        # gnomeExtensions.ascii-emoji
-        gnomeExtensions.dim-background-windows
-        gnomeExtensions.just-perfection
-        # gnomeExtensions.paperwm
-        gnomeExtensions.tailscale-status
+        gnomeExtensions.dash-to-dock
+        gnomeExtensions.appindicator
         gnomeExtensions.auto-accent-colour
         gnomeExtensions.auto-move-windows
         gnomeExtensions.bring-out-submenu-of-power-offlogout-button
+        gnomeExtensions.blur-my-shell
+        gnomeExtensions.top-panel-logo
+        gnomeExtensions.workspace-indicator
+        gnomeExtensions.emoji-copy
+        gnomeExtensions.windownavigator
+        gnomeExtensions.caffeine
+        gnomeExtensions.clipboard-indicator
+        gnomeExtensions.tailscale-status
+        gnomeExtensions.bluetooth-battery-meter
+        gnomeExtensions.dim-background-windows
 
-        # Extension-specific packages that might be needed
-        lm_sensors # For system monitoring extensions
-        curl # For weather extensions
-        jq # For data processing
-        xclip # For clipboard extensions
-        wl-clipboard # For Wayland clipboard
-
-        # Extensions from user configuration
+        # Helpers used by various extensions at runtime.
+        lm_sensors
+        curl
+        jq
+        xclip
+        wl-clipboard
       ]
       ++ cfg.extensions.packages;
   };


### PR DESCRIPTION
UUID list and installed packages were drifting. Every UUID in
enabled-extensions now has a matching package; every installed package
is enabled. UUIDs verified against gnomeExtensions.<name>.passthru.extensionUuid.

- Add packages: dash-to-dock, appindicator, blur-my-shell (was
  workstation-only), top-panel-logo, workspace-indicator, windownavigator,
  emoji-copy, caffeine, clipboard-indicator, bluetooth-battery-meter
- Drop unpackaged UUIDs that were silently failing: Gnofi@aylur,
  panel-osd@berend.de.schouwer.gmail.com
- Drop UUID duplicates: bring-out-submenu gcampax variant (real package
  has UUID BringOutSubmenuOfPowerOffLogoutButton@pratap.fastmail.fm),
  user-themes plural (singular user-theme is correct)
- Replace bluetooth-battery@michalw.github.com with the maniacx fork
  that nixpkgs actually packages
- Add dim-background-windows UUID (package + dconf already present)
- Drop unused just-perfection package (not enabled, no dconf)
- Remove orphan Gnofi dconf block

Also migrate cantarell-fonts -> adwaita-fonts (GNOME 48 default).

Closes #472

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
