### PR TITLE
fix(wezterm): force XWayland on GNOME (CSD broken on Mutter Wayland)

### DIFF
--- a/home/desktop/terminals/wezterm/default.nix
+++ b/home/desktop/terminals/wezterm/default.nix
@@ -173,9 +173,18 @@ in
                           os.getenv("NIXOS_WAYLAND") == "1"
 
           if wayland then
-            config.enable_wayland = true
+            -- Force XWayland instead of native Wayland. GNOME Mutter does
+            -- not implement xdg-decoration (no server-side decorations on
+            -- Wayland), and WezTerm's client-side decoration renderer is
+            -- broken on Mutter — issues wezterm/wezterm#4962, #7134, #1659.
+            -- Result: with `enable_wayland = true`, the window has NO
+            -- titlebar/borders in GNOME no matter what `window_decorations`
+            -- is set to. XWayland delegates decorations to GNOME's X11 path
+            -- which works correctly. Negligible perf cost for a terminal.
+            config.enable_wayland = false
 
-            -- Wayland-specific optimizations
+            -- Wayland-specific optimizations (still applied under XWayland;
+            -- WebGpu works fine on X11)
             config.front_end = "WebGpu"  -- Better performance on modern systems with Wayland
             -- Note: WezTerm has no `enable_wayland_ime` option (it errors
             -- at startup with "not a valid Config field"). IME on Wayland


### PR DESCRIPTION
## Summary
Yesterday's "TITLE | RESIZE" change didn't actually fix borderless WezTerm windows on GNOME. **The bug isn't in our config — it's in WezTerm.** GNOME Mutter doesn't implement `xdg-decoration` (no SSD on Wayland), and WezTerm's CSD renderer is broken on Mutter, so the window gets zero decorations regardless of `window_decorations`.

## Upstream tracking
- [wezterm/wezterm#4962](https://github.com/wezterm/wezterm/issues/4962) — no decorations on Mutter/Wayland
- [wezterm/wezterm#7134](https://github.com/wezterm/wezterm/issues/7134) — 2025+ nightly regression
- [wezterm/wezterm#1659](https://github.com/wezterm/wezterm/issues/1659) — CSD architecture problem
- [wezterm/wezterm#5419](https://github.com/wezterm/wezterm/issues/5419), [#5332](https://github.com/wezterm/wezterm/issues/5332), [#6472](https://github.com/wezterm/wezterm/issues/6472) — related across compositors

## Fix
Flip `config.enable_wayland` to `false` inside the Wayland detection branch. Forces XWayland → GNOME's X11 decoration path works correctly. Trade-off: no native Wayland fractional scaling / clipboard, but for a terminal this is invisible.

Other Wayland-conditional settings still apply under XWayland:
- `front_end = "WebGpu"` — works on X11 too
- `window_decorations = "TITLE | RESIZE"`
- `selection_word_boundary`, DPI handling, etc.

## Test plan
- [x] `nix eval` confirms `config.enable_wayland = false` resolves correctly
- [x] Host matrix clean: p620, razer, p510
- [ ] After deploy + relaunch WezTerm from GNOME app menu: window has normal titlebar with WM controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)