### PR TITLE
fix(tmux-palette): correct theme.json schema + use stylix colors directly

### DIFF
--- a/home/shell/tmux/default.nix
+++ b/home/shell/tmux/default.nix
@@ -318,12 +318,34 @@ in
       '';
     };
 
-    # tmux-palette active theme — match the rest of our stylix gruvbox
-    # config. Slug `gruvbox-dark` is one of the 12 bundled themes
-    # (src/themes-bundled.ts). Read by the palette on each invocation;
-    # no tmux reload needed after `nh switch`.
+    # tmux-palette active theme — full color override sourced from our
+    # active stylix base16 scheme, so the palette popup is BYTE-IDENTICAL
+    # to the rest of our terminal/UI gruvbox theming (not just close-ish
+    # to the tmux-palette-bundled gruvbox-dark, which uses slightly
+    # different panel/selected/muted/accent values).
+    #
+    # Schema discovered from src/theme.ts:
+    #   { name: "<slug>" }              → look up bundled/user slug
+    #   { bg, panel, selected, fg, muted, accent }  → full Theme override
+    #   partial Theme                   → merged onto default theme
+    # Note: the field is `name`, NOT `theme` — earlier `theme.json` of
+    # `{ "theme": "gruvbox-dark" }` was silently ignored (treated as a
+    # Partial<Theme>) and crashed the palette with exit 1.
+    #
+    # base16 → tmux-palette Theme mapping:
+    #   bg       = base00 (default background)
+    #   panel    = base01 (lighter background)
+    #   selected = base02 (selection / line-highlight)
+    #   fg       = base05 (default foreground)
+    #   muted    = base03 (comments / dim)
+    #   accent   = base0B (green — gruvbox's classic positive accent)
     xdg.configFile."tmux-palette/theme.json".text = builtins.toJSON {
-      theme = "gruvbox-dark";
+      bg = "#${colors.base00}";
+      panel = "#${colors.base01}";
+      selected = "#${colors.base02}";
+      fg = "#${colors.base05}";
+      muted = "#${colors.base03}";
+      accent = "#${colors.base0B}";
     };
 
     # tmux-palette AI launcher: triggered by the M-a bind defined above.


### PR DESCRIPTION
## Summary
Two related fixes for the gruvbox-dark theme just deployed in PR #556.

### 1. theme.json schema was wrong → caused exit 1
Previous file was `{ "theme": "gruvbox-dark" }`. The actual schema (`src/theme.ts`) expects `name`, not `theme`:

```json
{ "name": "<slug>" }                          // look up bundled/user slug
{ "bg", "panel", "selected", "fg", "muted", "accent" }   // full Theme override
```

With `theme` instead of `name`, the file was silently treated as a `Partial<Theme>` with an invalid key, which crashed the palette with **exit 1** inside `display-popup`.

### 2. Use stylix base16 colors instead of the bundled slug
The bundled `gruvbox-dark` slug is **close** but not identical to our active stylix scheme — its panel/selected/muted/accent values differ. Switched to a full `Theme` override populated from `config.lib.stylix.colors`:

| Field | Source |
|---|---|
| `bg` | `base00` |
| `panel` | `base01` |
| `selected` | `base02` |
| `fg` | `base05` |
| `muted` | `base03` |
| `accent` | `base0B` (gruvbox green) |

The palette popup is now byte-for-byte identical to every other stylix-themed surface. If we ever swap the stylix base16 scheme, the palette follows automatically — no separate config to remember.

## Test plan
- [x] `nix eval` confirms `theme.json` renders as `{"bg":"#282828","panel":"#3c3836","selected":"#504945","fg":"#ebdbb2","muted":"#665c54","accent":"#98971a"}` (matches our gruvbox-dark.yaml exactly)
- [x] Host matrix clean: p620, razer, p510
- [ ] After deploy: press M-p — no more exit 1, popup colors match other stylix-themed surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)