### PR TITLE
feat(home/shell/rmux): declarative rmux config + shell alias auto-loading it

### DIFF
--- a/home/shell/default.nix
+++ b/home/shell/default.nix
@@ -15,6 +15,7 @@ _: {
     ./zellij/default.nix
     ./bat/default.nix
     ./tmux/default.nix
+    ./rmux/default.nix # multiplexer config + alias auto-loading it
     ./lazyvim/default.nix
     ./markdown/default.nix
     ./gh/default.nix

--- a/home/shell/rmux/default.nix
+++ b/home/shell/rmux/default.nix
@@ -1,0 +1,99 @@
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib) mkEnableOption mkIf;
+  cfg = config.multiplexer.rmux;
+
+  # rmux config file. tmux-style syntax (rmux is tmux-compatible at the
+  # config level — see https://github.com/Helvesec/rmux/blob/main/docs/
+  # human-friendly-config.md). Loaded via `-f` because rmux has no
+  # XDG-default config auto-load (unlike tmux), so we plumb it through
+  # a shell alias below.
+  rmuxConf = pkgs.writeText "rmux.conf" ''
+    # ============================================================
+    # rmux config — coexists with tmux.
+    # tmux uses prefix C-b (see home/shell/tmux/default.nix); rmux
+    # uses C-a here so muscle memory doesn't collide when both
+    # multiplexers are attached.
+    # ============================================================
+
+    # ----- Prefix -----
+    set -g prefix C-a
+    unbind C-b
+    bind C-a send-prefix
+
+    # ----- Sensible defaults -----
+    set -g history-limit 100000
+    set -g renumber-windows on
+    set -g base-index 1
+    setw -g pane-base-index 1
+    setw -g mode-keys vi
+    set -g status-keys vi
+    set -g escape-time 0
+    set -g focus-events on
+
+    # ----- Mouse off by default (native terminal selection works) -----
+    # Toggle on with `prefix + T` when you want pane-aware mouse mode.
+    set -g mouse off
+    bind T if-shell -F '#{mouse}' \
+      'set -g mouse off ; display-message "mouse OFF: native selection"' \
+      'set -g mouse on  ; display-message "mouse ON: pane mouse mode"'
+
+    # ----- Wayland clipboard (wl-copy) -----
+    # Copy-mode yank pipes selection to wl-copy. Works in ghostty,
+    # wezterm, foot, kitty — anywhere a wl-clipboard session is running.
+    set -s copy-command '${pkgs.wl-clipboard}/bin/wl-copy'
+
+    # ----- Cwd-preserving splits + new windows -----
+    bind | split-window -h -c "#{pane_current_path}"
+    bind - split-window -v -c "#{pane_current_path}"
+    bind v split-window -h -c "#{pane_current_path}"
+    bind b split-window -v -c "#{pane_current_path}"
+    bind c new-window -c "#{pane_current_path}"
+
+    # ----- vi copy mode -----
+    bind [ copy-mode
+    bind -T copy-mode-vi v send-keys -X begin-selection
+    bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel
+    bind -T copy-mode-vi C-c send-keys -X copy-pipe-and-cancel
+
+    # ----- Vim-style pane navigation -----
+    bind h select-pane -L
+    bind j select-pane -D
+    bind k select-pane -U
+    bind l select-pane -R
+
+    # ----- Reload key -----
+    bind r source-file ${rmuxConf} \; display-message "rmux config reloaded"
+  '';
+in
+{
+  options.multiplexer.rmux = {
+    enable = mkEnableOption {
+      default = true;
+      description = "rmux multiplexer config + shell alias auto-loading it";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Drop the config file at the well-known path. The shell alias
+    # below references the same store path via `${rmuxConf}` so the two
+    # always stay in sync (no risk of editing one and forgetting the
+    # other).
+    xdg.configFile."rmux/rmux.conf".source = rmuxConf;
+
+    # Auto-load the config on every rmux invocation. Without this you'd
+    # have to type `rmux -f ~/.config/rmux/rmux.conf attach` each time,
+    # or call `source-file` after attaching — rmux doesn't auto-load
+    # XDG configs the way tmux does.
+    programs.zsh.shellAliases = {
+      rmux = "rmux -f ${rmuxConf}";
+    };
+    programs.bash.shellAliases = {
+      rmux = "rmux -f ${rmuxConf}";
+    };
+
+    # Ensure wl-clipboard is in $PATH so copy-mode yank works without
+    # the alias hardcoding store paths everywhere downstream.
+    home.packages = [ pkgs.wl-clipboard ];
+  };
+}


### PR DESCRIPTION
## Summary

Adds a Home Manager module for rmux so the binary (installed by PR #596) actually has a config to use.

### What ships

**\`home/shell/rmux/default.nix\`** — a new HM module that:

1. Writes \`~/.config/rmux/rmux.conf\` with sensible defaults:
   - Prefix \`C-a\` (avoids collision with tmux's \`C-b\` — both multiplexers can be attached at once without keystroke conflicts)
   - vi-mode copy + status keys
   - 100,000-line history, base-index 1, focus-events on, escape-time 0
   - Mouse OFF by default so terminal-native text selection works; \`prefix + T\` toggles between native and pane-mouse mode
   - \`wl-copy\` for copy-mode yank (works in ghostty/wezterm/foot/kitty)
   - Cwd-preserving splits (\`|\`, \`-\`, \`v\`, \`b\`) + cwd-preserving new-window
   - vim-style pane navigation (\`h/j/k/l\`)
   - \`prefix + r\` reloads the config in place

2. Aliases \`rmux\` to \`rmux -f ~/.config/rmux/rmux.conf\` for zsh + bash.

3. Adds \`wl-clipboard\` to home.packages so the copy-command is guaranteed to find \`wl-copy\` at runtime.

**\`home/shell/default.nix\`** — imports the new module.

### Why the alias

rmux has **no XDG config auto-discovery** (unlike tmux which auto-loads \`~/.config/tmux/tmux.conf\`). Without the alias, \`~/.config/rmux/rmux.conf\` would sit on disk unread — you'd have to type \`rmux -f ~/.config/rmux/rmux.conf attach\` every time, or \`rmux source-file ~/.config/rmux/rmux.conf\` after attaching. The alias hides that.

The alias references the same Nix-store path the config file is sourced from (\`\${rmuxConf}\` in the module), so the two can never drift.

### Scope note: no daemon autostart

Earlier I'd proposed bundling a systemd-user service to auto-start the rmux daemon. After reading rmux's docs more carefully I dropped it from this PR: rmux's \`start-server\` doesn't load any config at startup, so a warm daemon would still need a \`source-file\` call on first attach — meaning a daemon-autostart unit only helps SDK orchestrators that don't exist in your tree yet. Premature. The systemd-user service is a ~20-line drop-in we can add later when there's actual orchestrator code that needs it.

### Coexistence with tmux

Both multiplexers can be active simultaneously:
- Different sockets (\`/tmp/rmux-1000/default\` vs \`/tmp/tmux-1000/default\`)
- Different prefix keys (\`C-a\` for rmux, \`C-b\` for tmux)
- tmux still owns the interactive ergonomics here (gruvbox theme, tilish, t-smart, tmux-expose, tmux-palette with AI launcher) — rmux is the multiplexer for future Claude Code SDK orchestration code

### Test plan

- [ ] CI \`check-configurations (p620|razer|p510)\` builds
- [ ] After deploy: \`alias rmux\` shows the \`-f\` wrapper
- [ ] \`rmux new-session -s test\` picks up the config (\`prefix + r\` reloads, etc.)
- [ ] \`ls ~/.config/rmux/rmux.conf\` is a symlink to /nix/store

🤖 Generated with [Claude Code](https://claude.com/claude-code)