### PR TITLE
feat(splashboard): adopt home_feed + project_github upstream presets

### DIFF
--- a/.splashboard/dashboard.toml
+++ b/.splashboard/dashboard.toml
@@ -1,0 +1,167 @@
+# project_github — per-repo preset. Hero is the repo name as a figlet banner
+# (fetched dynamically via `git_repo_name` → git remote origin), subtitle shows the repo
+# slug / description / license. Header band sits on `bg = "subtle"` so it reads as a
+# distinct panel; body pairs languages / releases, PRs / issues, commits / contributors
+# into 2-column rows so the dashboard reads as a tight grid rather than a tall stack.
+#
+# Drop this file in as `./.splashboard/dashboard.toml` at a repo root. Nothing here is
+# repo-specific — every widget discovers the repo at fetch time, so the same template
+# produces a tailored dashboard for whichever project the user cd's into.
+#
+# Source: https://splashboard.unhappychoice.com/guides/presets/#project_github--repo-hero--activity-grid
+#
+# Trust: on first cd into the repo, splashboard will prompt to trust this file
+# (or `splashboard trust` ahead of time). The hash is stored in ~/.splashboard/trust.toml.
+# Editing this file invalidates the entry — re-run `splashboard trust`.
+
+# ── Widgets ────────────────────────────────────────────────────────
+
+[[widget]]
+id = "hero"
+fetcher = "git_repo_name"
+render = { type = "text_ascii", style = "figlet", font = "ansi_shadow", color = "panel_title", align = "center" }
+
+# Subtitle: `github_repo` emits TextBlock (slug / description / license on their own rows).
+# `list_plain` renders via ratatui's `Paragraph` which centers each line individually,
+# so short lines like "ISC" still sit under the hero centreline instead of hugging the
+# block's left edge.
+[[widget]]
+id = "subtitle"
+fetcher = "github_repo"
+render = { type = "list_plain", align = "center" }
+
+[[widget]]
+id = "repo_stats"
+fetcher = "github_repo_stars"
+render = { type = "grid_table", layout = "inline", align = "center" }
+
+[[widget]]
+id = "repo_prs"
+fetcher = "github_repo_prs"
+render = { type = "list_links", max_items = 5 }
+
+[[widget]]
+id = "repo_issues"
+fetcher = "github_repo_issues"
+render = { type = "list_links", max_items = 5 }
+
+[[widget]]
+id = "commits_heatmap"
+fetcher = "git_commits_activity"
+render = "grid_heatmap"
+
+[[widget]]
+id = "top_contributors"
+fetcher = "git_contributors"
+render = { type = "chart_bar", max_bars = 5 }
+
+[[widget]]
+id = "languages"
+fetcher = "github_languages"
+render = { type = "chart_bar", horizontal = true }
+
+[[widget]]
+id = "releases"
+fetcher = "github_recent_releases"
+render = { type = "list_links", max_items = 3 }
+
+# ── Layout ──────────────────────────────────────────────────────────
+
+[[row]]
+height = { length = 1 }
+bg = "subtle"
+
+# Hero gets the full band width — `ansi_shadow` figlet is 7 rows tall, with the
+# inner `align = "center"` in the render options recentring the glyphs.
+[[row]]
+height = { length = 7 }
+bg = "subtle"
+  [[row.child]]
+  widget = "hero"
+
+# Subtitle: 3 stacked lines (slug / description / license) via github_repo's TextBlock
+# shape. Centered on a 70-cell column inside the band.
+[[row]]
+height = { length = 3 }
+bg = "subtle"
+flex = "center"
+  [[row.child]]
+  widget = "subtitle"
+  width = { length = 70 }
+
+[[row]]
+height = { length = 1 }
+bg = "subtle"
+flex = "center"
+  [[row.child]]
+  widget = "repo_stats"
+  width = { length = 70 }
+
+[[row]]
+height = { length = 1 }
+bg = "subtle"
+
+[[row]]
+height = { length = 1 }
+
+# Row 1: languages horizontal bar chart | releases timeline.
+[[row]]
+height = { length = 6 }
+flex = "center"
+gap = 2
+  [[row.child]]
+  widget = "languages"
+  width = { length = 34 }
+  border = "top"
+  title = "  languages  "
+  title_align = "center"
+  [[row.child]]
+  widget = "releases"
+  width = { length = 34 }
+  border = "top"
+  title = "  released  "
+  title_align = "center"
+
+[[row]]
+height = { length = 1 }
+
+# Row 2: PRs | issues — two list_plain columns.
+[[row]]
+height = { length = 9 }
+flex = "center"
+gap = 2
+  [[row.child]]
+  widget = "repo_prs"
+  width = { length = 34 }
+  border = "top"
+  title = "  PRs  "
+  title_align = "center"
+  [[row.child]]
+  widget = "repo_issues"
+  width = { length = 34 }
+  border = "top"
+  title = "  issues  "
+  title_align = "center"
+
+[[row]]
+height = { length = 1 }
+
+# Row 3: commits heatmap | top contributors. Heatmap shows the 52-week contribution
+# grid (repo-level, not viewer-level). Top contributors is a horizontal bar chart
+# capped at 5.
+[[row]]
+height = { length = 10 }
+flex = "center"
+gap = 2
+  [[row.child]]
+  widget = "commits_heatmap"
+  width = { length = 34 }
+  border = "top"
+  title = "  commits  "
+  title_align = "center"
+  [[row.child]]
+  widget = "top_contributors"
+  width = { length = 34 }
+  border = "top"
+  title = "  top contributors  "
+  title_align = "center"

--- a/home/shell/splashboard/home.dashboard.toml
+++ b/home/shell/splashboard/home.dashboard.toml
@@ -1,153 +1,282 @@
-# home.dashboard.toml — rendered when splashboard runs outside any git
-# repository. Schema reference:
-# https://splashboard.unhappychoice.com/guides/configuration/
+# home_feed — morning briefing. Hero band (lifted on `bg = "subtle"`): figlet date as
+# masthead, "good morning" greeting, live `Day · HH:MM`, and an almanac strip
+# (moon · zodiac · day-of-year). Body: 2 cols × 3 rows of curated feeds — HN | r/programming,
+# Wired | BBC Tech, Engadget | Wikipedia on this day. Footer: a daily fortune flourish.
 #
+# Trust: this preset wires Network-class widgets (`rss`, `reddit_subreddit_posts`). When
+# installed to `$HOME/.splashboard/home.dashboard.toml` (global config) it's implicitly
+# trusted; as a per-directory `.splashboard/dashboard.toml` it needs `splashboard trust`
+# before the network panels render.
+#
+# Source: https://splashboard.unhappychoice.com/guides/presets/#home_feed--morning-briefing
 # Managed by home-manager: edit this file in the repo, not in ~/.splashboard/.
 
-# ---------------- Widgets ----------------
+# ── Widgets ────────────────────────────────────────────────────────
 
+# Hero centerpiece — date in moderate text_ascii blocks (quadrant pixel size, ~3 rows tall),
+# colored with `panel_title` so it reads as the masthead.
 [[widget]]
-id = "hostname_banner"
-fetcher = "system_info_host"
-  [widget.options]
-  kind = "hostname"
-  [widget.render]
-  type = "text_ascii"
-  style = "figlet"
-  font = "standard"
-  align = "center"
-
-[[widget]]
-id = "clock"
+id = "hero_date"
 fetcher = "clock"
-format = "%A, %d %B %Y · %H:%M"
+format = "%a %e %b"
+render = { type = "text_ascii", style = "blocks", pixel_size = "quadrant", color = "panel_title", align = "center" }
+
+# Footer flourish — daily fortune. `length = "auto"` row sizes itself to whatever cookie was
+# drawn so 1-line fortunes hug the closing line and 4-line ones get the room they need.
+[[widget]]
+id = "fortune"
+fetcher = "random_fortune"
+render = { type = "list_plain", align = "center", color = "panel_title" }
+
+# Greeting seam — "good " (right) + time-of-day (left), home_minimal pattern.
+[[widget]]
+id = "greeting_prefix"
+fetcher = "basic_static"
+format = "good "
+render = { type = "text_plain", align = "right" }
 
 [[widget]]
-id = "os"
-fetcher = "system_info_host"
+id = "greeting"
+fetcher = "clock_derived"
+render = { type = "text_plain", align = "left" }
   [widget.options]
-  kind = "os"
+  kind = "time_of_day"
 
+# Subtitle — full day name + current HH:MM. Different vocabulary from the figlet
+# ("Sun 26 Apr" → abbreviated; subtitle uses "Sunday · 14:23" for the live "right now"
+# read), so the band stops feeling like a date duplication.
 [[widget]]
-id = "shell"
-fetcher = "system_info_host"
-  [widget.options]
-  kind = "shell"
+id = "now"
+fetcher = "clock"
+format = "%A · %H:%M"
+render = { type = "text_plain", align = "center" }
 
-[[widget]]
-id = "uptime"
-fetcher = "system_monitor_uptime"
-
-[[widget]]
-id = "load"
-fetcher = "system_monitor_load"
-
-[[widget]]
-id = "memory"
-fetcher = "system_monitor_memory"
-
-[[widget]]
-id = "cpu"
-fetcher = "system_monitor_cpu"
-
+# Almanac strip — moon · zodiac · day-of-year, centred. Three `clock_derived` values joined
+# by basic_static " · " separators so today's sky reads as one decorative line.
 [[widget]]
 id = "moon"
 fetcher = "clock_derived"
+render = { type = "text_plain", align = "right" }
   [widget.options]
-  kind = "moon"
+  kind = "moon_phase"
 
 [[widget]]
-id = "gh_prs"
-fetcher = "github_my_prs"
-  [widget.options]
-  limit = 5
+id = "sep1"
+fetcher = "basic_static"
+format = "  ·  "
+render = { type = "text_plain", align = "center" }
 
 [[widget]]
-id = "gh_issues"
-fetcher = "github_assigned_issues"
+id = "zodiac"
+fetcher = "clock_derived"
+render = { type = "text_plain", align = "center" }
   [widget.options]
-  limit = 5
+  kind = "zodiac"
 
 [[widget]]
-id = "gh_heatmap"
-fetcher = "github_contributions"
+id = "sep2"
+fetcher = "basic_static"
+format = "  ·  "
+render = { type = "text_plain", align = "center" }
 
-# ---------------- Layout ----------------
+[[widget]]
+id = "day_of_year"
+fetcher = "clock_derived"
+render = { type = "text_plain", align = "left" }
+  [widget.options]
+  kind = "day_of_year"
 
-# Banner row — hostname rendered as figlet
-[[row]]
-height = { length = 6 }
-  [[row.child]]
-  widget = "hostname_banner"
-  width = { fill = 1 }
+# Row 1 — Hacker News | Reddit r/programming
+[[widget]]
+id = "hn"
+fetcher = "hackernews_top"
+render = { type = "list_links", max_items = 5 }
 
-# Clock under the banner
+[[widget]]
+id = "reddit"
+fetcher = "reddit_subreddit_posts"
+render = { type = "list_links", max_items = 5 }
+  [widget.options]
+  subreddit = "programming"
+  type = "top"
+  period = "day"
+
+# Row 2 — Wired (rss) | BBC Tech (rss)
+[[widget]]
+id = "wired"
+fetcher = "rss"
+render = { type = "list_links", max_items = 5 }
+  [widget.options]
+  url = "https://www.wired.com/feed/rss"
+
+[[widget]]
+id = "bbc"
+fetcher = "rss"
+render = { type = "list_links", max_items = 5 }
+  [widget.options]
+  url = "https://feeds.bbci.co.uk/news/technology/rss.xml"
+
+# Row 3 — Engadget (rss) | Wikipedia on this day
+[[widget]]
+id = "engadget"
+fetcher = "rss"
+render = { type = "list_links", max_items = 5 }
+  [widget.options]
+  url = "https://www.engadget.com/rss.xml"
+
+[[widget]]
+id = "on_this_day"
+fetcher = "wikipedia_on_this_day"
+render = { type = "list_links", max_items = 5 }
+
+# ── Layout ─────────────────────────────────────────────────────────
+#
+# Hero band sits on `bg = "subtle"` so the date masthead / greeting / almanac strip read as
+# a header surface lifted off the body feeds. Footer band mirrors the same subtle bg with
+# the fortune flourish, closing the splash in the same visual register.
+
 [[row]]
 height = { length = 1 }
+bg = "subtle"
+
+# Hero date — text_ascii blocks @ quadrant pixel size. Needs 4 rows for the 5×6 pixel font
+# rendered as quadrants (≈3 cells of glyph + 1 cell of breathing room above/below).
+[[row]]
+height = { length = 4 }
+bg = "subtle"
+  [[row.child]]
+  widget = "hero_date"
+
+[[row]]
+height = { length = 1 }
+bg = "subtle"
+
+# Greeting seam.
+[[row]]
+height = { length = 1 }
+bg = "subtle"
 flex = "center"
   [[row.child]]
-  widget = "clock"
-  width = { fill = 1 }
+  widget = "greeting_prefix"
+  width = { length = 5 }
+  [[row.child]]
+  widget = "greeting"
+  width = { length = 12 }
 
-# System info row — 4 columns
+# Now — full day + live HH:MM. Complements the figlet without repeating the date.
 [[row]]
-height = { length = 3 }
-gap = 2
+height = { length = 1 }
+bg = "subtle"
   [[row.child]]
-  widget = "uptime"
-  width = { fill = 1 }
-  border = "rounded"
-  title = " Uptime "
-  title_align = "center"
-  [[row.child]]
-  widget = "load"
-  width = { fill = 1 }
-  border = "rounded"
-  title = " Load "
-  title_align = "center"
-  [[row.child]]
-  widget = "memory"
-  width = { fill = 1 }
-  border = "rounded"
-  title = " Memory "
-  title_align = "center"
-  [[row.child]]
-  widget = "cpu"
-  width = { fill = 1 }
-  border = "rounded"
-  title = " CPU "
-  title_align = "center"
+  widget = "now"
 
-# GitHub row — open PRs + assigned issues side by side
+# Almanac strip — moon · zodiac · day_of_year.
 [[row]]
-height = { length = 8 }
-gap = 2
-  [[row.child]]
-  widget = "gh_prs"
-  width = { fill = 1 }
-  border = "rounded"
-  title = " Open PRs "
-  title_align = "center"
-  [[row.child]]
-  widget = "gh_issues"
-  width = { fill = 1 }
-  border = "rounded"
-  title = " Assigned Issues "
-  title_align = "center"
-
-# Contribution heatmap + moon phase
-[[row]]
-height = { length = 9 }
-gap = 2
-  [[row.child]]
-  widget = "gh_heatmap"
-  width = { fill = 4 }
-  border = "rounded"
-  title = " Contributions "
-  title_align = "center"
+height = { length = 1 }
+bg = "subtle"
+flex = "center"
   [[row.child]]
   widget = "moon"
-  width = { fill = 1 }
-  border = "rounded"
-  title = " Moon "
+  width = { length = 22 }
+  [[row.child]]
+  widget = "sep1"
+  width = { length = 5 }
+  [[row.child]]
+  widget = "zodiac"
+  width = { length = 12 }
+  [[row.child]]
+  widget = "sep2"
+  width = { length = 5 }
+  [[row.child]]
+  widget = "day_of_year"
+  width = { length = 12 }
+
+[[row]]
+height = { length = 1 }
+bg = "subtle"
+
+[[row]]
+height = { length = 1 }
+
+# Body row 1 — HN | Reddit. 100-cell content band (49+gap2+49); 5 items + 1 border = 6.
+[[row]]
+height = { length = 6 }
+flex = "center"
+gap = 2
+  [[row.child]]
+  widget = "hn"
+  width = { length = 49 }
+  border = "top"
+  title = "  HACKER NEWS  "
   title_align = "center"
+  [[row.child]]
+  widget = "reddit"
+  width = { length = 49 }
+  border = "top"
+  title = "  R/PROGRAMMING  "
+  title_align = "center"
+
+[[row]]
+height = { length = 1 }
+
+# Body row 2 — Wired | BBC Tech
+[[row]]
+height = { length = 6 }
+flex = "center"
+gap = 2
+  [[row.child]]
+  widget = "wired"
+  width = { length = 49 }
+  border = "top"
+  title = "  WIRED  "
+  title_align = "center"
+  [[row.child]]
+  widget = "bbc"
+  width = { length = 49 }
+  border = "top"
+  title = "  BBC TECH  "
+  title_align = "center"
+
+[[row]]
+height = { length = 1 }
+
+# Body row 3 — Engadget | Wikipedia on this day
+[[row]]
+height = { length = 6 }
+flex = "center"
+gap = 2
+  [[row.child]]
+  widget = "engadget"
+  width = { length = 49 }
+  border = "top"
+  title = "  ENGADGET  "
+  title_align = "center"
+  [[row.child]]
+  widget = "on_this_day"
+  width = { length = 49 }
+  border = "top"
+  title = "  ON THIS DAY  "
+  title_align = "center"
+
+[[row]]
+height = { length = 1 }
+
+# ── Footer band ────────────────────────────────────────────────────
+#
+# Fortune flourish closes the splash on the default body bg — the hero alone wears the
+# subtle band, so the bottom feels like the splash settling rather than another header.
+
+[[row]]
+height = { length = 1 }
+
+[[row]]
+# `height = "auto"` — text_plain's `natural_height` returns the TextBlock line count, so
+# 1-line fortunes hug the closing line and multi-line cookies get the room they need.
+height = "auto"
+flex = "center"
+  [[row.child]]
+  widget = "fortune"
+  width = { length = 80 }
+
+[[row]]
+height = { length = 1 }


### PR DESCRIPTION
## Summary

Swap both dashboards to the canonical upstream presets from <https://splashboard.unhappychoice.com/guides/presets/>:

- `~/.splashboard/home.dashboard.toml` → **home_feed** ("morning briefing")
- `./.splashboard/dashboard.toml` (this repo) → **project_github** ("repo hero + activity grid")

The hand-rolled versions from PR #515 had several widget-name guesses (one of which broke `code_loc`, fixed in PR #516). The upstream presets are authored against the real fetcher/render registry and tuned for terminal-width readability.

## home_feed — morning briefing

Replaces `home/shell/splashboard/home.dashboard.toml` wholesale:

- Figlet date masthead in quadrant blocks
- "good <time-of-day>" greeting seam
- Subtitle: `Day · HH:MM`
- Almanac strip: moon phase · zodiac · day-of-year
- 2×3 feed grid: **Hacker News | r/programming**, **Wired | BBC Tech**, **Engadget | Wikipedia "on this day"**
- Footer fortune cookie

Hero band sits on `bg = "subtle"` so the masthead reads as a header surface lifted off the feeds.

## project_github — per-repo override for this repo

New tracked file at `.splashboard/dashboard.toml` in the repo root. Wins over the central `project.dashboard.toml` fallback when splashboard is invoked inside this repo.

- Hero: repo name as `ansi_shadow` figlet (`git_repo_name`)
- Subtitle: `github_repo` TextBlock (slug / description / license)
- `github_repo_stars` stats row
- 2-column grid: languages | releases, PRs | issues, commits-heatmap | top-contributors

Nothing repo-specific in the template — every widget discovers the repo at fetch time. We can drop this same file into other repos and it'll just work.

## Trust

`project_github` doesn't wire Network-class fetchers, but splashboard gates per-directory dashboards by file hash regardless. First `cd` into this repo will prompt to trust the file; or run `splashboard trust` proactively. Editing `.splashboard/dashboard.toml` invalidates the trust entry.

## Out of scope

- Central `home/shell/splashboard/project.dashboard.toml` fallback is **untouched** — repos that don't bring their own `.splashboard/dashboard.toml` still get the hand-rolled default from PR #515 + #516.
- Not adopting `project_github` as the central project default. If you want that later, easy follow-up.

## Verification

- ✅ `nix build .#nixosConfigurations.p620.config.system.build.toplevel`
- ✅ `nix build .#nixosConfigurations.razer.config.system.build.toplevel`
- ✅ Rendered `~/.splashboard/home.dashboard.toml` in HM closure has `hero_date`, `random_fortune`, `hackernews_top`, `rss`, `wikipedia_on_this_day` widgets
- ✅ `.splashboard/dashboard.toml` in repo has `git_repo_name`, `github_repo`, `git_commits_activity`, `github_languages`, `github_recent_releases` widgets

## Test plan

- [ ] After merge: `nhs p620`
- [ ] Open new zsh in `$HOME` → home_feed renders (date masthead, feeds grid, fortune)
- [ ] `cd ~/.config/nixos` → first time will prompt to trust `.splashboard/dashboard.toml`; run `splashboard trust` if needed
- [ ] After trust → project_github renders (repo hero, languages, PRs/issues, heatmap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)