### PR TITLE
chore(gitignore): ignore .aifactory/ local agent state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ result-*
 .claude/scheduled_tasks.lock
 .claude/*.lock
 
+# aifactory / agent tooling local state (contains .env with secrets,
+# PR scratch state, and spec drafts — must never be committed)
+.aifactory/
+
 # OS generated files
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary

Adds `.aifactory/` to `.gitignore`. The directory contains:
- `.env` with secrets
- PR scratch state from agent tooling
- Spec drafts

These must never be committed.

## Why now

`just update-commit` was failing the dirty-tree safety check because `.aifactory/` was sitting untracked at the repo root. Gitignoring it makes future lock-bump runs idempotent.

## Test plan

- [x] `git check-ignore -v .aifactory/` reports the new rule
- [x] `git status` no longer shows `.aifactory/` as untracked
- [x] No tracked files are accidentally ignored (rule is `.aifactory/` only, scoped to the directory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)