### PR TITLE
feat(openclaw): autostart gateway at boot via linger + Install section

### DIFF
--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -82,6 +82,13 @@
     };
   };
 
+  # Add an [Install] section to the openclaw-gateway user service so it auto-
+  # starts at boot (the upstream nix-openclaw HM module deliberately omits it
+  # so the gateway is opt-in). Combined with `users.users.olafkfreund.linger
+  # = true` at the system level, this means heartbeats / scheduled agent runs
+  # keep working even when no shell session is active.
+  systemd.user.services.openclaw-gateway.Install.WantedBy = [ "default.target" ];
+
   # Workstation-specific additional packages
   home.packages = [
     # Newelle — AI Virtual Assistant (GTK4/Libadwaita)

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -366,6 +366,10 @@ in
       "render"
     ];
     shell = pkgs.zsh;
+    # Run user services even when not logged in — needed so the openclaw
+    # gateway (and any other systemd user units) keep working at boot
+    # before someone logs in via TTY/SSH/desktop session.
+    linger = true;
     # Only use secret-managed password if the secret exists
     hashedPasswordFile = lib.mkIf
       (


### PR DESCRIPTION
## Summary

Make the OpenClaw gateway boot-persistent on P620. Two pieces:

1. **`users.users.olafkfreund.linger = true`** (NixOS, `hosts/p620/configuration.nix`) — user-level systemd manager starts at boot rather than first login, so heartbeats / scheduled agent runs keep going without an active shell.

2. **`systemd.user.services.openclaw-gateway.Install.WantedBy = [ "default.target" ]`** (Home Manager, `Users/olafkfreund/p620_home.nix`) — the upstream `nix-openclaw` HM module deliberately omits `[Install]` (gateway is opt-in by design); this override layers an Install section on so Home Manager creates the `default.target.wants` symlink and the unit starts automatically once the user manager is up.

Combined: no more `systemctl --user start openclaw-gateway` after a reboot.

## Test plan

- [x] `just test-host p620` builds clean
- [ ] After deploy on p620 (post-merge):
  - `loginctl show-user olafkfreund -p Linger` → `Linger=yes`
  - `systemctl --user is-enabled openclaw-gateway` → `enabled`
  - Manual stop then check gateway comes back at next reboot (deferred — won't reboot p620 in this PR)

## Scope

P620 only. Razer/P510 don't have openclaw enabled and don't need the lock-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)