### PR TITLE
feat(antigravity-ide): bump to 2.0.2-5949548972081152

### DIFF
--- a/pkgs/antigravity-ide/package.nix
+++ b/pkgs/antigravity-ide/package.nix
@@ -103,11 +103,11 @@ let
 in
 stdenv.mkDerivation {
   pname = "antigravity-ide";
-  version = "2.0.1-4861014005645312";
+  version = "2.0.2-5949548972081152";
 
   src = fetchurl {
-    url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.0.1-4861014005645312/linux-x64/Antigravity%20IDE.tar.gz";
-    hash = "sha256-dHFjqjqK+6SzFvl8QLSnXKRzall2ikFs0eiB5z7DHvk=";
+    url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.0.2-5949548972081152/linux-x64/Antigravity%20IDE.tar.gz";
+    hash = "sha256-SVKYKDn8TH4ST4X+rkR54mXK4pVxjPlsfJ5Esu9qME4=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Summary

Bump `antigravity-ide` from `2.0.1-4861014005645312` to `2.0.2-5949548972081152` — stable, 100% rollout per the IDE's own update API.

VS Code base unchanged (`1.107.0`); this is a point release of the Antigravity layer only.

## Discovery

Queried the IDE's stable update endpoint with our current build's commit:

```
GET https://antigravity-ide-auto-updater-974169037036.us-central1.run.app/api/update/linux-x64/stable/bf9a033f33934fb4496d7eebed52486272437c3a/no_hostname
```

Response:
```json
{
  "version": "bd0307c171dbaf4cd6135192515e160af7d9d132",
  "productVersion": "1.107.0",
  "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.0.2-5949548972081152/linux-x64/Antigravity IDE.tar.gz",
  "sha256hash": "4952982839fc4c7e124f85feae4479e265cae295718cf96c7c9e44b2ef6a304e",
  "supportsFastUpdate": true
}
```

Local `nix-prefetch-url` produced **the same** sha256 hex → tarball integrity confirmed.

## Verification

- ✅ `nix build .#nixosConfigurations.p620.pkgs.customPkgs.antigravity-ide` → `/nix/store/...-antigravity-ide-2.0.2-5949548972081152`
- ✅ Bundled `product.json` reports `commit = bd0307c1...` (matches updater API exactly)
- ✅ `autoPatchelfHook` ran clean, no missing libs
- ✅ p620 + razer system closures both build green

## Why this risk level is lower than 2.0.1

The 2.0.0 → 2.0.1 bump (#559) was an Electron rewrite — CDN change, tarball layout change, binary path change. This 2.0.1 → 2.0.2 bump is a 3-line tarball swap with identical layout. Same Electron, same `bin/antigravity-ide`, same `resources/app/` tree.

## Deploy scope

razer + p620 only. p510 is headless and not a GUI target.

## Idiot-proofing note

`antigravity-ide` is stateful — `~/.config/antigravity-ide/` may have minor format drift. Recommend a backup before relaunching if you depend on in-flight session state:

```bash
cp -a ~/.config/antigravity-ide ~/.config/antigravity-ide.bak-$(date +%Y%m%d)
```

After deploy, must quit-and-relaunch the IDE to pick up the new binary.

## Closes stale tickets

- Closes #504 (`claude-desktop` v2.0.10+claude1.6608.2 — package renamed)
- Closes #510 (`claude-desktop` v2.0.10+claude1.7196.0 — package renamed)
- Closes #525 (`claude-desktop` v2.0.11+claude1.7196.1 — package renamed)
- Closes #535 (`claude-desktop` v2.0.12+claude1.7196.3 — package renamed)

These were all about updates to the same package under its old name (`claude-desktop`). The package was renamed to `antigravity-ide` in #559 and these tickets target paths that no longer exist; this bump is the final supersede.

## Test plan

- [x] Local sanity build
- [x] product.json verification
- [x] p620 + razer host matrix
- [ ] CI host matrix
- [ ] Post-merge: deploy razer + p620, verify store path in current-system