### PR TITLE
chore(p620,razer): remove cosmic-ext-connect and openclaw

### DIFF
--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -1,11 +1,9 @@
 { lib
 , pkgs
-, inputs
 , ...
 }: {
   imports = [
     ./profile.nix
-    inputs.nix-openclaw.homeManagerModules.openclaw
   ];
 
   desktop.gnome.profile = "workstation";
@@ -43,56 +41,6 @@
     theme = "custom";
     style = "powerline";
   };
-
-  # OpenClaw — personal AI assistant gateway (systemd user service).
-  # The wrapper reads /run/agenix/api-gemini at runtime and exports the contents
-  # as $GEMINI_API_KEY (see nix-openclaw config.nix wrapper logic). OpenClaw
-  # honours GEMINI_API_KEY as the Google provider fallback per
-  # docs.openclaw.ai/providers/google, so no models.providers.google.apiKey is
-  # set declaratively — keeps the key out of the Nix store.
-  programs.openclaw = {
-    enable = true;
-    environment.GEMINI_API_KEY = "/run/agenix/api-gemini";
-    config.agents.defaults.model = {
-      primary = "google/gemini-3.1-pro-preview";
-      # Fall back to Flash on watchdog timeout — the agent harness sends ~26
-      # tools + ~20 skills in the initial prompt, and 3.1-pro-preview's
-      # first-token latency frequently exceeds the gateway's idle watchdog.
-      # Flash (1M ctx, reasoning) starts streaming fast and keeps the agent
-      # responsive when 3.1 stalls.
-      fallbacks = [ "google/gemini-2.5-flash" ];
-    };
-
-    # Expose plugin CLIs on the user's interactive PATH (off by default). The
-    # gateway wrapper has them either way; this is so `gog auth credentials`
-    # and `gog auth add …` (one-time browser-based OAuth) can be run from a
-    # normal shell after deploy.
-    exposePluginPackages = true;
-
-    # Bundled plugins. Each puts its CLI on the gateway wrapper's PATH so the
-    # already-loaded matching `gog` / `summarize` / `qmd` skills can call it.
-    # `goplaces` is defaultEnable=true upstream — no need to list it here.
-    bundledPlugins = {
-      # Google Workspace — Gmail, Calendar, Drive, Contacts, Sheets, Docs.
-      # OAuth setup is one-time and interactive (browser flow): after deploy run
-      #   gog auth credentials /path/to/client_secret.json    # from GCP console
-      #   gog auth add olaf@freundcloud.com --services gmail,calendar,drive,contacts,docs,sheets
-      gogcli.enable = true;
-
-      # URL / PDF / YouTube summarisation — useful for inbox triage and reading.
-      summarize.enable = true;
-
-      # Local markdown KB search (Obsidian-friendly).
-      qmd.enable = true;
-    };
-  };
-
-  # Add an [Install] section to the openclaw-gateway user service so it auto-
-  # starts at boot (the upstream nix-openclaw HM module deliberately omits it
-  # so the gateway is opt-in). Combined with `users.users.olafkfreund.linger
-  # = true` at the system level, this means heartbeats / scheduled agent runs
-  # keep working even when no shell session is active.
-  systemd.user.services.openclaw-gateway.Install.WantedBy = [ "default.target" ];
 
   # Workstation-specific additional packages
   home.packages = [

--- a/flake.lock
+++ b/flake.lock
@@ -168,35 +168,13 @@
         "type": "github"
       }
     },
-    "cosmic-ext-connect": {
+    "cosmic-ext-radio-applet": {
       "inputs": {
         "flake-utils": "flake-utils_3",
         "nixpkgs": [
           "nixpkgs"
         ],
         "rust-overlay": "rust-overlay_2"
-      },
-      "locked": {
-        "lastModified": 1771245012,
-        "narHash": "sha256-34I7jBgSdJF8OUk776CIEtEoQPaIFpE7EZoQMwoAKXM=",
-        "owner": "olafkfreund",
-        "repo": "cosmic-ext-connect-desktop-app",
-        "rev": "3613bf5f0665f4330f3deb87748a617164822125",
-        "type": "github"
-      },
-      "original": {
-        "owner": "olafkfreund",
-        "repo": "cosmic-ext-connect-desktop-app",
-        "type": "github"
-      }
-    },
-    "cosmic-ext-radio-applet": {
-      "inputs": {
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-overlay": "rust-overlay_3"
       },
       "locked": {
         "lastModified": 1771408769,
@@ -236,7 +214,7 @@
     "cosmic-music-player": {
       "inputs": {
         "crane": "crane_2",
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_4",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -360,7 +338,7 @@
     },
     "emacs": {
       "inputs": {
-        "nixpkgs": "nixpkgs_10",
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
@@ -560,42 +538,6 @@
         "type": "github"
       }
     },
-    "flake-utils_10": {
-      "inputs": {
-        "systems": "systems_12"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_11": {
-      "inputs": {
-        "systems": "systems_13"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flake-utils_2": {
       "inputs": {
         "systems": "systems_3"
@@ -669,6 +611,21 @@
       }
     },
     "flake-utils_6": {
+      "locked": {
+        "lastModified": 1637014545,
+        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_7": {
       "inputs": {
         "systems": "systems_7"
       },
@@ -686,9 +643,9 @@
         "type": "github"
       }
     },
-    "flake-utils_7": {
+    "flake-utils_8": {
       "inputs": {
-        "systems": "systems_8"
+        "systems": "systems_10"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -704,24 +661,9 @@
         "type": "github"
       }
     },
-    "flake-utils_8": {
-      "locked": {
-        "lastModified": 1637014545,
-        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flake-utils_9": {
       "inputs": {
-        "systems": "systems_9"
+        "systems": "systems_11"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -833,27 +775,6 @@
         "type": "github"
       }
     },
-    "home-manager_3": {
-      "inputs": {
-        "nixpkgs": [
-          "nix-openclaw",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1767909183,
-        "narHash": "sha256-u/bcU0xePi5bgNoRsiqSIwaGBwDilKKFTz3g0hqOBAo=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "cd6e96d56ed4b2a779ac73a1227e0bb1519b3509",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
     "infuse": {
       "flake": false,
       "locked": {
@@ -872,8 +793,8 @@
     },
     "lan-mouse": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4",
-        "rust-overlay": "rust-overlay_4"
+        "nixpkgs": "nixpkgs_3",
+        "rust-overlay": "rust-overlay_3"
       },
       "locked": {
         "lastModified": 1779182766,
@@ -896,7 +817,7 @@
           "nixpkgs"
         ],
         "pre-commit": "pre-commit",
-        "rust-overlay": "rust-overlay_5"
+        "rust-overlay": "rust-overlay_4"
       },
       "locked": {
         "lastModified": 1765382359,
@@ -917,7 +838,7 @@
       "inputs": {
         "devshell": "devshell",
         "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1778979290,
@@ -935,7 +856,7 @@
     },
     "microvm": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_5",
         "spectrum": "spectrum"
       },
       "locked": {
@@ -972,53 +893,11 @@
         "type": "github"
       }
     },
-    "nix-openclaw": {
-      "inputs": {
-        "flake-utils": "flake-utils_7",
-        "home-manager": "home-manager_3",
-        "nix-openclaw-tools": "nix-openclaw-tools",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "qmd": "qmd"
-      },
-      "locked": {
-        "lastModified": 1778995825,
-        "narHash": "sha256-hlmwIvupaC/luN/SUHe6R/tqHzxAeXqTUt/1U5mcS4w=",
-        "owner": "openclaw",
-        "repo": "nix-openclaw",
-        "rev": "f5e6d2ea2355eb297af5b5e618b37b2fca244df9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "openclaw",
-        "repo": "nix-openclaw",
-        "type": "github"
-      }
-    },
-    "nix-openclaw-tools": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_7"
-      },
-      "locked": {
-        "lastModified": 1778060041,
-        "narHash": "sha256-tXWkN1VnwFG8XlRqW/e7VwbKnUfyU9tB7YDm9QHJXTY=",
-        "owner": "openclaw",
-        "repo": "nix-openclaw-tools",
-        "rev": "4c1cee3c7eaf68f9de0f756be1484534f5bb5f34",
-        "type": "github"
-      },
-      "original": {
-        "owner": "openclaw",
-        "repo": "nix-openclaw-tools",
-        "type": "github"
-      }
-    },
     "nix-snapd": {
       "inputs": {
         "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1761703712,
@@ -1070,7 +949,7 @@
       "inputs": {
         "emacs": "emacs",
         "infuse": "infuse",
-        "nixpkgs": "nixpkgs_11",
+        "nixpkgs": "nixpkgs_9",
         "nixpkgs-fmt": "nixpkgs-fmt",
         "parts": "parts"
       },
@@ -1091,7 +970,7 @@
     "nixpkgs-fmt": {
       "inputs": {
         "fenix": "fenix",
-        "flake-utils": "flake-utils_8",
+        "flake-utils": "flake-utils_6",
         "nixpkgs": [
           "nixpkgs-f2k",
           "nixpkgs"
@@ -1207,51 +1086,19 @@
       "locked": {
         "lastModified": 1778869304,
         "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
-        "owner": "NixOS",
+        "owner": "nixos",
         "repo": "nixpkgs",
         "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
+        "owner": "nixos",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_11": {
-      "locked": {
-        "lastModified": 1779343714,
-        "narHash": "sha256-pitr+vhLWBn75pTHzSVcLh9uTq7fS5PiddFz5yvomzQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "2902cb6db2da263dc80ccd06055c6fbb70a218b9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "master",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_12": {
-      "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_13": {
       "locked": {
         "lastModified": 1778869304,
         "narHash": "sha256-VdRy3A14M5vIE882DJcaaR+5wrss9Qsg4YNVbr7uj3k=",
@@ -1264,7 +1111,7 @@
         "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
-    "nixpkgs_14": {
+    "nixpkgs_12": {
       "locked": {
         "lastModified": 1776255774,
         "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
@@ -1298,22 +1145,6 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1772963539,
         "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
         "owner": "nixos",
@@ -1328,7 +1159,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1776548001,
         "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
@@ -1344,7 +1175,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1778869304,
         "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
@@ -1360,23 +1191,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
-      "locked": {
-        "lastModified": 1767364772,
-        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_8": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1761442529,
         "narHash": "sha256-8aDps5fCt0Ndw56ZgeBvdT7E5zeUSFi3CJaNR7ZJKnA=",
@@ -1391,7 +1206,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_9": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1778869304,
         "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
@@ -1407,10 +1222,42 @@
         "type": "github"
       }
     },
+    "nixpkgs_8": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1779343714,
+        "narHash": "sha256-pitr+vhLWBn75pTHzSVcLh9uTq7fS5PiddFz5yvomzQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2902cb6db2da263dc80ccd06055c6fbb70a218b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_4",
-        "nixpkgs": "nixpkgs_12"
+        "nixpkgs": "nixpkgs_10"
       },
       "locked": {
         "lastModified": 1779391762,
@@ -1492,32 +1339,6 @@
         "type": "github"
       }
     },
-    "qmd": {
-      "inputs": {
-        "flake-utils": [
-          "nix-openclaw",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nix-openclaw",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775429264,
-        "narHash": "sha256-bqIVaNRTa8H5vrw3RwsD7QdtTa0xNvRuEVzlzE1hIBQ=",
-        "owner": "tobi",
-        "repo": "qmd",
-        "rev": "65cd1b3fd02891d1ee0eefa751620918664fa321",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tobi",
-        "ref": "v2.1.0",
-        "repo": "qmd",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "agenix": "agenix",
@@ -1525,25 +1346,23 @@
         "claude-desktop-linux": "claude-desktop-linux",
         "claude-skills-borghei": "claude-skills-borghei",
         "cosmic-applet-spotify": "cosmic-applet-spotify",
-        "cosmic-ext-connect": "cosmic-ext-connect",
         "cosmic-ext-radio-applet": "cosmic-ext-radio-applet",
         "cosmic-ext-web-apps": "cosmic-ext-web-apps",
         "cosmic-music-player": "cosmic-music-player",
-        "flake-utils": "flake-utils_6",
+        "flake-utils": "flake-utils_5",
         "home-manager": "home-manager_2",
         "lan-mouse": "lan-mouse",
         "lanzaboote": "lanzaboote",
         "mcp-nixos": "mcp-nixos",
         "microvm": "microvm",
         "nix-index-database": "nix-index-database",
-        "nix-openclaw": "nix-openclaw",
         "nix-snapd": "nix-snapd",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_9",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-f2k": "nixpkgs-f2k",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur",
-        "rust-overlay": "rust-overlay_6",
+        "rust-overlay": "rust-overlay_5",
         "skill-pool": "skill-pool",
         "sops-nix": "sops-nix",
         "spicetify-nix": "spicetify-nix",
@@ -1592,24 +1411,6 @@
     },
     "rust-overlay_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1768359079,
-        "narHash": "sha256-a016mOfKconYrYo3fZLN6c2cnmqYYd44g2bUrBZAsQc=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "0357d1826057686637e41147545402cbbda420ce",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "rust-overlay_3": {
-      "inputs": {
         "nixpkgs": [
           "cosmic-ext-radio-applet",
           "nixpkgs"
@@ -1629,7 +1430,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_4": {
+    "rust-overlay_3": {
       "inputs": {
         "nixpkgs": [
           "lan-mouse",
@@ -1650,7 +1451,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_5": {
+    "rust-overlay_4": {
       "inputs": {
         "nixpkgs": [
           "lanzaboote",
@@ -1671,7 +1472,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_6": {
+    "rust-overlay_5": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
@@ -1691,7 +1492,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_7": {
+    "rust-overlay_6": {
       "inputs": {
         "nixpkgs": [
           "zjstatus",
@@ -1714,7 +1515,7 @@
     },
     "skill-pool": {
       "inputs": {
-        "flake-utils": "flake-utils_9",
+        "flake-utils": "flake-utils_7",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -1772,8 +1573,8 @@
     },
     "spicetify-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_13",
-        "systems": "systems_10"
+        "nixpkgs": "nixpkgs_11",
+        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1779000518,
@@ -1802,7 +1603,7 @@
           "nixpkgs"
         ],
         "nur": "nur_2",
-        "systems": "systems_11",
+        "systems": "systems_9",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
@@ -1853,36 +1654,6 @@
       }
     },
     "systems_11": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_12": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_13": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -2083,7 +1854,7 @@
     },
     "yt-x": {
       "inputs": {
-        "flake-utils": "flake-utils_10",
+        "flake-utils": "flake-utils_8",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -2105,9 +1876,9 @@
     "zjstatus": {
       "inputs": {
         "crane": "crane_4",
-        "flake-utils": "flake-utils_11",
-        "nixpkgs": "nixpkgs_14",
-        "rust-overlay": "rust-overlay_7"
+        "flake-utils": "flake-utils_9",
+        "nixpkgs": "nixpkgs_12",
+        "rust-overlay": "rust-overlay_6"
       },
       "locked": {
         "lastModified": 1776491188,

--- a/flake.nix
+++ b/flake.nix
@@ -103,12 +103,6 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # COSMIC Connect - KDE Connect alternative for COSMIC Desktop
-    cosmic-ext-connect = {
-      url = "github:olafkfreund/cosmic-ext-connect-desktop-app";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
     # Hardware specific (removed unused razer-laptop-control)
 
     # Package collections
@@ -144,13 +138,6 @@
     # COSMIC Web Apps - Web application manager for COSMIC Desktop
     cosmic-ext-web-apps = {
       url = "github:olafkfreund/cosmic-ext-web-apps";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    # OpenClaw — personal AI assistant (official Nix flake, HM module).
-    # Used on P620 only; backed by the existing api-gemini.age agenix secret.
-    nix-openclaw = {
-      url = "github:openclaw/nix-openclaw";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -273,7 +260,6 @@
               inputs.agenix.nixosModules.default
               inputs.lanzaboote.nixosModules.lanzaboote
               nix-index-database.nixosModules.nix-index
-              inputs.cosmic-ext-connect.nixosModules.default
               # cosmic-ext-applet-radio: local module workaround for upstream mkPackageOption 'description' arg bug
               ./modules/services/cosmic-ext-radio-applet
               ./home/shell/zellij/zjstatus.nix

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -78,16 +78,6 @@ in
   # Add to panel via: COSMIC Settings > Panel > Applets
   programs.cosmic-ext-applet-radio.enable = true;
 
-  # COSMIC Connect - Device connectivity solution for COSMIC Desktop
-  services.cosmic-ext-connect = {
-    enable = true;
-    openFirewall = true; # Ports 1814-1864 (discovery), 1739-1764 (transfers), 5900 (VNC)
-    daemon = {
-      enable = true;
-      autoStart = true;
-    };
-  };
-
   # Use AI provider defaults with workstation profile
   aiDefaults = {
     enable = true;
@@ -365,8 +355,9 @@ in
       "render"
     ];
     shell = pkgs.zsh;
-    # Run user services even when not logged in — needed so the openclaw
-    # gateway (and any other systemd user units) keep working at boot
+    # Run user services even when not logged in so headless user units
+    # (e.g. the GNOME Remote Desktop headless service wired by
+    # modules/desktop/gnome-remote-desktop.nix) keep working at boot
     # before someone logs in via TTY/SSH/desktop session.
     linger = true;
     # Only use secret-managed password if the secret exists

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -100,17 +100,6 @@ in
   # Add to panel via: COSMIC Settings > Panel > Applets
   programs.cosmic-ext-applet-radio.enable = true;
 
-  # COSMIC Connect - Device connectivity solution for COSMIC Desktop
-  # TEMPORARILY DISABLED: Rust compilation errors in cosmic-ext-connect-protocol (issue #79)
-  # services.cosmic-ext-connect = {
-  #   enable = true;
-  #   openFirewall = true; # Ports 1814-1864 (discovery), 1739-1764 (transfers), 5900 (VNC)
-  #   daemon = {
-  #     enable = true;
-  #     autoStart = true;
-  #   };
-  # };
-
   # Use AI provider defaults with laptop profile (disables Ollama for battery life)
   aiDefaults = {
     enable = true;

--- a/modules/desktop/cosmic.nix
+++ b/modules/desktop/cosmic.nix
@@ -75,27 +75,6 @@ in
       '';
     };
 
-    enableConnect = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Enable COSMIC Connect for device connectivity (KDE Connect alternative).
-
-        Provides device synchronization, file sharing, clipboard sharing, notifications,
-        media control, and remote input capabilities across devices.
-        Includes daemon service and panel applet for COSMIC Desktop.
-      '';
-    };
-
-    connectOpenFirewall = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Open firewall ports for COSMIC Connect device discovery and file transfer.
-
-        Opens TCP/UDP 1814-1864 for discovery and TCP 1739-1764 for file transfer.
-      '';
-    };
   };
 
   config = mkIf cfg.enable {
@@ -326,10 +305,5 @@ in
       };
     };
 
-    # COSMIC Connect - KDE Connect alternative for device connectivity
-    services.cosmic-ext-connect = mkIf cfg.enableConnect {
-      enable = true;
-      openFirewall = cfg.connectOpenFirewall;
-    };
   };
 }

--- a/modules/nix/nix.nix
+++ b/modules/nix/nix.nix
@@ -38,17 +38,15 @@
     fallback = true; # Build locally if substitute not available
 
     # Multi-tier binary cache configuration
-    # Priority order: NixOS official → Nix community → Garnix (upstream openclaw)
+    # Priority order: NixOS official → Nix community
     substituters = [
       "https://cache.nixos.org" # Official NixOS cache (always available)
       "https://nix-community.cachix.org" # Community cache
-      "https://cache.garnix.io" # Upstream openclaw / nix-openclaw binary cache
     ];
 
     trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" # Official NixOS
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=" # Nix community
-      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=" # Garnix
     ];
 
     # Optional: Add Cachix personal cache (free tier: 5GB storage, unlimited downloads)

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -21,18 +21,10 @@
     cosmic-ext-web-apps = inputs.cosmic-ext-web-apps.packages.${prev.stdenv.hostPlatform.system}.default;
   })
 
-  inputs.cosmic-ext-connect.overlays.default
-
   # Rust toolchain overlay — exposes `rust-bin.*` on `final` so packages
   # that need a newer rustc than nixpkgs ships (e.g. splashboard) can
   # build with `makeRustPlatform`. Doesn't replace the default `rustc`.
   inputs.rust-overlay.overlays.default
-
-  # Replace nixpkgs `pkgs.openclaw` (marked insecure due to default unsandboxed
-  # tool access) with the upstream flake's repackaged build. The HM module
-  # defaults `programs.openclaw.package` to `pkgs.openclaw`, so the overlay is
-  # how the flake author intends consumers to wire it up.
-  inputs.nix-openclaw.overlays.default
 
   (import ./custom-packages.nix)
   (import ./citrix-workspace.nix)


### PR DESCRIPTION
## Summary

Two unrelated cleanups bundled into one PR because they shared the same scope (dev/personal services not wanted on these hosts) and a small overlap (overlays/default.nix, flake.nix, p620 config).

### cosmic-ext-connect (removed from all hosts)
- Drop flake input + nixosModules wiring (`flake.nix`)
- Drop overlay reference (`overlays/default.nix`)
- Drop `services.cosmic-ext-connect` block on p620
- Drop commented-out dead block on razer (was already disabled per #79)
- Drop `enableConnect` / `connectOpenFirewall` options + service config block in `modules/desktop/cosmic.nix`

**Trigger:** `cosmic-ext-connect-daemon.service` was in `activating/auto-restart` spawn-loop because a user-scope override at `~/.config/systemd/user/cosmic-ext-connect-daemon.service.d/override.conf` pointed at a stale dev binary (`/home/olafkfreund/Source/GitHub/cosmic-ext-connect-desktop-app/target/release/cosmic-ext-connect-daemon` — no such file). The override was deleted out-of-band; this PR removes the declarative unit so it doesn't reappear on next `switch`.

### openclaw (removed from p620 only — only host using it)
- Drop `nix-openclaw` flake input
- Drop overlay reference in `overlays/default.nix`
- Drop `programs.openclaw` block + `openclaw-gateway` systemd Install wire + nix-openclaw HM module import in `Users/olafkfreund/p620_home.nix`
- Drop `inputs` from that file's arg list (no longer used)
- Drop garnix binary cache from `modules/nix/nix.nix` — it was added specifically as the openclaw upstream cache, no other consumer
- Update linger comment on p620 (linger stays — GNOME Remote Desktop headless user unit also depends on it)

## Diff

Net: **-351 lines** across 8 files (most of it transitive lock entries).

## Test plan

- [x] `just test-host p620` builds clean (1m26s)
- [x] `just test-host razer` builds clean (1m17s)
- [x] Pre-commit hooks pass (`nix flake check` re-locked cleanly)
- [x] No remaining `cosmic-ext-connect` or `openclaw` references in `*.nix` or `flake.lock`
- [ ] After deploy on p620: `cosmic-ext-connect-daemon.service` no longer exists at `/etc/systemd/user/`
- [ ] After deploy on p620: `openclaw-gateway.service` no longer exists at `~/.config/systemd/user/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)