### PR TITLE
fix(splashboard): redesign project dashboards + dedup contributors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Olaf Krasicki-Freund <olaf@freundcloud.com> olafkfreund <olaf.loken@gmail.com>
+Olaf Krasicki-Freund <olaf@freundcloud.com> Olaf K-Freund <olaf.loken@google.com>
+Olaf Krasicki-Freund <olaf@freundcloud.com> Olaf Krasicki-Freund <olaf.freund@r3.com>
+Olaf Krasicki-Freund <olaf@freundcloud.com> Olaf Krasicki-Freund <olaf.loken@gmail.com>

--- a/.splashboard/dashboard.toml
+++ b/.splashboard/dashboard.toml
@@ -1,18 +1,28 @@
-# project_github — per-repo preset. Hero is the repo name as a figlet banner
-# (fetched dynamically via `git_repo_name` → git remote origin), subtitle shows the repo
-# slug / description / license. Header band sits on `bg = "subtle"` so it reads as a
-# distinct panel; body pairs languages / releases, PRs / issues, commits / contributors
-# into 2-column rows so the dashboard reads as a tight grid rather than a tall stack.
+# Per-repo dashboard for this nixos config repo. Overrides the bundled
+# project.dashboard.toml from ~/.splashboard/project.dashboard.toml when
+# splashboard runs inside this directory.
 #
-# Drop this file in as `./.splashboard/dashboard.toml` at a repo root. Nothing here is
-# repo-specific — every widget discovers the repo at fetch time, so the same template
-# produces a tailored dashboard for whichever project the user cd's into.
+# Schema: https://splashboard.unhappychoice.com/guides/configuration/
 #
-# Source: https://splashboard.unhappychoice.com/guides/presets/#project_github--repo-hero--activity-grid
+# Tuned for an infrastructure-as-code repo:
+#   • Hero band on `bg = "subtle"` with the repo name in `ansi_shadow` figlet
+#   • Subtitle: slug / description / license from github_repo
+#   • Inline stats table (stars / forks / watchers / issues) — kept as
+#     grid_table since github_repo_stars emits `entries`, not `badge`
+#   • Status badges row underneath: age, working-tree state, stash count
+#   • Full-width 12-month GitHub contributions heatmap (border = "thick")
+#   • Codebase split: github_languages as a pie chart | largest files ranking
+#   • GitHub work split: open PRs | open issues (border = "top")
+#   • Closer: releases timeline | monthly contributors ranking
 #
-# Trust: on first cd into the repo, splashboard will prompt to trust this file
-# (or `splashboard trust` ahead of time). The hash is stored in ~/.splashboard/trust.toml.
-# Editing this file invalidates the entry — re-run `splashboard trust`.
+# Trust: this dashboard wires Network-class widgets (github_*). On first
+# `cd` into the repo splashboard prompts for trust; run `splashboard trust`
+# ahead of time to skip the prompt. The hash is stored in
+# ~/.splashboard/trust.toml; editing this file invalidates the entry.
+#
+# Contributor dedup is handled at the git layer via ./.mailmap, which
+# collapses four committer identities into one canonical author before
+# `git_contributors` ever sees them.
 
 # ── Widgets ────────────────────────────────────────────────────────
 
@@ -21,20 +31,61 @@ id = "hero"
 fetcher = "git_repo_name"
 render = { type = "text_ascii", style = "figlet", font = "ansi_shadow", color = "panel_title", align = "center" }
 
-# Subtitle: `github_repo` emits TextBlock (slug / description / license on their own rows).
-# `list_plain` renders via ratatui's `Paragraph` which centers each line individually,
-# so short lines like "ISC" still sit under the hero centreline instead of hugging the
-# block's left edge.
+# Subtitle — slug / description / license, three stacked lines via the
+# `text_block` shape that github_repo emits.
 [[widget]]
 id = "subtitle"
 fetcher = "github_repo"
 render = { type = "list_plain", align = "center" }
 
+# Inline repo stats — stars / forks / watchers / open issues, all on one row.
 [[widget]]
 id = "repo_stats"
 fetcher = "github_repo_stars"
 render = { type = "grid_table", layout = "inline", align = "center" }
 
+# Status badges — three pills mirroring the bundled project dashboard so
+# both layouts share visual vocabulary.
+[[widget]]
+id = "badge_age"
+fetcher = "git_age"
+render = { type = "status_badge", shape = "rounded", align = "center" }
+
+[[widget]]
+id = "badge_status"
+fetcher = "git_status"
+render = { type = "status_badge", shape = "rounded", align = "center" }
+
+[[widget]]
+id = "badge_stash"
+fetcher = "git_stash_count"
+render = { type = "status_badge", shape = "rounded", align = "center" }
+
+# Centerpiece — 12-month GitHub contributions heatmap. Uses the
+# GitHub-mirrored view (one square per day, normalized contributor list)
+# rather than the local git_commits_activity so the heatmap reads as
+# "what does this project look like on GitHub" rather than "what's in my
+# local mirror".
+[[widget]]
+id = "contributions"
+fetcher = "github_contributions"
+render = { type = "grid_heatmap", align = "center" }
+
+# Codebase — languages as a pie, largest files as a numbered ranking with
+# medal glyphs on the top three.
+[[widget]]
+id = "languages"
+fetcher = "github_languages"
+render = { type = "chart_pie", legend = "right" }
+
+[[widget]]
+id = "largest_files"
+fetcher = "code_largest_files"
+render = { type = "list_ranking", style = "medal" }
+  [widget.options]
+  limit = 6
+
+# GitHub work — open PRs and open issues for this repo.
 [[widget]]
 id = "repo_prs"
 fetcher = "github_repo_prs"
@@ -45,42 +96,41 @@ id = "repo_issues"
 fetcher = "github_repo_issues"
 render = { type = "list_links", max_items = 5 }
 
-[[widget]]
-id = "commits_heatmap"
-fetcher = "git_commits_activity"
-render = "grid_heatmap"
-
-[[widget]]
-id = "top_contributors"
-fetcher = "git_contributors"
-render = { type = "chart_bar", max_bars = 5 }
-
-[[widget]]
-id = "languages"
-fetcher = "github_languages"
-render = { type = "chart_bar", horizontal = true }
-
+# Closer — releases as a timeline (date column + title), monthly
+# contributors as a ranking. Using github_contributors_monthly (which
+# honors GitHub's normalized contributor identities) for the closer
+# instead of git_contributors so the two contributor visualisations
+# bring different vocabularies — bars on the bundled default, ranking
+# here.
 [[widget]]
 id = "releases"
 fetcher = "github_recent_releases"
-render = { type = "list_links", max_items = 3 }
+render = { type = "list_timeline", bullet = "●", max_items = 5, date_format = "relative" }
 
-# ── Layout ──────────────────────────────────────────────────────────
+[[widget]]
+id = "monthly_contributors"
+fetcher = "github_contributors_monthly"
+render = { type = "list_ranking", style = "medal" }
+  [widget.options]
+  limit = 6
 
+  # ── Layout ─────────────────────────────────────────────────────────
+
+# Hero band — figlet repo name lifted on `bg = "subtle"`. Spacer row above
+# the figlet so the banner breathes inside the band.
 [[row]]
 height = { length = 1 }
 bg = "subtle"
 
-# Hero gets the full band width — `ansi_shadow` figlet is 7 rows tall, with the
-# inner `align = "center"` in the render options recentring the glyphs.
 [[row]]
 height = { length = 7 }
 bg = "subtle"
   [[row.child]]
   widget = "hero"
+  width = { fill = 1 }
 
-# Subtitle: 3 stacked lines (slug / description / license) via github_repo's TextBlock
-# shape. Centered on a 70-cell column inside the band.
+# Subtitle — slug / description / license, centered on a 70-cell column
+# so short lines like "ISC" sit under the hero centreline.
 [[row]]
 height = { length = 3 }
 bg = "subtle"
@@ -89,6 +139,7 @@ flex = "center"
   widget = "subtitle"
   width = { length = 70 }
 
+# Inline stats — stars / forks / watchers / issues table.
 [[row]]
 height = { length = 1 }
 bg = "subtle"
@@ -97,71 +148,98 @@ flex = "center"
   widget = "repo_stats"
   width = { length = 70 }
 
+# Status badges row — still on the hero band, three pills flex-centered.
+[[row]]
+height = { length = 1 }
+bg = "subtle"
+flex = "center"
+gap = 2
+  [[row.child]]
+  widget = "badge_age"
+  width = { length = 22 }
+  [[row.child]]
+  widget = "badge_status"
+  width = { length = 28 }
+  [[row.child]]
+  widget = "badge_stash"
+  width = { length = 18 }
+
 [[row]]
 height = { length = 1 }
 bg = "subtle"
 
+# Break out of the hero band.
 [[row]]
 height = { length = 1 }
 
-# Row 1: languages horizontal bar chart | releases timeline.
+# Centerpiece — GitHub contributions heatmap, full width, thick border.
 [[row]]
-height = { length = 6 }
-flex = "center"
+height = { length = 7 }
+  [[row.child]]
+  widget = "contributions"
+  width = { fill = 1 }
+  border = "thick"
+  title = "  12 months of commits  "
+  title_align = "center"
+
+[[row]]
+height = { length = 1 }
+
+# Codebase split — languages pie | largest files ranking.
+[[row]]
+height = { length = 8 }
 gap = 2
   [[row.child]]
   widget = "languages"
-  width = { length = 34 }
-  border = "top"
+  width = { fill = 1 }
+  border = "rounded"
   title = "  languages  "
   title_align = "center"
   [[row.child]]
-  widget = "releases"
-  width = { length = 34 }
-  border = "top"
-  title = "  released  "
+  widget = "largest_files"
+  width = { fill = 1 }
+  border = "rounded"
+  title = "  largest files  "
   title_align = "center"
 
 [[row]]
 height = { length = 1 }
 
-# Row 2: PRs | issues — two list_plain columns.
+# GitHub work — open PRs | open issues. Top border (lighter than rounded)
+# marks this as the most heavily-loaded data row visually.
 [[row]]
 height = { length = 9 }
-flex = "center"
 gap = 2
   [[row.child]]
   widget = "repo_prs"
-  width = { length = 34 }
+  width = { fill = 1 }
   border = "top"
-  title = "  PRs  "
+  title = "  open PRs  "
   title_align = "center"
   [[row.child]]
   widget = "repo_issues"
-  width = { length = 34 }
+  width = { fill = 1 }
   border = "top"
-  title = "  issues  "
+  title = "  open issues  "
   title_align = "center"
 
 [[row]]
 height = { length = 1 }
 
-# Row 3: commits heatmap | top contributors. Heatmap shows the 52-week contribution
-# grid (repo-level, not viewer-level). Top contributors is a horizontal bar chart
-# capped at 5.
+# Closer — releases timeline | monthly contributors ranking. Rounded
+# borders mirror the codebase split so the bottom echoes the middle.
 [[row]]
-height = { length = 10 }
-flex = "center"
+height = { length = 9 }
 gap = 2
   [[row.child]]
-  widget = "commits_heatmap"
-  width = { length = 34 }
-  border = "top"
-  title = "  commits  "
+  widget = "releases"
+  width = { fill = 1 }
+  border = "rounded"
+  title = "  recent releases  "
   title_align = "center"
   [[row.child]]
-  widget = "top_contributors"
-  width = { length = 34 }
-  border = "top"
-  title = "  top contributors  "
+  widget = "monthly_contributors"
+  width = { fill = 1 }
+  border = "rounded"
+  title = "  monthly contributors  "
   title_align = "center"

--- a/_typos.toml
+++ b/_typos.toml
@@ -51,6 +51,9 @@ nd = "nd"
 # AER is the PCIe Advanced Error Reporting acronym
 AER = "AER"
 
+# ratatui is the Rust TUI library splashboard is built on
+ratatui = "ratatui"
+
 [default.extend-identifiers]
 # Santa Claus - not "Clause"
 Claus = "Claus"

--- a/home/shell/splashboard/home.dashboard.toml
+++ b/home/shell/splashboard/home.dashboard.toml
@@ -19,7 +19,7 @@
 id = "hero_date"
 fetcher = "clock"
 format = "%a %e %b"
-render = { type = "text_ascii", style = "blocks", pixel_size = "quadrant", color = "panel_title", align = "center" }
+render = { type = "text_ascii", style = "blocks", pixel_size = "quadrant", color = "accent", align = "center" }
 
 # Footer flourish — daily fortune. `length = "auto"` row sizes itself to whatever cookie was
 # drawn so 1-line fortunes hug the closing line and 4-line ones get the room they need.
@@ -272,11 +272,14 @@ height = { length = 1 }
 [[row]]
 # `height = "auto"` — text_plain's `natural_height` returns the TextBlock line count, so
 # 1-line fortunes hug the closing line and multi-line cookies get the room they need.
+# `border = "top"` adds a closing seam under the body grid so the fortune reads as a
+# deliberate footer flourish rather than a stray line of text.
 height = "auto"
 flex = "center"
   [[row.child]]
   widget = "fortune"
   width = { length = 80 }
+  border = "top"
 
 [[row]]
 height = { length = 1 }

--- a/home/shell/splashboard/project.dashboard.toml
+++ b/home/shell/splashboard/project.dashboard.toml
@@ -1,132 +1,209 @@
 # project.dashboard.toml — rendered when splashboard runs inside a git
-# repository (and the repo has no ./.splashboard/dashboard.toml override).
-# Schema reference:
-# https://splashboard.unhappychoice.com/guides/configuration/
+# repository that has no ./.splashboard/dashboard.toml override.
 #
-# Managed by home-manager: edit this file in the repo, not in ~/.splashboard/.
+# Schema: https://splashboard.unhappychoice.com/guides/configuration/
+# Managed by home-manager — edit this file in the repo, not in ~/.splashboard/.
 #
-# Notes on widgets we deliberately DON'T include in the default:
-#  - github_action_status — fetcher requires `[widget.options] repo = "owner/name"`
-#    and can't auto-detect from cwd. Add it in ./.splashboard/dashboard.toml
-#    on a per-repo basis if you want the CI badge.
+# Design vocabulary (gruvbox_dark theme):
+#   • Hero band on `bg = "subtle"` with chunky `ansi_shadow` figlet repo name
+#   • Status badges strip — git_age / git_status / git_stash_count in one row
+#   • Full-width 12-month activity heatmap as the centerpiece (border = "thick")
+#   • Mixed widget vocabulary: heatmap + chart_pie + list_ranking +
+#     list_timeline + chart_bar + list_links — no two adjacent panels share
+#     the same renderer, so the eye keeps moving
+#   • Border hierarchy: thick (hero anchor) → rounded (body panels) → top
+#     (light sub-sections) → rounded (footer pair)
+#
+# Network widgets gated behind `github_my_prs` will show a 🔒 trust placeholder
+# in untrusted repos; safe widgets always render. Run `splashboard trust` once
+# inside a repo to unlock them.
 
-# ---------------- Widgets ----------------
+# ── Widgets ────────────────────────────────────────────────────────
 
+# Hero — repo name as ansi_shadow figlet, colored panel_title (theme accent).
 [[widget]]
 id = "repo_banner"
 fetcher = "git_repo_name"
-  [widget.render]
-  type = "text_ascii"
-  style = "figlet"
-  font = "standard"
-  align = "center"
+render = { type = "text_ascii", style = "figlet", font = "ansi_shadow", color = "panel_title", align = "center" }
 
+# Status badges — three single-line pills under the hero. All three fetchers
+# emit the `badge` shape natively, so `status_badge` is the canonical renderer.
 [[widget]]
-id = "status"
-fetcher = "git_status"
-
-[[widget]]
-id = "age"
+id = "badge_age"
 fetcher = "git_age"
-format = "full"
+render = { type = "status_badge", shape = "rounded", align = "center" }
 
 [[widget]]
-id = "commits"
-fetcher = "git_recent_commits"
-  [widget.options]
-  limit = 8
+id = "badge_status"
+fetcher = "git_status"
+render = { type = "status_badge", shape = "rounded", align = "center" }
 
 [[widget]]
-id = "contributors"
-fetcher = "git_contributors"
-  [widget.options]
-  limit = 6
+id = "badge_stash"
+fetcher = "git_stash_count"
+render = { type = "status_badge", shape = "rounded", align = "center" }
 
+# Centerpiece — 52-week commit heatmap. Renders the repo's commit cadence as a
+# year-at-a-glance grid; the highest-impact visual element on the dashboard.
 [[widget]]
-id = "loc"
+id = "activity"
+fetcher = "git_commits_activity"
+render = { type = "grid_heatmap", align = "center" }
+
+# Codebase split — LOC by language as a pie chart (more striking than yet
+# another bar chart) | largest files as a numbered ranking.
+[[widget]]
+id = "loc_pie"
 fetcher = "code_loc"
+render = { type = "chart_pie", legend = "right" }
   [widget.options]
   unit = "loc"
 
 [[widget]]
-id = "todos"
-fetcher = "code_todos"
+id = "largest_files"
+fetcher = "code_largest_files"
+render = { type = "list_ranking", style = "number" }
   [widget.options]
   limit = 6
+
+# Activity split — recent commits as a real timeline (time column + bullet) |
+# top contributors as a horizontal bar chart. Contributors honors the repo's
+# .mailmap, so a single developer with multiple git identities collapses to
+# one bar instead of two-three identical "ola | ola" entries.
+[[widget]]
+id = "commits"
+fetcher = "git_recent_commits"
+render = { type = "list_timeline", bullet = "●", max_items = 6, date_format = "relative" }
+
+[[widget]]
+id = "contributors"
+fetcher = "git_contributors"
+render = { type = "chart_bar", horizontal = true }
+  [widget.options]
+  limit = 5
+
+# Footer pair — TODO hotspots | my open PRs across all repos (GitHub-scoped).
+[[widget]]
+id = "todos"
+fetcher = "code_todos"
+render = { type = "list_links", max_items = 6 }
 
 [[widget]]
 id = "my_prs"
 fetcher = "github_my_prs"
-  [widget.options]
-  limit = 5
+render = { type = "list_links", max_items = 5 }
 
-  # ---------------- Layout ----------------
+# ── Layout ─────────────────────────────────────────────────────────
 
-# Banner — repo name as figlet (standard font, recognisable across widths)
+# Hero band — lifted on bg=subtle. Spacer row above the figlet so the banner
+# breathes inside the band rather than hugging the terminal edge.
 [[row]]
-height = { length = 6 }
+height = { length = 1 }
+bg = "subtle"
+
+[[row]]
+height = { length = 7 }
+bg = "subtle"
   [[row.child]]
   widget = "repo_banner"
   width = { fill = 1 }
 
-# Quick status row — branch info + repo age (no CI by default)
+# Status badge strip — three pills, flex-centered, still on the subtle band so
+# they read as part of the hero unit. Each badge sized to fit a typical label
+# ("1d 12h" / "main · clean" / "0 stashes") plus the rounded ( … ) frame.
 [[row]]
-height = { length = 3 }
+height = { length = 1 }
+bg = "subtle"
+flex = "center"
 gap = 2
   [[row.child]]
-  widget = "status"
-  width = { fill = 2 }
-  border = "rounded"
-  title = " Status "
-  title_align = "center"
+  widget = "badge_age"
+  width = { length = 22 }
   [[row.child]]
-  widget = "age"
+  widget = "badge_status"
+  width = { length = 28 }
+  [[row.child]]
+  widget = "badge_stash"
+  width = { length = 18 }
+
+[[row]]
+height = { length = 1 }
+bg = "subtle"
+
+# Clean break out of the hero band.
+[[row]]
+height = { length = 1 }
+
+# Activity heatmap centerpiece — full width, thick border anchors the dashboard.
+[[row]]
+height = { length = 7 }
+  [[row.child]]
+  widget = "activity"
   width = { fill = 1 }
-  border = "rounded"
-  title = " Age "
+  border = "thick"
+  title = "  activity · 12 months  "
   title_align = "center"
 
-# Activity row — recent commits + contributors bar chart.
-# Contributors gets 2/5 width so author names aren't clipped.
+[[row]]
+height = { length = 1 }
+
+# Codebase split — pie chart (LOC) | numbered ranking (largest files).
+[[row]]
+height = { length = 8 }
+gap = 2
+  [[row.child]]
+  widget = "loc_pie"
+  width = { fill = 1 }
+  border = "rounded"
+  title = "  languages  "
+  title_align = "center"
+  [[row.child]]
+  widget = "largest_files"
+  width = { fill = 1 }
+  border = "rounded"
+  title = "  largest files  "
+  title_align = "center"
+
+[[row]]
+height = { length = 1 }
+
+# Activity split — commits timeline (3/5 width) | contributors bars (2/5).
+# Commits gets more room because timeline entries have a time column + title
+# that benefit from horizontal space; contributors gets less because the bars
+# are horizontal and read cleanly at narrower widths.
 [[row]]
 height = { length = 9 }
 gap = 2
   [[row.child]]
   widget = "commits"
   width = { fill = 3 }
-  border = "rounded"
-  title = " Recent commits "
+  border = "top"
+  title = "  recent commits  "
   title_align = "center"
   [[row.child]]
   widget = "contributors"
   width = { fill = 2 }
-  border = "rounded"
-  title = " Top contributors "
+  border = "top"
+  title = "  top contributors  "
   title_align = "center"
 
-# Codebase row — LOC by language + TODO hotspots
 [[row]]
-height = { length = 8 }
+height = { length = 1 }
+
+# Footer pair — TODOs | my open PRs. Rounded borders mirror the codebase split
+# so the bottom of the dashboard echoes its top half.
+[[row]]
+height = { length = 7 }
 gap = 2
-  [[row.child]]
-  widget = "loc"
-  width = { fill = 1 }
-  border = "rounded"
-  title = " Lines of code "
-  title_align = "center"
   [[row.child]]
   widget = "todos"
   width = { fill = 1 }
   border = "rounded"
-  title = " TODOs "
+  title = "  TODOs  "
   title_align = "center"
-
-# My PRs across all repos (filtered by the GH fetcher)
-[[row]]
-height = { length = 7 }
   [[row.child]]
   widget = "my_prs"
   width = { fill = 1 }
   border = "rounded"
-  title = " My open PRs "
+  title = "  my open PRs  "
   title_align = "center"


### PR DESCRIPTION
## Summary

Redesigns the splashboard project dashboards so they read as composed layouts with strong typographic hierarchy and mixed widget vocabulary, instead of a stack of look-alike rounded boxes. Also fixes the broken `font = \"standard\"` figlet banner and the duplicate \"23 | 23 ola | ola\" contributor bars.

**Visual changes** (gruvbox_dark theme stays):
- Banner: `font = \"standard\"` (broken) → `font = \"ansi_shadow\"` with `color = \"panel_title\"`
- Status row: bland 2-column \"Status + Age\" → 3-pill `status_badge` strip (age / status / stash)
- Centerpiece: new full-width 12-month commit heatmap with `border = \"thick\"`
- LOC: `chart_bar` → `chart_pie` (with `legend = \"right\"`)
- Added `code_largest_files` ranking with medal glyphs (🥇🥈🥉) on the repo override
- Recent commits: plain list → proper `list_timeline` (bullet + relative time column)
- Mixed border hierarchy (thick → rounded → top → rounded) for visual rhythm

**Contributor dedup:** new `.mailmap` collapses four git identities (olafkfreund / Olaf K-Freund / Olaf Krasicki-Freund across three emails) into one canonical author. `git shortlog -sne` now shows 1908 commits under one line. `git_contributors` honors this via gix, so the duplicate \"ola | ola\" bars become a single full-height bar.

**Side fix:** `_typos.toml` adds `ratatui` (the Rust TUI library, not a misspelling of *ratatouille*) to the allowlist — was blocking the pre-commit hook on the pre-existing `pkgs/splashboard/default.nix` comment.

Files: `home/shell/splashboard/project.dashboard.toml` (bundled fallback), `.splashboard/dashboard.toml` (per-repo override, GitHub-heavy), `home/shell/splashboard/home.dashboard.toml` (minor tune), `.mailmap` (new), `_typos.toml` (allowlist).

## Test plan

- [x] All three TOMLs parse cleanly (`python3 -c 'import tomllib; tomllib.loads(open(f).read())'`)
- [x] Every widget's fetcher / render shape combo verified against `splashboard catalog renderer <name>` (caught one issue during validation — `github_repo_stars` does NOT emit `badge`, kept it as `grid_table` instead)
- [x] `git shortlog -sne` reports 1 author with 1908 commits (was 4 separate identities)
- [x] `just test-host p620` succeeds; new home-manager-files derivation contains the new TOMLs
- [x] `typos pkgs/splashboard/default.nix` passes with new allowlist
- [x] Pre-commit hooks pass (typos, TOML format, trailing whitespace, EOF)
- [ ] **After merge:** `just quick-deploy p620` then `cd ~/.config/nixos` to confirm new banner reads cleanly, badges render, heatmap is the centerpiece, pie chart replaces languages bar chart, and contributors collapses to one bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)