### PR TITLE
feat(claude-code): enable experimental Agent Teams

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -30,6 +30,16 @@
     package = pkgs.claude-code-native;
   };
 
+  # Enable Claude Code "Agent Teams" — experimental feature that lets one
+  # Claude session spawn a team of coordinated teammates (separate sessions
+  # with their own context windows that can talk to each other).
+  # Requires Claude Code v2.1.32+ (we're on 2.1.145). Per the docs, setting
+  # this env var or putting it under "env" in settings.json both work; the
+  # env-var route lets ~/.claude/settings.json remain runtime-mutable for
+  # plugin/theme changes via /config.
+  # https://code.claude.com/docs/en/agent-teams
+  home.sessionVariables.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+
   home.packages = [
     inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.opencode
     (pkgs.callPackage ../pkgs/weather-popup/default.nix { })


### PR DESCRIPTION
## Summary
Enable [Claude Code Agent Teams](https://code.claude.com/docs/en/agent-teams) by adding `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` to home-manager session variables. Active on p620 + razer (both interactive hosts that have Claude Code in their home-manager closure).

## What Agent Teams are
One Claude Code session spawns a team of teammates — separate sessions, each with its own context window, all communicating directly with each other (not just back to the lead). Different from regular sub-agents which only report results to the parent. Best fit: research, parallel code review, multi-hypothesis debugging.

## Why env-var-via-home.sessionVariables, not settings.json
- `~/.claude/settings.json` is runtime-mutable (used by /config UI for plugin installs, theme changes). Locking it declaratively would conflict with normal day-to-day use.
- The official docs explicitly state shell env var works equivalently to settings.json.
- `home.sessionVariables` is the lightest declarative knob — one line.

## Prerequisites
- Claude Code v2.1.32+ — we're on 2.1.145 (bumped via PR #545), well past the floor.

## Test plan
- [x] `nix eval` confirms `home.sessionVariables.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"`
- [x] Host matrix clean: p620, razer, p510 (p510's claude-code closure is unaffected)
- [ ] After deploy: open a fresh shell on p620, `env | grep CLAUDE_CODE_EXPERIMENTAL`, launch `claude`, prompt "spawn an agent team to research X from 3 angles", confirm teammates appear (Shift+Down to cycle)

## How to actually use it
After deploy, in any fresh shell:
```text
Create an agent team to investigate X from three angles:
- One focused on Y
- One focused on Z
- One playing devil's advocate
```

Cycle teammates: Shift+Down. Toggle task list: Ctrl+T. Clean up at the end: "Clean up the team."

Note: feature is **experimental** per upstream. Limitations: no /resume restoration for in-process teammates, occasional task-status lag, slow shutdown, one team at a time, no nested teams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)