### PR TITLE
feat(openclaw): enable gogcli, summarize, and qmd bundled plugins

### DIFF
--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -57,6 +57,29 @@
       # responsive when 3.1 stalls.
       fallbacks = [ "google/gemini-2.5-flash" ];
     };
+
+    # Expose plugin CLIs on the user's interactive PATH (off by default). The
+    # gateway wrapper has them either way; this is so `gog auth credentials`
+    # and `gog auth add …` (one-time browser-based OAuth) can be run from a
+    # normal shell after deploy.
+    exposePluginPackages = true;
+
+    # Bundled plugins. Each puts its CLI on the gateway wrapper's PATH so the
+    # already-loaded matching `gog` / `summarize` / `qmd` skills can call it.
+    # `goplaces` is defaultEnable=true upstream — no need to list it here.
+    bundledPlugins = {
+      # Google Workspace — Gmail, Calendar, Drive, Contacts, Sheets, Docs.
+      # OAuth setup is one-time and interactive (browser flow): after deploy run
+      #   gog auth credentials /path/to/client_secret.json    # from GCP console
+      #   gog auth add olaf@freundcloud.com --services gmail,calendar,drive,contacts,docs,sheets
+      gogcli.enable = true;
+
+      # URL / PDF / YouTube summarisation — useful for inbox triage and reading.
+      summarize.enable = true;
+
+      # Local markdown KB search (Obsidian-friendly).
+      qmd.enable = true;
+    };
   };
 
   # Workstation-specific additional packages


### PR DESCRIPTION
## Summary

Enables three bundled OpenClaw plugins on P620 that pair with skills the agent already loads:

| Plugin | Provides | Skill |
|---|---|---|
| `gogcli` | Gmail / Calendar / Drive / Contacts / Sheets / Docs (single Google Workspace CLI) | `gog` |
| `summarize` | URL / PDF / YouTube summarisation | `summarize` |
| `qmd` | Local markdown KB search (Obsidian-friendly) | `qmd` |

`goplaces` is `defaultEnable=true` upstream so it doesn't need an entry.

Also flips `programs.openclaw.exposePluginPackages = true` (default `false`) — without it the CLIs only live on the gateway wrapper's PATH, which blocks the one-time interactive `gog auth credentials` / `gog auth add` flow from a normal shell.

## Why this shape

OpenClaw splits Google integrations into a single CLI (`gog` / `gogcli`) covering all of Gmail, Calendar, Drive, Contacts, Sheets, and Docs — there is no per-product plugin. Enabling `gogcli` with no extra config gets you everything; per-account OAuth is then a one-time runtime step because it needs a browser.

## Test plan

- [x] `just test-host p620` clean
- [x] `just quick-deploy p620` succeeded
- [x] CLIs on user PATH:
  ```
  $ which gog summarize qmd
  /etc/profiles/per-user/olafkfreund/bin/gog
  /etc/profiles/per-user/olafkfreund/bin/summarize
  /etc/profiles/per-user/olafkfreund/bin/qmd
  ```
- [x] Versions respond: `gog v0.15.0`, `summarize 0.14.1`, `qmd 2.1.0`
- [ ] `gog auth credentials …` + `gog auth add …` (interactive, one-time post-merge)

## Post-merge runtime steps (Gmail/Calendar)

```bash
# 1. Google Cloud Console: project → enable Gmail/Calendar/Drive/Contacts/Sheets/Docs APIs
#    → OAuth 2.0 Client IDs → Application type: Desktop → download client_secret.json
# 2. (Optional, recommended) encrypt with agenix:
#      ./scripts/manage-secrets.sh create gog-client-secret
# 3. Wire the credential file:
gog auth credentials /path/to/client_secret.json   # or /run/agenix/gog-client-secret
# 4. Authorize the account (browser opens):
gog auth add olaf@freundcloud.com --services gmail,calendar,drive,contacts,docs,sheets
gog auth list
```

The agenix secret stub for `gog-client-secret` is **not** included in this PR — it would either fail the build (file not present) or need a placeholder. Easier to add it in a small follow-up once the JSON from Google is in hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)