### PR TITLE
chore(gemini-cli): bump to v0.42.0

### DIFF
--- a/home/development/gemini-cli/default.nix
+++ b/home/development/gemini-cli/default.nix
@@ -14,16 +14,16 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "gemini-cli";
-  version = "0.41.2";
+  version = "0.42.0";
 
   src = fetchFromGitHub {
     owner = "google-gemini";
     repo = "gemini-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4jwEviWYzan97pVn0RWfWU4XS8c27L4ZJUwa2iGlFxY=";
+    hash = "sha256-QYSzJdyjJ5SvPkI/uf/wu8MdM76W+djai6zD38IJpos=";
   };
 
-  npmDepsHash = "sha256-4znN1YR3AX2SKeCJjUS8cm6WGcOGPXI27xrQCotBjgQ=";
+  npmDepsHash = "sha256-hKNEJ/MAseYs8WLr36h40pYv+5nef8EPhZIfmPKYJPY=";
 
   nodejs = nodejs_22;
 


### PR DESCRIPTION
## Summary

Bump in-tree `gemini-cli` derivation from `0.41.2` → `0.42.0`. Tracks upstream `google-gemini/gemini-cli` v0.42.0.

## Changes

`home/development/gemini-cli/default.nix`:
- `version = "0.42.0"`
- `src.hash = "sha256-QYSzJdyjJ5SvPkI/uf/wu8MdM76W+djai6zD38IJpos="`
- `npmDepsHash = "sha256-hKNEJ/MAseYs8WLr36h40pYv+5nef8EPhZIfmPKYJPY="`

No postPatch tweaks needed — existing substitutions (node-pty stripping, ripgrep path, auto-update disable) still apply cleanly against the new source.

## Verification

- ✅ `nix-build .#gemini-cli` succeeds
- ✅ `gemini --version` → `0.42.0`
- ✅ `nix build .#nixosConfigurations.p620.config.system.build.toplevel`
- ✅ `nix build .#nixosConfigurations.razer.config.system.build.toplevel`
- ✅ `nix build .#nixosConfigurations.p510.config.system.build.toplevel`

## Test plan

- [ ] CI: all host builds pass
- [ ] After merge: `nhs <host>` to deploy
- [ ] Confirm `gemini --version` reports `0.42.0` post-deploy

## Also checked (no update needed)

- `antigravity-nix` flake input already pinned to upstream master HEAD (`a80b1bb9db50`, 2026-05-12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)