### PR TITLE
feat(tmux): add tmux-expose — Mission Control-style session switcher

### DIFF
--- a/home/shell/tmux/default.nix
+++ b/home/shell/tmux/default.nix
@@ -138,6 +138,14 @@ in
 
       # Enhanced configuration for modern terminal workflows
       extraConfig = ''
+        # ========== tmux-expose ==========
+        # Mission Control-style session switcher with live previews.
+        # Binary lives at ${pkgs.customPkgs.tmux-expose}/bin/tmux-expose.
+        # Default trigger M-e (matches upstream tmux.expose.tmux defaults).
+        # Inlined here rather than via mkTmuxPlugin because the upstream
+        # .tmux file is a thin 5-line keybinder we can replicate directly.
+        bind-key -T root M-e display-popup -w "100%" -h "100%" -E "${pkgs.customPkgs.tmux-expose}/bin/tmux-expose"
+
         # ========== Terminal and Display Settings ==========
         set-option -g default-terminal 'tmux-256color'
         set-option -g terminal-overrides ',xterm-256color:RGB,alacritty:RGB,kitty:RGB,foot:RGB,wezterm:RGB'

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -47,4 +47,9 @@
   # FlyCrys — GTK4-native GUI for Claude Code (Rust). Not in nixpkgs yet;
   # custom buildRustPackage derivation. Wraps the local `claude` binary.
   flycrys = pkgs.callPackage ./flycrys { };
+
+  # tmux-expose — Rust binary providing a Mission Control-style session
+  # switcher inside tmux. Wired into home/shell/tmux/default.nix via a
+  # display-popup bind-key (M-e by default).
+  tmux-expose = pkgs.callPackage ./tmux-expose { };
 }

--- a/pkgs/tmux-expose/default.nix
+++ b/pkgs/tmux-expose/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+,
+}:
+# tmux-expose — Mission Control-style tmux session switcher with live
+# terminal previews. Upstream is a Rust binary + a thin tmux.expose.tmux
+# wrapper that sets up the keybinding. We package the binary and inline
+# the keybinding in home/shell/tmux/default.nix.
+#
+# Upstream: https://github.com/cesarferreira/tmux.expose
+rustPlatform.buildRustPackage {
+  pname = "tmux-expose";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "cesarferreira";
+    repo = "tmux.expose";
+    rev = "837e22702b6938d26f15d956f315c0dff0463902"; # v0.4.1 commit (no release tag yet)
+    hash = "sha256-jNBjaFnvueB6Q+5AsC9BWRghdTIsZv93JqxgPM9CEIM=";
+  };
+
+  cargoHash = "sha256-cRl/5/nUNDayiygCpguv0A5ubw28GfX7MScbgTgjcoI=";
+
+  # Pure Rust (anyhow, clap, crossterm, ratatui) — no native deps.
+
+  meta = with lib; {
+    description = "Mission Control-style tmux session switcher with live terminal previews";
+    homepage = "https://github.com/cesarferreira/tmux.expose";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    mainProgram = "tmux-expose";
+  };
+}


### PR DESCRIPTION
## Summary
Adds [`cesarferreira/tmux.expose`](https://github.com/cesarferreira/tmux.expose) — a Rust binary that draws a popup grid of all your tmux sessions/windows with live terminal previews, macOS Mission Control style. Default trigger: **M-e** anywhere in tmux.

## Packaging
- `pkgs/tmux-expose/default.nix` — vanilla `rustPlatform.buildRustPackage`. Deps are pure Rust (`anyhow`, `clap`, `crossterm`, `ratatui`) — no native libs needed.
- Pinned to commit `837e22702b` (Cargo.toml version 0.4.1; upstream hasn't cut a GitHub release tag yet).
- Exposed as `pkgs.customPkgs.tmux-expose` in `pkgs/default.nix`.

## Wiring
- `home/shell/tmux/default.nix` gets one bind-key inside the existing `extraConfig`:

  ```
  bind-key -T root M-e display-popup -w "100%" -h "100%" -E "${pkgs.customPkgs.tmux-expose}/bin/tmux-expose"
  ```

  Skipped `mkTmuxPlugin` because upstream's `tmux.expose.tmux` is just a 5-line keybinder we can inline.

## Test plan
- [x] Rust binary builds → `$out/bin/tmux-expose` is a real ELF
- [x] Evaluated `extraConfig` contains the resolved store path
- [x] Host matrix clean: p620, razer, p510

## After deploy
- Any **new** tmux session has `M-e` wired up automatically.
- To trigger in an existing session: `tmux source-file ~/.config/tmux/tmux.conf` then press `M-e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)