### PR TITLE
fix(tmux-palette): absolute bun path + extra M-p / M-Space bindings

### DIFF
--- a/home/shell/tmux/default.nix
+++ b/home/shell/tmux/default.nix
@@ -147,12 +147,19 @@ in
         bind-key -T root M-e display-popup -w "100%" -h "100%" -E "${pkgs.customPkgs.tmux-expose}/bin/tmux-expose"
 
         # ========== tmux-palette ==========
-        # Raycast-style command palette. M-Space opens the default
-        # `commands` palette (built-in tmux actions + windows + sessions).
-        # M-a opens our custom `ai-tools` palette (Claude Code + Gemini CLI
-        # launcher — see xdg.configFile."tmux-palette/palettes/ai-tools.json"
+        # Raycast-style command palette. M-p opens the default `commands`
+        # palette (built-in tmux actions + windows + sessions). M-a opens
+        # our custom `ai-tools` palette (Claude Code, Claude Agents,
+        # Gemini CLI — see xdg.configFile."tmux-palette/palettes/ai-tools.json"
         # below).
+        #
+        # Note on M-Space: GNOME (Mutter) reserves Alt+Space by default
+        # for the Window Menu shortcut. Disable it in
+        # Settings → Keyboard → View and Customise Shortcuts → Windows
+        # → "Activate window menu" (or via dconf). Both M-Space and M-p
+        # are bound here so either works regardless of DE config.
         bind-key -n M-Space run-shell '${pkgs.customPkgs.tmux-palette}/bin/tmux-palette'
+        bind-key -n M-p     run-shell '${pkgs.customPkgs.tmux-palette}/bin/tmux-palette'
         bind-key -n M-a     run-shell '${pkgs.customPkgs.tmux-palette}/bin/tmux-palette ai-tools'
 
         # ========== Terminal and Display Settings ==========

--- a/pkgs/tmux-palette/default.nix
+++ b/pkgs/tmux-palette/default.nix
@@ -30,6 +30,18 @@ stdenvNoCC.mkDerivation {
   dontBuild = true;
   dontConfigure = true;
 
+  # The upstream bin/tmux-palette.sh runs `bun src/cli.ts` in two places.
+  # The first call inherits PATH from the wrapper, so it works. The second
+  # call is passed as a string to `tmux display-popup -E "... exec bun ..."`
+  # — tmux spawns a FRESH shell to execute that string, which does NOT
+  # inherit our wrapper's PATH augmentation, so `bun` is not found and the
+  # popup exits 127. Substitute the bare `bun` token with the absolute path.
+  postPatch = ''
+    substituteInPlace bin/tmux-palette.sh \
+      --replace-fail "exec bun " "exec ${bun}/bin/bun " \
+      --replace-fail "MEASURE=\"\$(bun " "MEASURE=\"\$(${bun}/bin/bun "
+  '';
+
   installPhase = ''
     runHook preInstall
 
@@ -37,8 +49,9 @@ stdenvNoCC.mkDerivation {
     cp -r ./. $out/share/tmux-palette/
 
     # The shell entry already calculates DIR relative to itself, so it
-    # works from any location as long as the layout is preserved. We just
-    # need `bun` on PATH at runtime.
+    # works from any location as long as the layout is preserved.
+    # Wrapper kept (despite postPatch) so anyone calling tmux-palette
+    # directly from a shell without bun on PATH still works.
     makeWrapper $out/share/tmux-palette/bin/tmux-palette.sh $out/bin/tmux-palette \
       --prefix PATH : ${lib.makeBinPath [ bun ]}
 


### PR DESCRIPTION
## Summary
Two fixes for the just-merged tmux-palette PR (#554).

### 1. Runtime exit 127
`tmux display-popup -E "... exec bun ..."` spawns a **fresh shell** that does NOT inherit `makeWrapper`'s PATH augmentation. Result: `bun` not found → popup exits 127, tmux shows `'/nix/store/.../tmux-palette' returned 127`.

Patched `bin/tmux-palette.sh` via `postPatch` to use the absolute `${bun}/bin/bun` everywhere. Affects:
- `MEASURE="$(bun ...)"` (works either way, kept consistent)
- `"exec bun ..."` inside `display-popup -E` (this was the actual bug)

The `makeWrapper` layer is kept so direct CLI invocation still works from any shell.

### 2. Extra keybindings
`M-Space` alone collides with **GNOME (Mutter)'s default "Activate window menu" shortcut** — tmux never sees the keystroke. Added `M-p` as a portable second binding. `M-Space` is preserved for users who've cleared the GNOME shortcut. New comment in the tmux module explains the conflict + the GNOME setting that needs to be cleared.

## Test plan
- [x] `substituteInPlace` ran (produced script contains `exec /nix/store/.../bun-1.3.13/bin/bun '...'`)
- [x] Host matrix clean: p620, razer, p510
- [ ] After deploy + tmux source-file or new session, M-p / M-Space / M-a all bring up the palette without 127

🤖 Generated with [Claude Code](https://claude.com/claude-code)