### PR TITLE
feat(claude-code): vendor borghei/Claude-Skills "claude-code-mastery"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,6 +130,22 @@
         "type": "github"
       }
     },
+    "claude-skills-borghei": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779100952,
+        "narHash": "sha256-+4gsVag/OG8pNYUad79p5GvVAAcyavWaXKHp/ZJfr+w=",
+        "owner": "borghei",
+        "repo": "Claude-Skills",
+        "rev": "b3f2d35b273bfc9621122c45e034c214ddd06f9e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "borghei",
+        "repo": "Claude-Skills",
+        "type": "github"
+      }
+    },
     "cosmic-applet-spotify": {
       "inputs": {
         "flake-utils": "flake-utils_2",
@@ -1505,6 +1521,7 @@
         "agenix": "agenix",
         "antigravity-nix": "antigravity-nix",
         "claude-desktop-linux": "claude-desktop-linux",
+        "claude-skills-borghei": "claude-skills-borghei",
         "cosmic-applet-spotify": "cosmic-applet-spotify",
         "cosmic-ext-connect": "cosmic-ext-connect",
         "cosmic-ext-radio-applet": "cosmic-ext-radio-applet",

--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,16 @@
     # Bump via /update-claude-code.
     claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/ba2846c8b3e99ac35563e6c2184dd999b19bbc95";
 
+    # Claude Code skill catalogue (borghei). flake = false because it's a
+    # plain markdown/assets catalogue, not a Nix flake. We symlink one
+    # subdirectory (engineering/claude-code-mastery) into ~/.claude/skills/
+    # via home/development/claude-code-skills. Bump with `nix flake update
+    # claude-skills-borghei` to pull in upstream skill updates.
+    claude-skills-borghei = {
+      url = "github:borghei/Claude-Skills";
+      flake = false;
+    };
+
     # Terminal YouTube browser
     yt-x = {
       url = "github:Benexl/yt-x";

--- a/home/development/claude-code-skills/default.nix
+++ b/home/development/claude-code-skills/default.nix
@@ -1,0 +1,30 @@
+{ config
+, lib
+, inputs
+, ...
+}:
+let
+  inherit (lib) mkIf mkEnableOption;
+  cfg = config.programs.claude-code-skills;
+in
+{
+  options.programs.claude-code-skills = {
+    enable = mkEnableOption ''
+      Declarative Claude Code skill catalogue (borghei).
+
+      Symlinks selected skill subdirectories from the
+      `claude-skills-borghei` flake input into ~/.claude/skills/ so
+      Claude Code picks them up on launch. The other ~18 imperatively
+      installed skills under that directory (managed via the `skills`
+      CLI) are untouched.
+    '';
+  };
+
+  config = mkIf cfg.enable {
+    # Vendor link to the borghei/Claude-Skills repo. Bump with:
+    #   nix flake update claude-skills-borghei
+    # then test-build and deploy.
+    home.file.".claude/skills/claude-code-mastery".source =
+      "${inputs.claude-skills-borghei}/engineering/claude-code-mastery";
+  };
+}

--- a/home/development/default.nix
+++ b/home/development/default.nix
@@ -16,6 +16,7 @@ _: {
     ./codex-cli.nix
     ./claude-desktop
     ./claude-powerline.nix
+    ./claude-code-skills
 
     # Version control and CI/CD
     ./gitlab/default.nix
@@ -35,4 +36,9 @@ _: {
     # Agent skills management (vercel-labs/skills CLI)
     ./skills-cli.nix
   ];
+
+  # Always-on declarative skill: claude-code-mastery from borghei/Claude-Skills.
+  # Symlinks into ~/.claude/skills/, complementing the ~18 imperatively
+  # installed catalogues already there.
+  programs.claude-code-skills.enable = true;
 }


### PR DESCRIPTION
## Summary
Add the [`engineering/claude-code-mastery`](https://github.com/borghei/Claude-Skills/tree/main/engineering/claude-code-mastery) skill from `borghei/Claude-Skills` as a declaratively-managed Claude Code skill. Symlinks the upstream subpath into `~/.claude/skills/claude-code-mastery/` via a new home-manager module so every interactive host (p620, razer) picks it up on the next `nh switch` without imperative `skills add`.

## What's added

- **Flake input** `claude-skills-borghei` (`github:borghei/Claude-Skills`, `flake = false`). Pinned to `b3f2d35b` (2026-05-18 main HEAD).
- **HM module** `home/development/claude-code-skills/default.nix` — opt-in with `programs.claude-code-skills.enable` flag. Currently symlinks one skill; easy to extend with sibling links if we vendor others from the same catalogue later.
- **Enabled by default** in `home/development/default.nix` alongside the other claude-code modules.

## What it doesn't touch
The other ~18 skills under `~/.claude/skills/` are imperatively installed via the `skills` CLI and are intentionally left alone — different ownership model, different update path.

## Bump procedure
```bash
nix flake update claude-skills-borghei
# then test-build + nh switch as usual
```

## Test plan
- [x] `nix eval` confirms `home.file.".claude/skills/claude-code-mastery".source` resolves to `/nix/store/.../source/engineering/claude-code-mastery`
- [x] Host matrix clean: p620 ✅ razer ✅ p510 ✅
- [ ] After merge + `nh switch` on p620 + razer: confirm `~/.claude/skills/claude-code-mastery/SKILL.md` exists and points into the nix store

🤖 Generated with [Claude Code](https://claude.com/claude-code)