### PR TITLE
chore(p510): drop redundant gnome-remote-desktop enable + stale comment

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -248,12 +248,13 @@ in
   # Desktop manager configuration - Full GNOME for headless RDP access
   services.desktopManager.gnome.enable = true;
 
-  # GNOME services for full desktop functionality
+  # GNOME services for full desktop functionality.
+  # Note: gnome-remote-desktop is enabled (with the headless-listener wiring
+  # fix) by features.gnome-remote-desktop above — no need to repeat it here.
   services.gnome = {
     gnome-settings-daemon.enable = true;
     gnome-keyring.enable = true;
     gnome-initial-setup.enable = false;
-    gnome-remote-desktop.enable = true; # Enable GNOME Remote Desktop for RDP support
   };
 
   # Ensure display manager is enabled in systemd
@@ -265,7 +266,6 @@ in
   # Add GSettings schema path for GDM login screen
   environment.sessionVariables.GSETTINGS_SCHEMA_DIR = "${pkgs.gdm}/share/gsettings-schemas/gdm-${pkgs.gdm.version}/glib-2.0/schemas";
 
-  # gnome-remote-desktop is installed by services.gnome.gnome-remote-desktop.enable
   environment.systemPackages = with pkgs; [
     gdm # Provides the Gdm-1.0 typelib required by GNOME Shell
     gnome-control-center # Provides login-screen schema


### PR DESCRIPTION
## Summary

Pure cleanup on p510, no behavioral change.

\`features.gnome-remote-desktop.enable = true\` (set in the \`features = {}\` block at lines 182-184) already turns on \`services.gnome.gnome-remote-desktop.enable\` AND adds the critical headless-listener auto-start wiring (the whole reason that feature module exists — see its inline comment about \"bad-symlink trap\").

The direct duplicate enable inside \`services.gnome = {...}\` (was line 256) was a redundant double-set — harmless but misleading. Anyone reading the host config would naturally infer that line was the source of truth and not realise the feature module was doing the heavy lifting. Dropped, plus a stale leftover comment that pointed to the removed line.

## Diff

\`\`\`diff
 services.gnome = {
   gnome-settings-daemon.enable = true;
   gnome-keyring.enable = true;
   gnome-initial-setup.enable = false;
-  gnome-remote-desktop.enable = true; # Enable GNOME Remote Desktop for RDP support
 };
\`\`\`

\`\`\`diff
-# gnome-remote-desktop is installed by services.gnome.gnome-remote-desktop.enable
 environment.systemPackages = with pkgs; [
\`\`\`

## Background

Earlier in this session I incorrectly grepped for \`features.gnome-remote-desktop\` and got zero matches (because the host writes the abbreviated form inside a \`features = {}\` block, like \`desktop.cosmic = {...}\` was using). Re-audited and discovered everything is already correctly wired — including the headless-listener fix that makes RDP \"just work\" without requiring a manual GNOME-Settings toggle that creates a bad-symlink trap.

This PR removes the redundancy now that we know the feature module is the canonical source of truth.

## Test plan

- [x] \`nix-instantiate --parse\` clean
- [ ] CI \`check-configurations (p510)\` build
- [ ] After deploy: \`systemctl --user status gnome-remote-desktop-headless\` shows running, port 3389 binds, RDP connect works after one-time \`grdctl rdp set-credentials\`

## Out-of-scope reminder (manual, post-deploy)

GNOME Remote Desktop requires a one-time credential setup, can't be declarative:

\`\`\`bash
# After first auto-login as olafkfreund on p510:
grdctl rdp set-credentials olafkfreund 'your-password-here'
grdctl rdp enable
grdctl rdp status

# From any other machine on the LAN or tailnet:
xfreerdp /v:p510:3389 /u:olafkfreund /p:'your-password-here' /size:1920x1080 /cert:ignore
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)