### PR TITLE
fix(openclaw): add gemini-2.5-flash fallback for agent watchdog timeouts

### DIFF
--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -48,7 +48,15 @@
   programs.openclaw = {
     enable = true;
     environment.GEMINI_API_KEY = "/run/agenix/api-gemini";
-    config.agents.defaults.model.primary = "google/gemini-3.1-pro-preview";
+    config.agents.defaults.model = {
+      primary = "google/gemini-3.1-pro-preview";
+      # Fall back to Flash on watchdog timeout — the agent harness sends ~26
+      # tools + ~20 skills in the initial prompt, and 3.1-pro-preview's
+      # first-token latency frequently exceeds the gateway's idle watchdog.
+      # Flash (1M ctx, reasoning) starts streaming fast and keeps the agent
+      # responsive when 3.1 stalls.
+      fallbacks = [ "google/gemini-2.5-flash" ];
+    };
   };
 
   # Workstation-specific additional packages


### PR DESCRIPTION
## Summary

Adds an explicit `agents.defaults.model.fallbacks = [ "google/gemini-2.5-flash" ]` so the agent harness has a fast, responsive fallback when `gemini-3.1-pro-preview` stalls on first-token latency.

## Why

Investigation after #485 revealed two separate problems tangled together:

1. **Session model pin** (operational, fixed out-of-band) — sessions cache `modelId` at creation time. The user's `agent:main:main` session was created during their TUI session before the model swap with `modelId=gemini-2.5-pro` baked into the trajectory's `session.started` event. OpenClaw resumed that pin even after `agents.defaults.model.primary` was bumped, so every run started by trying the stale model and only fell back to the configured primary after timeout. The stale session has been pruned (`~/.openclaw/agents/main/sessions/b11e9740-…` files removed + entry deleted from `sessions.json`).

2. **Watchdog timeout on 3.1-pro-preview** — even with a clean session pinned to 3.1-pro-preview, the agent harness sends a large initial prompt (~26 tools + ~20 skill definitions) and 3.1-pro-preview's first-token latency frequently exceeds the gateway's idle watchdog (~130s), triggering the documented `[llm-idle-timeout] … produced no reply before the idle watchdog; retrying same model` loop. This is what this PR addresses.

`gemini-2.5-flash` (1M context, `reasoning=true` per OpenClaw's catalog) is the documented fast-path google-provider model. With it as fallback:

- 3.1-pro-preview's quality is preserved when it responds in time
- Watchdog timeouts gracefully fall over to Flash instead of looping
- TUI stays responsive without manual retry

## Test plan

- [x] `just test-host p620` clean
- [x] `just quick-deploy p620` succeeded
- [x] Gateway log shows `config change detected; evaluating reload (agents.defaults.model.fallbacks, …)` after restart
- [x] `openclaw config get agents.defaults.model` returns:
  ```
  { "primary": "google/gemini-3.1-pro-preview",
    "fallbacks": ["google/gemini-2.5-flash"] }
  ```
- [ ] Live agent run confirms fallback path works on watchdog (running at PR-creation time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)