### PR TITLE
feat(terminals): add Wave Terminal as features.terminals.wave

### DIFF
--- a/Users/common/features-impl.nix
+++ b/Users/common/features-impl.nix
@@ -20,6 +20,7 @@ in
       kitty.enable = cfg.terminals.kitty;
       ghostty.enable = cfg.terminals.ghostty;
       warp.enable = cfg.terminals.warp;
+      wave.enable = cfg.terminals.wave;
     })
 
     # Editor implementations

--- a/Users/common/features.nix
+++ b/Users/common/features.nix
@@ -9,6 +9,7 @@ let inherit (lib) mkEnableOption; in {
       kitty = mkEnableOption "Enable Kitty terminal";
       ghostty = mkEnableOption "Enable Ghostty terminal";
       warp = mkEnableOption "Enable Warp terminal";
+      wave = mkEnableOption "Enable Wave terminal";
     };
 
     editors = {

--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -61,6 +61,7 @@ in
       kitty = mkDefault false;
       ghostty = mkDefault false;
       warp = true;
+      wave = true;
     };
 
     editors = {

--- a/home/desktop/terminals/default.nix
+++ b/home/desktop/terminals/default.nix
@@ -105,6 +105,7 @@ in
     ./ghostty
     ./wezterm
     ./warp
+    ./wave
   ];
 
   # Backward compatibility options for individual terminals

--- a/home/desktop/terminals/wave/default.nix
+++ b/home/desktop/terminals/wave/default.nix
@@ -1,0 +1,21 @@
+{ config
+, lib
+, ...
+}:
+let
+  inherit (lib) mkIf mkEnableOption;
+  cfg = config.wave;
+in
+{
+  options.wave = {
+    enable = mkEnableOption "Wave terminal emulator";
+  };
+
+  config = mkIf cfg.enable {
+    # Wave Terminal — Electron + Go hybrid, in nixpkgs as pkgs.waveterm.
+    # We use the home-manager module so future declarative `programs.waveterm.settings`
+    # / `programs.waveterm.themes` wiring is a one-line addition. The AppImage
+    # upstream ships does NOT render on NixOS, so nixpkgs is the only viable path.
+    programs.waveterm.enable = true;
+  };
+}


### PR DESCRIPTION
## Summary
Add [Wave Terminal](https://www.waveterm.dev/) (wavetermdev/waveterm) as a new `features.terminals.wave` flag, enabled on **p620 + razer** (p510 unaffected — headless).

Wave is an open-source AI-native terminal: Electron UI + Go PTY/SSH/IPC backend. Distinct from Warp Terminal (different product, already enabled) and Wezterm.

## Why nixpkgs and not the upstream AppImage
Wave's AppImage renders **blank** on NixOS — a known issue. nixpkgs ships `pkgs.waveterm` (currently 0.13.1) which works correctly. home-manager has `programs.waveterm` for declarative wiring.

## Changes (all follow the existing per-terminal pattern)
- `Users/common/features.nix` — declare `wave = mkEnableOption ...`
- `Users/common/features-impl.nix` — route under `cfg.terminals.enable`
- `home/desktop/terminals/wave/default.nix` — new module, modelled on `warp/default.nix`, sets `programs.waveterm.enable = true;`
- `home/desktop/terminals/default.nix` — add `./wave` import
- `Users/olafkfreund/profile.nix` — flip `wave = true` in shared terminals block (propagates to p620 + razer via existing imports)

## Test plan
- [x] `nix eval .#nixosConfigurations.razer.config.home-manager.users.olafkfreund.programs.waveterm.enable` → `true`
- [x] `nix eval --raw .#nixosConfigurations.razer.config.home-manager.users.olafkfreund.programs.waveterm.package.version` → `0.13.1`
- [x] Host matrix clean: p620, razer, p510 — all toplevel builds produced store paths
- [ ] Deploy with `nh os switch` (p620 local; razer over SSH) after review
- [ ] Manually launch Wave Terminal from app menu on razer and p620 to confirm GUI renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)