### PR TITLE
fix(tmux): style display-popup chrome to match Stylix gruvbox (#569)

### DIFF
--- a/home/shell/tmux/default.nix
+++ b/home/shell/tmux/default.nix
@@ -315,6 +315,14 @@ in
         # Ensure no powerline characters are used
         set -g window-status-separator " │ "
         set -g status-style "bg=#${colors.base00},fg=#${colors.base04}"
+
+        # Popup chrome — match the Stylix base16 scheme so display-popup
+        # (tmux-palette, tmux-expose, choose-tree -Z, etc.) blends into the
+        # terminal instead of using tmux's terminal-default fill which
+        # renders darker than gruvbox bg on kitty/ghostty.
+        set -g popup-style "bg=#${colors.base00}"
+        set -g popup-border-style "fg=#${colors.base0B},bg=#${colors.base00}"
+        set -g popup-border-lines rounded
       '';
     };
 


### PR DESCRIPTION
## Summary

`tmux-palette` popup + other `display-popup` consumers (`tmux-expose`, `choose-tree -Z`) didn't blend with gruvbox-themed terminal because tmux's default `popup-style` was never overridden. The palette's row contents were styled correctly (theme.json from Stylix base16) — the issue was purely the popup's negative space (border zone + unfilled padding cells).

## Change

3 active lines after the existing `status-style` block in `home/shell/tmux/default.nix`:

```nix
set -g popup-style "bg=#${colors.base00}"
set -g popup-border-style "fg=#${colors.base0B},bg=#${colors.base00}"
set -g popup-border-lines rounded
```

Sourced from `config.lib.stylix.colors` — automatically follows whatever Stylix scheme is active (currently `gruvbox-dark`).

## Verification

- ✅ p620 system closure builds clean
- ✅ razer system closure builds clean
- ✅ diff: `1 file changed, 8 insertions(+)` (3 active + 5 comment)

## Affects

All `display-popup` consumers — `tmux-palette` (M-p, M-Space, M-a), `tmux-expose` (M-e), `choose-tree -Z` (prefix-s), etc. Consistent gruvbox chrome across all of them.

## Test plan

- [x] Local host matrix build
- [ ] CI host matrix
- [ ] Post-deploy: reopen palette → confirm bg matches terminal, border is a subtle gruvbox-green outline

Closes #569