### PR TITLE
feat(p620): self-hosted skill-pool registry

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -578,6 +578,24 @@
         "type": "github"
       }
     },
+    "flake-utils_11": {
+      "inputs": {
+        "systems": "systems_13"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "flake-utils_2": {
       "inputs": {
         "systems": "systems_3"
@@ -703,7 +721,7 @@
     },
     "flake-utils_9": {
       "inputs": {
-        "systems": "systems_11"
+        "systems": "systems_9"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -1526,6 +1544,7 @@
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur",
         "rust-overlay": "rust-overlay_6",
+        "skill-pool": "skill-pool",
         "sops-nix": "sops-nix",
         "spicetify-nix": "spicetify-nix",
         "stylix": "stylix",
@@ -1693,6 +1712,28 @@
         "type": "github"
       }
     },
+    "skill-pool": {
+      "inputs": {
+        "flake-utils": "flake-utils_9",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779371251,
+        "narHash": "sha256-9H3RdlozdXXNybDLfZzUBnFczmQ3Axv/jiEJDMY40QI=",
+        "owner": "olafkfreund",
+        "repo": "skill_pool",
+        "rev": "67d7509a31524be1c3a66a6d1d36f86a5ef38b23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "olafkfreund",
+        "ref": "v0.2.2",
+        "repo": "skill_pool",
+        "type": "github"
+      }
+    },
     "sops-nix": {
       "inputs": {
         "nixpkgs": [
@@ -1732,7 +1773,7 @@
     "spicetify-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_13",
-        "systems": "systems_9"
+        "systems": "systems_10"
       },
       "locked": {
         "lastModified": 1779000518,
@@ -1761,7 +1802,7 @@
           "nixpkgs"
         ],
         "nur": "nur_2",
-        "systems": "systems_10",
+        "systems": "systems_11",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
@@ -1827,6 +1868,21 @@
       }
     },
     "systems_12": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_13": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -2027,7 +2083,7 @@
     },
     "yt-x": {
       "inputs": {
-        "flake-utils": "flake-utils_9",
+        "flake-utils": "flake-utils_10",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -2049,7 +2105,7 @@
     "zjstatus": {
       "inputs": {
         "crane": "crane_4",
-        "flake-utils": "flake-utils_10",
+        "flake-utils": "flake-utils_11",
         "nixpkgs": "nixpkgs_14",
         "rust-overlay": "rust-overlay_7"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -162,6 +162,14 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # skill-pool — self-hosted Claude Code skill/agent/command registry.
+    # Pinned to the v0.2.2 tagged release; consumed by
+    # modules/services/skill-pool.nix on p620.
+    skill-pool = {
+      url = "github:olafkfreund/skill_pool/v0.2.2";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
   };
 
   outputs =

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -37,6 +37,7 @@ in
     ../../modules/containers/docker.nix
     ../../modules/scrcpy/default.nix
     ../../modules/system/logging.nix
+    ../../modules/services/skill-pool.nix # local skill-pool registry portal
   ];
   host.class = "workstation";
 

--- a/modules/services/skill-pool.nix
+++ b/modules/services/skill-pool.nix
@@ -1,0 +1,167 @@
+# skill-pool — local-machine deployment of the registry portal.
+#
+# Single-node setup on p620:
+#   - pgvector pg17 in a rootful podman container on 127.0.0.1:5433
+#     (kept off the host's existing pg17 on 5432).
+#   - skill-pool-server (HTTP API) on 127.0.0.1:8080 via the upstream
+#     `nixosModules.skill-pool-server` module.
+#   - skill-pool-web (SvelteKit adapter-node bundle) on 127.0.0.1:3030
+#     via a custom systemd unit (the upstream module is server-only).
+#   - First-boot bootstrap unit generates an admin token into
+#     /var/lib/skill-pool/env (mode 0600, owned by skillpool).
+#
+# Secrets handling is dev-only on purpose: the postgres password is in
+# the Nix store (world-readable) and the admin token is generated once at
+# first boot. For any deploy that leaves this machine, route these through
+# agenix (modules/security/secrets.nix already wires it).
+
+{ lib, pkgs, inputs, ... }:
+
+let
+  system = pkgs.stdenv.hostPlatform.system;
+  serverPkg = inputs.skill-pool.packages.${system}.skill-pool-server;
+  cliPkg = inputs.skill-pool.packages.${system}.skill-pool-cli;
+  webPkg = inputs.skill-pool.packages.${system}.skill-pool-web;
+
+  pgPassword = "skillpool-dev-local";
+  # 5433 collides with an unrelated skillai-db-1 docker container on this box.
+  pgPort = 5434;
+  serverPort = 8080;
+  webPort = 3030;
+
+  databaseUrl =
+    "postgres://skillpool:${pgPassword}@127.0.0.1:${toString pgPort}/skillpool";
+in
+{
+  imports = [ inputs.skill-pool.nixosModules.skill-pool-server ];
+
+  # Make the admin (`skill-pool-server admin …`) and end-user (`skill-pool …`)
+  # binaries reachable on the system PATH so tenant bootstrap commands and
+  # local publishing both Just Work without hard-coded /nix/store paths.
+  environment.systemPackages = [ serverPkg cliPkg ];
+
+  # ---------------------------------------------------------------------------
+  # 1. pgvector pg17 in a podman container, isolated from the host pg17.
+  # ---------------------------------------------------------------------------
+
+  virtualisation.podman.enable = lib.mkDefault true;
+
+  virtualisation.oci-containers = {
+    backend = "podman";
+
+    containers."skill-pool-postgres" = {
+      image = "docker.io/pgvector/pgvector:pg17";
+      ports = [ "127.0.0.1:${toString pgPort}:5432" ];
+      environment = {
+        POSTGRES_USER = "skillpool";
+        POSTGRES_PASSWORD = pgPassword;
+        POSTGRES_DB = "skillpool";
+      };
+      volumes = [ "/var/lib/skill-pool-postgres:/var/lib/postgresql/data" ];
+      autoStart = true;
+      cmd = [ "postgres" ];
+    };
+  };
+
+  systemd.tmpfiles.rules = [
+    "d /var/lib/skill-pool-postgres 0700 root root - -"
+  ];
+
+  # ---------------------------------------------------------------------------
+  # 2. skill-pool-server (HTTP API) on 127.0.0.1:8080.
+  # ---------------------------------------------------------------------------
+
+  services.skill-pool-server = {
+    enable = true;
+    package = serverPkg;
+    bind = "127.0.0.1:${toString serverPort}";
+    databaseUrl = databaseUrl;
+    storageUri = "fs:///var/lib/skill-pool/bundles";
+    defaultTenant = "acme";
+    logLevel = "info,skill_pool=info";
+    logFormat = "pretty";
+    environmentFile = "/var/lib/skill-pool/env";
+    openFirewall = false;
+  };
+
+  # Make the server wait for the pg container's unit before launching.
+  # Connect-retries handle the brief "container up, postgres still
+  # initializing" window — Restart=on-failure + RestartSec=5s in the
+  # upstream module loops the server back to start.
+  systemd.services.skill-pool-server = {
+    after = lib.mkAfter [ "podman-skill-pool-postgres.service" ];
+    requires = [ "podman-skill-pool-postgres.service" ];
+  };
+
+  # First-boot env-file bootstrap. Idempotent: only writes if missing.
+  systemd.services.skill-pool-bootstrap = {
+    description = "skill-pool first-boot env-file bootstrap";
+    wantedBy = [ "skill-pool-server.service" ];
+    before = [ "skill-pool-server.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      set -euo pipefail
+      mkdir -p /var/lib/skill-pool
+      if [ ! -f /var/lib/skill-pool/env ]; then
+        umask 077
+        TOKEN=$(${pkgs.openssl}/bin/openssl rand -hex 32)
+        printf 'SKILL_POOL_ADMIN_TOKEN=%s\n' "$TOKEN" > /var/lib/skill-pool/env
+        chown skillpool:skillpool /var/lib/skill-pool/env
+        chmod 0600 /var/lib/skill-pool/env
+      fi
+    '';
+  };
+
+  # ---------------------------------------------------------------------------
+  # 3. skill-pool-web (SvelteKit adapter-node bundle) on 127.0.0.1:3030.
+  # ---------------------------------------------------------------------------
+
+  systemd.services.skill-pool-web = {
+    description = "skill-pool SvelteKit portal (adapter-node bundle)";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "skill-pool-server.service" ];
+    wants = [ "skill-pool-server.service" ];
+
+    environment = {
+      PORT = toString webPort;
+      HOST = "127.0.0.1";
+      ORIGIN = "http://localhost:${toString webPort}";
+      SKILL_POOL_API_BASE = "http://127.0.0.1:${toString serverPort}";
+      SP_DEFAULT_TENANT = "acme";
+      NODE_ENV = "production";
+    };
+
+    serviceConfig = {
+      Type = "simple";
+      ExecStart = "${pkgs.nodejs_22}/bin/node ${webPkg}/index.js";
+      Restart = "on-failure";
+      RestartSec = "5s";
+
+      DynamicUser = true;
+      StateDirectory = "skill-pool-web";
+
+      NoNewPrivileges = true;
+      ProtectSystem = "strict";
+      ProtectHome = true;
+      PrivateTmp = true;
+      PrivateDevices = true;
+      ProtectKernelTunables = true;
+      ProtectKernelModules = true;
+      ProtectControlGroups = true;
+      ProtectClock = true;
+      ProtectHostname = true;
+      ProtectKernelLogs = true;
+      RestrictSUIDSGID = true;
+      RestrictRealtime = true;
+      RestrictNamespaces = true;
+      LockPersonality = true;
+      SystemCallArchitectures = "native";
+      RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+      MemoryMax = "512M";
+      TasksMax = 256;
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Self-hosted skill-pool registry portal deployed locally on p620:

- **New flake input** `skill-pool` pinned to `v0.2.2`
- **pgvector pg17** container on `127.0.0.1:5434` (avoids host pg17 on 5432 and skillai-db-1 on 5433)
- **skill-pool-server** HTTP API on `127.0.0.1:8080` via upstream `nixosModules.skill-pool-server`
- **skill-pool-web** SvelteKit bundle on `127.0.0.1:3030` via custom systemd unit (upstream module is server-only)
- **First-boot bootstrap** generates admin token at `/var/lib/skill-pool/env` (mode 0600, owned by `skillpool`)

## Security caveat

Secrets are **dev-only and local-only**:
- Postgres password lives in the Nix store (world-readable)
- Admin token rotates at first boot

Productionizing beyond p620 requires routing both through agenix (`modules/security/secrets.nix` already wired).

## Test plan

- [ ] `just test-host p620` builds successfully
- [ ] `just p620` deploys cleanly
- [ ] Podman pgvector container reachable on `127.0.0.1:5434`
- [ ] `curl http://127.0.0.1:8080/healthz` returns 200
- [ ] `curl http://127.0.0.1:3030/` serves SvelteKit web bundle
- [ ] `/var/lib/skill-pool/env` exists with mode 0600, owned by skillpool
- [ ] `skill-pool-server admin --help` and `skill-pool --help` both work (PATH check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)