### PR TITLE
chore(gitignore): ignore .direnv cache + atomic-swap temp dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,14 @@ result-*
 .tmp/
 *.tmp
 
+# direnv cache + atomic-swap temp dirs.
+# direnv writes .direnv.tmp-<suffix>/ while rebuilding the cache, then renames
+# it over .direnv/. Without ignoring it, scripts/update-commit-deploy.sh's
+# pre-flight dirty-tree check (`git status --porcelain | awk '$2 != "flake.lock"'`)
+# trips and aborts.
+.direnv/
+.direnv.tmp-*/
+
 # Editor files
 .vscode/
 *.swp


### PR DESCRIPTION
## Summary

Adds `.direnv/` and `.direnv.tmp-*/` to `.gitignore` so direnv's transient atomic-swap temp dirs no longer show up as untracked.

## Why

\`just update-commit-deploy\` (and the underlying \`scripts/update-commit-deploy.sh\`) has a pre-flight check at line 81:

\`\`\`bash
dirty_others=\$(git status --porcelain | awk '\$2 != "flake.lock"' || true)
if [ -n "\$dirty_others" ]; then
  printf "!! unrelated dirty files present:\n%s\n" "\$dirty_others" >&2
  err "clean them up first (commit, stash, or revert) — aborting to avoid drift."
fi
\`\`\`

Only \`flake.lock\` is allowed to be dirty. Anything else — including untracked dirs like \`.direnv.tmp-warp/\` — aborts the run. Since direnv writes \`.direnv.tmp-<suffix>/\` then renames it over \`.direnv/\` (atomic swap), the temp dir frequently appears between cache rebuilds and trips the check on every invocation.

Ignoring both \`.direnv/\` (the cache itself, should never be tracked) and \`.direnv.tmp-*/\` (the swap temp) makes \`update-commit-deploy\` reliable without the user having to manually \`rm -rf .direnv.tmp-warp/\` first.

## Test plan

- [x] Pre-fix: \`git status --short\` showed \`?? .direnv.tmp-warp/\`
- [x] Post-fix: \`git status --porcelain | awk '\$2 != "flake.lock"'\` returns only \` M .gitignore\` (which goes away once this PR merges)
- [ ] Next \`just update-commit-deploy\` run completes the pre-flight check

🤖 Generated with [Claude Code](https://claude.com/claude-code)