### PR TITLE
chore(claude-code): bump to 2.1.150

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.146";
+  version = "2.1.150";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-gl1TATgPH19GbFJo3iWgYpJ75liTj8HWMM+gLFIbgYU=";
+      hash = "sha256-bAhqD1+/aE1BSLtpYpJotPUQlJjBp751es8YxR/QT0s=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-ryUzTHomMqUxs04/TA1pdjuZcUnTHV8NdI5EgTdYgG8=";
+      hash = "sha256-IFKUlUPqB24rXNpEwDGys0/DA9uY3FatZYO34KQX6+s=";
     };
   };
 


### PR DESCRIPTION
## Summary

Routine version bump of the claude-code-native package — picks up upstream 2.1.150 from Anthropic's GCS distribution channel.

Closes #592.

## Diff

Only `pkgs/claude-code-native/default.nix` — `version` and the two arch hashes.

## Local verification

```
$ ./scripts/update-claude-code-native.sh 2.1.150
Current pinned: 2.1.146
Target:         2.1.150
(hashes printed for both arches)

$ nix build .#claude-code-native --print-out-paths --no-link
/nix/store/...claude-code-native-2.1.150

$ $OUT/bin/claude --version
2.1.150 (Claude Code)

$ ldd $OUT/bin/claude | grep "not found" && echo MISSING || echo OK
OK
```

## Test plan

- [x] Hashes resolve cleanly via prefetch
- [x] Local build succeeds
- [x] Binary reports correct version + no missing libs
- [ ] CI `check-configurations (p620|razer|p510)` builds (all 3 hosts enable claude-code-native)
- [ ] After merge + deploy: `claude --version` reports 2.1.150 on each host

🤖 Generated with [Claude Code](https://claude.com/claude-code)