### PR TITLE
feat(splashboard): package terminal splash screen and wire into zsh on p620 + razer

### DIFF
--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -32,6 +32,11 @@
     debug = false;
   };
 
+  # splashboard — terminal splash screen on shell startup + cd. User config
+  # under ~/.splashboard/ (not nix-managed). Opt out per-shell with
+  # SPLASHBOARD_SILENT=1 or globally with NO_SPLASHBOARD=1.
+  programs.splashboard.enable = true;
+
   # Claude Code statusline with Gruvbox Dark theme
   programs.claude-powerline = {
     enable = true;

--- a/Users/olafkfreund/razer_home.nix
+++ b/Users/olafkfreund/razer_home.nix
@@ -18,6 +18,9 @@ in
 
   # obsidian stays disabled — see #370 (electron-39 build broken upstream)
 
+  # splashboard — terminal splash screen on shell startup + cd. Same as p620.
+  programs.splashboard.enable = true;
+
   # Windsurf theme derived from host variables (razer uses orange-desert variant)
   editor.windsurf.settings = {
     theme = lib.removePrefix "gruvbox-" vars.theme.scheme;

--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776411505,
-        "narHash": "sha256-7HILfdTOvWzAMmfS3lQV3MDmVrr2Epj8x4c9F3mzOSE=",
+        "lastModified": 1778594411,
+        "narHash": "sha256-8tSGwvaYv5vDBojo8zLKVii6R6GzyzRXSq5o9VvOUe4=",
         "owner": "jacopone",
         "repo": "antigravity-nix",
-        "rev": "9f31d28882185d30c0e3082fbc52dab1cd4e879f",
+        "rev": "a80b1bb9db5067639452dad2107504d60bfdd7ce",
         "type": "github"
       },
       "original": {
@@ -348,11 +348,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1778468537,
-        "narHash": "sha256-5utE4+ptVcpT8xX5dIuCflXgcBFp6PDhEH/gzcZgj2Q=",
+        "lastModified": 1778554382,
+        "narHash": "sha256-F6eqj6V5hn/d9b3YdSmsYVFZPxu+VnxgX5z4viGXOPY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "b4285e87b7f1eb0824b264a90316b3ccac9da1d8",
+        "rev": "d3b525951181218595677c3d92c5ecfaa4e80572",
         "type": "github"
       },
       "original": {
@@ -786,11 +786,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778503501,
-        "narHash": "sha256-08L/X4/do7nET4rzidJ76eV/1r+mB7DchVpdPypsghc=",
+        "lastModified": 1778609305,
+        "narHash": "sha256-muTc+WME6k3sfTr/Pvmw8hrK7zXrbl961TEF9wPeAnk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "85ba629c79449badf4338117c27f0ee92b4b9f1a",
+        "rev": "5878fdadfe2cfe1b3383b38d66117f7b80696b68",
         "type": "github"
       },
       "original": {
@@ -1002,11 +1002,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1778143761,
-        "narHash": "sha256-lkesY6x2X2qxlqLM7CT2iM/0rP2JB7fruPN3h8POXmI=",
+        "lastModified": 1778593042,
+        "narHash": "sha256-xYGrSg6354UK2K4WSQd4+TfyvfqmvFbSY+ZtGQUXK0c=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3bcaa367d4c550d687a17ac792fd5cda214ee871",
+        "rev": "9bd7c80d43e258aaa607d83b43661df11444d808",
         "type": "github"
       },
       "original": {
@@ -1041,11 +1041,11 @@
         "parts": "parts"
       },
       "locked": {
-        "lastModified": 1778479369,
-        "narHash": "sha256-W25+/x0rYGi2JCcGsTxybMBIRYktWx0KBUhhkCj3TdE=",
+        "lastModified": 1778564520,
+        "narHash": "sha256-bfwwHO/fmsFzyF9oK1hBODKI1VSJ0tHOrozuiUcGG50=",
         "owner": "moni-dz",
         "repo": "nixpkgs-f2k",
-        "rev": "6ce196f7d6cdc5bbbd8804e1e973d771a1cb9b0d",
+        "rev": "1be356ac52264e56f477bd6ae0e8e5515508561c",
         "type": "github"
       },
       "original": {
@@ -1139,11 +1139,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1778003029,
-        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "lastModified": 1778430510,
+        "narHash": "sha256-Ti+ZBvW6yrWWAg2szExVTwCd4qOJ3KlVr1tFHfyfi8Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "rev": "8fd9daa3db09ced9700431c5b7ad0e8ba199b575",
         "type": "github"
       },
       "original": {
@@ -1171,11 +1171,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {
@@ -1203,11 +1203,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1778477413,
-        "narHash": "sha256-CkXLpkDYtKK0t7g0lOWNtqHn3ZqTizc01tQZep1jYj0=",
+        "lastModified": 1778561540,
+        "narHash": "sha256-gByqOAakeTkxRw+DuBnjNqBpCrgKBbS/B04RN6mY2+0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "81b6b2dc56f2a08f851be34f4e396fcea50b1683",
+        "rev": "dd6202e540267d3547acb2694d5fe35e06424153",
         "type": "github"
       },
       "original": {
@@ -1219,11 +1219,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {
@@ -1375,11 +1375,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {
@@ -1395,11 +1395,11 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1778526614,
-        "narHash": "sha256-APNv9zacmOtd3iaS19wu6uoYM2RbUIMGKhjZ6rnhtDA=",
+        "lastModified": 1778611020,
+        "narHash": "sha256-RVuHN9g5m0ELox511IMV0nhTPkAhfKhvrc+UTxe+6SA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "231794627a0324b5e5e4407a3fdaaf806862a642",
+        "rev": "90e0c5ae8b8cdf1627a6bca90d02597b79f5a11e",
         "type": "github"
       },
       "original": {
@@ -1525,6 +1525,7 @@
         "nixpkgs-stable": "nixpkgs-stable_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur",
+        "rust-overlay": "rust-overlay_6",
         "sops-nix": "sops-nix",
         "spicetify-nix": "spicetify-nix",
         "stylix": "stylix",
@@ -1654,6 +1655,26 @@
     "rust-overlay_6": {
       "inputs": {
         "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778642276,
+        "narHash": "sha256-bhk4lawR4ZnFhPtamB5WkCyvfgyZmsEUbWfT/3FRxFY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "77265d2dc1e61b2abfd3b1d6609dbb66fe75e0a5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_7": {
+      "inputs": {
+        "nixpkgs": [
           "zjstatus",
           "nixpkgs"
         ]
@@ -1714,11 +1735,11 @@
         "systems": "systems_9"
       },
       "locked": {
-        "lastModified": 1778395012,
-        "narHash": "sha256-A/VRiNFQIwGp8cOC/8yNCRexFHjtFCzBwhajrkyGojo=",
+        "lastModified": 1778540809,
+        "narHash": "sha256-FNXls2QZTcxY0Dem3QtSewnr8vUKMDsTw9m8pLOnhTc=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "3b4991bfc064c3361957f23141351ae2d9833234",
+        "rev": "83939d7df4c0f1b8ee88cabde112223280a48554",
         "type": "github"
       },
       "original": {
@@ -2012,11 +2033,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778497610,
-        "narHash": "sha256-fOg3qjpOjd0OFcRGz4XhB6HeWH6P06G+QUqv9/CCYhU=",
+        "lastModified": 1778574041,
+        "narHash": "sha256-Pn7/qFP6TwJIm9h8pkXyWyBcl0GbRKtoxKDcyOWfWhI=",
         "owner": "Benexl",
         "repo": "yt-x",
-        "rev": "af483a08d0e1440f785e2b507f0e26decaee2872",
+        "rev": "37cb1e548a8a82b1641b108c14586087e57ae9aa",
         "type": "github"
       },
       "original": {
@@ -2030,7 +2051,7 @@
         "crane": "crane_4",
         "flake-utils": "flake-utils_10",
         "nixpkgs": "nixpkgs_14",
-        "rust-overlay": "rust-overlay_6"
+        "rust-overlay": "rust-overlay_7"
       },
       "locked": {
         "lastModified": 1776491188,

--- a/flake.nix
+++ b/flake.nix
@@ -137,6 +137,14 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # Rust toolchain overlay — pulls in newer rustc than current nixpkgs
+    # ships. Required by splashboard (needs rustc 1.95+ via sysinfo 0.39).
+    # Consumed only by overlays/custom-packages.nix when wiring splashboard.
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
   };
 
   outputs =

--- a/home/shell/default.nix
+++ b/home/shell/default.nix
@@ -5,6 +5,7 @@ _: {
     ./bash.nix
     ./zsh.nix
     ./zsh-ai-cmd.nix # AI-powered shell command suggestions
+    ./splashboard.nix # Terminal splash screen on shell startup
     ./starship/default.nix
     ./mail/default.nix
     ./fzf/default.nix

--- a/home/shell/splashboard.nix
+++ b/home/shell/splashboard.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkOption mkIf mkEnableOption mkPackageOption mkAfter types getExe;
+  cfg = config.programs.splashboard;
+in
+{
+  options.programs.splashboard = {
+    enable = mkEnableOption "splashboard terminal splash screen on shell startup";
+
+    package = mkPackageOption pkgs "splashboard" { };
+
+    enableZshIntegration = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Wire `eval "$(splashboard init zsh)"` into the zsh init.
+
+        The hook renders a TUI dashboard on every new interactive shell and
+        on `cd` into a directory. Set to false to install the binary but
+        skip the init hook (you can still invoke `splashboard` manually).
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    # Wire the init eval after Starship and other prompt setup so the
+    # splash renders against a fully-configured shell. Use mkAfter so the
+    # hook lands at the end of programs.zsh.initContent.
+    #
+    # Opt-out env vars are handled by splashboard itself, not declaratively:
+    #   - CI=1                 — auto-detected in CI environments
+    #   - SPLASHBOARD_SILENT=1 — suppress this session
+    #   - NO_SPLASHBOARD=1     — suppress permanently for shells where set
+    #
+    # Per-repo overrides live at ./.splashboard/dashboard.toml. Splashboard
+    # gates these via ~/.splashboard/trust.toml (prompts on first entry to
+    # an untrusted dir). User config lives at $HOME/.splashboard/ — override
+    # location via the SPLASHBOARD_HOME env var.
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration (mkAfter ''
+      # ========================================
+      # splashboard — shell startup dashboard
+      # ========================================
+      eval "$(${getExe cfg.package} init zsh)"
+    '');
+  };
+}

--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -5,4 +5,18 @@ final: _prev: {
   claude-code-native = final.callPackage ../pkgs/claude-code-native { };
   warp-terminal = final.callPackage ../pkgs/warp-terminal { };
   gemini-cli = final.callPackage ../home/development/gemini-cli { };
+
+  # splashboard — Rust TUI splash screen for shell startup. Needs rustc
+  # 1.95+ (sysinfo 0.39 transitive), which nixpkgs doesn't ship yet, so
+  # we build with the latest stable from rust-overlay via a custom
+  # rustPlatform.
+  splashboard =
+    let
+      rustToolchain = final.rust-bin.stable.latest.default;
+      rustPlatform = final.makeRustPlatform {
+        cargo = rustToolchain;
+        rustc = rustToolchain;
+      };
+    in
+    final.callPackage ../pkgs/splashboard { inherit rustPlatform; };
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -23,6 +23,11 @@
 
   inputs.cosmic-ext-connect.overlays.default
 
+  # Rust toolchain overlay — exposes `rust-bin.*` on `final` so packages
+  # that need a newer rustc than nixpkgs ships (e.g. splashboard) can
+  # build with `makeRustPlatform`. Doesn't replace the default `rustc`.
+  inputs.rust-overlay.overlays.default
+
   # Replace nixpkgs `pkgs.openclaw` (marked insecure due to default unsandboxed
   # tool access) with the upstream flake's repackaged build. The HM module
   # defaults `programs.openclaw.package` to `pkgs.openclaw`, so the overlay is

--- a/pkgs/splashboard/default.nix
+++ b/pkgs/splashboard/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, git
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "splashboard";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "unhappychoice";
+    repo = "splashboard";
+    rev = "v${version}";
+    hash = "sha256-51ljQbuK5irrJXHg4ZO/VMgZmjKQZi+GwXcw1b4kY/A=";
+  };
+
+  cargoHash = "sha256-igWOT6/kl27BItfwIHnOfLdRTjKMEHdu24l9jA/2g8A=";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    git
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Customizable terminal splash screen with plugin-based data sources";
+    longDescription = ''
+      splashboard renders a TUI dashboard at shell startup and on cd into a
+      directory. Built on ratatui + crossterm, pure-Rust git (gix) and rustls
+      (no OpenSSL). Per-repo overrides live at ./.splashboard/dashboard.toml
+      with a trust.toml allow-list. Config lives at $HOME/.splashboard/
+      (override via SPLASHBOARD_HOME). Opt-out env vars: CI, SPLASHBOARD_SILENT,
+      NO_SPLASHBOARD.
+    '';
+    homepage = "https://github.com/unhappychoice/splashboard";
+    changelog = "https://github.com/unhappychoice/splashboard/releases/tag/v${version}";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.linux;
+    mainProgram = "splashboard";
+  };
+}


### PR DESCRIPTION
## Summary

Adds [**splashboard**](https://github.com/unhappychoice/splashboard) v1.6.0 — a Rust TUI that renders a customisable dashboard at shell startup and on `cd`. Pure-Rust git (`gix`) + rustls — no OpenSSL, no libgit2, no GTK/Qt/Wayland deps. ISC licensed, active upstream (latest release 2026-05-12).

Enabled on **p620** and **razer**. **p510 stays off** (headless server — adds SSH-shell startup latency for no visible benefit; flip later if wanted).

## What's in

### New flake input: `rust-overlay`

splashboard's transitive dep `sysinfo` 0.39 requires rustc 1.95, but our nixpkgs 26.05 currently ships `rust_1_94` (1.94.1). Adding `github:oxalica/rust-overlay` lets us build splashboard against `rust-bin.stable.latest` (currently 1.95.0) via `makeRustPlatform`, **without bumping the global default `rustc`** — every other Rust derivation in the tree (`glim`, `citrix-workspace`, etc.) keeps using the nixpkgs default. The toolchain swap is scoped to one overlay entry in `custom-packages.nix`.

### Derivation: `pkgs/splashboard/default.nix`

- `rustPlatform.buildRustPackage` against `fetchFromGitHub` @ tag `v1.6.0`
- `doCheck = false` (per upstream; tests need network)
- Custom `rustPlatform` injected via overlay so only this build uses rust 1.95
- `src` hash + `cargoHash` discovered by build-and-correct (upstream flake's declared hashes don't match what `fetchFromGitHub` produces against current nixpkgs — likely tarball-vs-git normalisation drift)

### HM module: `home/shell/splashboard.nix`

Mirrors the `zsh-ai-cmd` precedent shape:
- `options.programs.splashboard.{enable, package, enableZshIntegration}`
- `mkAfter` into `programs.zsh.initContent` so the eval lands after Starship and other prompt setup
- Opt-out env vars (`CI`, `SPLASHBOARD_SILENT`, `NO_SPLASHBOARD`) are handled by splashboard itself — no nix wiring needed

### Per-host enablement

```nix
# Users/olafkfreund/p620_home.nix + razer_home.nix
programs.splashboard.enable = true;
```

## What's NOT in (deferred)

- **bash/fish hooks** — only zsh is wired (matches your shell)
- **p510 enablement** — headless server, doesn't need it
- **agenix wiring for `~/.splashboard/secrets.toml`** — drop `GH_TOKEN` / `TODOIST_TOKEN` manually if you want the PR/Todoist widgets. Splashboard works fine without (git/moon/calendar widgets need no creds)
- **Declarative `home.dashboard.toml`** — splashboard creates sensible defaults on first run; user customises post-deploy

## Verification (no deploy yet)

- ✅ `pkgs.splashboard --version` → `splashboard 1.6.0`
- ✅ `pkgs.splashboard init zsh` → emits correct `chpwd` hook + interactive guard
- ✅ `nix build .#nixosConfigurations.p620.config.system.build.toplevel` succeeds
- ✅ `nix build .#nixosConfigurations.razer.config.system.build.toplevel` succeeds
- ✅ Both closures contain `splashboard` at the same store path (`jysy75qnmz95a1nsp1n8hf8j1n2fs802-splashboard-1.6.0`)
- ✅ Both generated `.zshrc` files contain `eval "$(.../splashboard init zsh)"` after Starship setup

## Test plan (post-merge)

- [ ] CI: both host builds pass
- [ ] `just quick-deploy p620` → open new zsh → expect dashboard
- [ ] `splashboard --version` on p620 → `1.6.0`
- [ ] Verify opt-out: `NO_SPLASHBOARD=1 zsh -ic true` → no dashboard
- [ ] Measure startup cost: `time zsh -ic exit` before/after
- [ ] `just quick-deploy razer` → same checks
- [ ] (Optional) on first `cd` into this repo, accept the trust prompt if it appears

## Files

**New (2):**
- `pkgs/splashboard/default.nix`
- `home/shell/splashboard.nix`

**Modified (7):**
- `flake.nix` — add `inputs.rust-overlay`
- `flake.lock` — pin
- `overlays/default.nix` — apply rust-overlay
- `overlays/custom-packages.nix` — wire splashboard with custom rustPlatform
- `home/shell/default.nix` — import splashboard module
- `Users/olafkfreund/p620_home.nix` — enable
- `Users/olafkfreund/razer_home.nix` — enable

🤖 Generated with [Claude Code](https://claude.com/claude-code)