### PR TITLE
chore(warp-terminal): bump to v0.2026.05.13.09.15.stable_03

### DIFF
--- a/pkgs/warp-terminal/versions.json
+++ b/pkgs/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "linux_x86_64": {
-    "hash": "sha256-9SUbv2IuON8s3ewVze/ynoVvfQu+Tb/fNqMZVY/Ze+w=",
-    "version": "0.2026.05.06.15.42.stable_05"
+    "hash": "sha256-5Gl7EYXSLHsp0GDx89RZiCDhOqCbHZuxJYOKuOzEz3Y=",
+    "version": "0.2026.05.13.09.15.stable_03"
   },
   "linux_aarch64": {
-    "hash": "sha256-taeEA10ij8tTwFjF8aMbYuP3GJMBFXCOMJPgmZoNj/U=",
-    "version": "0.2026.05.06.15.42.stable_05"
+    "hash": "sha256-BzMaD1z6hsabQfgdJRPrqQNKOLHlRFKYQ5xAvfNNLhA=",
+    "version": "0.2026.05.13.09.15.stable_03"
   }
 }


### PR DESCRIPTION
## Summary

Bump `pkgs/warp-terminal/versions.json` from `0.2026.05.06.15.42.stable_05` to `0.2026.05.13.09.15.stable_03` on both `linux_x86_64` and `linux_aarch64`.

## Verification

- `./scripts/update-warp-terminal.sh --check` → exit 1 (newer available)
- `./scripts/update-warp-terminal.sh` → wrote new hashes via `nix store prefetch-file`
- `nix build .#nixosConfigurations.p620.pkgs.warp-terminal` → built cleanly, autoPatchelfHook passed
- `nix build .#nixosConfigurations.p620.config.system.build.toplevel` → 3:52, no overlay surprises
- Binary verified ELF
- Version pin in `pkgs.warp-terminal.version` matches `versions.json`

## Test plan

- [ ] Merge
- [ ] `nhs p620` (or `nhs razer`) — overlay picks up the new version, launches cleanly