### PR TITLE
feat(gemini-cli): bump to v0.41.2 + add /update-gemini slash command

### DIFF
--- a/.claude/commands/update-gemini.md
+++ b/.claude/commands/update-gemini.md
@@ -1,0 +1,169 @@
+# Update Gemini CLI
+
+One-shot bump of `home/development/gemini-cli/default.nix` to the latest
+upstream `google-gemini/gemini-cli` release, followed by a verification
+**build + host matrix** (no `switch`, no deploy). Stops short of
+activating the new generation so you can review and deploy on your own
+schedule with `nhs <host>` (or `just quick-deploy <host>`).
+
+## When to use
+
+- You want the latest gemini-cli but the npm release is ahead of the
+  in-tree pin.
+- You launched `gemini` and noticed it's behind upstream's release notes.
+- Nixpkgs is on an older minor and you'd rather not wait for it to
+  catch up (the in-tree derivation is intentionally ahead-of-nixpkgs).
+
+## Prerequisites
+
+- [ ] Working tree clean enough to commit (`git status` — at minimum, no
+      uncommitted edits to `home/development/gemini-cli/default.nix`).
+- [ ] `gh auth status` OK (PR step uses `gh`).
+- [ ] On a host that can build x86_64-linux closures (any of p620, razer,
+      p510).
+
+## Steps
+
+1. **Check current vs npm latest.**
+
+   ```bash
+   echo "current pin:"
+   grep '^\s*version = ' home/development/gemini-cli/default.nix
+   echo "npm latest:"
+   curl -s https://registry.npmjs.org/@google/gemini-cli/latest | jq -r .version
+   ```
+
+   If equal → tell the user, stop. Not an error.
+
+2. **Branch.**
+
+   ```bash
+   git checkout -b chore/gemini-cli-<NEW_VERSION>
+   ```
+
+3. **Fetch new source hash.**
+
+   ```bash
+   nix shell nixpkgs#nix-prefetch-github -c \
+     nix-prefetch-github google-gemini gemini-cli --rev v<NEW_VERSION> --json
+   ```
+
+   Note the returned `hash` and `rev` — you'll paste both.
+
+4. **Edit `home/development/gemini-cli/default.nix` — three lines:**
+
+   ```nix
+   version = "<NEW_VERSION>";
+   ...
+   hash = "<NEW_SRC_HASH>";
+   ...
+   npmDepsHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";   # placeholder
+   ```
+
+   The npmDepsHash placeholder forces step 5 to surface the real hash.
+
+5. **Build once to harvest the npmDepsHash.**
+
+   ```bash
+   nix-build -E 'with import <nixpkgs> {}; callPackage ./home/development/gemini-cli {}' --no-out-link 2>&1 \
+     | grep "got:" | head -1
+   ```
+
+   Copy the `sha256-...` after `got:` and replace the placeholder.
+
+6. **Real build + version sanity.**
+
+   ```bash
+   OUT=$(nix-build -E 'with import <nixpkgs> {}; callPackage ./home/development/gemini-cli {}' --no-out-link 2>&1 | tail -1)
+   "$OUT/bin/gemini" --version            # must equal <NEW_VERSION>
+   file "$OUT/bin/gemini"                 # symlink to gemini.js, fine
+   ```
+
+   If `--version` reports something other than the target → upstream
+   stamped a different version into the build; investigate before
+   continuing.
+
+7. **Host matrix — all three must build.**
+
+   ```bash
+   for h in p620 razer p510; do
+     printf "%-8s " "$h"
+     nix build --no-link --print-out-paths .#nixosConfigurations.$h.config.system.build.toplevel 2>&1 | tail -1
+   done
+   ```
+
+   Any failure → stop. The most common cause is the bundle layout
+   shifting between releases; check the build log for paths under
+   `share/gemini-cli/` that no longer exist.
+
+8. **Commit, push, PR.**
+
+   ```bash
+   NEW_VERSION=<...>
+   git add home/development/gemini-cli/default.nix
+   git commit -m "chore(gemini-cli): bump to v${NEW_VERSION}"
+   git push -u origin chore/gemini-cli-${NEW_VERSION}
+   gh pr create --title "chore(gemini-cli): bump to v${NEW_VERSION}" --fill
+   ```
+
+9. **Tell the user how to deploy.** Do NOT run `nhs` or
+   `nixos-rebuild switch` from this command — deployment is an explicit
+   user decision.
+
+   ```text
+   Bumped gemini-cli to v<NEW_VERSION>. PR: <URL>.
+   To deploy after merge:
+       nhs <host>          # current host or a remote host
+   ```
+
+## Failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `--version` reports old number | upstream tag drift OR our patch corrupted the version write | inspect `packages/cli/package.json` of the source; align our pin with what's actually tagged |
+| `hash mismatch` even with the prefetched hash | upstream re-tagged the same version, or `fetchFromGitHub` is being applied with `--no-deep-clone` | rerun step 3 to refresh the hash |
+| `npm build` fails on TS errors like `TS2578 Unused '@ts-expect-error'` | upstream fixed the underlying error our patch was suppressing | remove the obsolete `substituteInPlace … @ts-expect-error` line from `postPatch` |
+| `noBrokenSymlinks: dangling symlink … docs/CONTRIBUTING.md → /build/...` | upstream's bundle script symlinks docs into the source tree | extend installPhase to `rm -f $out/share/gemini-cli/docs/CONTRIBUTING.md` |
+| `git: not found` early in build phase | `generate-git-commit-info.js` writes to a new path we haven't pre-stubbed | add the new path to `preConfigure`'s file-creation loop |
+| Bundle script renamed | upstream switched `bundle` → some other npm script | update `npmBuildScript = "bundle";` to match upstream's `package.json` scripts |
+
+## Anti-patterns to avoid
+
+- ❌ Do NOT chain a `switch` into this command. The whole reason for
+  build-not-switch is to give the user a checkpoint between "bumped
+  source" and "running it on production".
+- ❌ Do NOT skip the host matrix step. gemini-cli is in the system
+  closure on all three hosts via `home/development/`; a successful
+  per-package build doesn't guarantee the system rebuilds clean.
+- ❌ Do NOT auto-bump nixpkgs `pkgs.gemini-cli` instead of our custom
+  derivation. We're intentionally ahead-of-nixpkgs; the custom
+  derivation under `home/development/gemini-cli/` is the source of
+  truth. (When nixpkgs catches up, that's a separate decision to retire
+  the custom derivation — not the job of this command.)
+- ❌ Do NOT carry forward obsolete `postPatch` substitutions just
+  because the previous version had them. Each line in `postPatch` is
+  there for a specific upstream issue; if the issue is fixed, the
+  patch becomes either a no-op (wasted CPU) or an error
+  (`substituteInPlace --replace-fail` failing).
+
+## Related files
+
+- `home/development/gemini-cli/default.nix` — the derivation this
+  command bumps. Single source of truth.
+- `pkgs/default.nix` — exposes the package to the rest of the repo.
+- `modules/ai/gemini-cli.nix` — Home Manager / NixOS module that wires
+  the binary into a user environment.
+- `modules/ai/providers/gemini.nix` — provider plumbing for the
+  unified AI client (not version-coupled; safe to ignore from this
+  command).
+
+## Why this exists
+
+`pkgs.gemini-cli` from nixpkgs lags upstream by 1–2 minor releases
+because nixpkgs maintainers cycle on a different cadence (and the
+bundle / build-script reshuffles upstream does each minor release tend
+to break their automated updater). The in-tree derivation under
+`home/development/gemini-cli/` is intentionally a thin fork of the
+nixpkgs packaging pattern, pinned ahead of nixpkgs's lag. This command
+keeps that lead intact without forcing the user to remember the
+`nix-prefetch-github` + hash-harvest dance.

--- a/home/development/gemini-cli/default.nix
+++ b/home/development/gemini-cli/default.nix
@@ -14,16 +14,16 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "gemini-cli";
-  version = "0.34.0";
+  version = "0.41.2";
 
   src = fetchFromGitHub {
     owner = "google-gemini";
     repo = "gemini-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/HmcLnScZ2pmzGnRLsNHoqrakyt++1fCv/P2IeE8pGo=";
+    hash = "sha256-4jwEviWYzan97pVn0RWfWU4XS8c27L4ZJUwa2iGlFxY=";
   };
 
-  npmDepsHash = "sha256-3Y9QJC4dqvnCH3qFSsvFMK+XtHnZyYPBP1voLpHpHA4=";
+  npmDepsHash = "sha256-4znN1YR3AX2SKeCJjUS8cm6WGcOGPXI27xrQCotBjgQ=";
 
   nodejs = nodejs_22;
 
@@ -39,56 +39,96 @@ buildNpmPackage (finalAttrs: {
     libsecret
   ];
 
+  # `scripts/generate-git-commit-info.js` is invoked very early by the
+  # `bundle` script and calls `git` — not available in the sandbox. Pre-
+  # generate the file at both locations the script writes to (it moved
+  # between 0.34 and 0.41), so the script becomes a no-op.
   preConfigure = ''
-    mkdir -p packages/generated
-    echo "export const GIT_COMMIT_INFO = { commitHash: '${finalAttrs.src.rev}' };" > packages/generated/git-commit.ts
+    mkdir -p packages/cli/src/generated packages/core/src/generated packages/generated
+    for f in packages/cli/src/generated/git-commit.ts \
+             packages/core/src/generated/git-commit.ts \
+             packages/generated/git-commit.ts; do
+      echo "export const GIT_COMMIT_INFO = { commitHash: '${finalAttrs.src.rev}' };" > "$f"
+    done
   '';
 
   postPatch = ''
-    # Remove node-pty and native optional dependencies from package.json
-    ${jq}/bin/jq 'del(.optionalDependencies."node-pty", .optionalDependencies."@lydell/node-pty", .optionalDependencies."@lydell/node-pty-darwin-arm64", .optionalDependencies."@lydell/node-pty-darwin-x64", .optionalDependencies."@lydell/node-pty-linux-x64", .optionalDependencies."@lydell/node-pty-win32-arm64", .optionalDependencies."@lydell/node-pty-win32-x64", .optionalDependencies."keytar")' package.json > package.json.tmp && mv package.json.tmp package.json
+    # Drop node-pty and friends — they're native modules we can't build,
+    # and gemini-cli already falls back gracefully when they're absent.
+    ${jq}/bin/jq 'del(
+      .optionalDependencies."node-pty",
+      .optionalDependencies."@lydell/node-pty",
+      .optionalDependencies."@lydell/node-pty-darwin-arm64",
+      .optionalDependencies."@lydell/node-pty-darwin-x64",
+      .optionalDependencies."@lydell/node-pty-linux-x64",
+      .optionalDependencies."@lydell/node-pty-win32-arm64",
+      .optionalDependencies."@lydell/node-pty-win32-x64",
+      .optionalDependencies."keytar"
+    )' package.json > package.json.tmp && mv package.json.tmp package.json
 
-    # Remove node-pty and native optional dependencies from packages/core/package.json
-    ${jq}/bin/jq 'del(.optionalDependencies."node-pty", .optionalDependencies."@lydell/node-pty", .optionalDependencies."@lydell/node-pty-darwin-arm64", .optionalDependencies."@lydell/node-pty-darwin-x64", .optionalDependencies."@lydell/node-pty-linux-x64", .optionalDependencies."@lydell/node-pty-win32-arm64", .optionalDependencies."@lydell/node-pty-win32-x64", .optionalDependencies."keytar")' packages/core/package.json > packages/core/package.json.tmp && mv packages/core/package.json.tmp packages/core/package.json
+    ${jq}/bin/jq 'del(
+      .optionalDependencies."node-pty",
+      .optionalDependencies."@lydell/node-pty",
+      .optionalDependencies."@lydell/node-pty-darwin-arm64",
+      .optionalDependencies."@lydell/node-pty-darwin-x64",
+      .optionalDependencies."@lydell/node-pty-linux-x64",
+      .optionalDependencies."@lydell/node-pty-win32-arm64",
+      .optionalDependencies."@lydell/node-pty-win32-x64",
+      .optionalDependencies."keytar"
+    )' packages/core/package.json > packages/core/package.json.tmp && mv packages/core/package.json.tmp packages/core/package.json
 
-    # Fix ripgrep path for SearchText; ensureRgPath() on its own may return the path to a dynamically-linked ripgrep binary without required libraries
+    # Fix ripgrep path for SearchText; ensureRgPath() on its own may return
+    # a dynamically-linked binary without the required libraries.
     substituteInPlace packages/core/src/tools/ripGrep.ts \
       --replace-fail "await ensureRgPath();" "'${lib.getExe ripgrep}';"
 
-    # Disable auto-update and update notifications by changing defaults in settingsSchema
-    # (API changed in 0.26.0 from disableAutoUpdate to enableAutoUpdate)
-    sed -i '/enableAutoUpdate: {/,/default: true/ s/default: true/default: false/' packages/cli/src/config/settingsSchema.ts
-    sed -i '/enableAutoUpdateNotification: {/,/default: true/ s/default: true/default: false/' packages/cli/src/config/settingsSchema.ts
+    # Disable auto-update and notifications (we deliver new versions via
+    # the /update-gemini slash command, not in-process self-updates).
+    sed -i '/enableAutoUpdate:/,/default: true/ s/default: true/default: false/' \
+      packages/cli/src/config/settingsSchema.ts
+    sed -i '/enableAutoUpdateNotification:/,/default: true/ s/default: true/default: false/' \
+      packages/cli/src/config/settingsSchema.ts
 
-    # Fix: devtools package builds after cli in workspace order, causing TS2307.
-    # Add @ts-expect-error to suppress the type error on the dynamic import.
-    sed -i "s|const mod = await import('@google/gemini-cli-devtools');|// @ts-expect-error devtools is an optional peer workspace\n    const mod = await import('@google/gemini-cli-devtools');|" packages/cli/src/utils/devtoolsService.ts
+    # Belt-and-braces — also pin the runtime checks to false so even if
+    # someone's existing settings.json has the keys set true, no update
+    # action fires.
+    substituteInPlace packages/cli/src/utils/handleAutoUpdate.ts \
+      --replace-fail "if (!settings.merged.general.enableAutoUpdateNotification) {" "if (false) {" \
+      --replace-fail "settings.merged.general.enableAutoUpdate," "false," \
+      --replace-fail "!settings.merged.general.enableAutoUpdate" "!false"
   '';
+
+  # Use upstream's `bundle` script — it produces a single esbuild output
+  # rather than building each workspace package, which avoids the
+  # devtools / workspace-order TS errors that hit us on 0.34→0.41.
+  npmBuildScript = "bundle";
+
+  # Keep python (a transitive of npm) out of the closure.
+  disallowedReferences = [
+    finalAttrs.npmDeps
+    finalAttrs.nodejs.python
+  ];
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/{bin,share/gemini-cli}
 
+    mkdir -p $out/{bin,share}
+    cp -r bundle $out/share/gemini-cli
+
+    # bundle/docs/CONTRIBUTING.md is a symlink into /build/source/ and
+    # trips the noBrokenSymlinks postFixup check. Drop it — docs aren't
+    # runtime-relevant.
+    rm -f $out/share/gemini-cli/docs/CONTRIBUTING.md
+
+    # Reduce closure: drop devDependencies + non-optional bundled deps.
+    # Only optionalDependencies (the platform-specific native bits we
+    # didn't already strip in postPatch) remain on disk.
+    ${jq}/bin/jq '.dependencies = {} | del(.devDependencies) | del(.workspaces)' \
+      package.json > package.json.tmp && mv package.json.tmp package.json
     npm prune --omit=dev
-    rm node_modules/shell-quote/print.py # remove python demo to prevent python from getting into the closure
-    cp -r node_modules $out/share/gemini-cli/
+    rm -rf node_modules/.bin
 
-    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli
-    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli-core
-    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli-a2a-server
-    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli-sdk
-    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli-devtools
-    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli-test-utils
-    rm -f $out/share/gemini-cli/node_modules/gemini-cli-vscode-ide-companion
-    cp -r packages/cli $out/share/gemini-cli/node_modules/@google/gemini-cli
-    cp -r packages/core $out/share/gemini-cli/node_modules/@google/gemini-cli-core
-    cp -r packages/a2a-server $out/share/gemini-cli/node_modules/@google/gemini-cli-a2a-server
-    cp -r packages/devtools $out/share/gemini-cli/node_modules/@google/gemini-cli-devtools
-    cp -r packages/sdk $out/share/gemini-cli/node_modules/@google/gemini-cli-sdk
-
-    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli-core/dist/docs/CONTRIBUTING.md
-
-    ln -s $out/share/gemini-cli/node_modules/@google/gemini-cli/dist/index.js $out/bin/gemini
+    ln -s $out/share/gemini-cli/gemini.js $out/bin/gemini
     chmod +x "$out/bin/gemini"
 
     runHook postInstall


### PR DESCRIPTION
## Summary

Two related changes shipped together:

1. **gemini-cli 0.34.0 → 0.41.2** (npm `@google/gemini-cli` latest). The 0.34→0.41 jump restructured upstream's build pipeline, so the derivation under `home/development/gemini-cli/default.nix` was rewritten to match nixpkgs's 0.40.1 bundle-based pattern (`npmBuildScript = "bundle"`, esbuild output under `share/gemini-cli/`, single binary symlink).
2. **New `/update-gemini` slash command** at `.claude/commands/update-gemini.md` capturing the bump procedure end-to-end so future bumps don't require re-deriving the hash-harvest dance.

## Why a custom derivation at all?

Nixpkgs is on `0.40.1` (1 minor behind npm latest). The in-tree derivation under `home/development/gemini-cli/` is intentionally a thin fork of the nixpkgs packaging pattern, pinned ahead of nixpkgs's lag. The bump cadence is on the user, not on nixpkgs maintainers.

## Patches updated for 0.41.2

| Change | Why |
|---|---|
| `preConfigure` now stubs `git-commit.ts` at **three paths** | Upstream's `generate-git-commit-info.js` moved the output location between 0.34 and 0.41; pre-stubbing all known paths makes the script a no-op regardless |
| Dropped `@ts-expect-error` postPatch | Upstream fixed the underlying TS error in 0.41; the directive is now flagged `TS2578 Unused` |
| Added `handleAutoUpdate.ts` substitution | Belt-and-braces — forces auto-update OFF at runtime even when a user's existing `settings.json` has the keys set true |
| Added `rm -f docs/CONTRIBUTING.md` in installPhase | Upstream's bundle symlinks docs into `/build/source/`; trips `noBrokenSymlinks` postFixup |
| Added `disallowedReferences` for `npmDeps` + `nodejs.python` | Keeps python out of the closure |
| Switched to `npmBuildScript = "bundle"` | Avoids the workspace-order TS errors that hit the default `build` script |

## Test plan

- [x] `nix-build … callPackage` succeeds: `/nix/store/wqajapmm1jfxdl8kqcd6yicjjhsb7jy8-gemini-cli-0.41.2`
- [x] `gemini --version` → `0.41.2`
- [x] Host matrix builds clean (all three):
  ```
  p620   /nix/store/gslpjh54ljgfybw3aqbkzy5jyyxsnqp5-nixos-system-p620-...
  razer  /nix/store/mynp8hqr2shjaf9bf6cw9pwrgh3an62a-nixos-system-razer-...
  p510   /nix/store/f6hzv8km4p16kyyx8gfcnspbm145wzdb-nixos-system-p510-...
  ```
- [x] `/update-gemini` slash command appears in Claude Code's skill list after `.claude/commands/update-gemini.md` lands

## What you get going forward

Type `/update-gemini` to re-run the bump procedure. The command:

- Checks current pin vs npm latest, early-exits if equal
- Prefetches the new source hash
- Edits `default.nix` (version + src hash + placeholder npmDepsHash)
- Builds once to harvest the real `npmDepsHash` from the hash-mismatch error
- Real build + `gemini --version` sanity check
- Host matrix (p620 / razer / p510)
- Commit + PR (does NOT auto-deploy — leaves that to you)
- Documents the 6 most common failure modes with concrete fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)