### PR TITLE
feat(tmux-palette): set Gruvbox Dark as the active theme

### DIFF
--- a/home/shell/tmux/default.nix
+++ b/home/shell/tmux/default.nix
@@ -318,6 +318,14 @@ in
       '';
     };
 
+    # tmux-palette active theme — match the rest of our stylix gruvbox
+    # config. Slug `gruvbox-dark` is one of the 12 bundled themes
+    # (src/themes-bundled.ts). Read by the palette on each invocation;
+    # no tmux reload needed after `nh switch`.
+    xdg.configFile."tmux-palette/theme.json".text = builtins.toJSON {
+      theme = "gruvbox-dark";
+    };
+
     # tmux-palette AI launcher: triggered by the M-a bind defined above.
     # The palette runs `command` and parses its JSON output as a list of
     # items, each with its own action. We emit a static JSON array via


### PR DESCRIPTION
## Summary
Adds `~/.config/tmux-palette/theme.json` declaratively via home-manager, selecting the bundled `gruvbox-dark` theme so the palette popup matches the rest of our stylix gruvbox setup.

## Why the built-in slug, not a custom override
- `gruvbox-dark` is one of 12 curated bundled themes in `src/themes-bundled.ts`
- Same Gruvbox colors as stylix: `bg #282828`, `fg #ebdbb2`, `accent #8ec07c`
- Already tuned for contrast/readability by upstream
- One line to maintain
- If we ever want to fine-tune we can switch to a partial override (`{ bg = ...; accent = ...; }`) — the palette merges partial overrides onto the resolved theme

## Test plan
- [x] `nix eval` confirms `xdg.configFile."tmux-palette/theme.json".text = "{\"theme\":\"gruvbox-dark\"}"`
- [x] Host matrix clean: p620, razer, p510
- [ ] After deploy: press `M-p` — popup should be gruvbox-coloured (dark background, beige fg, green accent on selection). No tmux reload needed, the palette reads `theme.json` on every invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)