### PR TITLE
chore(stylix): switch base16 scheme to plain gruvbox-dark

### DIFF
--- a/hosts/common/shared-variables.nix
+++ b/hosts/common/shared-variables.nix
@@ -43,7 +43,7 @@
   # `host.theme.wallpaper` in modules/desktop/stylix-theme.nix as an
   # override that defaults to baseTheme.wallpaper.
   baseTheme = {
-    scheme = "gruvbox-dark-medium";
+    scheme = "gruvbox-dark";
     wallpaper = ../../assets/wallpapers/orange-desert.jpg;
     cursor = {
       name = "Bibata-Modern-Classic";


### PR DESCRIPTION
One-line change in `hosts/common/shared-variables.nix`: `baseTheme.scheme = "gruvbox-dark-medium"` → `"gruvbox-dark"`.

Both schemes ship in `pkgs.base16-schemes`; differ only in palette tuning. All Stylix-managed targets regenerate from this single switch — GTK theme, GNOME Terminal palette (via `config.lib.stylix.colors.baseNN` in `home/desktop/gnome/theme.nix`), wezterm/kitty/ghostty colour schemes, etc.

## Test plan

- [x] Host matrix builds clean (closure hashes shifted for all three, confirming palette regeneration):
  ```
  p620   iz6dr9w4rq3vnasbrd4jsa9sbmaibypk
  razer  1a7nncyhqdp4m759h43m1cvnjg5dkdwq
  p510   8q2mdcvgimgp9whyfydcvqk6hn4f1xyv
  ```
- [ ] Post-deploy on p620: GTK theme + terminal palette reflect plain gruvbox-dark colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)