### PR TITLE
chore(flake): drop nixpkgs-stable input + remove multipass

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1169,22 +1169,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable_2": {
-      "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-25.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1778869304,
@@ -1539,7 +1523,6 @@
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_9",
         "nixpkgs-f2k": "nixpkgs-f2k",
-        "nixpkgs-stable": "nixpkgs-stable_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur",
         "rust-overlay": "rust-overlay_6",

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,6 @@
   inputs = {
     # Core
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
     flake-utils.url = "github:numtide/flake-utils";
@@ -167,7 +166,6 @@
 
   outputs =
     { nixpkgs
-    , nixpkgs-stable
     , nixpkgs-unstable
     , nur
     , agenix
@@ -248,7 +246,6 @@
         {
           inherit system;
           specialArgs = {
-            pkgs-stable = import nixpkgs-stable (mkPkgs nixpkgs-stable system);
             pkgs-unstable = import nixpkgs-unstable (mkPkgs nixpkgs-unstable system);
             inherit inputs host hostTypes;
             username = primaryUser; # Primary user for backward compatibility
@@ -293,7 +290,6 @@
                     }
                   ];
                   extraSpecialArgs = {
-                    pkgs-stable = import nixpkgs-stable (mkPkgs nixpkgs-stable system);
                     pkgs-unstable = import nixpkgs-unstable (mkPkgs nixpkgs-unstable system);
                     inherit
                       inputs

--- a/modules/cloud/packages.nix
+++ b/modules/cloud/packages.nix
@@ -1,7 +1,6 @@
 { config
 , lib
 , pkgs
-, pkgs-stable
 , ...
 }:
 let
@@ -20,7 +19,7 @@ in
   config = mkMerge [
     (mkIf config.aws.packages.enable {
       environment.systemPackages = [
-        pkgs-stable.awscli2
+        pkgs.customPkgs.awscli2 # local override disables flaky doCheck
         pkgs.awsrm
         pkgs.awsls
         pkgs.awsume

--- a/modules/email/neomutt/default.nix
+++ b/modules/email/neomutt/default.nix
@@ -1,7 +1,6 @@
 { config
 , lib
 , pkgs
-, pkgs-stable
 , ...
 }:
 let
@@ -89,8 +88,8 @@ in
         image/*; ${pkgs.chafa}/bin/chafa --size=80x24 %s; copiousoutput;
 
         # Other document types
-        application/msword; ${pkgs-stable.libreoffice}/bin/libreoffice --writer %s;
-        application/vnd.openxmlformats-officedocument.wordprocessingml.document; ${pkgs-stable.libreoffice}/bin/libreoffice --writer %s;
+        application/msword; ${pkgs.libreoffice}/bin/libreoffice --writer %s;
+        application/vnd.openxmlformats-officedocument.wordprocessingml.document; ${pkgs.libreoffice}/bin/libreoffice --writer %s;
       '';
       mode = "0644";
     };

--- a/modules/packages/sets.nix
+++ b/modules/packages/sets.nix
@@ -1,7 +1,6 @@
 # Consolidated package sets for performance optimization
 # This reduces redundant package declarations across modules
 { pkgs
-, pkgs-stable
 , mcp-nixos-pkg
 , ...
 }: {
@@ -160,7 +159,7 @@
 
   # Cloud and infrastructure tools
   cloud = {
-    aws = with pkgs-stable; [
+    aws = with pkgs; [
       awscli2
       aws-sam-cli
       ssm-session-manager-plugin

--- a/modules/virt/virt.nix
+++ b/modules/virt/virt.nix
@@ -1,7 +1,6 @@
 { config
 , lib
 , pkgs
-, pkgs-stable
 , ...
 }:
 let
@@ -98,7 +97,8 @@ in
       pkgs.kvmtool
       pkgs.libvirt
       pkgs.virtiofsd # virtio-fs daemon for host/VM file sharing
-      pkgs-stable.multipass
+      # multipass: removed 2026-05-20 (dropped from nixpkgs as unmaintained;
+      # we never actually used it for any active VM workflow).
       pkgs.spice
       pkgs.spice-gtk
       pkgs.spice-protocol
@@ -109,7 +109,8 @@ in
       pkgs.virt-viewer
       pkgs.win-spice
       pkgs.virtio-win
-      pkgs-stable.virtualbox # Using stable version to avoid libcurl proxy enum build errors in unstable
+      pkgs.virtualbox # 7.2.8: old libcurl-proxy-enum build break on unstable
+      # has been resolved upstream; safe to use main pkgs again.
       pkgs.btrfs-progs
       pkgs.quickemu
       # pkgs.vmware-workstation


### PR DESCRIPTION
## Summary

`nixpkgs-stable` tracked the `nixos-25.05` branch, which is now **EOL** (frozen since 2026-01-02, no further backports). All four consumers verified to work on the main `nixpkgs` (nixos-unstable), so the whole input + plumbing is removed.

## Per-package status

| Pkg | Was (25.05) | Now (unstable) | Notes |
|---|---|---|---|
| `awscli2` | 2.27.2 | 2.34.24 | newer; `pkgs.customPkgs.awscli2` keeps the test-disabling override |
| `libreoffice` | alias-only | 25.8.5.2 | binary-cached |
| `virtualbox` | 7.1.12 | 7.2.8 | old "libcurl proxy enum build error" comment was stale; builds clean on current unstable |
| `multipass` | 1.15.1 | **removed** | dropped from nixpkgs upstream (unmaintained); user confirms no active use |

## Files touched
- `flake.nix`: removed `nixpkgs-stable` input, function-sig entry, and both `pkgs-stable = import ...` `(extra)SpecialArgs` lines
- `flake.lock`: `nix flake lock` pruned the orphan node
- `modules/cloud/packages.nix`: `pkgs-stable.awscli2` → `pkgs.customPkgs.awscli2`; fn arg removed
- `modules/email/neomutt/default.nix`: 2× `${pkgs-stable.libreoffice}` → `${pkgs.libreoffice}`; fn arg removed
- `modules/packages/sets.nix`: aws set `with pkgs-stable` → `with pkgs`; fn arg removed
- `modules/virt/virt.nix`: multipass deleted, virtualbox unstable, fn arg removed

## Test plan
- [x] No remaining references to `pkgs-stable` / `nixpkgs-stable` in any `.nix` file
- [x] `nix flake lock` removed the input cleanly
- [x] Host matrix clean: p620, razer, p510 — all toplevels rebuild
- [ ] Deploy + verify `aws --version`, `libreoffice --version`, `virtualbox --help` still work on p620 + razer

🤖 Generated with [Claude Code](https://claude.com/claude-code)