### PR TITLE
chore(claude-code): update to 2.1.140

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.139";
+  version = "2.1.140";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-wYAKCuUbWkx7M75qMtYrYWnZP2F0EZsu62iWzwzV1+Y=";
+      hash = "sha256-gHpdbKBj9eA+S3KDk0A2oxInI7KMKOGml46Yzy1D0LU=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-OYWq91s7/x2NAxtybIBOQVLhUwJhaDzc4U6VTwryyRI=";
+      hash = "sha256-Dsb8Bi6ZqpWm7btTCKVjJi0noHcrEH0B1PphEQ+0RHI=";
     };
   };
 


### PR DESCRIPTION
## Summary

Bump `claude-code-native` from 2.1.139 → 2.1.140. Tracks Anthropic's GCS binary distribution channel.

## Changes

`pkgs/claude-code-native/default.nix`:
- `version = "2.1.140"`
- x86_64-linux hash: `sha256-gHpdbKBj9eA+S3KDk0A2oxInI7KMKOGml46Yzy1D0LU=`
- aarch64-linux hash: `sha256-Dsb8Bi6ZqpWm7btTCKVjJi0noHcrEH0B1PphEQ+0RHI=`

Both prefetched via `./scripts/update-claude-code-native.sh latest`.

## Verification

- ✅ `nix build .#claude-code-native` succeeds
- ✅ `claude --version` → `2.1.140 (Claude Code)`
- ✅ `ldd $OUT/bin/claude` → static binary, no missing libs
- ✅ `nix build .#nixosConfigurations.p620.config.system.build.toplevel`
- ✅ `nix build .#nixosConfigurations.razer.config.system.build.toplevel`
- ✅ `nix build .#nixosConfigurations.p510.config.system.build.toplevel`

## Test plan

- [ ] CI: all host builds pass
- [ ] After merge: `just quick-deploy <host>` on each host (or single-host as needed)
- [ ] Confirm `claude --version` reports `2.1.140` post-deploy

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)