### PR TITLE
chore(claude-code): bump native binary 2.1.143 → 2.1.144

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.143";
+  version = "2.1.144";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-91/cP/nZzUlLhhkvnjSbXFxtOXDtTVzVx7MwxaKx3MQ=";
+      hash = "sha256-FHSAd0Ry5XIP1eg2F7PpKZNE5yE++oTDJrJb1aDyC04=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-MujtxKXDxB0YYHx10bjnvsZDMwwD4ma+Rqw7QaRGxOs=";
+      hash = "sha256-yMzMv84S1oRYi9OvNmOUEy9hTc88hr6yBm+GveJwRRM=";
     };
   };
 


### PR DESCRIPTION
## Summary
Bump `claude-code-native` from 2.1.143 to 2.1.144 (Anthropic GCS `latest` channel).

Closes #534. Supersedes the stale #522 (which asked for 2.1.142).

## Test plan
- [x] `nix build .#claude-code-native` → `claude --version` reports `2.1.144 (Claude Code)`
- [x] `ldd $out/bin/claude` → no missing libs
- [x] Host matrix builds clean: p620, razer, p510 — all `nixosConfigurations.<host>.config.system.build.toplevel` produced store paths
- [ ] Deploy with `nh os switch` (p620 local; razer/p510 via SSH) after review

🤖 Generated with [Claude Code](https://claude.com/claude-code)