### PR TITLE
feat(gnome): polish bundle — accent colour, GDM greeter, libadwaita comment (#476)

### DIFF
--- a/home/desktop/gnome/default.nix
+++ b/home/desktop/gnome/default.nix
@@ -105,6 +105,9 @@ in
       "org/gnome/desktop/interface" = {
         clock-format = "24h";
         show-battery-percentage = true;
+        # libadwaita accent (GNOME 47+). Picks the gruvbox-orange tone that
+        # matches the wallpaper / base16 scheme set in shared-variables.nix.
+        accent-color = "orange";
         gtk-theme = mkDefault (
           if cfg.theme.enable
           then "Adwaita-dark"

--- a/home/desktop/gnome/theme.nix
+++ b/home/desktop/gnome/theme.nix
@@ -14,6 +14,11 @@ in
     # runtime symlink (gtk.css -> ~/.config/gtk-4.0/cosmic/dark.css). With
     # `stylix.targets.gtk.enable = false` system-wide, GNOME themes from
     # gsettings + the GTK theme package on PATH and does not need this file.
+    #
+    # libadwaita constraint: even if Stylix wrote gtk.css here, native GNOME
+    # apps (Nautilus, GNOME Console, Settings) intentionally ignore third-
+    # party themes by upstream policy. Stylix theming for GNOME apps is
+    # unfixable on this side; do not chase it.
     xdg.configFile."gtk-3.0/gtk.css".enable = false;
     xdg.configFile."gtk-4.0/gtk.css".enable = false;
 

--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -228,6 +228,18 @@ in
     };
   };
 
+  # GDM greeter visual baseline (only shown when autoLogin can't proceed,
+  # e.g. after a session crash). Keeps clock 24h and forces dark colour
+  # scheme so the greeter doesn't flash light during boot transitions.
+  programs.dconf.profiles.gdm.databases = [{
+    settings = {
+      "org/gnome/desktop/interface" = {
+        clock-format = "24h";
+        color-scheme = "prefer-dark";
+      };
+    };
+  }];
+
   # Desktop manager configuration - Full GNOME for headless RDP access
   services.desktopManager.gnome.enable = true;
 


### PR DESCRIPTION
Tier 3 of the GNOME audit plan.

- libadwaita accent-color set to "orange" (matches the gruvbox base16
  scheme and the orange-desert wallpaper). Native GTK4 / libadwaita apps
  pick this up automatically on GNOME 47+.
- p510 GDM greeter gets a minimal dconf profile (24h clock, prefer-dark
  colour scheme) so it matches the user session and doesn't flash light
  during boot. Greeter is mostly hidden behind autoLogin but fires after
  session crashes.
- home/desktop/gnome/theme.nix now documents *both* reasons gtk.css is
  disabled — the COSMIC runtime symlink (existing) and libadwaita's
  intentional refusal to honour third-party themes. Prevents a future
  cleanup pass from chasing an unfixable GNOME-app theming bug.

Closes #476

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
