### PR TITLE
chore(pre-commit): split fast/slow stages — 700x speedup, fix silent typos misconfig

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -191,7 +191,10 @@ repos:
 
       - id: typos
         name: Check spelling
-        entry: typos
+        # --config required: typos auto-discovers `typos.toml` (no dot
+        # prefix), not `.typos.toml`. Without --config the project's
+        # extend-ignore-re rules silently don't apply.
+        entry: typos --config .typos.toml
         language: system
         pass_filenames: false
         stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,37 @@
-# Pre-commit hooks configuration
-# All hooks use Nix-packaged tools only - no external dependencies
+# Pre-commit hooks — split into two stages for speed:
 #
-# Install: pre-commit install
-# Run all: pre-commit run --all-files
-# Run one: pre-commit run HOOK_ID --all-files
+#   pre-commit (runs on every `git commit`):    formatters + cheap hygiene
+#                                               target: < 3 seconds wall time
+#   pre-push   (runs only on `git push`):       linters and slower checks
+#                                               target: < 30 seconds wall time
+#
+# Whole-flake validation (`nix flake check`) and the full linter sweep are
+# NOT in either stage — they're CI's job (check-configurations, lint-check
+# jobs run on every PR). Doing them locally on every commit was duplicating
+# work and adding 30s–7min to every commit (nixpkgs-lint-community was
+# pathologically slow on files with large embedded heredocs).
+#
+# Install both stages locally:
+#   pre-commit install --hook-type pre-commit --hook-type pre-push
+#
+# Run all hooks manually:
+#   pre-commit run --all-files                       # pre-commit stage
+#   pre-commit run --all-files --hook-stage pre-push # pre-push stage
+#
+# Run a single hook on the whole tree:
+#   pre-commit run HOOK_ID --all-files
+
+default_stages: [pre-commit]
 
 repos:
   - repo: local
     hooks:
-      # =============================================================================
-      # Nix Formatting and Linting
-      # =============================================================================
+      # ========================================================================
+      # PRE-COMMIT STAGE — formatters + cheap hygiene checks
+      # Everything here MUST be fast (< 1s per file). No linters.
+      # ========================================================================
+
+      # --- Nix ---
       - id: nixpkgs-fmt
         name: Format Nix files
         entry: nixpkgs-fmt
@@ -18,38 +39,7 @@ repos:
         files: '\.nix$'
         description: Format Nix files using nixpkgs-fmt
 
-      - id: nixpkgs-lint
-        name: Lint Nix files (nixpkgs-lint-community, tree-sitter)
-        entry: nixpkgs-lint
-        language: system
-        files: '\.nix$'
-        pass_filenames: true
-        description: Fast semantic linter for Nix; runs only on changed files
-
-      - id: deadnix
-        name: Check for dead Nix code
-        entry: bash -c 'for f in "$@"; do deadnix --fail "$f" || exit 1; done' --
-        language: system
-        files: '\.nix$'
-        pass_filenames: true
-        description: Check changed Nix files for dead/unused code
-
-      # =============================================================================
-      # Shell Script Formatting and Linting
-      # =============================================================================
-      - id: shellcheck
-        name: Lint shell scripts
-        entry: shellcheck
-        language: system
-        files: '\.sh$'
-        # SC1091: external sourced files; SC2034: vars used externally;
-        # SC2086: word-splitting (often intentional in our scripts);
-        # SC2329/SC2317: false positives for functions called via case dispatch;
-        # SC2029: ssh client-side expansion is intentional in our admin scripts;
-        # SC2009: pgrep not always available in minimal live envs.
-        args: [-e, SC1091, -e, SC2034, -e, SC2086, -e, SC2329, -e, SC2317, -e, SC2029, -e, SC2009]
-        description: Lint shell scripts with shellcheck
-
+      # --- Shell ---
       - id: shfmt
         name: Format shell scripts
         entry: shfmt
@@ -58,9 +48,7 @@ repos:
         args: [-w, -i, "2", -bn, -ci]
         description: Format shell scripts with shfmt
 
-      # =============================================================================
-      # Lua Formatting
-      # =============================================================================
+      # --- Lua ---
       - id: stylua
         name: Format Lua files
         entry: stylua
@@ -68,9 +56,7 @@ repos:
         files: '\.lua$'
         description: Format Lua files with stylua
 
-      # =============================================================================
-      # TOML Formatting
-      # =============================================================================
+      # --- TOML ---
       - id: taplo
         name: Format TOML files
         entry: taplo fmt
@@ -78,20 +64,7 @@ repos:
         files: '\.toml$'
         description: Format TOML files with taplo
 
-      # =============================================================================
-      # YAML Linting
-      # =============================================================================
-      - id: yamllint
-        name: Lint YAML files
-        entry: yamllint
-        language: system
-        files: '\.(yaml|yml)$'
-        args: [-d, relaxed]
-        description: Lint YAML files with yamllint
-
-      # =============================================================================
-      # JSON Formatting
-      # =============================================================================
+      # --- JSON ---
       - id: json-format
         name: Format JSON files
         entry: bash -c 'for f in "$@"; do jq . "$f" > "$f.tmp" && mv "$f.tmp" "$f"; done'
@@ -100,20 +73,7 @@ repos:
         exclude: 'package-lock\.json|flake\.lock'
         description: Format JSON files with jq
 
-      # =============================================================================
-      # Markdown Linting
-      # =============================================================================
-      - id: markdownlint
-        name: Lint Markdown files
-        entry: markdownlint
-        language: system
-        files: '\.md$'
-        args: [--fix]
-        description: Lint and fix Markdown files
-
-      # =============================================================================
-      # Python Formatting and Linting
-      # =============================================================================
+      # --- Python ---
       - id: ruff-format
         name: Format Python files
         entry: ruff format
@@ -121,27 +81,7 @@ repos:
         files: '\.py$'
         description: Format Python files with ruff
 
-      - id: ruff-check
-        name: Lint Python files
-        entry: ruff check
-        language: system
-        files: '\.py$'
-        args: [--fix]
-        description: Lint Python files with ruff
-
-      # =============================================================================
-      # Spell Checking
-      # =============================================================================
-      - id: typos
-        name: Check spelling
-        entry: typos
-        language: system
-        pass_filenames: false
-        description: Check for typos in code and documentation
-
-      # =============================================================================
-      # GitHub Actions Linting
-      # =============================================================================
+      # --- GitHub Actions (scoped to workflow files only — fast even when it runs) ---
       - id: actionlint
         name: Lint GitHub Actions
         entry: actionlint
@@ -149,9 +89,7 @@ repos:
         files: '^\.github/workflows/.*\.(yml|yaml)$'
         description: Lint GitHub Actions workflows
 
-      # =============================================================================
-      # General File Hygiene
-      # =============================================================================
+      # --- Generic file hygiene ---
       - id: trailing-whitespace
         name: Trim trailing whitespace
         entry: bash -c 'for f in "$@"; do sed -i "s/[[:space:]]*$//" "$f"; done'
@@ -168,7 +106,14 @@ repos:
 
       - id: check-merge-conflict
         name: Check for merge conflicts
-        entry: bash -c 'for f in "$@"; do ! grep -qE "^(<<<<<<<|=======|>>>>>>>)" "$f" || { echo "Merge conflict in $f"; exit 1; }; done'
+        # Match real git conflict markers exactly:
+        #   <<<<<<< <ref>     (7 chevrons + space)
+        #   =======           (exactly 7 equals, alone on the line)
+        #   >>>>>>> <ref>     (7 chevrons + space)
+        # The previous regex matched any line starting with 7+ equals, which
+        # gave false positives on markdown setext-style headings (`====...`)
+        # and visual section dividers.
+        entry: bash -c 'for f in "$@"; do ! grep -qE "^(<{7} |={7}$|>{7} )" "$f" || { echo "Merge conflict in $f"; exit 1; }; done'
         language: system
         files: '\.(nix|sh|lua|toml|yaml|yml|json|md|py)$'
         description: Check for merge conflict markers
@@ -180,17 +125,7 @@ repos:
         files: '\.sh$'
         description: Ensure executables have shebangs
 
-      # =============================================================================
-      # Nix Flake Validation
-      # =============================================================================
-      - id: flake-check
-        name: Check Nix flake
-        entry: nix flake check --no-build
-        language: system
-        files: '\.nix$'
-        pass_filenames: false
-        description: Validate Nix flake configuration (runs on all .nix file changes)
-
+      # --- Justfile validation (instant) ---
       - id: just-validate
         name: Validate justfile
         entry: just --list
@@ -198,3 +133,83 @@ repos:
         files: "justfile$"
         pass_filenames: false
         description: Validate justfile syntax
+
+      # ========================================================================
+      # PRE-PUSH STAGE — linters that may take a few seconds.
+      # Runs only on `git push`, not every commit. CI runs equivalents too,
+      # but these catch problems before they hit the PR.
+      # ========================================================================
+
+      - id: deadnix
+        name: Check for dead Nix code
+        entry: bash -c 'for f in "$@"; do deadnix --fail "$f" || exit 1; done' --
+        language: system
+        files: '\.nix$'
+        stages: [pre-push]
+        description: Check changed Nix files for dead/unused code
+
+      - id: shellcheck
+        name: Lint shell scripts
+        entry: shellcheck
+        language: system
+        files: '\.sh$'
+        # SC1091: external sourced files; SC2034: vars used externally;
+        # SC2086: word-splitting (often intentional in our scripts);
+        # SC2329/SC2317: false positives for functions called via case dispatch;
+        # SC2029: ssh client-side expansion is intentional in our admin scripts;
+        # SC2009: pgrep not always available in minimal live envs.
+        args: [-e, SC1091, -e, SC2034, -e, SC2086, -e, SC2329, -e, SC2317, -e, SC2029, -e, SC2009]
+        stages: [pre-push]
+        description: Lint shell scripts with shellcheck
+
+      - id: yamllint
+        name: Lint YAML files
+        entry: yamllint
+        language: system
+        files: '\.(yaml|yml)$'
+        args: [-d, relaxed]
+        stages: [pre-push]
+        description: Lint YAML files with yamllint
+
+      - id: markdownlint
+        name: Lint Markdown files
+        entry: markdownlint
+        language: system
+        files: '\.md$'
+        args: [--fix]
+        stages: [pre-push]
+        description: Lint and fix Markdown files
+
+      - id: ruff-check
+        name: Lint Python files
+        entry: ruff check
+        language: system
+        files: '\.py$'
+        args: [--fix]
+        stages: [pre-push]
+        description: Lint Python files with ruff
+
+      - id: typos
+        name: Check spelling
+        entry: typos
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+        description: Check for typos in code and documentation
+
+      # ========================================================================
+      # DROPPED HOOKS — left here as comments so the rationale is discoverable.
+      #
+      # - nixpkgs-lint (was: nixpkgs-lint-community, Perl + tree-sitter)
+      #   Pathologically slow on files with large embedded heredocs (e.g.
+      #   modules/services/litellm-router.nix wedged for 7+ minutes on a
+      #   single 145-line file in one observed run). CI's `lint-check` job
+      #   already runs nixpkgs-fmt + deadnix + shellcheck across the whole
+      #   tree, so we lose nothing actionable.
+      #
+      # - flake-check (was: `nix flake check --no-build` on every .nix change)
+      #   Evaluates the entire flake across all 3 hosts + 141 modules on
+      #   every commit — 30–120s wall time. CI runs `check-configurations`
+      #   per host on every PR, which is the same thing. Locally,
+      #   `just validate-quick` or `just test-host HOST` covers it on demand.
+      # ========================================================================

--- a/.typos.toml
+++ b/.typos.toml
@@ -9,59 +9,61 @@ extend-ignore-re = [
   "#[0-9a-fA-F]{8}",
   # Ignore base64 encoded strings
   "[A-Za-z0-9+/]{40,}={0,2}",
-  # Ignore SHA256 hashes
+  # Ignore SHA256 hashes (SRI format, e.g. sha256-XXXX...)
   "sha256-[A-Za-z0-9+/=]{43,}",
+  # Ignore Nix-base32 SHA256 hashes (older 52-char format, alphabet excludes e/o/t/u)
+  "[0-9a-df-np-svwxyz]{52}",
   # Ignore UUIDs
   "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
 ]
 
-[default.extend-words]
-# NixOS-specific terms
-nixos = "nixos"
-nixpkgs = "nixpkgs"
-flake = "flake"
-derivation = "derivation"
-mkif = "mkif"
+  [default.extend-words]
+  # NixOS-specific terms
+  nixos = "nixos"
+  nixpkgs = "nixpkgs"
+  flake = "flake"
+  derivation = "derivation"
+  mkif = "mkif"
 
-# Common technical terms that might be flagged
-coreutils = "coreutils"
-systemd = "systemd"
-tailscale = "tailscale"
-cachix = "cachix"
-agenix = "agenix"
-hyprland = "hyprland"
+  # Common technical terms that might be flagged
+  coreutils = "coreutils"
+  systemd = "systemd"
+  tailscale = "tailscale"
+  cachix = "cachix"
+  agenix = "agenix"
+  hyprland = "hyprland"
 
-# Package names
-neovim = "neovim"
-lazyvim = "lazyvim"
-starship = "starship"
-zellij = "zellij"
-tmux = "tmux"
+  # Package names
+  neovim = "neovim"
+  lazyvim = "lazyvim"
+  starship = "starship"
+  zellij = "zellij"
+  tmux = "tmux"
 
-# File/directory names
-nix = "nix"
-usr = "usr"
-var = "var"
-etc = "etc"
-tmp = "tmp"
+  # File/directory names
+  nix = "nix"
+  usr = "usr"
+  var = "var"
+  etc = "etc"
+  tmp = "tmp"
 
-# Common abbreviations
-env = "env"
-cfg = "cfg"
-pkgs = "pkgs"
-lib = "lib"
-attr = "attr"
-fn = "fn"
+  # Common abbreviations
+  env = "env"
+  cfg = "cfg"
+  pkgs = "pkgs"
+  lib = "lib"
+  attr = "attr"
+  fn = "fn"
 
-# Hardware terms
-amd = "amd"
-rocm = "rocm"
-nvidia = "nvidia"
-intel = "intel"
+  # Hardware terms
+  amd = "amd"
+  rocm = "rocm"
+  nvidia = "nvidia"
+  intel = "intel"
 
-# User-specific
-olafkfreund = "olafkfreund"
-freundcloud = "freundcloud"
+  # User-specific
+  olafkfreund = "olafkfreund"
+  freundcloud = "freundcloud"
 
 [files]
 extend-exclude = [
@@ -90,7 +92,7 @@ extend-exclude = [
 ]
 
 [type.nix]
-extend-glob = ["*.nix"]
+extend-glob = [ "*.nix" ]
 
 [type.shell]
-extend-glob = ["*.sh", "*.bash"]
+extend-glob = [ "*.sh", "*.bash" ]


### PR DESCRIPTION
## Summary

Pre-commit was routinely taking 30s+ on every commit and **wedged for 7+ minutes on a single file** during PR #593 (`nixpkgs-lint-community` against `modules/services/litellm-router.nix`). This PR restructures hooks into two stages and fixes a silent typos misconfiguration discovered in the process.

## Changes

### 1. Split hooks into `pre-commit` (fast) + `pre-push` (slow) stages

| Stage | When | Hooks | Target wall time |
|-------|------|-------|------------------|
| `pre-commit` | every `git commit` | formatters (nixpkgs-fmt, shfmt, stylua, taplo, json-format, ruff-format) + hygiene (trailing-whitespace, end-of-file, check-merge-conflict, check-executables-have-shebangs) + actionlint + just-validate | **< 3 s** |
| `pre-push` | only on `git push` | linters (deadnix, shellcheck, yamllint, markdownlint, ruff-check, typos) | **< 30 s** |

### 2. Dropped two hooks (CI already covers them)

- **`nixpkgs-lint-community`** — pathologically slow on heredoc-heavy files (observed: 7+ min on one 145-line file). CI's `lint-check` job runs equivalent coverage on every PR.
- **`flake-check`** (`nix flake check --no-build` on every `.nix` change) — 30–120s per commit, duplicated CI's per-host `check-configurations` jobs. Locally use `just validate-quick` or `just test-host HOST`.

### 3. Fixed false-positive in `check-merge-conflict`

Old regex `^(<<<<<<<|=======|>>>>>>>)` flagged markdown setext headings (`========`) and visual section dividers in 6 doc files. Tightened to match real git markers only:

```
^<<<<<<<\s  ^=======$  ^>>>>>>>\s
```

### 4. Fixed silent typos misconfiguration

**Root cause:** `typos` auto-discovers `typos.toml` (no dot), NOT `.typos.toml`. Without an explicit `--config`, the project's curated `extend-ignore-re` (hex codes, base64, SHA256 hashes, UUIDs) and `extend-words` allowlist were silently inactive — typos ran with only the default dictionary.

**Why it stayed hidden:** typos was the 12th hook; nixpkgs-lint wedged before reaching it on most commits, so the misconfig never manifested.

**Fix:** hook entry now passes `--config .typos.toml` explicitly. (Renaming the file would also work but cascades through any docs/scripts referencing it.)

### 5. Added Nix-base32 SHA256 pattern to `.typos.toml`

The existing `sha256-[A-Za-z0-9+/=]{43,}` only covers SRI hashes. The older 52-char `nix-hash --base32` format (alphabet `[0-9a-df-np-svwxyz]`) needs its own rule — one such hash in `pkgs/gnome-ext-spotify-controller/default.nix` contains `inh` which typos flags as a misspelling of `in`.

## Measured

| Scenario | Before | After |
|---|---|---|
| Real single-file commit (this branch's commits) | 30s+ typical | **~0.65 s** |
| Whole-repo `pre-commit run --all-files` | 7+ min (wedged) | **~2.1 s** |
| Real push with all linters | n/a (was pre-commit, slow) | **~2.6 s total** |

## Migration (one-time, per clone)

After merging, anyone with a local clone should run:

```bash
pre-commit install --hook-type pre-commit --hook-type pre-push
```

This installs `.git/hooks/pre-push`. Without it, commits stay fast but the pre-push lint coverage is skipped (you'd only catch those issues in CI).

## Test plan

- [x] `pre-commit validate-config` passes
- [x] `pre-commit install --hook-type pre-commit --hook-type pre-push` succeeds
- [x] Real commit with hooks active runs in < 1 s (every commit on this branch demonstrates this)
- [x] `pre-commit run --all-files` (worst case) completes in ~2 s
- [x] `check-merge-conflict` no longer false-positives on markdown setext headings
- [x] `typos` correctly ignores Nix-base32 SHA256 hashes
- [x] Full pre-push run on this branch passes all linters

## Follow-ups (out of scope)

Running `pre-commit run --all-files` on this branch surfaced these pre-existing issues:

- `actionlint` SC2086 + SC2129 in `.github/workflows/update-flake.yml` and `claude-desktop-watch.yml`
- `trailing-whitespace` would auto-trim 8 files (mostly IDE settings + a docs file)

Worth a small follow-up PR; intentionally not bundled here to keep scope tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)