### PR TITLE
fix(workflows): unbreak claude-{code,desktop}-watch YAML + ci.yml nix evals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,18 +27,29 @@ jobs:
             experimental-features = nix-command flakes
             accept-flake-config = true
 
+      # --no-write-lock-file: a transitive flake (nix-openclaw-tools's
+      # `tools/gogcli` sub-flake) has an unlocked `root.url = "../.."`
+      # path input. Nix 2.20+ refuses to update the lock for such inputs,
+      # so any flake-eval that tries to lock it dies with `lock file
+      # contains unlocked input '{"path":"../..","type":"path"}'`. Local
+      # builds avoid this because the eval cache is already populated;
+      # CI starts fresh and hits it on every run. Telling Nix not to
+      # write the lock skips that attempt and uses our already-resolved
+      # state from flake.lock.
       - name: Check flake
-        run: nix flake check --show-trace
+        run: nix flake check --show-trace --no-write-lock-file
 
       - name: Validate ${{ matrix.host }} configuration
         run: |
           echo "Validating ${{ matrix.host }} configuration (no build)..."
-          nix eval .#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel.outPath --show-trace
+          nix eval --no-write-lock-file --show-trace \
+            .#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel.outPath
           echo "✓ ${{ matrix.host }} configuration is valid"
 
       - name: Validate Home Manager configurations
         run: |
-          if nix eval .#homeConfigurations.olafkfreund@${{ matrix.host }}.activationPackage 2>/dev/null; then
+          if nix eval --no-write-lock-file \
+              .#homeConfigurations.olafkfreund@${{ matrix.host }}.activationPackage 2>/dev/null; then
             echo "✓ Home Manager configuration for olafkfreund@${{ matrix.host }} is valid"
           else
             echo "WARNING: No Home Manager configuration for olafkfreund@${{ matrix.host }}"
@@ -61,11 +72,16 @@ jobs:
         run: |
           if [ -f "secrets.nix" ]; then
             echo "Validating secrets configuration..."
-            if nix eval .#nixosConfigurations.p620.config.age.secrets --json > /dev/null 2>&1; then
+            # --no-write-lock-file: same reason as the check-configurations
+            # job — avoid the unlocked-path-input failure in transitive
+            # flake locks (nix-openclaw-tools/tools/gogcli's root path).
+            if nix eval --no-write-lock-file \
+                .#nixosConfigurations.p620.config.age.secrets --json > /dev/null 2>&1; then
               echo "PASS: Secrets configuration is valid"
             else
               echo "FAIL: Secrets configuration has errors"
-              nix eval .#nixosConfigurations.p620.config.age.secrets --json
+              nix eval --no-write-lock-file \
+                .#nixosConfigurations.p620.config.age.secrets --json
               exit 1
             fi
           else

--- a/.github/workflows/claude-code-watch.yml
+++ b/.github/workflows/claude-code-watch.yml
@@ -89,24 +89,38 @@ jobs:
           build_date=$(curl -fsSL --max-time 10 "$GCS/$UPSTREAM/manifest.json" 2>/dev/null \
             | jq -r '.buildDate // "(unknown)"' 2>/dev/null || echo "(unknown)")
 
+          # Build the issue body in a heredoc so the markdown bullet
+          # points (- foo) live inside the shell heredoc instead of at
+          # YAML column 0, which would break out of the `run: |` block
+          # scalar (caused a 'expected <block end>, but found ''-''
+          # YAML parse error on every run).
+          body=$(cat <<EOF
+          Anthropic has published **claude-code $UPSTREAM** on the \`latest\` channel.
+
+          - Currently pinned: **$PINNED**
+          - Upstream latest:  **$UPSTREAM**
+          - Upstream build date: $build_date
+
+          Links:
+          - Manifest: ${GCS}/${UPSTREAM}/manifest.json
+          - Release notes (if any): https://github.com/anthropics/claude-code/releases/tag/v$UPSTREAM
+          - npm page: https://www.npmjs.com/package/@anthropic-ai/claude-code/v/$UPSTREAM
+
+          ## To act on this
+
+          Run \`/update-claude-code $UPSTREAM\` in Claude Code. The slash command
+          will fetch hashes, edit \`pkgs/claude-code-native/default.nix\`, build,
+          test, and open the PR.
+
+          This issue will auto-close when that PR merges.
+          EOF
+          )
+          # Strip the leading 10 spaces YAML required for the heredoc body
+          # so the rendered GitHub issue renders bullet points at column 0
+          # rather than as a code block.
+          body=$(printf '%s\n' "$body" | sed 's/^          //')
+
           gh issue create \
             --label claude-code-update \
             --title "chore(claude-code): update to $UPSTREAM" \
-            --body "Anthropic has published **claude-code $UPSTREAM** on the \`latest\` channel.
-
-- Currently pinned: **$PINNED**
-- Upstream latest:  **$UPSTREAM**
-- Upstream build date: $build_date
-
-Links:
-- Manifest: ${GCS}/${UPSTREAM}/manifest.json
-- Release notes (if any): https://github.com/anthropics/claude-code/releases/tag/v$UPSTREAM
-- npm page: https://www.npmjs.com/package/@anthropic-ai/claude-code/v/$UPSTREAM
-
-## To act on this
-
-Run \`/update-claude-code $UPSTREAM\` in Claude Code. The slash command
-will fetch hashes, edit \`pkgs/claude-code-native/default.nix\`, build,
-test, and open the PR.
-
-This issue will auto-close when that PR merges."
+            --body "$body"

--- a/.github/workflows/claude-desktop-watch.yml
+++ b/.github/workflows/claude-desktop-watch.yml
@@ -118,29 +118,42 @@ jobs:
           NOTES:         ${{ steps.notes.outputs.body }}
         run: |
           set -euo pipefail
+          # Build the issue body in a heredoc so the markdown bullets
+          # (- foo) live inside the shell heredoc instead of at YAML
+          # column 0, which would break out of the `run: |` block
+          # scalar (caused a 'expected <block end>, but found ''-''
+          # YAML parse error on every run).
+          body=$(cat <<EOF
+          Upstream \`aaddrick/claude-desktop-debian\` has a new release: **$TAG**.
+
+          - Currently pinned commit: \`${PINNED_COMMIT:0:10}\` (locked $PINNED_DATE)
+          - Latest release commit:   \`${LATEST_COMMIT:0:10}\` (tag \`$TAG\`)
+
+          ### Release notes
+
+          $NOTES
+
+          ### Links
+
+          - Release: https://github.com/aaddrick/claude-desktop-debian/releases/tag/$TAG
+          - Compare: https://github.com/aaddrick/claude-desktop-debian/compare/${PINNED_COMMIT}...${LATEST_COMMIT}
+          - Open issues (regression watch): https://github.com/aaddrick/claude-desktop-debian/issues?q=is%3Aissue+is%3Aopen+label%3Abug
+
+          ### To act on this
+
+          Run \`/update-claude-code\` in Claude Code and follow the **B. Update
+          claude-desktop** section. **Read the release notes first** — upstream
+          occasionally ships regressions (e.g. v1.3.31 broke Cowork daemon recovery)
+          and our overlay may need a patch rev.
+
+          This issue will auto-close when that PR merges.
+          EOF
+          )
+          # Strip the YAML-required leading 10 spaces so bullet points
+          # render at column 0 in the GitHub issue body.
+          body=$(printf '%s\n' "$body" | sed 's/^          //')
+
           gh issue create \
             --label claude-desktop-update \
             --title "chore(claude-desktop): update to $TAG" \
-            --body "Upstream \`aaddrick/claude-desktop-debian\` has a new release: **$TAG**.
-
-- Currently pinned commit: \`${PINNED_COMMIT:0:10}\` (locked $PINNED_DATE)
-- Latest release commit:   \`${LATEST_COMMIT:0:10}\` (tag \`$TAG\`)
-
-### Release notes
-
-$NOTES
-
-### Links
-
-- Release: https://github.com/aaddrick/claude-desktop-debian/releases/tag/$TAG
-- Compare: https://github.com/aaddrick/claude-desktop-debian/compare/${PINNED_COMMIT}...${LATEST_COMMIT}
-- Open issues (regression watch): https://github.com/aaddrick/claude-desktop-debian/issues?q=is%3Aissue+is%3Aopen+label%3Abug
-
-### To act on this
-
-Run \`/update-claude-code\` in Claude Code and follow the **B. Update
-claude-desktop** section. **Read the release notes first** — upstream
-occasionally ships regressions (e.g. v1.3.31 broke Cowork daemon recovery)
-and our overlay may need a patch rev.
-
-This issue will auto-close when that PR merges."
+            --body "$body"


### PR DESCRIPTION
## Summary

Three CI workflows have been red on every push since 2026-05-11 for three distinct reasons. Fixed in one PR because the diagnostic loop was shared.

| Workflow | Root cause | Fix |
|---|---|---|
| `claude-code-watch.yml` | YAML parse error at line 97: multi-line `--body "…"` arg has markdown bullets (`- Currently pinned:` etc.) at YAML column 0, breaking out of the `run: \|` block scalar. Python yaml: `expected <block end>, but found '-'`. | Move body into a shell heredoc indented to match the script block; `sed`-strip the leading whitespace before passing to `gh`. |
| `claude-desktop-watch.yml` | Same pattern, line 126. | Same fix. |
| `ci.yml` `check-configurations` | `nix flake check` / `nix eval` died with `lock file contains unlocked input '{"path":"../..","type":"path"}'` while resolving `nix-openclaw-tools/tools/gogcli/flake.nix` (which has `root.url = "../.."`). Local builds work because the eval cache is warm; CI starts fresh and Nix 2.20+ refuses to update a sub-flake lock containing unlocked path inputs. | Add `--no-write-lock-file` to `nix flake check` and every `nix eval` in the affected jobs. Tells Nix to use our resolved state from `flake.lock` and skip the sub-flake lock-update that was failing. |

## Verification

- [x] `python3 -c "import yaml; yaml.safe_load(open('<f>'))"` → OK for all three workflow files
- [x] `actionlint` clean for the parse layer (only a pre-existing SC2129 style warning remains, unrelated)
- [ ] CI must go green on this PR (will know in ~1-2 minutes after open)

## Why three at once

The watcher fixes are pure YAML / shell — independent of the nix CI fix. But all three failed identically on every push and surfaced together in `/check-nixos-issues`, so the natural cleanup is one focused PR. They could be split if you'd rather have a smaller blast radius — say the word and I'll restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)