### PR TITLE
fix(splashboard): correct project dashboard widget errors + tune layout

### DIFF
--- a/home/shell/splashboard/home.dashboard.toml
+++ b/home/shell/splashboard/home.dashboard.toml
@@ -14,7 +14,7 @@ fetcher = "system_info_host"
   [widget.render]
   type = "text_ascii"
   style = "figlet"
-  font = "small"
+  font = "standard"
   align = "center"
 
 [[widget]]
@@ -76,7 +76,7 @@ fetcher = "github_contributions"
 
 # Banner row — hostname rendered as figlet
 [[row]]
-height = { length = 5 }
+height = { length = 6 }
   [[row.child]]
   widget = "hostname_banner"
   width = { fill = 1 }

--- a/home/shell/splashboard/project.dashboard.toml
+++ b/home/shell/splashboard/project.dashboard.toml
@@ -4,6 +4,11 @@
 # https://splashboard.unhappychoice.com/guides/configuration/
 #
 # Managed by home-manager: edit this file in the repo, not in ~/.splashboard/.
+#
+# Notes on widgets we deliberately DON'T include in the default:
+#  - github_action_status — fetcher requires `[widget.options] repo = "owner/name"`
+#    and can't auto-detect from cwd. Add it in ./.splashboard/dashboard.toml
+#    on a per-repo basis if you want the CI badge.
 
 # ---------------- Widgets ----------------
 
@@ -13,7 +18,7 @@ fetcher = "git_repo_name"
   [widget.render]
   type = "text_ascii"
   style = "figlet"
-  font = "small"
+  font = "standard"
   align = "center"
 
 [[widget]]
@@ -24,10 +29,6 @@ fetcher = "git_status"
 id = "age"
 fetcher = "git_age"
 format = "full"
-
-[[widget]]
-id = "ci"
-fetcher = "github_action_status"
 
 [[widget]]
 id = "commits"
@@ -45,7 +46,7 @@ fetcher = "git_contributors"
 id = "loc"
 fetcher = "code_loc"
   [widget.options]
-  unit = "raw"
+  unit = "loc"
 
 [[widget]]
 id = "todos"
@@ -61,14 +62,14 @@ fetcher = "github_my_prs"
 
   # ---------------- Layout ----------------
 
-# Banner — repo name as figlet
+# Banner — repo name as figlet (standard font, recognisable across widths)
 [[row]]
-height = { length = 5 }
+height = { length = 6 }
   [[row.child]]
   widget = "repo_banner"
   width = { fill = 1 }
 
-# Quick status: branch + age + CI
+# Quick status row — branch info + repo age (no CI by default)
 [[row]]
 height = { length = 3 }
 gap = 2
@@ -84,26 +85,21 @@ gap = 2
   border = "rounded"
   title = " Age "
   title_align = "center"
-  [[row.child]]
-  widget = "ci"
-  width = { fill = 1 }
-  border = "rounded"
-  title = " CI "
-  title_align = "center"
 
-# Activity row — recent commits + contributors
+# Activity row — recent commits + contributors bar chart.
+# Contributors gets 2/5 width so author names aren't clipped.
 [[row]]
-height = { length = 10 }
+height = { length = 9 }
 gap = 2
   [[row.child]]
   widget = "commits"
-  width = { fill = 2 }
+  width = { fill = 3 }
   border = "rounded"
   title = " Recent commits "
   title_align = "center"
   [[row.child]]
   widget = "contributors"
-  width = { fill = 1 }
+  width = { fill = 2 }
   border = "rounded"
   title = " Top contributors "
   title_align = "center"


### PR DESCRIPTION
## Summary

Three issues surfaced when the project dashboard first rendered on p620 (see screenshot in the original report). All three fixed in this PR.

## Fixes

### 1. `code_loc` widget — invalid `unit = "raw"`

Upstream rejects `raw` with:
> `⚠ fetch failed: invalid options: unknown variant 'raw', expected one of 'loc', 'kloc', '%', 'per' in 'unit'`

Changed to `unit = "loc"`.

### 2. `github_action_status` widget — `no repo: set 'repo = "owner/name"'`

The CI badge fetcher requires an explicit `[widget.options] repo = "<owner>/<name>"` and cannot auto-detect from cwd. Dropping it from the default project dashboard. Documented in a comment that users add it in `./.splashboard/dashboard.toml` per-repo if they want it.

### 3. Figlet font and layout

`font = "small"` rendered repo banners as unreadable ASCII glyphs. Switched both project and home banners to `font = "standard"` (the classic 5-line figlet font). Bumped home banner row height 5→6 to match.

Layout: contributors column was narrow enough that author names truncated to "ola ola". Rebalanced the activity row to `commits=fill(3)` + `contributors=fill(2)`. With CI gone, the status row is now `Status=fill(2)` + `Age=fill(1)` — Status has room to show ahead/behind without wrapping.

## Verification

- ✅ `nix build .#nixosConfigurations.p620.config.system.build.toplevel`
- ✅ Rendered `project.dashboard.toml` no longer contains `github_action_status`
- ✅ `unit = "loc"` confirmed in rendered file
- ✅ `font = "standard"` in both dashboards

## Test plan

- [ ] After merge: `nhs p620`
- [ ] Open new zsh in `~/.config/nixos` (or any other repo) → project dashboard renders without the `⚠ fetch failed` red lines for LOC or CI
- [ ] Banner is readable
- [ ] Contributors column shows full author names

🤖 Generated with [Claude Code](https://claude.com/claude-code)