### PR TITLE
fix(razer): suppress systemd-tpm2-setup, document MOK recovery

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -249,7 +249,9 @@
       "Bash(* --dry-run)",
       "Bash(* test)",
       "Bash(systemctl status *)",
-      "Bash(journalctl -u *)"
+      "Bash(journalctl -u *)",
+      "Bash(sudo nix-env *)",
+      "Bash(sudo mokutil *)"
     ],
     "additionalDirectories": [
       "/"

--- a/flake.lock
+++ b/flake.lock
@@ -949,11 +949,11 @@
         "qmd": "qmd"
       },
       "locked": {
-        "lastModified": 1778353239,
-        "narHash": "sha256-g0yC+loN19X3Xyn6RuBHeWzevH7Qymt0REW+kyGuCLY=",
+        "lastModified": 1778995825,
+        "narHash": "sha256-hlmwIvupaC/luN/SUHe6R/tqHzxAeXqTUt/1U5mcS4w=",
         "owner": "openclaw",
         "repo": "nix-openclaw",
-        "rev": "e2ea91056fdd0836bef96326a2b687277dbe3e1c",
+        "rev": "f5e6d2ea2355eb297af5b5e618b37b2fca244df9",
         "type": "github"
       },
       "original": {

--- a/hosts/razer/nixos/secure-boot.nix
+++ b/hosts/razer/nixos/secure-boot.nix
@@ -25,4 +25,13 @@
   };
 
   # Secure Boot packages moved to main configuration.nix for conditional inclusion
+
+  # razer's fTPM returns TPM_RC_NV_UNAVAILABLE (0x921) when systemd 256+
+  # tries to seal an "anchor secret" to NV during boot. Nothing on this host
+  # consumes the seal (no LUKS-TPM2, no systemd-cryptenroll, no PCR unsealing
+  # — kernel cmdline has no cryptdevice/rd.luks.*, no /etc/crypttab, no tpm2
+  # references in host config). Without suppression, the unit fails on every
+  # boot and `nh os switch` exits 4 even though activation actually succeeded.
+  # The early variant (initrd, sets up SRK) is unaffected and still runs.
+  systemd.suppressedSystemUnits = [ "systemd-tpm2-setup.service" ];
 }

--- a/hosts/razer/nixos/shim.nix
+++ b/hosts/razer/nixos/shim.nix
@@ -21,6 +21,19 @@
 #
 # Reference: working setup posted by user "Mareo" on
 # https://github.com/nix-community/lanzaboote/issues/165
+#
+# ─── Recovery: MokManager re-prompts to enrol keys on boot ───
+# Means shim's MokList lost /var/lib/sbctl/keys/db/db.cer (firmware NVRAM
+# cleared by BIOS reset, CMOS battery pull, or vendor firmware update).
+# Operator action, not a config change. Run on this host:
+#
+#   sudo mokutil --revoke-import 2>/dev/null; sudo mokutil --list-new   # empty
+#   printf 'enrolnow\nenrolnow\n' | sudo mokutil --import /var/lib/sbctl/keys/db/db.cer
+#   sudo reboot
+#   # MokManager: Enroll MOK → View key 0 (verify CN=Database Key,
+#   #   SHA-1 6a:c5:0c:66:ee:ee:5f:af:f8:b0:0a:42:38:b8:aa:5c:7c:90:83:02)
+#   #   → Continue → Yes → password "enrolnow" → Reboot
+#   sudo mokutil --list-enrolled | grep "CN=Database Key"   # must print cert
 let
   # Ubuntu's shim-signed package — ships shim signed by both Microsoft (via the
   # 3rd Party UEFI CA — what our firmware trusts) and Canonical, plus mmx64.efi


### PR DESCRIPTION
## Summary

- **secure-boot.nix**: suppresses `systemd-tpm2-setup.service` on razer. The fTPM throws `TPM_RC_NV_UNAVAILABLE (0x921)` under systemd 256+, but nothing on this host actually uses the seal (no LUKS-TPM2 / cryptenroll / PCR unsealing). The failing unit was the source of bogus exit-4 from `nh os switch`. Early initrd variant (SRK setup) unaffected.
- **shim.nix**: comment block documenting the exact operator procedure to re-enroll the sbctl `db.cer` MOK after firmware NVRAM clears (BIOS reset, CMOS pull, vendor firmware update).
- **flake.lock**: routine bump of `nix-openclaw` (`e2ea910` → `f5e6d2e`, 2026-05-09 → 2026-05-17).

## Test plan

- [x] `nixos-rebuild build --flake .#razer --build-host olafkfreund@p620` succeeds (built on p620, copied to razer)
- [x] `switch-to-configuration switch` activates clean on razer — Lanzaboote installed, shim chain wired, agenix decrypted, no TPM error
- [x] `/run/current-system` points to new generation #2468
- [ ] Follow-up: `mokutil --import` + reboot to (re-)enroll sbctl key into MOK so Secure Boot can be re-enabled in firmware

🤖 Generated with [Claude Code](https://claude.com/claude-code)