### PR TITLE
feat(tmux): add tmux-palette — Raycast-style palette + AI launcher

### DIFF
--- a/home/shell/tmux/default.nix
+++ b/home/shell/tmux/default.nix
@@ -146,6 +146,15 @@ in
         # .tmux file is a thin 5-line keybinder we can replicate directly.
         bind-key -T root M-e display-popup -w "100%" -h "100%" -E "${pkgs.customPkgs.tmux-expose}/bin/tmux-expose"
 
+        # ========== tmux-palette ==========
+        # Raycast-style command palette. M-Space opens the default
+        # `commands` palette (built-in tmux actions + windows + sessions).
+        # M-a opens our custom `ai-tools` palette (Claude Code + Gemini CLI
+        # launcher — see xdg.configFile."tmux-palette/palettes/ai-tools.json"
+        # below).
+        bind-key -n M-Space run-shell '${pkgs.customPkgs.tmux-palette}/bin/tmux-palette'
+        bind-key -n M-a     run-shell '${pkgs.customPkgs.tmux-palette}/bin/tmux-palette ai-tools'
+
         # ========== Terminal and Display Settings ==========
         set-option -g default-terminal 'tmux-256color'
         set-option -g terminal-overrides ',xterm-256color:RGB,alacritty:RGB,kitty:RGB,foot:RGB,wezterm:RGB'
@@ -300,6 +309,40 @@ in
         set -g window-status-separator " │ "
         set -g status-style "bg=#${colors.base00},fg=#${colors.base04}"
       '';
+    };
+
+    # tmux-palette AI launcher: triggered by the M-a bind defined above.
+    # The palette runs `command` and parses its JSON output as a list of
+    # items, each with its own action. We emit a static JSON array via
+    # `echo` of a Nix-generated string — keeps the keystrokes/args
+    # bullet-proof (Nix handles all shell escaping) and makes it trivial
+    # to add more AI tools later without touching the .nix file.
+    xdg.configFile."tmux-palette/palettes/ai-tools.json".text = builtins.toJSON {
+      title = "AI Tools";
+      icon = "🤖";
+      command = "echo " + lib.escapeShellArg (builtins.toJSON [
+        {
+          icon = "⚡";
+          iconColor = "#cc8822";
+          title = "Claude Code";
+          subtitle = "Anthropic CLI — skip-perms, resume last session, remote-control";
+          action.tmux = "send-keys 'claude --dangerously-skip-permissions --resume --remote-control' Enter";
+        }
+        {
+          icon = "🛰";
+          iconColor = "#a48ec3";
+          title = "Claude Agents";
+          subtitle = "Anthropic CLI in agent-orchestration mode (skip-perms)";
+          action.tmux = "send-keys 'claude agents --dangerously-skip-permissions' Enter";
+        }
+        {
+          icon = "💎";
+          iconColor = "#22aaff";
+          title = "Gemini CLI";
+          subtitle = "Google AI CLI";
+          action.tmux = "send-keys 'gemini' Enter";
+        }
+      ]);
     };
   };
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -52,4 +52,10 @@
   # switcher inside tmux. Wired into home/shell/tmux/default.nix via a
   # display-popup bind-key (M-e by default).
   tmux-expose = pkgs.callPackage ./tmux-expose { };
+
+  # tmux-palette — Raycast-style command palette for tmux. Bun + TypeScript.
+  # Wired via two bind-keys in home/shell/tmux/default.nix: M-Space for the
+  # general commands palette, M-a for the AI launcher (Claude Code +
+  # Gemini CLI). The AI palette JSON is declared in the tmux module too.
+  tmux-palette = pkgs.callPackage ./tmux-palette { };
 }

--- a/pkgs/tmux-palette/default.nix
+++ b/pkgs/tmux-palette/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, makeWrapper
+, bun
+,
+}:
+# tmux-palette — Raycast-style command palette for tmux. TypeScript app
+# that runs on Bun.
+#
+# Packaging is trivial because the project's runtime "dependencies" object
+# in package.json is empty — Bun executes the TS source directly, no
+# node_modules needed. We just copy the source into the store and wrap the
+# entry script so it can find `bun` at runtime.
+#
+# Upstream: https://github.com/eduwass/tmux-palette
+stdenvNoCC.mkDerivation {
+  pname = "tmux-palette";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "eduwass";
+    repo = "tmux-palette";
+    rev = "v0.2.1";
+    hash = "sha256-bVdd8YAFYwob6y5nATcdLC8nzBKdaCDzqZHqyc+04/k=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/tmux-palette $out/bin
+    cp -r ./. $out/share/tmux-palette/
+
+    # The shell entry already calculates DIR relative to itself, so it
+    # works from any location as long as the layout is preserved. We just
+    # need `bun` on PATH at runtime.
+    makeWrapper $out/share/tmux-palette/bin/tmux-palette.sh $out/bin/tmux-palette \
+      --prefix PATH : ${lib.makeBinPath [ bun ]}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Raycast-style command palette for tmux — fast, scriptable, easy to extend";
+    homepage = "https://github.com/eduwass/tmux-palette";
+    # Upstream repo has no LICENSE file as of v0.2.1; README implies open source
+    # (no explicit ToS). Treating as unfree-redistributable until upstream clarifies.
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    mainProgram = "tmux-palette";
+  };
+}


### PR DESCRIPTION
## Summary
Adds [`eduwass/tmux-palette`](https://github.com/eduwass/tmux-palette) (v0.2.1) — a Raycast-style command palette for tmux — plus a custom AI-tools palette wired to launch Claude Code, Claude Agents, and Gemini CLI.

## Packaging
`pkgs/tmux-palette/` — vanilla `stdenvNoCC.mkDerivation`. Copies the TS source into `$out/share/tmux-palette/` and `makeWrapper`s `bin/tmux-palette.sh` with `bun` on PATH.

Trivial because `package.json` has `"dependencies": {}` — Bun executes the TS directly, no `node_modules` needed.

## Bindings (no-prefix, Raycast-feel)
| Key | Action |
|---|---|
| `M-Space` | Default `commands` palette (tmux actions, windows, sessions) |
| `M-a` | Custom `ai-tools` palette (Claude Code + Claude Agents + Gemini CLI) |
| `M-e` | tmux-expose (from previous PR — unchanged) |

## AI launcher palette
Defined declaratively via `xdg.configFile."tmux-palette/palettes/ai-tools.json"` as a Nix attrset → `toJSON`. Each item carries icon, color, title, subtitle, and an `action.tmux` `send-keys` invocation.

| Item | Sends |
|---|---|
| Claude Code | `claude --dangerously-skip-permissions --resume --remote-control` |
| Claude Agents | `claude agents --dangerously-skip-permissions` |
| Gemini CLI | `gemini` |

Adding more tools later: edit the list in `home/shell/tmux/default.nix` — `lib.escapeShellArg` handles all the shell-quoting so the `.nix` is the only place to touch.

## Test plan
- [x] `tmux-palette` wrapper script built with `bun` on PATH
- [x] Generated palette JSON has all three items with correctly escaped shell commands
- [x] Host matrix clean: p620, razer, p510
- [ ] After deploy: in any new tmux session, `M-Space` opens the default palette, `M-a` opens the AI launcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)