### PR TITLE
feat(gnome): install aurora-shell v49.2 with 10 modules enabled

### DIFF
--- a/home/desktop/gnome/extensions.nix
+++ b/home/desktop/gnome/extensions.nix
@@ -35,6 +35,7 @@ in
           "tailscale-status@maxgallup.github.com"
           "Bluetooth-Battery-Meter@maniacx.github.com"
           "dim-background-windows@stephane-13.github.com"
+          "aurora-shell@luminusos.github.io"
         ];
       };
 
@@ -129,6 +130,25 @@ in
         strip-text = false;
         topbar-preview-size = 10;
       };
+
+      # Aurora Shell — 10 quality-of-life modules bundled behind one
+      # extension UUID (aurora-shell@luminusos.github.io). All modules
+      # ON except `module-dock`, which would conflict with `dash-to-dock`
+      # configured above. Re-enable module-dock only if you also disable
+      # dash-to-dock in this same file.
+      "org/gnome/shell/extensions/aurora-shell" = {
+        module-no-overview = true;
+        module-pip-on-top = true;
+        module-theme-changer = true;
+        module-dock = false;
+        module-volume-mixer = true;
+        module-xwayland-indicator = true;
+        module-privacy = true;
+        privacy-dnd-on-share = true;
+        module-icon-weave = true;
+        module-app-search-tooltip = true;
+        module-auto-theme-switcher = true;
+      };
     };
 
     # Note: Custom keybindings are defined in keybindings.nix to avoid conflicts
@@ -154,6 +174,7 @@ in
         gnomeExtensions.tailscale-status
         gnomeExtensions.bluetooth-battery-meter
         gnomeExtensions.dim-background-windows
+        aurora-shell
 
         # Helpers used by various extensions at runtime.
         lm_sensors

--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -5,4 +5,5 @@ final: _prev: {
   claude-code-native = final.callPackage ../pkgs/claude-code-native { };
   warp-terminal = final.callPackage ../pkgs/warp-terminal { };
   gemini-cli = final.callPackage ../home/development/gemini-cli { };
+  aurora-shell = final.callPackage ../pkgs/aurora-shell { };
 }

--- a/pkgs/aurora-shell/default.nix
+++ b/pkgs/aurora-shell/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, unzip
+, glib
+,
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "aurora-shell";
+  version = "49.2";
+
+  uuid = "aurora-shell@luminusos.github.io";
+
+  src = fetchurl {
+    url = "https://github.com/luminusOS/aurora-shell/releases/download/v${version}/${uuid}.zip";
+    # `name =` is required because the upstream filename contains '@',
+    # which nix-prefetch-url and fetchurl reject by default.
+    name = "${pname}-${version}.zip";
+    hash = "sha256-GhknsZ6weF9EKNzKTluXdo6Gfxa/4By4GYYlyrpRPtU=";
+  };
+
+  nativeBuildInputs = [
+    unzip
+    glib
+  ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -d "$out/share/gnome-shell/extensions/${uuid}"
+    unzip -q "$src" -d "$out/share/gnome-shell/extensions/${uuid}"
+
+    # Compile gschemas so GNOME's settings daemon can read the
+    # module-toggle keys (`org.gnome.shell.extensions.aurora-shell`).
+    if [ -d "$out/share/gnome-shell/extensions/${uuid}/schemas" ]; then
+      glib-compile-schemas "$out/share/gnome-shell/extensions/${uuid}/schemas"
+    fi
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Modular GNOME Shell extension with quality-of-life features (no-overview, pip-on-top, theme-changer, volume-mixer, …)";
+    homepage = "https://github.com/luminusOS/aurora-shell";
+    license = licenses.lgpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
## Summary

Adds [aurora-shell](https://github.com/luminusOS/aurora-shell) — a modular GNOME Shell extension that bundles 10 quality-of-life features as toggleable modules behind one extension UUID (`aurora-shell@luminusos.github.io`). LGPL-3.0-or-later.

Tracks **v49.2** (`shell-version: ["45","46","47","48","49"]`) — compatible with our current GNOME Shell 49.4. v50 of the extension is GNOME-50-only and would refuse to load; bump is a follow-up once nixos-unstable ships GNOME 50.

Not in nixpkgs; not in NUR. Upstream ships a prebuilt `.shell-extension.zip` as a Release asset, so we package via `stdenvNoCC.mkDerivation` + `fetchurl` + `unzip` (no Yarn/Node/`just` pipeline needed). Same shape as `pkgs/neuwaita-icon-theme/`.

## Modules

| Module | Enabled by default | Rationale |
|---|---|---|
| `module-no-overview` | ✓ | Don't show Activities on login |
| `module-pip-on-top` | ✓ | Picture-in-picture always-on-top |
| `module-theme-changer` | ✓ | UI for theme switching |
| **`module-dock`** | **✗** | **conflicts with `dash-to-dock` configured in the same file** |
| `module-volume-mixer` | ✓ | Per-app volume |
| `module-xwayland-indicator` | ✓ | Show Xwayland status |
| `module-privacy` (with `privacy-dnd-on-share`) | ✓ | DND during screen share |
| `module-icon-weave` | ✓ | Icon styling |
| `module-app-search-tooltip` | ✓ | Tooltips in app search |
| `module-auto-theme-switcher` | ✓ | Auto light/dark switch |

## Files

- **New**: `pkgs/aurora-shell/default.nix` — derivation. Pre-built zip → unzip into `share/gnome-shell/extensions/<UUID>/` → `glib-compile-schemas`.
- **Modified**: `overlays/custom-packages.nix` — one-line `callPackage` wiring.
- **Modified**: `home/desktop/gnome/extensions.nix` — three additions: UUID into `enabled-extensions`, dconf module-toggles block, `aurora-shell` in `home.packages`.

## Test plan

- [x] `nix-build -E '… callPackage ./pkgs/aurora-shell {}'` succeeds → `/nix/store/gds5ly132jy7rgjbh0liyzyi2hgp0wb5-aurora-shell-49.2`
- [x] `metadata.json` confirms `shell-version: ["45","46","47","48","49"]`
- [x] `schemas/gschemas.compiled` present after build (glib-compile-schemas ran)
- [x] Host matrix: p620 ✓ / razer ✓ / p510 ✓ (p510's closure hash unchanged; profile doesn't pull in the GNOME extension home module, expected)
- [ ] Post-deploy: `gnome-extensions list --enabled | grep aurora-shell` shows the UUID
- [ ] Post-deploy: `gsettings get org.gnome.shell.extensions.aurora-shell module-dock` returns `false`

## Deploy + activate

After merge:

```bash
just quick-deploy p620
# then log out + log in (Wayland) OR `pkill -SIGUSR2 gnome-shell` (Xorg)
gnome-extensions list --enabled | grep aurora-shell
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)