### PR TITLE
fix(razer/shim): export coreutils in install-bootloader-with-shim PATH (#530)

### DIFF
--- a/hosts/razer/nixos/shim.nix
+++ b/hosts/razer/nixos/shim.nix
@@ -76,6 +76,11 @@ in
     system.build.installBootLoader = lib.mkForce (pkgs.writeShellScript "install-bootloader-with-shim" ''
       set -euo pipefail
 
+      # `nixos-rebuild` invokes us via `systemd-run --pipe` with `env -i`, so
+      # PATH is empty and bare `cp` / `install` fail with "command not found".
+      # Inject coreutils explicitly.
+      export PATH=${lib.makeBinPath [ pkgs.coreutils ]}:''${PATH:-}
+
       # Step 1: lanzaboote's standard install. Writes signed BOOTX64.EFI
       # (= lanzaboote-stub) and per-generation UKIs in /EFI/Linux/.
       #


### PR DESCRIPTION
## Summary

`nixos-rebuild` invokes `system.build.installBootLoader` via `systemd-run --pipe` with `env -i PATH=""`, so our shim wrapper's bare `cp` / `install` calls hit *command not found* and leave razer with lanzaboote-stub at `/EFI/BOOT/BOOTX64.EFI` — unbootable in Secure Boot mode.

Fix: inject coreutils into PATH at the top of the generated script:

```nix
export PATH=${lib.makeBinPath [ pkgs.coreutils ]}:${PATH:-}
```

## Test plan

- [x] `nix build .#nixosConfigurations.razer.config.system.build.toplevel` rc=0
- [x] Generated script header now includes `export PATH=/nix/store/…coreutils-9.10/bin:…`
- [ ] Post-merge: `just deploy-via-p620 razer` (or `nixos-rebuild switch …`) completes through bootloader install

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)