### PR TITLE
chore(warp-terminal): bump to v0.2026.05.06.15.42.stable_03

### DIFF
--- a/pkgs/warp-terminal/versions.json
+++ b/pkgs/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "linux_x86_64": {
-    "hash": "sha256-93IBcHfExMduG2idnpCif6hD3vO+/tsQGF7FlgS6meE=",
-    "version": "0.2026.04.29.08.57.stable_01"
+    "hash": "sha256-zTB39kN/uKbzSN6Yz7/wIJ2Mw5gnga2usfYmKUPSMU0=",
+    "version": "0.2026.05.06.15.42.stable_03"
   },
   "linux_aarch64": {
-    "hash": "sha256-2XGgK20SLFiSBix/WXuW0yCkp46HzBtWJD+5I+H9js8=",
-    "version": "0.2026.04.29.08.57.stable_01"
+    "hash": "sha256-eQxwtkiFZFsrsjjEoF0wryrPIUsvghYurR/i06vCzuk=",
+    "version": "0.2026.05.06.15.42.stable_03"
   }
 }


### PR DESCRIPTION
## Summary

Bumps `warp-terminal` from `v0.2026.04.29.08.57.stable_01` to `v0.2026.05.06.15.42.stable_03` via `pkgs/warp-terminal/versions.json`. The bump was produced by the standard tool:

```
./scripts/update-warp-terminal.sh
```

Only `version` + per-arch SRI `hash` for `linux_x86_64` and `linux_aarch64` changed — no derivation-logic edits.

## Test plan

- [x] `./scripts/update-warp-terminal.sh --check` reported newer release available
- [x] `nix build .#nixosConfigurations.p620.pkgs.warp-terminal` succeeded
- [x] `nix build .#nixosConfigurations.p620.config.system.build.toplevel` succeeded
- [x] Built binary is ELF: `file …/opt/warpdotdev/warp-terminal/warp` → `ELF`
- [x] `version` attr matches: `nix eval --raw .#nixosConfigurations.p620.pkgs.warp-terminal.version` → `0.2026.05.06.15.42.stable_03`
- [x] **Deployed live on p620 already** — `warp-terminal --version` reports `Oz v0.2026.05.06.15.42.stable_03`

Was committed locally on main per the `/update-warp` skill's "local, on main" convention; routing through a PR now because branch protection rightfully blocks direct pushes to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)