### PR TITLE
feat(gnome): snapshot p620 desktop config and replicate on razer

### DIFF
--- a/home/desktop/gnome/apps.nix
+++ b/home/desktop/gnome/apps.nix
@@ -96,6 +96,19 @@ in
 
     # GNOME applications configuration via dconf
     dconf.settings = {
+      # Dock favorites — snapshot of p620's live state (2026-05). Both razer
+      # and p620 have these .desktop files in their HM closure (Warp is
+      # included for both via the terminals module chain). If a future host
+      # drops Warp, replace dev.warp.Warp.desktop here or override per-host.
+      "org/gnome/shell" = {
+        favorite-apps = [
+          "org.gnome.Nautilus.desktop"
+          "google-chrome.desktop"
+          "org.gnome.Settings.desktop"
+          "dev.warp.Warp.desktop"
+        ];
+      };
+
       # Nautilus (File Manager) configuration
       "org/gnome/nautilus/preferences" = {
         default-folder-viewer = "list-view";

--- a/home/desktop/gnome/default.nix
+++ b/home/desktop/gnome/default.nix
@@ -130,15 +130,10 @@ in
         experimental-features = [ "variable-refresh-rate" ];
       };
 
-      "org/gnome/shell" = {
-        favorite-apps = [
-          "org.gnome.Nautilus.desktop"
-          "google-chrome.desktop"
-          "org.gnome.Terminal.desktop"
-          "code.desktop"
-          "org.gnome.Settings.desktop"
-        ];
-      };
+      # Note: org/gnome/shell.favorite-apps is declared once in apps.nix
+      # (snapshot of p620 live state). Don't re-declare here — HM merges
+      # rather than replaces dconf array values, which produces a dock
+      # with duplicate entries.
 
       # Privacy settings
       "org/gnome/desktop/privacy" = {

--- a/home/desktop/gnome/extensions.nix
+++ b/home/desktop/gnome/extensions.nix
@@ -9,44 +9,42 @@ let
 in
 {
   config = mkIf (cfg.enable && cfg.extensions.enable) {
-    # GNOME Shell extensions configuration via dconf
+    # GNOME Shell extensions configuration via dconf.
+    #
+    # Snapshot policy: the enabled-extensions list captures the exact set of
+    # extensions ACTIVE on p620 today (2026-05). Anything that was declared
+    # but in state INITIALIZED/INACTIVE was dropped — see git log for the
+    # cull. aurora-shell is included here without a matching nix package
+    # because the binary lives in ~/.local/share/gnome-shell/extensions/
+    # from a manual install; including the UUID prevents this dconf block
+    # from stripping it on activation. razer doesn't have the binary, so
+    # GNOME will silently skip aurora-shell there.
     dconf.settings = {
-      # Enable installed extensions
       "org/gnome/shell" = {
         disable-user-extensions = false;
-        # UUIDs verified against gnomeExtensions.<name>.passthru.extensionUuid.
-        # Each UUID must have a matching package in home.packages below or in
-        # cfg.extensions.packages (per-profile). Adding a UUID without its
-        # package makes gnome-shell silently skip it on session start.
+        # UUIDs verified against gnomeExtensions.<name>.passthru.extensionUuid
+        # (for nixpkgs entries) or against metadata.json of the manual zips
+        # we re-package in pkgs/gnome-ext-*. Each UUID must have either a
+        # matching package in home.packages below, or be an explicit
+        # user-managed drift entry (aurora-shell — see policy comment above).
         enabled-extensions = [
           "user-theme@gnome-shell-extensions.gcampax.github.com"
           "dash-to-dock@micxgx.gmail.com"
           "appindicatorsupport@rgcjonas.gmail.com"
-          "auto-accent-colour@Wartybix"
-          "auto-move-windows@gnome-shell-extensions.gcampax.github.com"
-          "BringOutSubmenuOfPowerOffLogoutButton@pratap.fastmail.fm"
-          "blur-my-shell@aunetx"
-          "top-panel-logo@jmpegi.github.com"
-          "workspace-indicator@gnome-shell-extensions.gcampax.github.com"
-          "emoji-copy@felipeftn"
-          "windowsNavigator@gnome-shell-extensions.gcampax.github.com"
           "caffeine@patapon.info"
-          "clipboard-indicator@tudmotu.com"
           "tailscale-status@maxgallup.github.com"
           "Bluetooth-Battery-Meter@maniacx.github.com"
           "dim-background-windows@stephane-13.github.com"
+          "allowlockedremotedesktop@kamens.us"
+          "claude-code-usage@haletran.com"
+          "otp-keys@osmank3.net"
+          "rudra@narkagni"
+          "spotify-controller@narkagni"
+          "accent-directories@taiwbi.com"
+          # User-managed drift — see policy comment above.
+          "aurora-shell@luminusos.github.io"
         ];
       };
-
-      # User Themes extension configuration
-      # Note: Disabled until Gruvbox Shell theme is properly installed
-      # "org/gnome/shell/extensions/user-theme" = {
-      #   name = mkDefault (
-      #     if cfg.theme.enable
-      #     then "Gruvbox-Dark-BL"
-      #     else "Adwaita"
-      #   );
-      # };
 
       # Dash to Dock configuration
       "org/gnome/shell/extensions/dash-to-dock" = {
@@ -79,21 +77,6 @@ in
         tray-pos = "right";
       };
 
-      # Blur My Shell configuration
-      "org/gnome/shell/extensions/blur-my-shell" = {
-        brightness = 0.75;
-        dash-opacity = 0.25;
-        sigma = 30;
-        static-blur = true;
-      };
-
-      # Accent-gtk-theme configuration
-      "org/gnome/shell/extensions/accent-gtk-theme" = {
-        blue-theme-light = "Gruvbox";
-        set-link-gtk4 = true;
-        set-theme-path = "home/olafkfreund/.local/share/themes";
-      };
-
       # Caffeine configuration
       "org/gnome/shell/extensions/caffeine" = {
         enable-fullscreen = true;
@@ -102,32 +85,11 @@ in
         show-notification = false;
       };
 
-      # Auto Accent Colour configuration
-      "org/gnome/shell/extensions/auto-accent-colour" = {
-        hide-indicator = false;
-        highlight-mode = true;
-      };
-
       # Dim Background Windows configuration
       "org/gnome/shell/extensions/dim-background-windows" = {
         dim-background = true;
         dimming-enabled = true;
         toogle-shortcut = "<Super>g";
-      };
-
-      # Clipboard Indicator configuration
-      "org/gnome/shell/extensions/clipboard-indicator" = {
-        cache-size = 50;
-        clear-history = [ ];
-        confirm-clear = false;
-        display-mode = 0;
-        enable-keybindings = true;
-        history-size = 30;
-        move-item-first = true;
-        notify-on-copy = false;
-        preview-size = 30;
-        strip-text = false;
-        topbar-preview-size = 10;
       };
     };
 
@@ -138,22 +100,23 @@ in
     # Users/<user>/profile.nix).
     home.packages = with pkgs;
       [
+        # nixpkgs entries
         gnomeExtensions.user-themes
         gnomeExtensions.dash-to-dock
         gnomeExtensions.appindicator
-        gnomeExtensions.auto-accent-colour
-        gnomeExtensions.auto-move-windows
-        gnomeExtensions.bring-out-submenu-of-power-offlogout-button
-        gnomeExtensions.blur-my-shell
-        gnomeExtensions.top-panel-logo
-        gnomeExtensions.workspace-indicator
-        gnomeExtensions.emoji-copy
-        gnomeExtensions.windownavigator
         gnomeExtensions.caffeine
-        gnomeExtensions.clipboard-indicator
         gnomeExtensions.tailscale-status
         gnomeExtensions.bluetooth-battery-meter
         gnomeExtensions.dim-background-windows
+
+        # Manually-packaged extensions (extensions.gnome.org pinned ZIPs,
+        # see pkgs/gnome-ext-*). Not in nixpkgs.
+        gnome-ext-allow-locked-remote-desktop
+        gnome-ext-claude-code-usage
+        gnome-ext-otp-keys
+        gnome-ext-rudra
+        gnome-ext-spotify-controller
+        gnome-ext-accent-directories
 
         # Helpers used by various extensions at runtime.
         lm_sensors

--- a/home/desktop/gnome/keybindings.nix
+++ b/home/desktop/gnome/keybindings.nix
@@ -59,6 +59,16 @@ in
         move-to-workspace-up = [ "<Super><Shift><Ctrl>Up" ];
         move-to-workspace-down = [ "<Super><Shift><Ctrl>Down" ];
 
+        # Move windows between monitors (multi-display setups)
+        move-to-monitor-left = [ "<Super><Shift>Left" ];
+        move-to-monitor-right = [ "<Super><Shift>Right" ];
+        move-to-monitor-up = [ "<Super><Shift>Up" ];
+        move-to-monitor-down = [ "<Super><Shift>Down" ];
+
+        # Switch among windows of the same application (Alt+Tab-style group)
+        switch-group = [ "<Super>Above_Tab" "<Alt>Above_Tab" ];
+        switch-group-backward = [ "<Shift><Super>Above_Tab" "<Shift><Alt>Above_Tab" ];
+
         # Window tiling (GNOME 45+)
         toggle-tiled-left = [ "<Super>Left" ];
         toggle-tiled-right = [ "<Super>Right" ];

--- a/hosts/common/shared-variables.nix
+++ b/hosts/common/shared-variables.nix
@@ -44,7 +44,7 @@
   # override that defaults to baseTheme.wallpaper.
   baseTheme = {
     scheme = "gruvbox-dark";
-    wallpaper = ../../assets/wallpapers/orange-desert.jpg;
+    wallpaper = ../../assets/wallpapers/amdgruvorange.png;
     cursor = {
       name = "Bibata-Modern-Classic";
       size = 16;

--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -4,7 +4,6 @@ final: _prev: {
   zsh-ai-cmd = final.callPackage ../pkgs/zsh-ai-cmd { };
   claude-code-native = final.callPackage ../pkgs/claude-code-native { };
   warp-terminal = final.callPackage ../pkgs/warp-terminal { };
-
   # splashboard — Rust TUI splash screen for shell startup. Needs rustc
   # 1.95+ (sysinfo 0.39 transitive), which nixpkgs doesn't ship yet, so
   # we build with the latest stable from rust-overlay via a custom
@@ -18,4 +17,17 @@ final: _prev: {
       };
     in
     final.callPackage ../pkgs/splashboard { inherit rustPlatform; };
+
+  gemini-cli = final.callPackage ../home/development/gemini-cli { };
+
+  # GNOME Shell extensions not packaged in nixpkgs. Pinned to the
+  # extensions.gnome.org ZIP for the exact version currently active on
+  # p620, so the snapshot is byte-stable. Source-of-truth for the UUID +
+  # version is the metadata.json inside each zip.
+  gnome-ext-claude-code-usage = final.callPackage ../pkgs/gnome-ext-claude-code-usage { };
+  gnome-ext-otp-keys = final.callPackage ../pkgs/gnome-ext-otp-keys { };
+  gnome-ext-rudra = final.callPackage ../pkgs/gnome-ext-rudra { };
+  gnome-ext-spotify-controller = final.callPackage ../pkgs/gnome-ext-spotify-controller { };
+  gnome-ext-accent-directories = final.callPackage ../pkgs/gnome-ext-accent-directories { };
+  gnome-ext-allow-locked-remote-desktop = final.callPackage ../pkgs/gnome-ext-allow-locked-remote-desktop { };
 }

--- a/pkgs/gnome-ext-accent-directories/default.nix
+++ b/pkgs/gnome-ext-accent-directories/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, unzip
+, glib
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "gnome-ext-accent-directories";
+  version = "17";
+  uuid = "accent-directories@taiwbi.com";
+
+  src = fetchurl {
+    url = "https://extensions.gnome.org/extension-data/accent-directoriestaiwbi.com.v${version}.shell-extension.zip";
+    sha256 = "1l62iacbkbqg0ariqzg634vspbky26myigp5d1f5qyvz27bjw710";
+  };
+
+  nativeBuildInputs = [ unzip glib ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -d "$out/share/gnome-shell/extensions/${uuid}"
+    unzip -q "$src" -d "$out/share/gnome-shell/extensions/${uuid}"
+    if [ -d "$out/share/gnome-shell/extensions/${uuid}/schemas" ]; then
+      glib-compile-schemas "$out/share/gnome-shell/extensions/${uuid}/schemas"
+    fi
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Make GNOME folder icons follow the system accent colour";
+    homepage = "https://github.com/taiwbi/gnome-accent-directories";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/gnome-ext-allow-locked-remote-desktop/default.nix
+++ b/pkgs/gnome-ext-allow-locked-remote-desktop/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, unzip
+, glib
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "gnome-ext-allow-locked-remote-desktop";
+  version = "17";
+  uuid = "allowlockedremotedesktop@kamens.us";
+
+  src = fetchurl {
+    url = "https://extensions.gnome.org/extension-data/allowlockedremotedesktopkamens.us.v${version}.shell-extension.zip";
+    sha256 = "16zb7kdlydq5fi50hbpa9kababf1izwpc82kiznmyi4ain9s5h4p";
+  };
+
+  nativeBuildInputs = [ unzip glib ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -d "$out/share/gnome-shell/extensions/${uuid}"
+    unzip -q "$src" -d "$out/share/gnome-shell/extensions/${uuid}"
+    if [ -d "$out/share/gnome-shell/extensions/${uuid}/schemas" ]; then
+      glib-compile-schemas "$out/share/gnome-shell/extensions/${uuid}/schemas"
+    fi
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Allow GNOME remote desktop connections when the screen is locked";
+    homepage = "https://github.com/jikamens/allow-locked-remote-desktop";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/gnome-ext-claude-code-usage/default.nix
+++ b/pkgs/gnome-ext-claude-code-usage/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, unzip
+, glib
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "gnome-ext-claude-code-usage";
+  version = "4";
+  uuid = "claude-code-usage@haletran.com";
+
+  src = fetchurl {
+    url = "https://extensions.gnome.org/extension-data/claude-code-usagehaletran.com.v${version}.shell-extension.zip";
+    sha256 = "07wgwm6sbhldmlcv2b6pnwdmf21y59984vg3xavci9qjn9413ys8";
+  };
+
+  nativeBuildInputs = [ unzip glib ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -d "$out/share/gnome-shell/extensions/${uuid}"
+    unzip -q "$src" -d "$out/share/gnome-shell/extensions/${uuid}"
+    if [ -d "$out/share/gnome-shell/extensions/${uuid}/schemas" ]; then
+      glib-compile-schemas "$out/share/gnome-shell/extensions/${uuid}/schemas"
+    fi
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Display Claude Code usage in the GNOME top panel";
+    homepage = "https://github.com/Haletran/claude-usage-extension";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/gnome-ext-otp-keys/default.nix
+++ b/pkgs/gnome-ext-otp-keys/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, unzip
+, glib
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "gnome-ext-otp-keys";
+  version = "33";
+  uuid = "otp-keys@osmank3.net";
+
+  src = fetchurl {
+    url = "https://extensions.gnome.org/extension-data/otp-keysosmank3.net.v${version}.shell-extension.zip";
+    sha256 = "1r0c63g6a1bkw7q151glm865rrcg07wk2lja4kxkq9rnbcxrh7qf";
+  };
+
+  nativeBuildInputs = [ unzip glib ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -d "$out/share/gnome-shell/extensions/${uuid}"
+    unzip -q "$src" -d "$out/share/gnome-shell/extensions/${uuid}"
+    if [ -d "$out/share/gnome-shell/extensions/${uuid}/schemas" ]; then
+      glib-compile-schemas "$out/share/gnome-shell/extensions/${uuid}/schemas"
+    fi
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Show and copy OTP keys from the GNOME top panel";
+    homepage = "https://github.com/osmank3/otp-keys";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/gnome-ext-rudra/default.nix
+++ b/pkgs/gnome-ext-rudra/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, unzip
+, glib
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "gnome-ext-rudra";
+  version = "7";
+  uuid = "rudra@narkagni";
+
+  src = fetchurl {
+    url = "https://extensions.gnome.org/extension-data/rudranarkagni.v${version}.shell-extension.zip";
+    sha256 = "0mpbakxs440rbl5h596zxqskva90dbzqg2xqlgm1ll8lb29vapvm";
+  };
+
+  nativeBuildInputs = [ unzip glib ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -d "$out/share/gnome-shell/extensions/${uuid}"
+    unzip -q "$src" -d "$out/share/gnome-shell/extensions/${uuid}"
+    if [ -d "$out/share/gnome-shell/extensions/${uuid}/schemas" ]; then
+      glib-compile-schemas "$out/share/gnome-shell/extensions/${uuid}/schemas"
+    fi
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Lightning-fast keyboard-centric launcher for GNOME Shell";
+    homepage = "https://github.com/narkagni/rudra";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/gnome-ext-spotify-controller/default.nix
+++ b/pkgs/gnome-ext-spotify-controller/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, unzip
+, glib
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "gnome-ext-spotify-controller";
+  version = "4";
+  uuid = "spotify-controller@narkagni";
+
+  src = fetchurl {
+    url = "https://extensions.gnome.org/extension-data/spotify-controllernarkagni.v${version}.shell-extension.zip";
+    sha256 = "1nhkl3dcvs9b8di7ahh1q2nni02blmkfvnx3i6njm3y3knm44inh";
+  };
+
+  nativeBuildInputs = [ unzip glib ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -d "$out/share/gnome-shell/extensions/${uuid}"
+    unzip -q "$src" -d "$out/share/gnome-shell/extensions/${uuid}"
+    if [ -d "$out/share/gnome-shell/extensions/${uuid}/schemas" ]; then
+      glib-compile-schemas "$out/share/gnome-shell/extensions/${uuid}/schemas"
+    fi
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Feature-rich Spotify controller for GNOME Shell with synced lyrics";
+    homepage = "https://github.com/NarkAgni/spotify-controller";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
## Summary

Captures the live GNOME 49.4 state of p620 into declarative HM modules so **razer** (which already imports the same GNOME profile chain via `desktop.gnome.profile = \"laptop\"`) inherits the identical setup on next deploy.

p510 is **out of scope** (headless media server, server template — not converting it).

## What changed

### Manually-installed extensions → nix-packaged

Six extensions that were installed manually into `~/.local/share/gnome-shell/extensions/` are now proper nix derivations under `pkgs/gnome-ext-*` (none of them are in nixpkgs). Each fetches the **exact extensions.gnome.org ZIP** for the version currently active, so the binaries are byte-stable across hosts.

| UUID | Version | Source |
|---|---|---|
| `claude-code-usage@haletran.com` | v4 | `Haletran/claude-usage-extension` |
| `otp-keys@osmank3.net` | v33 (1.1.2) | `osmank3/otp-keys` |
| `rudra@narkagni` | v7 | `narkagni/rudra` |
| `spotify-controller@narkagni` | v4 | `NarkAgni/spotify-controller` |
| `accent-directories@taiwbi.com` | v17 (2.2) | `taiwbi/gnome-accent-directories` |
| `allowlockedremotedesktop@kamens.us` | v17 | `jikamens/allow-locked-remote-desktop` |

### Inactive extensions dropped

The previous `extensions.nix` declared 16 UUIDs in `enabled-extensions`, but 9 of them were in state `INITIALIZED` or `INACTIVE` per `gnome-extensions info` — i.e. not actually running:

- `auto-accent-colour@Wartybix`
- `auto-move-windows@gnome-shell-extensions.gcampax.github.com`
- `BringOutSubmenuOfPowerOffLogoutButton@pratap.fastmail.fm`
- `blur-my-shell@aunetx`
- `top-panel-logo@jmpegi.github.com`
- `workspace-indicator@gnome-shell-extensions.gcampax.github.com`
- `emoji-copy@felipeftn`
- `windowsNavigator@gnome-shell-extensions.gcampax.github.com`
- `clipboard-indicator@tudmotu.com`

All removed from `enabled-extensions`, `home.packages`, and their orphan dconf blocks. Net: −9 UUIDs +6 manuals.

### aurora-shell drift handling

`aurora-shell@luminusos.github.io` (reverted in PR #506) is still ACTIVE on p620 because the binary lives in `~/.local/share/gnome-shell/extensions/` (nix couldn't manage that). The new `enabled-extensions` list explicitly includes its UUID **without a matching nix package**, so dconf load doesn't strip it on activation and p620 keeps it running. razer doesn't have the binary, so GNOME silently skips the unknown UUID there.

### favorite-apps centralised

Removed the older `[Nautilus, Chrome, Terminal, code, Settings]` block from `home/desktop/gnome/default.nix`. apps.nix is now the single declaration site with the live `[Nautilus, Chrome, Settings, Warp]` set. (HM merges array-valued dconf paths from multiple declaration sites rather than replacing them, which is why two `favorite-apps` blocks would produce a 9-item dock with duplicates.)

### Keybinding gaps filled

`keybindings.nix` gains `move-to-monitor-{left,right,up,down}`, `switch-group`, `switch-group-backward` — all matching live values exactly.

### Wallpaper

`assets/wallpapers/amdgruvorange.png` is byte-identical (sha256 verified) to `~/.local/share/backgrounds/2025-11-28-13-40-50-amdgruvorange.png` which has been the live wallpaper on p620 since November 2025. `shared-variables.nix` now declares this path so Stylix pushes the same wallpaper to razer. Base16 scheme (`gruvbox-dark`) unchanged — Stylix re-derives accent colours from the scheme, not the wallpaper, so no theming knock-on.

## HM-write delta (pre-deploy verification)

Of ~278 dconf keys HM manages for the user, **only 10 are actually written on next switch** — the rest have unchanged declared values so HM skips them. Diff between currently-installed `hm-dconf.ini` and the new build:

| Key | Old declared | New declared | Live | Visible impact |
|---|---|---|---|---|
| `desktop/background/picture-uri{,-dark}` | `orange-desert.jpg` | `amdgruvorange.png` | (user-set path, same bytes) | None (same pixels) |
| `wm/keybindings/move-to-monitor-*` (×4) | (unset) | `<Super><Shift>arrow` | already set to same values | None (no-op write) |
| `wm/keybindings/switch-group{,-backward}` | (unset) | `<Super>Above_Tab`, `<Shift><Super>Above_Tab` | already set | None |
| `shell/enabled-extensions` | 16 UUIDs (with 9 not running) | 14 UUIDs (only active) | similar live set with aurora-shell + extras | None — removed 9 weren't running, 6 manuals + aurora-shell remain active |
| `shell/favorite-apps` | 5-item with Terminal+code | 4-item with Warp | already 4-item with Warp | None (declared catches up to live) |

Removed dconf blocks (`accent-gtk-theme`, `auto-accent-colour`, `blur-my-shell`, `clipboard-indicator`): dconf-load doesn't *delete* keys when a block is removed — the orphan entries stay in user dconf but go unused. No visible regression because none of these extensions were running.

Pre-existing drift between repo declaration and live state (`gtk-theme=Gruvbox-Dark` vs declared `adw-gtk3`, `icon-theme=Adwaita-Orange` vs declared `Adwaita`, `mutter.dynamic-workspaces=false` vs declared `true`, dash-to-dock customisations, etc.) is **left alone** — HM only writes keys whose *declared* value changed between generations, and none of those values changed in this PR. Your manual GUI overrides survive untouched.

## Test plan

- [ ] CI: `nix build .#nixosConfigurations.p620.config.system.build.toplevel` ✅ (verified locally before commit)
- [ ] CI: `nix build .#nixosConfigurations.razer.config.system.build.toplevel`
- [ ] After merge: `just quick-deploy p620` — visible state should be unchanged
- [ ] Verify: `gnome-extensions list --enabled` on p620 still shows the same 14 extensions plus aurora-shell
- [ ] After merge: `just quick-deploy razer` — razer should pick up the 13 packaged extensions + matching dconf
- [ ] Visual sanity on razer (next login): dock favourites match p620, wallpaper applies, all 13 extensions load

🤖 Generated with [Claude Code](https://claude.com/claude-code)