### PR TITLE
feat(antigravity): local fork for 2.0.0 while upstream is on 1.23.2

### DIFF
--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -149,7 +149,11 @@ in
 
   # Packages common to all interactive (non-headless) hosts
   home.packages = [
-    antigravity-nix.packages.${pkgs.stdenv.hostPlatform.system}.google-antigravity-no-fhs
+    # Antigravity 2.0.0 — local fork in pkgs/antigravity-2x/ while
+    # upstream jacopone/antigravity-nix is still on 1.23.2. Switch back to
+    # `antigravity-nix.packages.${...}.google-antigravity-no-fhs` once upstream
+    # handles the 2.0 layout. See pkgs/default.nix for the rationale.
+    pkgs.customPkgs.antigravity-2x
     pkgs.customPkgs.kosli-cli
     pkgs.customPkgs.aurynk
     pkgs.wayfarer

--- a/pkgs/antigravity-2x/LICENSE.upstream
+++ b/pkgs/antigravity-2x/LICENSE.upstream
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 antigravity-nix contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkgs/antigravity-2x/package.nix
+++ b/pkgs/antigravity-2x/package.nix
@@ -1,59 +1,60 @@
-{
-  lib,
-  stdenv,
-  fetchurl,
-  buildFHSEnv,
-  autoPatchelfHook,
-  makeDesktopItem,
-  copyDesktopItems,
-  makeWrapper,
-  writeShellScript,
-  asar,
-  bash,
-  alsa-lib,
-  at-spi2-atk,
-  at-spi2-core,
-  atk,
-  cairo,
-  chromium,
-  cups,
-  dbus,
-  expat,
-  glib,
-  gtk3,
-  libdrm,
-  libgbm,
-  libglvnd,
-  libnotify,
-  libsecret,
-  libuuid,
-  libxkbcommon,
-  nspr,
-  nss,
-  pango,
-  systemdLibs,
-  vulkan-loader,
-  libx11,
-  libxscrnsaver,
-  libxcomposite,
-  libxcursor,
-  libxdamage,
-  libxext,
-  libxfixes,
-  libxi,
-  libxrandr,
-  libxrender,
-  libxtst,
-  libxcb,
-  libxshmfence,
-  libxkbfile,
-  zlib,
-  useFHS ? true,
-  useSystemChromeProfile ? true,
-  google-chrome ? null,
-  extraBwrapArgs ? [],
-  srcOverride ? null,
-}: let
+{ lib
+, stdenv
+, fetchurl
+, buildFHSEnv
+, autoPatchelfHook
+, makeDesktopItem
+, copyDesktopItems
+, makeWrapper
+, writeShellScript
+, asar
+, bash
+, alsa-lib
+, at-spi2-atk
+, at-spi2-core
+, atk
+, cairo
+, chromium
+, cups
+, dbus
+, expat
+, glib
+, gtk3
+, libdrm
+, libgbm
+, libglvnd
+, libnotify
+, libsecret
+, libuuid
+, libxkbcommon
+, nspr
+, nss
+, pango
+, systemdLibs
+, vulkan-loader
+, libx11
+, libxscrnsaver
+, libxcomposite
+, libxcursor
+, libxdamage
+, libxext
+, libxfixes
+, libxi
+, libxrandr
+, libxrender
+, libxtst
+, libxcb
+, libxshmfence
+, libxkbfile
+, zlib
+, useFHS ? true
+, useSystemChromeProfile ? true
+, google-chrome ? null
+, extraBwrapArgs ? [ ]
+, srcOverride ? null
+,
+}:
+let
   pname = "google-antigravity";
   # Antigravity 2.0.0 — Google's 2026-05-19 major release. Vendored locally
   # because upstream jacopone/antigravity-nix is still on 1.23.2 and 2.0
@@ -171,7 +172,7 @@
     comment = "Next-generation agentic IDE";
     exec = "antigravity --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto --enable-wayland-ime=true --wayland-text-input-version=3 %U";
     icon = "antigravity";
-    categories = ["Development" "IDE"];
+    categories = [ "Development" "IDE" ];
     startupNotify = true;
     startupWMClass = "Antigravity";
     mimeTypes = [
@@ -184,7 +185,7 @@
     homepage = "https://antigravity.google";
     license = licenses.unfree;
     platforms = platforms.linux;
-    maintainers = [];
+    maintainers = [ ];
     mainProgram = "antigravity";
   };
 
@@ -200,7 +201,7 @@
     dontPatchELF = true;
     dontStrip = true;
 
-    nativeBuildInputs = [asar];
+    nativeBuildInputs = [ asar ];
 
     # 2.0: standard Electron asar layout, no sudo-prompt to patch.
 
@@ -251,9 +252,9 @@
     dontUnpack = true;
     dontBuild = true;
 
-    nativeBuildInputs = [copyDesktopItems asar];
+    nativeBuildInputs = [ copyDesktopItems asar ];
 
-    desktopItems = [desktopItem];
+    desktopItems = [ desktopItem ];
 
     installPhase = ''
       runHook preInstall
@@ -310,7 +311,7 @@
     # layout (resources/app.asar + resources/app.asar.unpacked/). No patching
     # required — Electron handles the layout natively at runtime.
 
-    desktopItems = [desktopItem];
+    desktopItems = [ desktopItem ];
 
     installPhase = ''
       runHook preInstall
@@ -357,6 +358,6 @@
     '';
   };
 in
-  if useFHS
-  then fhs-package
-  else no-fhs-package
+if useFHS
+then fhs-package
+else no-fhs-package

--- a/pkgs/antigravity-2x/package.nix
+++ b/pkgs/antigravity-2x/package.nix
@@ -1,0 +1,362 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  buildFHSEnv,
+  autoPatchelfHook,
+  makeDesktopItem,
+  copyDesktopItems,
+  makeWrapper,
+  writeShellScript,
+  asar,
+  bash,
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  chromium,
+  cups,
+  dbus,
+  expat,
+  glib,
+  gtk3,
+  libdrm,
+  libgbm,
+  libglvnd,
+  libnotify,
+  libsecret,
+  libuuid,
+  libxkbcommon,
+  nspr,
+  nss,
+  pango,
+  systemdLibs,
+  vulkan-loader,
+  libx11,
+  libxscrnsaver,
+  libxcomposite,
+  libxcursor,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxi,
+  libxrandr,
+  libxrender,
+  libxtst,
+  libxcb,
+  libxshmfence,
+  libxkbfile,
+  zlib,
+  useFHS ? true,
+  useSystemChromeProfile ? true,
+  google-chrome ? null,
+  extraBwrapArgs ? [],
+  srcOverride ? null,
+}: let
+  pname = "google-antigravity";
+  # Antigravity 2.0.0 — Google's 2026-05-19 major release. Vendored locally
+  # because upstream jacopone/antigravity-nix is still on 1.23.2 and 2.0
+  # changes the CDN path, internal asar layout, launcher location and icon
+  # path all at once (see pkgs/antigravity-2x/README.md if you create one,
+  # or the PR description). Revert this whole directory once upstream
+  # catches up; the only consumer is Users/olafkfreund/profile.nix.
+  version = "2.0.0-6324554176528384";
+
+  isAarch64 = stdenv.hostPlatform.system == "aarch64-linux";
+
+  browserPkg =
+    if isAarch64
+    then chromium
+    else if google-chrome != null
+    then google-chrome
+    else
+      throw ''
+        google-chrome is required on ${stdenv.hostPlatform.system} builds.
+        Make sure you have allowUnfree = true or pass a google-chrome package.
+      '';
+
+  browserCommand =
+    if isAarch64
+    then "chromium"
+    else "google-chrome-stable";
+
+  browserProfileDir =
+    if isAarch64
+    then "$HOME/.config/chromium"
+    else "$HOME/.config/google-chrome";
+
+  finalSrc =
+    if srcOverride != null
+    then srcOverride
+    else
+      fetchurl {
+        # 2.0 ships from a different CDN bucket than 1.x. Old:
+        #   edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/...
+        url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/${version}/linux-x64/Antigravity.tar.gz";
+        hash = "sha256-FLyctIClvo+zt9w+Kwzr+mbTcK1YzB4PoBFA0SBNQpc=";
+      };
+
+  # Create a browser wrapper
+  # When useSystemChromeProfile is true (default), forces use of the user's
+  # existing Chrome profile so extensions are available to Antigravity.
+  # When false, omits profile flags so Chrome runs with its own default
+  # behavior, isolating Antigravity from the user's main profile.
+  chrome-wrapper = writeShellScript "${browserCommand}-with-profile" ''
+    set -euo pipefail
+
+    system_browser="/run/current-system/sw/bin/${browserCommand}"
+    browser_cmd="$system_browser"
+
+    if [ ! -x "$system_browser" ]; then
+      browser_cmd=${browserPkg}/bin/${browserCommand}
+    fi
+
+    exec "$browser_cmd" \
+      ${lib.optionalString useSystemChromeProfile ''--user-data-dir="${browserProfileDir}" --profile-directory=Default''} \
+      "$@"
+  '';
+
+  # Libraries loaded via dlopen() at runtime
+  dlopenLibs = [
+    libglvnd
+    vulkan-loader
+    systemdLibs
+    libnotify
+    libsecret
+  ];
+
+  # Libraries linked normally (resolved by autoPatchelf via rpath)
+  linkedLibs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    glib
+    gtk3
+    libdrm
+    libgbm
+    libuuid
+    libxkbcommon
+    nspr
+    nss
+    pango
+    stdenv.cc.cc.lib
+    libx11
+    libxscrnsaver
+    libxcomposite
+    libxcursor
+    libxdamage
+    libxext
+    libxfixes
+    libxi
+    libxrandr
+    libxrender
+    libxtst
+    libxcb
+    libxshmfence
+    libxkbfile
+    zlib
+  ];
+
+  runtimeLibs = linkedLibs ++ dlopenLibs;
+
+  desktopItem = makeDesktopItem {
+    name = "antigravity";
+    desktopName = "Google Antigravity";
+    comment = "Next-generation agentic IDE";
+    exec = "antigravity --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto --enable-wayland-ime=true --wayland-text-input-version=3 %U";
+    icon = "antigravity";
+    categories = ["Development" "IDE"];
+    startupNotify = true;
+    startupWMClass = "Antigravity";
+    mimeTypes = [
+      "x-scheme-handler/antigravity"
+    ];
+  };
+
+  meta = with lib; {
+    description = "Google Antigravity - Next-generation agentic IDE";
+    homepage = "https://antigravity.google";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = [];
+    mainProgram = "antigravity";
+  };
+
+  # ── FHS variant (default) ──────────────────────────────────
+
+  # Extract the upstream tarball without modification
+  antigravity-unwrapped = stdenv.mkDerivation {
+    inherit pname version;
+    src = finalSrc;
+
+    dontBuild = true;
+    dontConfigure = true;
+    dontPatchELF = true;
+    dontStrip = true;
+
+    nativeBuildInputs = [asar];
+
+    # 2.0: standard Electron asar layout, no sudo-prompt to patch.
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/lib/antigravity
+      cp -r ./* $out/lib/antigravity/
+
+      runHook postInstall
+    '';
+
+    inherit meta;
+  };
+
+  # FHS environment for running Antigravity
+  fhs = buildFHSEnv {
+    name = "antigravity-fhs";
+    targetPkgs = pkgs:
+      runtimeLibs
+      ++ [
+        pkgs.udev
+        pkgs.libudev0-shim
+      ]
+      ++ lib.optional (browserPkg != null) browserPkg;
+
+    extraBwrapArgs = [
+      "--bind-try /etc/nixos/ /etc/nixos/"
+      "--ro-bind-try /etc/xdg/ /etc/xdg/"
+      "--ro-bind-try /etc/nixpkgs/ /etc/nixpkgs/"
+    ] ++ extraBwrapArgs;
+
+    runScript = writeShellScript "antigravity-wrapper" ''
+      # Set Chrome paths to use our wrapper that forces user profile
+      # This ensures extensions installed in user's Chrome profile are available
+      export CHROME_BIN=${chrome-wrapper}
+      export CHROME_PATH=${chrome-wrapper}
+
+      exec ${antigravity-unwrapped}/lib/antigravity/antigravity "$@"
+    '';
+
+    inherit meta;
+  };
+
+  fhs-package = stdenv.mkDerivation {
+    inherit pname version meta;
+
+    dontUnpack = true;
+    dontBuild = true;
+
+    nativeBuildInputs = [copyDesktopItems asar];
+
+    desktopItems = [desktopItem];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin
+      ln -s ${fhs}/bin/antigravity-fhs $out/bin/antigravity
+
+      # 2.0 icon is packed inside app.asar. `asar extract-file` writes to
+      # cwd/<filename>, so cd into the output dir before extracting.
+      mkdir -p $out/share/pixmaps $out/share/icons/hicolor/1024x1024/apps
+      ( cd $out/share/pixmaps && \
+        asar extract-file ${antigravity-unwrapped}/lib/antigravity/resources/app.asar icon.png && \
+        mv icon.png antigravity.png )
+      cp $out/share/pixmaps/antigravity.png \
+        $out/share/icons/hicolor/1024x1024/apps/antigravity.png
+
+      runHook postInstall
+    '';
+  };
+
+  # ── Non-FHS variant ────────────────────────────────────────
+  # Uses autoPatchelfHook instead of buildFHSEnv.
+  # This avoids the bubblewrap sandbox that sets the kernel
+  # "no new privileges" flag, which prevents sudo from working
+  # in the integrated terminal.
+
+  no-fhs-package = stdenv.mkDerivation {
+    inherit pname version meta;
+    src = finalSrc;
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      makeWrapper
+      copyDesktopItems
+      asar
+    ];
+
+    buildInputs = runtimeLibs;
+
+    runtimeDependencies = dlopenLibs;
+
+    # Optional deps from the bundled Microsoft Authentication extension
+    autoPatchelfIgnoreMissingDeps = [
+      "libwebkit2gtk-4.1.so.0"
+      "libsoup-3.0.so.0"
+      "libcurl.so.4"
+      "libcrypto.so.3"
+    ];
+
+    dontBuild = true;
+    dontConfigure = true;
+
+    # 2.0 dropped @vscode/sudo-prompt and adopted the standard Electron asar
+    # layout (resources/app.asar + resources/app.asar.unpacked/). No patching
+    # required — Electron handles the layout natively at runtime.
+
+    desktopItems = [desktopItem];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/lib/antigravity
+      cp -r ./* $out/lib/antigravity/
+
+      # 2.0: the launcher binary is at the tarball root, not under bin/.
+      # No tunnel shim needed — 2.0 handles tunnel internally (or absence
+      # thereof) without the 1.x ENOENT shim.
+      #
+      # We don't use makeWrapper here because Electron's bundled
+      # electron-log transport writes synchronously to stdout, and when
+      # the app is launched from a .desktop file (DE app menu) the parent
+      # closes the inherited stdout pipe — first console.info() triggers
+      # `Error: write EPIPE` from electron-log/src/node/transports/console.js
+      # and crashes the main process. Redirecting stdout/stderr to
+      # /dev/null when not attached to a TTY sidesteps this without
+      # silencing terminal launches.
+      mkdir -p $out/bin
+      cat > $out/bin/antigravity <<EOF
+      #!/usr/bin/env bash
+      export CHROME_BIN=${chrome-wrapper}
+      export CHROME_PATH=${chrome-wrapper}
+      if [ -t 1 ]; then
+        exec "$out/lib/antigravity/antigravity" "\$@"
+      else
+        exec "$out/lib/antigravity/antigravity" "\$@" >/dev/null 2>&1
+      fi
+      EOF
+      chmod +x $out/bin/antigravity
+
+      # Icon is packed inside app.asar in 2.0 (was a loose file under
+      # resources/app/resources/linux/ in 1.x). `asar extract-file` writes
+      # to cwd/<filename>, so cd into the output dir before extracting.
+      mkdir -p $out/share/pixmaps $out/share/icons/hicolor/1024x1024/apps
+      ( cd $out/share/pixmaps && \
+        asar extract-file $out/lib/antigravity/resources/app.asar icon.png && \
+        mv icon.png antigravity.png )
+      cp $out/share/pixmaps/antigravity.png \
+        $out/share/icons/hicolor/1024x1024/apps/antigravity.png
+
+      runHook postInstall
+    '';
+  };
+in
+  if useFHS
+  then fhs-package
+  else no-fhs-package

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -37,4 +37,10 @@
 
   # Claude Code native binary (alternative to npm-based package)
   claude-code-native = pkgs.callPackage ./claude-code-native { };
+
+  # Antigravity 2.x — local fork of jacopone/antigravity-nix until upstream
+  # handles Google's 2026-05-19 v2.0 release (new CDN path, new asar layout,
+  # different launcher location, icon now packed inside app.asar). Revert to
+  # the antigravity-nix flake input once upstream catches up.
+  antigravity-2x = pkgs.callPackage ./antigravity-2x/package.nix { useFHS = false; };
 }


### PR DESCRIPTION
## Summary

Google released **Antigravity 2.0** on 2026-05-19. Upstream `jacopone/antigravity-nix` is still pinned at 1.23.2 because the 2.0 release introduced five structural changes that the upstream Playwright-based auto-updater silently no-op'd.

This PR vendors a local fork of upstream's `package.nix` into `pkgs/antigravity-2x/`, applies the 2.0-specific edits inline, exposes it as `pkgs.customPkgs.antigravity-2x`, and swaps the single consumer in `Users/olafkfreund/profile.nix` to use it. Revert is a one-line change to `profile.nix` once upstream catches up — the antigravity-nix flake input is intentionally left in place.

## The five upstream deltas

| # | Layer | 1.x | 2.0 |
|---|---|---|---|
| 1 | CDN | `edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/${ver}/linux-x64/Antigravity.tar.gz` | `storage.googleapis.com/antigravity-public/antigravity-hub/${ver}/linux-x64/Antigravity.tar.gz` |
| 2 | asar layout | `resources/app/node_modules.asar` (modular) | `resources/app.asar` + `resources/app.asar.unpacked/` (standard Electron) |
| 3 | Launcher | `bin/antigravity` + tunnel shim | top-level `antigravity` (no `bin/`) |
| 4 | Icon | `resources/app/resources/linux/code.png` (loose) | inside `app.asar` at `/icon.png` |
| 5 | sudo-prompt | bundled (patched for nix paths) | **removed upstream** |

## Runtime fix: EPIPE on desktop launch

Replaced `makeWrapper` with a small bash launcher that redirects stdout/stderr to `/dev/null` when not connected to a TTY. Without this, `electron-log`'s console transport throws `Error: write EPIPE` and crashes the main process when launched from a `.desktop` entry — the parent (DE shell) closes the inherited stdout pipe. Terminal launches keep full output for debugging.

## Test plan

- [x] `nix build .#nixosConfigurations.razer.pkgs.customPkgs.antigravity-2x` succeeds
- [x] Inner `package.json` (inside `app.asar`) reports `"version": "2.0.0"`
- [x] Icon extracted correctly (PNG, 512x512, ~49KB)
- [x] Launcher is a real autoPatchelf'd ELF
- [x] Host matrix clean: p620, razer, p510
- [ ] Deploy to razer/p620 and verify launch from desktop entry no longer EPIPEs (left for user — not deployed)

## Follow-up

Open an issue at https://github.com/jacopone/antigravity-nix listing the five deltas so upstream can fix the Playwright scraper + URL builder + asar handling. Once that lands and we bump `antigravity-nix` to a 2.x-aware version, revert this PR: `profile.nix` returns to `antigravity-nix.packages.${system}.google-antigravity-no-fhs` and `pkgs/antigravity-2x/` is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)