### PR TITLE
chore(claude-code): bump native binary 2.1.140 → 2.1.141

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.140";
+  version = "2.1.141";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-gHpdbKBj9eA+S3KDk0A2oxInI7KMKOGml46Yzy1D0LU=";
+      hash = "sha256-gyvibo8Vsq6Z5SCiKwNPxL+tHLW4Tea3BkhwcsVrtC4=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-Dsb8Bi6ZqpWm7btTCKVjJi0noHcrEH0B1PphEQ+0RHI=";
+      hash = "sha256-3JMeJPYq+63I3GgRUniwhJOCWj7R6nU9WHB3GBpsxjs=";
     };
   };
 


### PR DESCRIPTION
## Summary

Bumps `pkgs/claude-code-native` to the latest GCS channel.

| | |
|---|---|
| Before | 2.1.140 |
| After  | 2.1.141 |
| Source | Anthropic GCS distribution bucket |

Closes #518

## Test plan

- [x] \`nix build .#claude-code-native\` clean
- [x] \`\$OUT/bin/claude --version\` → \`2.1.141 (Claude Code)\`
- [x] \`ldd\` clean (no missing libs)
- [x] p620 toplevel builds
- [x] razer toplevel builds
- [x] p510 toplevel builds
- [ ] CI green
- [ ] Deploy to p620

🤖 Generated with [Claude Code](https://claude.com/claude-code)