### PR TITLE
chore(warp-terminal): bump to v0.2026.05.06.15.42.stable_04

### DIFF
--- a/pkgs/warp-terminal/versions.json
+++ b/pkgs/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "linux_x86_64": {
-    "hash": "sha256-zTB39kN/uKbzSN6Yz7/wIJ2Mw5gnga2usfYmKUPSMU0=",
-    "version": "0.2026.05.06.15.42.stable_03"
+    "hash": "sha256-zBX930Ha9ixC4TFRjQIuyTfQNsGe01hGz0jaA2GFaPs=",
+    "version": "0.2026.05.06.15.42.stable_04"
   },
   "linux_aarch64": {
-    "hash": "sha256-eQxwtkiFZFsrsjjEoF0wryrPIUsvghYurR/i06vCzuk=",
-    "version": "0.2026.05.06.15.42.stable_03"
+    "hash": "sha256-ZtcUfPV3Dbfxsxnu+QhiQpfJB1T50ciVVyKMOh4DHPU=",
+    "version": "0.2026.05.06.15.42.stable_04"
   }
 }


### PR DESCRIPTION
## Summary

Patch bump of `pkgs/warp-terminal/versions.json` from `stable_03` to `stable_04` on the same upstream build date (2026-05-06). Per-arch hashes prefetched via `./scripts/update-warp-terminal.sh`. Only `version` + `hash` for both arches change — no derivation logic edits.

## Test plan

- [x] `./scripts/update-warp-terminal.sh --check` reported newer release available
- [x] `nix build .#nixosConfigurations.p620.pkgs.warp-terminal` succeeds → `/nix/store/f5bqgd92gjphc6q5529j6659cjzajl74-warp-terminal-0.2026.05.06.15.42.stable_04`
- [x] `nix build .#nixosConfigurations.p620.config.system.build.toplevel` succeeds (overlay-interaction check)
- [x] Built binary at `opt/warpdotdev/warp-terminal/warp` is ELF
- [x] `nix eval --raw .#nixosConfigurations.p620.pkgs.warp-terminal.version` returns `0.2026.05.06.15.42.stable_04`

🤖 Generated with [Claude Code](https://claude.com/claude-code)