### PR TITLE
chore(claude-code): bump native binary 2.1.145 → 2.1.146 (#562)

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.145";
+  version = "2.1.146";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-s/+8Emib/oE4nWV3eH/OpMq4G9O2u6m3Gec3cLYtcg4=";
+      hash = "sha256-gl1TATgPH19GbFJo3iWgYpJ75liTj8HWMM+gLFIbgYU=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-da1h1pDXlEDIK1hBRE4bQsquVXNq83yX3Q4GjvIM45A=";
+      hash = "sha256-ryUzTHomMqUxs04/TA1pdjuZcUnTHV8NdI5EgTdYgG8=";
     };
   };
 


### PR DESCRIPTION
## Summary

Routine bump of `claude-code-native` from 2.1.145 to 2.1.146, the latest channel version per Anthropic's GCS distribution.

## Verification

- ✅ `nix build .#claude-code-native` → `claude --version` reports `2.1.146 (Claude Code)`
- ✅ `ldd` against the new binary — no missing libs
- ✅ Host matrix builds: p620, razer, p510 all green
- ✅ Diff is exactly 3 lines (version + x86_64 hash + aarch64 hash) — no scope creep

## Note

Committed with `--no-verify` per the documented statix pre-commit hook workaround in `.claude/commands/update-claude-code.md`.

## Test plan

- [x] Local sanity build with `claude --version` check
- [x] All 3 host system derivations build
- [ ] CI host matrix
- [ ] Post-merge: deploy + verify `claude --version` on each host

Closes #562