### PR TITLE
fix(openclaw): bump default agent model to gemini-3.1-pro-preview

### DIFF
--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -48,7 +48,7 @@
   programs.openclaw = {
     enable = true;
     environment.GEMINI_API_KEY = "/run/agenix/api-gemini";
-    config.agents.defaults.model.primary = "google/gemini-2.5-pro";
+    config.agents.defaults.model.primary = "google/gemini-3.1-pro-preview";
   };
 
   # Workstation-specific additional packages


### PR DESCRIPTION
## Summary

Bumps `programs.openclaw.config.agents.defaults.model.primary` from `google/gemini-2.5-pro` to `google/gemini-3.1-pro-preview`.

## Why

Two motivations:

1. **User request** — wanted to use the newer Gemini 3.1 model.
2. **Agent timeouts on 2.5-pro** — the gateway log showed two `embedded_run_failover_decision` events with `failoverReason=timeout`, `fallbackConfigured=false`, `aborted=true` while running on `gemini-2.5-pro` under the agent harness (with `thinking=medium`). The bare `capability model run` smoke path worked fine on 2.5-pro because it skips the agent system prompt and tool loop, but real agent turns exceeded the default per-call timeout.

3.1-pro-preview is OpenClaw's documented recommended default per docs.openclaw.ai/providers/google, has reasoning support, and is exposed under the `google` provider in OpenClaw's catalog.

## Verified

- `just test-host p620` and `just quick-deploy p620` clean (agenix gen 12)
- After `systemctl --user restart openclaw-gateway`, log shows `agent model: google/gemini-3.1-pro-preview (thinking=medium, fast=off)`
- Persisted config (`~/.openclaw/openclaw.json`) and runtime config (`openclaw config get agents.defaults.model`) both report the new primary
- One-shot inference: `openclaw capability model run --model google/gemini-3.1-pro-preview` returns cleanly
- Agent turn (`openclaw agent --agent main --message "..."`) completes successfully

## Known residual issue (out of scope for this PR)

Agent runs still stall on a first-attempt model call to `gemini-2.5-pro` (~2-min latency before falling back to 3.1-pro-preview). The execution trail shows:

```json
{"model": "gemini-2.5-pro",          "result": "timeout"},
{"model": "gemini-3.1-pro-preview",  "result": "success"}
"fallbackUsed": true
```

The source of the leading 2.5-pro attempt is unclear — it's not in the persisted config, not in the session-level model pin, and not in `~/.openclaw/agents/main/agent/models.json`. Likely an auto-detected fallback in the harness that ignores the configured primary order. Could be addressed by setting `config.agents.defaults.model.fallbacks` explicitly or by raising `timeoutMs`, but that's a follow-up once the source is identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)