### PR TITLE
chore(ci): disable automatic triggers for Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,8 +1,8 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+  workflow_dispatch:
+
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,14 +1,8 @@
 name: Claude Code
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-  issues:
-    types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+  workflow_dispatch:
+
 
 jobs:
   claude:


### PR DESCRIPTION
This PR disables automatic events triggers (pull_request, issue_comments, etc.) for Claude Code workflows to prevent running into rate limits and requiring approvals.