### PR TITLE
feat(claude-desktop): bump to v2.0.6+claude1.5354.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,17 +116,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1777513221,
-        "narHash": "sha256-DgAIB8w7lm3KFVmt++TZ5O9DdhWXmJNHK6hBIp7ITus=",
+        "lastModified": 1777611002,
+        "narHash": "sha256-wdwbGiW2qkXpnoZj1b8JycCoDwAqIpGMYAFt2s/O8+Q=",
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "dc762a35a02782415fcaa84f0d7ed9d2a6064215",
+        "rev": "c973f4922bac6b5b5b4d07929ee4a98a69cb71a9",
         "type": "github"
       },
       "original": {
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "dc762a35a02782415fcaa84f0d7ed9d2a6064215",
+        "rev": "c973f4922bac6b5b5b4d07929ee4a98a69cb71a9",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -72,13 +72,13 @@
     # Additional tools
     lan-mouse.url = "github:feschber/lan-mouse";
     zjstatus.url = "github:dj95/zjstatus";
-    # = tag v2.0.5+claude1.5354.0 (2026-04-30). Wrapper at v2.0.5 includes
-    # upstream's own CRLF-strip fix for cowork-plugin-shim.sh (PRs #499,
-    # #505) — our overlay's postInstall workaround is now unneeded; the
-    # overlay below simplifies to a direct FHS pass-through.
-    # claude binary at 1.5354.0.
+    # = tag v2.0.6+claude1.5354.0 (2026-05-01). Bumped from ≈v2.0.5 for
+    # X-button-to-tray (#451), persistent autostart toggle (#450), tray
+    # icon in-place updates (#515), and window visibility fix (#496).
+    # Stayed on v2.0.6 (not v2.0.7+) to avoid the frame-fix-wrapper.js
+    # syslog flood (upstream #582). claude binary unchanged at 1.5354.0.
     # Bump via /update-claude-code.
-    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/dc762a35a02782415fcaa84f0d7ed9d2a6064215";
+    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/c973f4922bac6b5b5b4d07929ee4a98a69cb71a9";
 
     # Terminal YouTube browser
     yt-x = {


### PR DESCRIPTION
## Summary

- Bump `claude-desktop-linux` flake input from `dc762a35a` (≈v2.0.5, 2026-04-30) → `c973f4922b` (**v2.0.6+claude1.5354.0**, 2026-05-01)
- Picks up X-button-to-tray, persistent autostart, in-place tray icon updates, window visibility fix, doctor warnings — see commit body for full list
- Stays on v2.0.6 deliberately to avoid v2.0.7's frame-fix-wrapper.js syslog flood (upstream #582). No Cowork → v2.0.8 fix not needed
- claude binary unchanged at 1.5354.0 → no vm_bundles migration risk
- Side effect: un-orphans our pin (previous SHA was force-pushed away upstream; v2.0.6 is a tagged commit)

## Test plan

- [x] `nix build .#nixosConfigurations.razer.pkgs.claude-desktop-linux` → succeeds
- [x] Inner package = `claude-desktop-1.5354.0` (verified — same claude binary as before)
- [x] `pty.node` is ELF (asar packaging intact)
- [x] `nix build .#nixosConfigurations.p620.config.system.build.toplevel` → ✅
- [x] `nix build .#nixosConfigurations.razer.config.system.build.toplevel` → ✅
- [x] `nix build .#nixosConfigurations.p510.config.system.build.toplevel` → ✅
- [ ] Deploy to p620 (local), razer (pending — host offline), p510 (build-test only, no claude-desktop in profile)

## Post-deploy heads-up

Running claude-desktop instances on p620 will keep using the OLD inner store path until killed and relaunched. After deploy, the user can `pkill -f claude-desktop` and relaunch from the app menu when they're ready (warning: in-flight session state will be lost). The next launch will pick up v2.0.6.

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)