### PR TITLE
chore(claude-code): bump native binary 2.1.141 → 2.1.143 (#524)

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.141";
+  version = "2.1.143";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-gyvibo8Vsq6Z5SCiKwNPxL+tHLW4Tea3BkhwcsVrtC4=";
+      hash = "sha256-91/cP/nZzUlLhhkvnjSbXFxtOXDtTVzVx7MwxaKx3MQ=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-3JMeJPYq+63I3GgRUniwhJOCWj7R6nU9WHB3GBpsxjs=";
+      hash = "sha256-MujtxKXDxB0YYHx10bjnvsZDMwwD4ma+Rqw7QaRGxOs=";
     };
   };
 


### PR DESCRIPTION
## Summary

- Bumps `pkgs/claude-code-native/default.nix` from **2.1.141 → 2.1.143** (Anthropic's `latest` GCS channel).
- Updates `x86_64-linux` and `aarch64-linux` SRI hashes from the official manifest.

## Test plan

- [x] `nix build .#claude-code-native` succeeds
- [x] `result/bin/claude --version` → `2.1.143 (Claude Code)`
- [x] `ldd` shows no missing libs
- [x] All 3 host top-levels build clean (p620, razer, p510)
- [ ] Post-merge deploy to p620 (local), razer + p510 (remote)

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)