### PR TITLE
chore(gnome): cleanup bundle — power dconf, RDP everywhere, excludePackages (#474)

### DIFF
--- a/home/desktop/gnome/apps.nix
+++ b/home/desktop/gnome/apps.nix
@@ -4,7 +4,7 @@
 , ...
 }:
 let
-  inherit (lib) mkIf mkForce mkMerge;
+  inherit (lib) mkIf mkMerge;
   cfg = config.desktop.gnome;
 in
 {
@@ -263,8 +263,10 @@ in
 
       # Disable power management for remote desktop sessions
       "org/gnome/settings-daemon/plugins/power" = {
+        sleep-inactive-ac-type = "nothing";
         sleep-inactive-ac-timeout = 0;
-        sleep-inactive-battery-timeout = mkForce 0; # Override default 1200 setting
+        sleep-inactive-battery-type = "nothing";
+        sleep-inactive-battery-timeout = 0;
       };
 
       "org/gnome/desktop/peripherals/touchpad" = {

--- a/home/desktop/gnome/default.nix
+++ b/home/desktop/gnome/default.nix
@@ -143,12 +143,9 @@ in
         send-software-usage-stats = false;
       };
 
-      # Power settings
-      "org/gnome/settings-daemon/plugins/power" = {
-        sleep-inactive-ac-type = "nothing";
-        sleep-inactive-battery-type = "suspend";
-        sleep-inactive-battery-timeout = 1200; # 20 minutes
-      };
+      # Power settings live in apps.nix under the Remote Desktop block —
+      # GNOME RDP is enabled on every host so the no-sleep policy applies
+      # uniformly there.
 
       # Window management
       "org/gnome/desktop/wm/keybindings" = {

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -161,9 +161,8 @@ in
       enableReadyNotifications = true;
     };
 
-    # GNOME Remote Desktop disabled - using headless service instead
     gnome-remote-desktop = {
-      enable = false;
+      enable = true;
     };
 
     virtualization = {
@@ -364,9 +363,6 @@ in
 
   # Hardware and service specific configurations
   services = {
-    # Explicitly disable gnome-remote-desktop system service (using headless instead)
-    gnome.gnome-remote-desktop.enable = lib.mkForce false;
-
     playerctld.enable = true;
     fwupd.enable = true;
     nfs.server = lib.mkIf vars.services.nfs.enable {
@@ -434,7 +430,6 @@ in
       cosmic-ext-applet-weather
       # Remote desktop
       rustdesk-flutter
-      gnome-remote-desktop # For headless RDP service
       # Messaging applications
       karere # GTK4 WhatsApp client
 

--- a/modules/desktop/gnome-remote-desktop.nix
+++ b/modules/desktop/gnome-remote-desktop.nix
@@ -44,8 +44,11 @@ in
         gnome-remote-desktop.wantedBy = [ "graphical.target" ];
       };
 
-      # Disable power management for remote desktop sessions
-      targets = {
+      # Disable systemd sleep/suspend on hosts that should always be reachable
+      # (workstations, headless servers). Laptops keep suspend so lid-close
+      # behaves; the dconf no-sleep policy in home/desktop/gnome/apps.nix
+      # already prevents idle suspend during active RDP sessions.
+      targets = mkIf (config.host.class or "workstation" != "laptop") {
         sleep.enable = mkForce false;
         suspend.enable = mkForce false;
       };

--- a/modules/services/gnome/gnome-services.nix
+++ b/modules/services/gnome/gnome-services.nix
@@ -13,6 +13,20 @@
     };
     gvfs.enable = true;
   };
+
+  # Trim GNOME defaults that survive `core-apps.enable = false` via transitive
+  # deps. The packages we *do* want (gnome-calendar, gnome-contacts, etc.) are
+  # listed in environment.systemPackages below.
+  environment.gnome.excludePackages = with pkgs; [
+    gnome-tour
+    epiphany
+    geary
+    gnome-music
+    gnome-photos
+    yelp
+    cheese
+  ];
+
   environment.systemPackages = with pkgs; [
     gnome-themes-extra
     nautilus


### PR DESCRIPTION
Tier 2 of the GNOME audit plan, with one extra fix.

- Power dconf is set in exactly one place (apps.nix) under the Remote
  Desktop block. The duplicate in default.nix was silently overridden by
  apps.nix's mkForce; removed both the dup and the mkForce.
- razer now enables features.gnome-remote-desktop. The previous
  mkForce false predates cosmic-remote-desktop being disabled cluster-
  wide; the workaround was no longer load-bearing. Drop the mkForce, the
  redundant gnome-remote-desktop package install, and the comment.
- The RDP feature module's systemd sleep/suspend disable is now gated on
  host.class != "laptop" so razer keeps lid-close suspend. The dconf
  no-sleep policy still prevents idle suspend during active sessions.
- environment.gnome.excludePackages added in gnome-services.nix
  (gnome-tour, epiphany, geary, gnome-music, gnome-photos, yelp,
  cheese) as defense in depth on top of core-apps.enable = false.
  Verified gnome-tour is now out of razer's closure.

Closes #474

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
