### PR TITLE
feat(stylix): enable GTK target fleet-wide (#478)

### DIFF
--- a/Users/common/base-home.nix
+++ b/Users/common/base-home.nix
@@ -64,17 +64,13 @@
 
   # Stylix theming targets (Home Manager level).
   # `enableReleaseChecks = false` is set once in modules/desktop/stylix-theme.nix
-  # at the system level — no need to repeat it here.
-  #
-  # COSMIC firewall: gtk.enable stays false so HM never writes
-  # ~/.config/gtk-{3,4}.0/gtk.css. cosmic-comp owns that path at runtime
-  # (symlinks gtk.css to its own ~/.config/gtk-4.0/cosmic/dark.css). GNOME
-  # themes correctly without it via Stylix's targets.gnome (gsettings + theme
-  # package).
+  # at the system level — no need to repeat it here. GTK is enabled fleet-wide
+  # because COSMIC's GTK theme sync is off on every host; cosmic-comp does not
+  # clobber ~/.config/gtk-{3,4}.0/gtk.css at runtime.
   stylix.targets = {
     wezterm.enable = true;
     ghostty.enable = true;
-    gtk.enable = false; # COSMIC firewall — see comment above
+    gtk.enable = true;
     qt.enable = false; # Qt theming handled by home/desktop/theme/qt.nix
   };
 

--- a/home/desktop/gnome/theme.nix
+++ b/home/desktop/gnome/theme.nix
@@ -10,17 +10,9 @@ let
 in
 {
   config = mkIf (cfg.enable && cfg.theme.enable) {
-    # COSMIC firewall: keep ~/.config/gtk-{3,4}.0/gtk.css free for cosmic-comp's
-    # runtime symlink (gtk.css -> ~/.config/gtk-4.0/cosmic/dark.css). With
-    # `stylix.targets.gtk.enable = false` system-wide, GNOME themes from
-    # gsettings + the GTK theme package on PATH and does not need this file.
-    #
-    # libadwaita constraint: even if Stylix wrote gtk.css here, native GNOME
-    # apps (Nautilus, GNOME Console, Settings) intentionally ignore third-
-    # party themes by upstream policy. Stylix theming for GNOME apps is
-    # unfixable on this side; do not chase it.
-    xdg.configFile."gtk-3.0/gtk.css".enable = false;
-    xdg.configFile."gtk-4.0/gtk.css".enable = false;
+    # libadwaita constraint: native GNOME apps (Nautilus, GNOME Console,
+    # Settings) intentionally ignore third-party themes by upstream policy.
+    # Stylix's GTK target themes everything else; don't chase libadwaita.
 
     # Fonts that GNOME-specific bits rely on. Stylix already supplies the
     # mono/sans/serif packages declared in modules/desktop/stylix-theme.nix.

--- a/modules/desktop/stylix-theme.nix
+++ b/modules/desktop/stylix-theme.nix
@@ -47,11 +47,12 @@ in
       targets = {
         chromium.enable = false;
 
-        # COSMIC firewall: Stylix must NOT write ~/.config/gtk-{3,4}.0/gtk.css.
-        # cosmic-comp owns that path at runtime (symlinks gtk.css to its own
-        # ~/.config/gtk-4.0/cosmic/dark.css). GNOME themes correctly without
-        # gtk.css from the GTK theme package referenced in gsettings.
-        gtk.enable = false;
+        # COSMIC's GTK theme sync is disabled on this fleet, so cosmic-comp
+        # does NOT clobber ~/.config/gtk-{3,4}.0/gtk.css at runtime. Stylix
+        # can own that file safely and theme GTK3 / non-libadwaita GTK4 apps
+        # everywhere. libadwaita apps still ignore third-party themes by
+        # upstream policy regardless of gtk.css contents.
+        gtk.enable = true;
 
         # GNOME target writes org.gnome.desktop.interface/* via gsettings and
         # ships a generated GTK theme package. COSMIC stores its own theme in


### PR DESCRIPTION
The COSMIC firewall (gtk.enable = false in three places to keep
~/.config/gtk-{3,4}.0/gtk.css free for cosmic-comp's runtime symlink)
is no longer needed: COSMIC's GTK theme sync is disabled across the
fleet, so Stylix can own that path safely on every host.

- modules/desktop/stylix-theme.nix: gtk.enable = true
- Users/common/base-home.nix: gtk.enable = true
- home/desktop/gnome/theme.nix: drop the defensive xdg.configFile
  enable=false block; keep a short note about the libadwaita
  constraint (native GNOME apps still ignore third-party themes by
  upstream policy regardless of gtk.css contents)

GTK3 and non-libadwaita GTK4 apps now theme to gruvbox base16
colours fleet-wide. Verified: stylix.targets.gtk.enable evaluates to
true on p620, razer, p510.

Closes #478

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
