### PR TITLE
chore(claude-code): bump native binary 2.1.126 → 2.1.128

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.126";
+  version = "2.1.128";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-/OlpaNJ1Fh/2WkwZ/GQ078aXPZ9tNdw5kqK6BVPKwY4=";
+      hash = "sha256-dwyBNzrUKXDvV2Z22njWvmBBP0reI6utvxNDyggJuz4=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-iKbcphOkBVnzusipRqLsbmCocLkZONPfk9ysHexISMs=";
+      hash = "sha256-4qMYebdDP2WNkV5nFiSfELkTtGeHOVDo5+BmunxNluk=";
     };
   };
 


### PR DESCRIPTION
## Summary

- Bump `claude-code-native` from `2.1.126` to `2.1.128` (Anthropic GCS `latest` channel)
- Updates `version` + two platform sha256 hashes only (3 lines total)

Tracks the Anthropic GCS binary distribution, immune to npm-side packaging churn.

## Test plan

- [x] `./scripts/update-claude-code-native.sh latest` → confirmed `2.1.128` is latest, hashes captured
- [x] `nix build .#claude-code-native` → builds successfully
- [x] `result/bin/claude --version` → `2.1.128 (Claude Code)`
- [x] `ldd` on patched binary → no missing libraries
- [x] `nix build .#nixosConfigurations.p620.config.system.build.toplevel` → ✅
- [x] `nix build .#nixosConfigurations.razer.config.system.build.toplevel` → ✅
- [x] `nix build .#nixosConfigurations.p510.config.system.build.toplevel` → ✅
- [ ] Deploy to p620 (local), razer (SSH), p510 (SSH) — pending review

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)