### PR TITLE
fix(p620): add systemd-resolved DNS fallback (#564)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,62 +1,67 @@
 # typos configuration - exclude false positives
 # See: https://github.com/crate-ci/typos/blob/master/docs/reference.md
 
-[default.extend-words]
-# AMD HSA (Heterogeneous System Architecture) - valid technical term
-HSA = "HSA"
-hsa = "hsa"
+[default]
+# Skip git short/full SHAs in comments and pinning notes (4-40 hex chars).
+# Stops typos misreading e.g. ba2846c8 as 'ba should be by/be'.
+extend-ignore-re = [ "\\b[0-9a-f]{4,40}\\b" ]
 
-# k3sserver is a hostname, not a typo
-sserver = "sserver"
+  [default.extend-words]
+  # AMD HSA (Heterogeneous System Architecture) - valid technical term
+  HSA = "HSA"
+  hsa = "hsa"
 
-# nitch is a system info tool package name
-nitch = "nitch"
+  # k3sserver is a hostname, not a typo
+  sserver = "sserver"
 
-# dbe is a shell alias for "distrobox enter"
-dbe = "dbe"
+  # nitch is a system info tool package name
+  nitch = "nitch"
 
-# AGS is "Aylur's GTK Shell" - valid acronym
-AGS = "AGS"
+  # dbe is a shell alias for "distrobox enter"
+  dbe = "dbe"
 
-# serie is a valid Nix package name (system info tool)
-serie = "serie"
+  # AGS is "Aylur's GTK Shell" - valid acronym
+  AGS = "AGS"
 
-# darcula is a valid theme name (different from dracula)
-darcula = "darcula"
+  # serie is a valid Nix package name (system info tool)
+  serie = "serie"
 
-# exportfs is a valid NFS command/config option
-exportfs = "exportfs"
+  # darcula is a valid theme name (different from dracula)
+  darcula = "darcula"
 
-# enew is a valid Neovim buffer function
-enew = "enew"
+  # exportfs is a valid NFS command/config option
+  exportfs = "exportfs"
 
-# hdinsight is Azure HDInsight service name
-hdinsight = "hdinsight"
+  # enew is a valid Neovim buffer function
+  enew = "enew"
 
-# styl is a valid file extension (Stylus CSS)
-styl = "styl"
+  # hdinsight is Azure HDInsight service name
+  hdinsight = "hdinsight"
 
-# edn is a valid file extension (Extensible Data Notation)
-edn = "edn"
+  # styl is a valid file extension (Stylus CSS)
+  styl = "styl"
 
-# toogle is a GNOME extension config key (upstream typo)
-toogle = "toogle"
+  # edn is a valid file extension (Extensible Data Notation)
+  edn = "edn"
 
-# usig is in a third-party plugin comment
-usig = "usig"
+  # toogle is a GNOME extension config key (upstream typo)
+  toogle = "toogle"
 
-# nd is a valid lsblk flag (-nd = no headings, no dependents)
-nd = "nd"
+  # usig is in a third-party plugin comment
+  usig = "usig"
 
-# AER is the PCIe Advanced Error Reporting acronym
-AER = "AER"
+  # nd is a valid lsblk flag (-nd = no headings, no dependents)
+  nd = "nd"
 
-# ratatui is the Rust TUI library splashboard is built on
-ratatui = "ratatui"
+  # AER is the PCIe Advanced Error Reporting acronym
+  AER = "AER"
 
-[default.extend-identifiers]
-# Santa Claus - not "Clause"
-Claus = "Claus"
+  # ratatui is the Rust TUI library splashboard is built on
+  ratatui = "ratatui"
+
+  [default.extend-identifiers]
+  # Santa Claus - not "Clause"
+  Claus = "Claus"
 
 [files]
 # Skip archive directory and binary/data files

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -20,6 +20,7 @@ in
     ./nixos/amd.nix
     ./nixos/usb-power-fix.nix # Fix USB mouse freezing issues
     ./nixos/aqc107-link-pin.nix # Pin Aquantia AQC107 to 1G to dodge AER flapping
+    ./nixos/dns-fallback.nix # systemd-resolved with public DNS fallback (issue #564)
     ../common/nixos/i18n.nix
     ../common/nixos/hosts.nix
     ../common/nixos/envvar.nix
@@ -50,16 +51,13 @@ in
     # Note: Tailscale is enabled via services.tailscale (built-in NixOS module)
     # Custom networking.tailscale module was removed during anti-pattern cleanup
 
-    # NetworkManager configuration with explicit DNS management
-    networkmanager = {
-      dns = lib.mkForce "default"; # Force NetworkManager to handle DNS directly
-    };
+    # NetworkManager DNS handoff to systemd-resolved configured in
+    # ./nixos/dns-fallback.nix (issue #564).
 
-    # Pin this host's own Tailscale MagicDNS name. Tailscale's DNS resolver is
-    # not accepted on p620 (conflicts with NetworkManager DNS), so without this
-    # entry the host cannot resolve its own .ts.net hostname to its tailnet
-    # IPv4 — local dev tools whose auth callbacks redirect to the tailnet
-    # hostname would otherwise time out.
+    # Pin this host's own Tailscale MagicDNS name as a safety net in case the
+    # tailscaled→resolved D-Bus push hasn't fired yet at boot (e.g. during
+    # nixos-rebuild switch). Local dev tools whose auth callbacks redirect to
+    # the tailnet hostname would otherwise time out.
     extraHosts = ''
       100.69.100.115 p620.tail833f7.ts.net
     '';

--- a/hosts/p620/nixos/dns-fallback.nix
+++ b/hosts/p620/nixos/dns-fallback.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+{
+  services.resolved = {
+    enable = lib.mkForce true;
+    settings.Resolve = {
+      FallbackDNS = [
+        "1.1.1.1"
+        "9.9.9.9"
+        "1.0.0.1"
+      ];
+      Domains = [ "~." ];
+      DNSOverTLS = "opportunistic";
+      MulticastDNS = "no";
+    };
+  };
+
+  networking.networkmanager.dns = lib.mkForce "systemd-resolved";
+}


### PR DESCRIPTION
## Summary

Fixes recurring DNS outages on p620 where Tailscale's MagicDNS forwarder hiccups caused all hostname resolution to fail (no public fallback was configured). Observed twice today (04:25 UTC, 08:25-08:34 UTC) via splashboard log.

## Root cause

- p620's `/etc/resolv.conf` had only Tailscale nameservers (`100.100.100.100`, `fd7a:115c:a1e0::53`).
- `hosts/p620/nixos/network-stability.nix` (which would have wired up `secure-dns` with public fallback) is dead code — not imported anywhere. Eval confirms `services.network-stability.enable = false`.
- `hosts/p620/configuration.nix` explicitly did `networkmanager.dns = mkForce "default"`, locking NM to its own DNS writer.

## Changes

1. **New file** `hosts/p620/nixos/dns-fallback.nix`: force-enables `systemd-resolved` with FallbackDNS=[1.1.1.1, 9.9.9.9, 1.0.0.1], DNSOverTLS=opportunistic, MulticastDNS=no.
2. **Wires** the new file into p620's imports list.
3. **Removes** the redundant `networkmanager.dns = mkForce "default"` block from `hosts/p620/configuration.nix` — the new file owns this setting.
4. **Drive-by:** `_typos.toml` ignore-regex for short hex tokens so `typos` stops flagging git SHAs in pinning comments (was blocking `pre-commit`).

## Why this is safe

- Uses current `services.resolved.settings.Resolve` schema (avoids the `extraConfig` mkRemovedOptionModule assertion).
- Tailscale's default `acceptDns = true` keeps working: `tailscaled` pushes MagicDNS into `resolved` via D-Bus, so `*.ts.net` still resolves via `100.100.100.100`.
- Only changes p620. razer/p510 untouched.

## Eval verification (pre-build)

```
services.resolved.enable                           = true
services.resolved.settings.Resolve.FallbackDNS     = ["1.1.1.1","9.9.9.9","1.0.0.1"]
services.resolved.settings.Resolve.Domains         = ["~."]
networking.networkmanager.dns                      = "systemd-resolved"
```

## Test plan

- [x] `just test-host p620` — builds clean (system derivation built, resolved unit + activation drv built)
- [x] Pre-commit hooks (typos, statix, deadnix, format) — all pass
- [ ] After merge: `just p620` to deploy
- [ ] Post-deploy: `resolvectl status` shows fallback DNS list
- [ ] Post-deploy: `getent hosts foo.ts.net` resolves via MagicDNS
- [ ] Post-deploy: `getent hosts hacker-news.firebaseio.com` resolves
- [ ] Post-deploy: simulate Tailscale daemon stop — public DNS still works

## Out of scope (separate PRs)

- Cleanup of dead `hosts/p620/nixos/network-stability.nix`
- Tailscale 1.98.2 bump for upstream #520715 (waiting for nixos-unstable channel cascade)
- Applying same pattern to razer/p510 (after p620 burn-in)

Closes #564