### PR TITLE
chore(update-deploy): default SCOPE from 'nixpkgs' to 'all'

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -22,28 +22,32 @@ update-flake:
     just deploy
 
 # Idiot-proof update + commit + deploy (local OR remote). Does:
-#   1. nix flake update (scope = nixpkgs by default, or 'all' or any input name)
+#   1. nix flake update (scope = 'all' by default; pass 'nixpkgs' or any input name to scope down)
 #   2. no-op exit if nothing moved
 #   3. test-build target host closure (aborts if fails)
 #   4. commit flake.lock to main + git push (lock never gets orphaned)
 #   5. nh os switch (local) OR nh os switch --target-host HOST (remote via SSH)
 #
 # HOST defaults to the local hostname; any SSH-reachable host in ~/.ssh/config
-# works too. SCOPE defaults to 'nixpkgs' — use 'all' to bump every input, or
-# pass a specific input name (e.g. 'home-manager', 'claude-desktop-linux').
+# works too. SCOPE defaults to 'all' (every input). Pass 'nixpkgs' to scope it
+# down to just the nixpkgs pin, or pass a specific input name (e.g.
+# 'home-manager', 'claude-desktop-linux') to bump one input.
 #
 # Examples:
-#   just update-commit-deploy                     # local, nixpkgs only
-#   just update-commit-deploy p620                # explicit local host
-#   just update-commit-deploy razer               # remote via SSH
-#   just update-commit-deploy p510 all            # remote, update all inputs
+#   just update-commit-deploy                     # local, all inputs
+#   just update-commit-deploy p620                # explicit local host, all inputs
+#   just update-commit-deploy razer               # remote via SSH, all inputs
+#   just update-commit-deploy p510 nixpkgs        # remote, nixpkgs only
 #   just update-commit-deploy razer home-manager  # remote, single input
-update-commit-deploy HOST="$(hostname)" SCOPE="nixpkgs":
+update-commit-deploy HOST="$(hostname)" SCOPE="all":
     ./scripts/update-commit-deploy.sh {{HOST}} {{SCOPE}}
 
 # Stage 1 of split deploy: bump lock + build + commit + PR-merge, no switch.
-# Use when the target host is offline; later `nhs HOST` does the deploy.
-update-commit HOST="$(hostname)" SCOPE="nixpkgs":
+# Use when you want to update + build + commit but defer the actual switch
+# (e.g. target host is offline, or you want to switch on your own schedule
+# with `nhs HOST` later). SCOPE defaults to 'all'; pass 'nixpkgs' or an input
+# name to scope it down.
+update-commit HOST="$(hostname)" SCOPE="all":
     ./scripts/update-commit-deploy.sh {{HOST}} {{SCOPE}} --no-deploy
 
 # Preview updates with detailed package changes (before building)

--- a/docs/UPDATE-DEPLOY.md
+++ b/docs/UPDATE-DEPLOY.md
@@ -27,7 +27,7 @@ Both invoke the same script: `scripts/update-commit-deploy.sh`.
    - Must be on branch `main`
    - Working tree must be clean — only `flake.lock` may be dirty
    - If HOST is remote: check SSH reachability. Abort early if not.
-2. **Update** — `nix flake update <SCOPE>` (default `nixpkgs`; accepts `all` or any input name)
+2. **Update** — `nix flake update <SCOPE>` (default `all`; accepts `nixpkgs` or any specific input name)
 3. **Freshness check** — cheap `nix eval --raw` to compute what the target's
    closure should be, compared against its current `/run/current-system`.
    If lock didn't change AND host already on latest → exit "nothing to do".
@@ -53,12 +53,12 @@ Both invoke the same script: `scripts/update-commit-deploy.sh`.
 | Position | Name | Default | Values |
 |---|---|---|---|
 | 1 | `HOST` | `$(hostname)` | any name in `flake.nix` `nixosConfigurations.*` |
-| 2 | `SCOPE` | `nixpkgs` | `all`, `nixpkgs`, or any specific input name |
+| 2 | `SCOPE` | `all` | `all`, `nixpkgs`, or any specific input name |
 
 ### Common scopes
 
-- `nixpkgs` — only the root nixpkgs input (default, most common)
-- `all` — update every input in the flake
+- `all` — update every input in the flake (default; the most common case)
+- `nixpkgs` — only the root nixpkgs input (use for targeted security-driven bumps)
 - `home-manager`, `claude-desktop-linux`, `sops-nix`, ... — any input name from `flake.nix`
 
 ## Idiot-proofing guarantees

--- a/scripts/update-commit-deploy.sh
+++ b/scripts/update-commit-deploy.sh
@@ -4,7 +4,7 @@
 # Idiot-proof update flow for NixOS (works for local AND remote targets):
 #   1) pre-flight: must be on main, working tree clean (flake.lock OK),
 #      and remote target (if any) reachable via SSH
-#   2) nix flake update <SCOPE>         (default SCOPE=nixpkgs)
+#   2) nix flake update <SCOPE>         (default SCOPE=all)
 #   3) no-op exit if lock unchanged AND host already current
 #   4) test-build target host closure   (abort commit on build failure)
 #   5) feature-branch + PR-merge of flake.lock → main
@@ -55,7 +55,7 @@ for arg in "$@"; do
   esac
 done
 HOST="${positional[0]:-$(hostname)}"
-SCOPE="${positional[1]:-nixpkgs}"
+SCOPE="${positional[1]:-all}"
 
 # Resolve repo root from script location.
 cd "$(dirname "$0")/.."


### PR DESCRIPTION
## Summary

Flips the default `SCOPE` argument from `nixpkgs` to `all` across the three places that have to agree:

- **`Justfile`** — `update-commit-deploy` and `update-commit` recipes
- **`scripts/update-commit-deploy.sh`** — positional-argument fallback
- **`docs/UPDATE-DEPLOY.md`** — argument table + "common scopes" reordered

## Why

The original `nixpkgs` default was conservative but surprising — most actual use is "bring everything to latest, build, commit, push, optionally switch", which previously required typing `all` every time. Targeted bumps (e.g. `just update-commit-deploy p620 nixpkgs` for a security-driven nixpkgs-only refresh) still work — just pass the scope explicitly.

## Reminder for the "switch later" workflow

`just update-commit` (no `-deploy` suffix) was already there and is the right command for "update + build + commit + push, but let me run the switch myself when I want". It uses `--no-deploy` under the hood. With this PR, both recipes default to `all`, so:

```
just update-commit                # all inputs, build, commit, push — no switch
nhs p620                          # switch when you're ready
```

## Test plan

- [x] `just --show update-commit-deploy` shows `SCOPE="all"`
- [x] `just --show update-commit` shows `SCOPE="all"`
- [x] No stale `default nixpkgs` references left (`grep -rn "default.*nixpkgs"` in Justfile/script/docs returns only the "accepts nixpkgs" mentions, which are correct)
- [ ] Next `just update-commit-deploy` (no args) runs `nix flake update` (all inputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)