### PR TITLE
feat(claude-desktop): bump v2.0.6 → v2.0.12+claude1.7196.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,17 +116,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1777611002,
-        "narHash": "sha256-wdwbGiW2qkXpnoZj1b8JycCoDwAqIpGMYAFt2s/O8+Q=",
+        "lastModified": 1779155095,
+        "narHash": "sha256-NAOfLgF2uiDdjmfrKsEQi6bFpw/3+i6eMDpzyS0Oyhk=",
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "c973f4922bac6b5b5b4d07929ee4a98a69cb71a9",
+        "rev": "ba2846c8b3e99ac35563e6c2184dd999b19bbc95",
         "type": "github"
       },
       "original": {
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "c973f4922bac6b5b5b4d07929ee4a98a69cb71a9",
+        "rev": "ba2846c8b3e99ac35563e6c2184dd999b19bbc95",
         "type": "github"
       }
     },
@@ -435,11 +435,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -1079,11 +1079,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {
@@ -1264,11 +1264,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1776949667,
-        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -72,13 +72,21 @@
     # Additional tools
     lan-mouse.url = "github:feschber/lan-mouse";
     zjstatus.url = "github:dj95/zjstatus";
-    # = tag v2.0.6+claude1.5354.0 (2026-05-01). Bumped from ≈v2.0.5 for
-    # X-button-to-tray (#451), persistent autostart toggle (#450), tray
-    # icon in-place updates (#515), and window visibility fix (#496).
-    # Stayed on v2.0.6 (not v2.0.7+) to avoid the frame-fix-wrapper.js
-    # syslog flood (upstream #582). claude binary unchanged at 1.5354.0.
+    # = main HEAD ba2846c8 (2026-05-19), release tag v2.0.12+claude1.7196.3.
+    # Bumped from v2.0.6 (53 commits, 11 releases). Picks up:
+    #   - #581 fix(nix): make electron binary executable (Nix-specific)
+    #   - #583/#585 GPU FATAL mitigations (CLAUDE_DISABLE_GPU=1 opt-in;
+    #     electron pinned to 41.5.0 to match app.asar ABI)
+    #   - #555 cowork.sh defensive lastIndexOf
+    #   - _svcLaunched cowork daemon recovery (closed #408, #236)
+    #   - claude binary 1.5354.0 → 1.7196.3 (~1842-version advance)
+    # Held-back blocker #582 (syslog flood) turned out to be Ubuntu
+    # apport-specific (no apport on NixOS), so safe to leave behind.
+    # Known caveat carried in: #605 (Electron holds systemd-inhibit
+    # forever, blocking suspend while app runs). Razer-relevant.
+    # Workaround: close claude-desktop entirely to release inhibitor.
     # Bump via /update-claude-code.
-    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/c973f4922bac6b5b5b4d07929ee4a98a69cb71a9";
+    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/ba2846c8b3e99ac35563e6c2184dd999b19bbc95";
 
     # Terminal YouTube browser
     yt-x = {


### PR DESCRIPTION
## Summary
53 commits, 11 releases ahead of the prior pin (`c973f49` v2.0.6+claude1.5354.0 → `ba2846c8` v2.0.12+claude1.7196.3). Pin is main HEAD which corresponds to today's release tag.

### Picks up
- **#581 `fix(nix): make electron binary executable`** — Nix-specific
- **#583/#585** GPU FATAL mitigations: `CLAUDE_DISABLE_GPU=1` opt-in + electron pinned to `41.5.0` to match `app.asar` ABI
- **#555** `cowork.sh` defensive `lastIndexOf`
- **#408 / #236** Cowork `_svcLaunched` daemon recovery — both closed upstream
- claude binary `1.5354.0` → `1.7196.3`

### Reassessed held-back blocker
The prior comment held us at v2.0.6 to avoid #582 (syslog flood). Reading the issue thread end-to-end shows the mechanism is an **Ubuntu apport feedback loop** (Electron crash → `core_pattern` pipe → `update-notifier-crash` → rsyslog → `/var/log/syslog`). **NixOS does not run apport**, so this is not a Nix-applicable regression. Safe to leave v2.0.6 behind.

### Known carry-in (open upstream)
- **#605** — Electron registers `systemd-inhibit` (`sleep, Application cleanup before suspend, delay`) on startup and never releases it. **Razer suspend is blocked while claude-desktop is running.** Workaround: close the app entirely to release the inhibitor. Likely already present at v2.0.6.

## Test plan
- [x] `nix flake lock --update-input claude-desktop-linux` → resolved rev `ba2846c8b3` (2026-05-19)
- [x] FHS package builds: inner closure `claude-desktop-1.7196.3`
- [x] `pty.node` is ELF and present in `app.asar.unpacked/.../node-pty/build/Release/`
- [x] Host matrix clean: p620, razer, p510 — all `nixosConfigurations.<host>.config.system.build.toplevel` produced store paths
- [ ] Deploy to razer first (primary claude-desktop host). Requires `pkill -f claude-desktop` after switch to pick up the new binary — **warn user before pkill** per /update-claude-code idiot-proofing.
- [ ] Deploy to p620 once razer is stable.

If the launcher fails immediately after switch (e.g. "VM service not running"), first remediation is `rm -rf ~/.config/Claude/vm_bundles/` (state can go stale across a ~1842-version claude-binary advance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)