### PR TITLE
feat(claude-code): add FlyCrys — GTK4-native Claude Code GUI

### DIFF
--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -158,6 +158,9 @@ in
     pkgs.customPkgs.kosli-cli
     pkgs.customPkgs.aurynk
     pkgs.wayfarer
+    # FlyCrys — GTK4-native Claude Code GUI. Wraps the local `claude`
+    # binary (installed via programs.claude-code.enable in home/default.nix).
+    pkgs.customPkgs.flycrys
   ];
 
   # Windsurf LSP/formatter packages (identical across interactive hosts)

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -43,4 +43,8 @@
   # different launcher location, icon now packed inside app.asar). Revert to
   # the antigravity-nix flake input once upstream catches up.
   antigravity-2x = pkgs.callPackage ./antigravity-2x/package.nix { useFHS = false; };
+
+  # FlyCrys — GTK4-native GUI for Claude Code (Rust). Not in nixpkgs yet;
+  # custom buildRustPackage derivation. Wraps the local `claude` binary.
+  flycrys = pkgs.callPackage ./flycrys { };
 }

--- a/pkgs/flycrys/default.nix
+++ b/pkgs/flycrys/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, wrapGAppsHook4
+, gtk4
+, vte-gtk4
+, webkitgtk_6_0
+, libsoup_3
+, glib
+,
+}:
+# FlyCrys — GTK4/Libadwaita-native GUI for Anthropic's Claude Code CLI.
+# Upstream: https://github.com/SergKam/FlyCrys
+#
+# Wraps the locally-installed `claude` binary. We install Claude Code via
+# `programs.claude-code.enable` in home-manager, so the wrapper lands at
+# ~/.nix-profile/bin/claude in the user's PATH, which is what FlyCrys
+# spawns at runtime — no env-var wiring needed here.
+rustPlatform.buildRustPackage rec {
+  pname = "flycrys";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "SergKam";
+    repo = "FlyCrys";
+    rev = "v${version}";
+    hash = "sha256-MNVC2yOrJCAecvNqtRycZAJ1oX7NLo6d/587XWyBa0I=";
+  };
+
+  cargoHash = "sha256-zIHlhLWhqgx7fTPgDguOa3NoBR2VVoGvXpgrJiFtGnw=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4
+    vte-gtk4
+    webkitgtk_6_0
+    libsoup_3
+    glib
+  ];
+
+  # Upstream's .deb assets reference a desktop entry + icons that
+  # buildRustPackage's default install doesn't pick up. Drop them into the
+  # standard share/ layout so GNOME finds the launcher and icon.
+  postInstall = ''
+    install -Dm644 com.flycrys.app.desktop \
+      $out/share/applications/com.flycrys.app.desktop
+    for size in 48 128 256 512; do
+      install -Dm644 "data/icons/hicolor/''${size}x''${size}/apps/flycrys.png" \
+        "$out/share/icons/hicolor/''${size}x''${size}/apps/flycrys.png"
+    done
+    install -Dm644 data/about-logo.png $out/share/flycrys/data/about-logo.png
+  '';
+
+  meta = with lib; {
+    description = "Lightning-fast, Linux-native agentic UI on top of Claude Code CLI";
+    homepage = "https://github.com/SergKam/FlyCrys";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    mainProgram = "flycrys";
+  };
+}


### PR DESCRIPTION
## Summary
[FlyCrys](https://github.com/SergKam/FlyCrys) (`SergKam/FlyCrys`, MIT) is the only currently-maintained GNOME-native GUI for Anthropic's Claude Code CLI: Rust + GTK4, WebKit6, VTE 2.91, **no Electron**. It's a workspace UI (file tree, viewer, agent chat, terminal, git panel) that wraps the local `claude` binary — doesn't replace it.

Not in nixpkgs, so vendored as a custom `buildRustPackage` derivation under `pkgs/flycrys/`. Enabled on **p620 + razer** through the existing profile import chain. **p510 unaffected** (server profile composition).

## Changes
- `pkgs/flycrys/default.nix` — new derivation, version 0.3.0, src + cargoHash both populated
- `pkgs/default.nix` — exposes `customPkgs.flycrys`
- `Users/olafkfreund/profile.nix` — `pkgs.customPkgs.flycrys` added to shared `home.packages`

## Build verification
- ✅ Builds: cargoHash captured, src hash populated
- ✅ `$out/bin/flycrys` is a `makeBinaryWrapper` C wrapper (16K) that sets GAPP env vars before exec'ing `$out/bin/.flycrys-wrapped` (4.3M ELF)
- ✅ `ldd` clean — no missing libs
- ✅ `com.flycrys.app.desktop` + icon set (48/128/256/512px) installed
- ✅ Host matrix: p620 + razer hash changed, p510 unchanged

## Upgrade procedure
Edit `pkgs/flycrys/default.nix`'s `version`, set both hashes to `lib.fakeHash`, rebuild twice to capture the real hashes. Same flow as any `rustPlatform.buildRustPackage`.

## Test plan
- [x] Local build of `nixosConfigurations.razer.pkgs.customPkgs.flycrys`
- [x] Host matrix clean
- [ ] Deploy to p620 + razer
- [ ] Launch `flycrys` from app menu on p620, confirm GTK window renders, file tree visible, `claude` discoverable from inside the workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)