### PR TITLE
fix(home/shell/rmux): mkEnableOption default=true silently failed; use mkOption

### DIFF
--- a/home/shell/rmux/default.nix
+++ b/home/shell/rmux/default.nix
@@ -63,7 +63,10 @@ let
     bind l select-pane -R
 
     # ----- Reload key -----
-    bind r source-file ${rmuxConf} \; display-message "rmux config reloaded"
+    # Use the stable XDG path (HM symlinks it to this rmux.conf store entry).
+    # Cannot use $${rmuxConf} here — would self-reference and cause an
+    # infinite-recursion error during module evaluation.
+    bind r source-file ~/.config/rmux/rmux.conf \; display-message "rmux config reloaded"
   '';
 in
 {

--- a/home/shell/rmux/default.nix
+++ b/home/shell/rmux/default.nix
@@ -1,6 +1,6 @@
 { config, lib, pkgs, ... }:
 let
-  inherit (lib) mkEnableOption mkIf;
+  inherit (lib) mkOption mkIf types;
   cfg = config.multiplexer.rmux;
 
   # rmux config file. tmux-style syntax (rmux is tmux-compatible at the
@@ -68,7 +68,13 @@ let
 in
 {
   options.multiplexer.rmux = {
-    enable = mkEnableOption {
+    # Using mkOption (not mkEnableOption { default = true; ... }) because
+    # the latter's `default = true` doesn't take effect in our HM context —
+    # observed empirically: cfg.enable evaluated to `false` despite the
+    # attrset arg, so the whole config block never fired. Plain mkOption
+    # always honors default.
+    enable = mkOption {
+      type = types.bool;
       default = true;
       description = "rmux multiplexer config + shell alias auto-loading it";
     };


### PR DESCRIPTION
## Summary

After PR #600 deployed, the rmux HM config + alias didn't actually take effect. Root cause: the option declaration

\`\`\`nix
enable = mkEnableOption { default = true; description = \"...\"; };
\`\`\`

doesn't honor \`default = true\` in our HM context. \`nix eval\` of \`config.home-manager.users.olafkfreund.multiplexer.rmux.enable\` after deploy returned **\`false\`**, so the entire \`config = mkIf cfg.enable { ... }\` block was a silent no-op — no \`~/.config/rmux/rmux.conf\`, no \`rmux\` alias, no \`wl-clipboard\` in home.packages.

Switching to plain \`mkOption\` always honors \`default\`:

\`\`\`nix
enable = mkOption {
  type = types.bool;
  default = true;
  description = \"...\";
};
\`\`\`

## Local verification

\`\`\`
\$ nix eval '.#nixosConfigurations.p620.config.home-manager.users.olafkfreund.multiplexer.rmux.enable'
true                                                          ← was: false

\$ nix eval --raw '.#nixosConfigurations.p620.config.home-manager.users.olafkfreund.xdg.configFile.\"rmux/rmux.conf\".source'
/nix/store/...rmux.conf                                       ← was: missing attribute
\`\`\`

## Why \`mkEnableOption\`'s default = true didn't apply

The pattern \`mkEnableOption { default = true; description = \"...\"; }\` was added to nixpkgs in a relatively recent release. It works in some contexts but seems to lose the \`default\` in HM evaluation. The tmux module uses the same pattern and *appears* to work — tmux.conf IS at \`~/.config/tmux/tmux.conf\` — but that may be because tmux is also explicitly enabled somewhere I haven't located, masking the same bug.

Plain \`mkOption\` is universally honored, so this PR uses that. The other multiplexer module (tmux) is unchanged for now; if it turns out it's also silently relying on an explicit \`= true\` somewhere, a follow-up can switch tmux too.

## Test plan

- [x] Local \`nix eval\` returns \`true\` post-fix
- [x] Local \`nix eval\` of \`xdg.configFile.\"rmux/rmux.conf\".source\` returns a store path post-fix
- [ ] CI \`check-configurations (p620|razer|p510)\` builds
- [ ] After deploy: \`ls -la ~/.config/rmux/rmux.conf\` shows a /nix/store symlink, \`alias rmux\` shows the \`-f\` wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)