### PR TITLE
chore(antigravity): bump flake input a80b1bb → db285f7

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778594411,
-        "narHash": "sha256-8tSGwvaYv5vDBojo8zLKVii6R6GzyzRXSq5o9VvOUe4=",
+        "lastModified": 1778836484,
+        "narHash": "sha256-DN6FpQFdT1ik/FDsdq7PM7yLogejjJerq7HcNHH+UPA=",
         "owner": "jacopone",
         "repo": "antigravity-nix",
-        "rev": "a80b1bb9db5067639452dad2107504d60bfdd7ce",
+        "rev": "db285f7d21f691407ea9264ee8b4ad58f82064fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
Bump `antigravity-nix` flake input from `a80b1bb` (2026-05-12) to `db285f7` (2026-05-15).

Upstream change in range:
- `db285f7` fix: detect merged PRs via API instead of git ancestry (#42)

Only `flake.lock` touched (3 lines: rev, narHash, lastModified). No other inputs moved.

## Test plan
- [x] Host matrix builds clean: p620, razer, p510 — all three `nixosConfigurations.<host>.config.system.build.toplevel` produced store paths
- [ ] Deploy with `nhs <host>` after review

🤖 Generated with [Claude Code](https://claude.com/claude-code)