### PR TITLE
fix(nix): add cache.garnix.io substituter to fix openclaw FOD (#527)

### DIFF
--- a/modules/nix/nix.nix
+++ b/modules/nix/nix.nix
@@ -38,15 +38,17 @@
     fallback = true; # Build locally if substitute not available
 
     # Multi-tier binary cache configuration
-    # Priority order: NixOS official → Nix community
+    # Priority order: NixOS official → Nix community → Garnix (upstream openclaw)
     substituters = [
       "https://cache.nixos.org" # Official NixOS cache (always available)
       "https://nix-community.cachix.org" # Community cache
+      "https://cache.garnix.io" # Upstream openclaw / nix-openclaw binary cache
     ];
 
     trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" # Official NixOS
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=" # Nix community
+      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=" # Garnix
     ];
 
     # Optional: Add Cachix personal cache (free tier: 5GB storage, unlimited downloads)


### PR DESCRIPTION
## Summary

- Adds `https://cache.garnix.io` (with public key `cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=`) to `modules/nix/nix.nix`.
- Unblocks builds that depend on `programs.openclaw.enable = true;` (which pulls `openclaw-gateway-pnpm-deps` — an FOD upstream pins to a hash that local rebuilds cannot reproduce).

## Why

The pnpm-deps fetcher's `fixupPhase` is non-deterministic (no `--threads=1` on its `tar --zstd` call → parallel compression varies). Upstream publishes the canonical output to garnix; without garnix in our substituter list, every cold build of openclaw fails with:

```
hash mismatch: specified c2q59h1u…   got FCfdbhz… / qIiQe/wf… (different each rebuild)
```

## Test plan

- [x] `nix-store --realise /nix/store/gdbn2c30…-openclaw-gateway-pnpm-deps` succeeds with garnix added
- [x] `nix build .#nixosConfigurations.p620.config.system.build.toplevel` completes (rc=0)
- [ ] Post-merge deploy to p620 succeeds without `--option substituters` overrides

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)