### PR TITLE
chore(devshell): slim default from ~12 GiB to ~1.5 GiB

### DIFF
--- a/tools/dev.nix
+++ b/tools/dev.nix
@@ -1,82 +1,78 @@
 # Primary Development Shell Environment
+#
+# Intentionally slim. Anything you'd reach for during ordinary edit / build /
+# commit work lives here. Tools used only occasionally (mdbook, graphviz,
+# typos, taplo, nix-tree, nix-diff, nix-eval-jobs, commitizen, …) were moved
+# out because each drags in a hefty closure (Haskell GHC for nix-tree,
+# python+toolchains for commitizen, full LLVM/clang for some build-time deps,
+# even an arm64 .NET runtime via transitives) — collectively ~9 GB the
+# direnv-loaded shell doesn't need on a daily basis. Reach for them via:
+#
+#   nix develop .#docs                # mdbook, graphviz, typos, taplo, ...
+#   nix shell nixpkgs#nix-tree        # one-off nix introspection
+#   nix shell nixpkgs#nix-diff
+#   nix shell nixpkgs#nix-eval-jobs
+#   nix shell nixpkgs#commitizen
+#
 { pkgs, ... }:
 pkgs.mkShell {
   name = "nixos-dev-environment";
 
   packages = with pkgs; [
-    # Modern Nix tooling
-    nixd # Advanced LSP server
-    nil # Alternative LSP
-    nix-output-monitor # Beautiful build output
-    nix-tree # Dependency visualization
-    nix-diff # Configuration comparison
-    nix-eval-jobs # Parallel evaluation
+    # Nix LSP + build UX
+    nixd # Advanced LSP server (nil dropped — nixd is the better LSP)
+    nix-output-monitor # prettier build output
 
-    # Development workflow
-    just # Command runner (already using)
-    pre-commit # Git hooks
-    commitizen # Conventional commits
+    # Linters + formatter (run on every edit / pre-commit)
+    nixpkgs-lint-community # Primary linter (tree-sitter, whole-tree-safe)
+    statix # Secondary linter (rule-based: `statix check FILE`)
+    deadnix # Dead-code detection
+    nixpkgs-fmt # Formatter
 
-    # Quality assurance
-    nixpkgs-lint-community # Primary linter (tree-sitter, fast, whole-tree-safe)
-    statix # Secondary linter (rule-based, run per-file: `statix check FILE`)
-    deadnix # Dead code detection
-    nixpkgs-fmt # Code formatting
-    typos # Spell checking
-    taplo # TOML formatting
+    # Workflow
+    just # Command runner
+    pre-commit # Git hooks (pre-commit hook fires on every commit)
 
-    # Documentation and analysis
-    mdbook # Documentation generation
-    graphviz # Dependency graphs
+    # System tools any shell command in this repo expects
+    git
+    curl
+    jq
 
-    # System tools
-    git # Version control
-    curl # HTTP requests
-    jq # JSON processing
-
-    # Development utilities
-    direnv # Environment management
-    nix-direnv # Nix integration for direnv
+    # direnv integration
+    direnv
+    nix-direnv
   ];
 
   shellHook = ''
     export PATH=$PWD/scripts:$PATH
-    echo "🚀 NixOS Development Environment v2.0"
+    echo "🚀 NixOS Development Environment v2.1 (slim)"
     echo ""
-    echo "📋 Available Commands:"
+    echo "📋 Common commands:"
     echo "  just validate        - Complete validation suite"
     echo "  just test-host X     - Test specific host config"
-    echo "  just deploy-all      - Deploy all hosts"
-    echo "  just quick-test      - Fast parallel testing"
-    echo "  just quick-all       - Test and deploy all"
+    echo "  just quick-deploy X  - Smart deploy (only if changed)"
+    echo "  just update-commit   - update + build + commit (no switch)"
     echo ""
-    echo "🔧 Development Tools:"
-    echo "  nixd                - Start LSP server"
-    echo "  nixpkgs-lint .      - Fast tree-sitter lint (whole tree)"
-    echo "  statix check FILE   - Rule-based lint (single file)"
-    echo "  deadnix             - Check for dead code"
-    echo "  nix-tree            - Visualize dependencies"
-    echo "  nix-diff .#old .#new - Compare configurations"
+    echo "🔧 Linters / formatter (in this shell):"
+    echo "  nixpkgs-lint .       - Fast tree-sitter lint (whole tree)"
+    echo "  statix check FILE    - Rule-based lint (single file)"
+    echo "  deadnix              - Dead-code detection"
+    echo "  nixpkgs-fmt          - Format"
     echo ""
-    echo "📚 Documentation:"
-    echo "  mdbook build        - Generate documentation"
-    echo "  nix flake show      - Show flake outputs"
+    echo "📦 Occasional tools (NOT in this shell — reach via):"
+    echo "  nix develop .#docs           # mdbook, graphviz, typos, taplo"
+    echo "  nix shell nixpkgs#nix-tree   # dependency visualisation"
+    echo "  nix shell nixpkgs#nix-diff   # closure comparison"
     echo ""
 
-    # Initialize pre-commit if not already done
+    # Initialise pre-commit if the hook isn't installed
     if [ ! -f .git/hooks/pre-commit ]; then
-      echo "🔨 Initializing pre-commit hooks..."
+      echo "🔨 Initialising pre-commit hooks..."
       pre-commit install --install-hooks 2>/dev/null || echo "Pre-commit setup skipped"
-    fi
-
-    # Setup direnv if .envrc doesn't exist
-    if [ ! -f .envrc ] && command -v direnv >/dev/null 2>&1; then
-      echo "use flake" > .envrc
-      echo "📂 Created .envrc for automatic environment loading"
     fi
   '';
 
-  # Environment variables for development
+  # Environment
   NIX_CONFIG = "experimental-features = nix-command flakes";
   NIXPKGS_ALLOW_UNFREE = "1";
   DIRENV_LOG_FORMAT = "";

--- a/tools/docs.nix
+++ b/tools/docs.nix
@@ -37,6 +37,8 @@ pkgs.mkShell {
     # Linting and formatting
     markdownlint-cli # Markdown linting
     vale # Prose linting
+    typos # Spell checking (moved out of the slim default shell)
+    taplo # TOML formatting (moved out of the slim default shell)
   ];
 
   shellHook = ''


### PR DESCRIPTION
## Summary

Direnv's auto-loaded `default` devShell was pulling a **12.3 GiB closure** on every cd into the repo (3.4 GiB fresh download), most of which was transitive bloat. This PR slims it to **1.5 GiB** by keeping only the daily-essentials in `default` and moving occasional tools to `docs` / ad-hoc `nix shell`.

## Why so big?

Beyond the obvious package sizes (nixd 702 MB, pre-commit 327 MB, commitizen 213 MB), the closure was dragging in:

- **Haskell GHC runtime** (~500 MB) — pulled by `nix-tree`
- **Full clang-20.1.8** + LLVM
- **Microsoft .NET ARM64 runtime** — somehow reachable as a transitive (probably a Rust crate's test infra)
- **python3 + libs** — for `commitizen` and `pre-commit`
- 16 different transitive nixpkgs revisions (inputs that don't `follows = "nixpkgs"`)

## What changed

\`tools/dev.nix\` — kept:
- `nixd` (LSP), `nix-output-monitor`
- `nixpkgs-lint-community`, `statix`, `deadnix`, `nixpkgs-fmt`
- `just`, `pre-commit`, `git`, `curl`, `jq`, `direnv`, `nix-direnv`

Moved out:
- `mdbook`, `graphviz` — already in `tools/docs.nix`
- `typos`, `taplo` — added to `tools/docs.nix` (fits the text-tooling theme)
- `nix-tree`, `nix-diff`, `nix-eval-jobs`, `commitizen` — not given a dedicated shell; `nix shell nixpkgs#<name>` ad-hoc is the right ergonomics. The new shellHook documents this.
- `nil` — dropped (redundant with `nixd`)

## Verified

```
$ nix path-info --closure-size --human-readable .#devShells.x86_64-linux.default
…  1.5 GiB
```

Down from 12.3 GiB. \`nix develop .#docs\` still builds clean and now carries the moved-out text/format tools.

## Reaching the moved-out tools

```
nix develop .#docs              # mdbook, graphviz, typos, taplo, …
nix shell nixpkgs#nix-tree      # one-off nix introspection
nix shell nixpkgs#nix-diff
nix shell nixpkgs#nix-eval-jobs
nix shell nixpkgs#commitizen
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)