### PR TITLE
fix(gnome-ext-rudra): patch metadata.json for GNOME 50 compat

### DIFF
--- a/pkgs/gnome-ext-rudra/default.nix
+++ b/pkgs/gnome-ext-rudra/default.nix
@@ -3,6 +3,7 @@
 , fetchurl
 , unzip
 , glib
+, jq
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "gnome-ext-rudra";
@@ -14,7 +15,7 @@ stdenvNoCC.mkDerivation rec {
     sha256 = "0mpbakxs440rbl5h596zxqskva90dbzqg2xqlgm1ll8lb29vapvm";
   };
 
-  nativeBuildInputs = [ unzip glib ];
+  nativeBuildInputs = [ unzip glib jq ];
 
   dontUnpack = true;
   dontBuild = true;
@@ -23,6 +24,18 @@ stdenvNoCC.mkDerivation rec {
     runHook preInstall
     install -d "$out/share/gnome-shell/extensions/${uuid}"
     unzip -q "$src" -d "$out/share/gnome-shell/extensions/${uuid}"
+
+    # GNOME 50 compat patch: the published v7 ZIP's metadata.json declares
+    # shell-version up to "49" only, so GNOME Shell silently disables rudra
+    # on GNOME 50+. Upstream's master HEAD has already added "50" to the
+    # array (https://github.com/NarkAgni/rudra/blob/master/metadata.json)
+    # but hasn't pushed a v8 to extensions.gnome.org. Patch the metadata
+    # in place until then — drop this block when a newer ZIP with "50"
+    # baked in lands upstream.
+    meta="$out/share/gnome-shell/extensions/${uuid}/metadata.json"
+    jq '.["shell-version"] |= (. + ["50"] | unique)' "$meta" > "$meta.tmp"
+    mv "$meta.tmp" "$meta"
+
     if [ -d "$out/share/gnome-shell/extensions/${uuid}/schemas" ]; then
       glib-compile-schemas "$out/share/gnome-shell/extensions/${uuid}/schemas"
     fi


### PR DESCRIPTION
## Summary

The pinned v7 ZIP from \`extensions.gnome.org\` declares \`shell-version\` only up to \`\"49\"\` — GNOME Shell 50+ silently disables rudra (no error, just absent from the active extensions list). [Upstream master](https://github.com/NarkAgni/rudra/blob/master/metadata.json) has already added \`\"50\"\`, but the maintainer hasn't pushed a v8 to extensions.gnome.org.

Patch the metadata in \`installPhase\` until upstream catches up:

\`\`\`bash
jq '.[\"shell-version\"] |= (. + [\"50\"] | unique)' \"\$meta\" > \"\$meta.tmp\"
\`\`\`

## Local verification

\`\`\`
\$ nix-build -E 'with import <nixpkgs> {}; callPackage ./pkgs/gnome-ext-rudra { }' --no-out-link
/nix/store/xisvs5dc9hx59s6i0xl9h0d4hw3w1a7b-gnome-ext-rudra-7

\$ jq '.[\"shell-version\"]' /nix/store/.../metadata.json
[\"45\",\"46\",\"47\",\"48\",\"49\",\"50\"]
\`\`\`

New store path differs from the unpatched build → confirms the patch ran (not a cache hit).

## Migration note for the deploying user

After this lands and \`nh os switch\` runs, the **system** install gets the patched metadata. **But** if you've previously installed rudra via GNOME's Extension Manager web UI, the user-local copy at \`~/.local/share/gnome-shell/extensions/rudra@narkagni/\` will still mask the Nix one. Clean it up:

\`\`\`bash
rm -rf ~/.local/share/gnome-shell/extensions/rudra@narkagni
# log out + log in (Wayland — no Alt+F2 'r' trick available)
gnome-extensions enable rudra@narkagni
# Then Ctrl+Shift+Space should bring up the launcher
\`\`\`

## When to remove this patch

Once upstream pushes v8 (or higher) to extensions.gnome.org with \`\"50\"\` baked in, drop the \`jq\` block and just bump \`version\` + \`sha256\`. Track NarkAgni/rudra for that.

## Test plan

- [x] Local \`nix-build\` clean
- [x] Patched \`shell-version\` includes \`\"50\"\`
- [x] New store path differs from unpatched build (confirms patch ran)
- [ ] CI \`check-configurations (p620|razer|p510)\` builds
- [ ] After deploy + \`rm ~/.local/share/.../rudra@narkagni\` + relog: \`gnome-extensions show rudra@narkagni\` reports State: ENABLED

🤖 Generated with [Claude Code](https://claude.com/claude-code)