### PR TITLE
chore(claude-code): bump native binary 2.1.138 → 2.1.139

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.138";
+  version = "2.1.139";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-w8Vv+8Es8W5AwzaHyf5jYe0lDDWp4XGNDDjUkEn1+MM=";
+      hash = "sha256-wYAKCuUbWkx7M75qMtYrYWnZP2F0EZsu62iWzwzV1+Y=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-aT7MpBpi1Y/uZgiEvZgspc3qtbJ3kl/N/ogM3wL5hnE=";
+      hash = "sha256-OYWq91s7/x2NAxtybIBOQVLhUwJhaDzc4U6VTwryyRI=";
     };
   };
 


### PR DESCRIPTION
## Summary

Bumps `claude-code-native` from `2.1.138` → `2.1.139` (Anthropic GCS `latest` channel). Three lines changed in `pkgs/claude-code-native/default.nix` — version + two SRI hashes, no derivation logic edits.

Closes #499

## Test plan

- [x] `scripts/update-claude-code-native.sh latest` reported `latest = 2.1.139` and emitted matching SRI hashes
- [x] `nix build .#claude-code-native` succeeds → `/nix/store/mfpm13805lf5c4rcanspdrngnapgrcf4-claude-code-native-2.1.139`
- [x] `$OUT/bin/claude --version` → `2.1.139 (Claude Code)`
- [x] `ldd $OUT/bin/claude` shows no missing libs
- [x] Host matrix builds clean (all three system closures):
  ```
  p620   /nix/store/pafpmzd39hy1n7crvc69lcmm6yx2d24i-nixos-system-p620-...
  razer  /nix/store/ji7hhxmh1h74azqids4d8lhqsavy7vrp-nixos-system-razer-...
  p510   /nix/store/f6hzv8km4p16kyyx8gfcnspbm145wzdb-nixos-system-p510-...
  ```

## Notes

- `--no-verify` used at commit time per the established statix-pre-commit-hook workaround documented in the `/update-claude-code` skill
- claude-desktop (separate flake input) intentionally **not** touched — different release cadence and risk surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)