### PR TITLE
chore(warp-terminal): bump to v0.2026.05.06.15.42.stable_05

### DIFF
--- a/pkgs/warp-terminal/versions.json
+++ b/pkgs/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "linux_x86_64": {
-    "hash": "sha256-zBX930Ha9ixC4TFRjQIuyTfQNsGe01hGz0jaA2GFaPs=",
-    "version": "0.2026.05.06.15.42.stable_04"
+    "hash": "sha256-9SUbv2IuON8s3ewVze/ynoVvfQu+Tb/fNqMZVY/Ze+w=",
+    "version": "0.2026.05.06.15.42.stable_05"
   },
   "linux_aarch64": {
-    "hash": "sha256-ZtcUfPV3Dbfxsxnu+QhiQpfJB1T50ciVVyKMOh4DHPU=",
-    "version": "0.2026.05.06.15.42.stable_04"
+    "hash": "sha256-taeEA10ij8tTwFjF8aMbYuP3GJMBFXCOMJPgmZoNj/U=",
+    "version": "0.2026.05.06.15.42.stable_05"
   }
 }


### PR DESCRIPTION
## Summary

Bump warp-terminal: `stable_04` → `stable_05`.

## Changes

`pkgs/warp-terminal/versions.json`:
- `linux_x86_64.version`: `0.2026.05.06.15.42.stable_04` → `stable_05`
- `linux_x86_64.hash`: refreshed
- `linux_aarch64.version`: same bump
- `linux_aarch64.hash`: refreshed

Generated via `./scripts/update-warp-terminal.sh`.

## Verification

- ✅ `nix build .#nixosConfigurations.p620.pkgs.warp-terminal` succeeds
- ✅ `$OUT/opt/warpdotdev/warp-terminal/warp` is ELF
- ✅ Version pin matches: `0.2026.05.06.15.42.stable_05`
- ✅ `nix build .#nixosConfigurations.p620.config.system.build.toplevel` succeeds

## Test plan

- [ ] After merge: `nhs p620` and `nhs razer`
- [ ] Launch warp on each, confirm version bump in About

🤖 Generated with [Claude Code](https://claude.com/claude-code)