### PR TITLE
chore(claude-desktop): bump to v2.0.12+claude1.8555.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,17 +116,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1779155095,
-        "narHash": "sha256-NAOfLgF2uiDdjmfrKsEQi6bFpw/3+i6eMDpzyS0Oyhk=",
+        "lastModified": 1779500429,
+        "narHash": "sha256-+I4+5EvY1QR0hZsIuoVYqMbXGa6dWYpgmcjCIZ+MN8U=",
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "ba2846c8b3e99ac35563e6c2184dd999b19bbc95",
+        "rev": "b8fe6b850266c25b6e588ac82202ea9cfb9294e3",
         "type": "github"
       },
       "original": {
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "ba2846c8b3e99ac35563e6c2184dd999b19bbc95",
+        "rev": "b8fe6b850266c25b6e588ac82202ea9cfb9294e3",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -85,7 +85,7 @@
     # forever, blocking suspend while app runs). Razer-relevant.
     # Workaround: close claude-desktop entirely to release inhibitor.
     # Bump via /update-claude-code.
-    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/ba2846c8b3e99ac35563e6c2184dd999b19bbc95";
+    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/b8fe6b850266c25b6e588ac82202ea9cfb9294e3";
 
     # Claude Code skill catalogue (borghei). flake = false because it's a
     # plain markdown/assets catalogue, not a Nix flake. We symlink one


### PR DESCRIPTION
## Summary

Routine version bump of the claude-desktop-linux flake input — picks up upstream tag `v2.0.12+claude1.8555.2`.

Closes #591.

## Diff

| File | Change |
|---|---|
| `flake.nix` | input rev `ba2846c8` → `b8fe6b85` |
| `flake.lock` | lockfile entry for claude-desktop-linux refreshed (`nix flake lock --update-input`) |

## Resolving the right commit SHA

The issue body said the target commit was `b195154ddf`. That actually resolves as the **annotated-tag-object SHA**, not a commit:

```
$ gh api repos/aaddrick/claude-desktop-debian/git/refs/tags/v2.0.12+claude1.8555.2
{ "ref": "refs/tags/v2.0.12+claude1.8555.2", "sha": "b195154ddf73c761fd83e95ea3100481aaf24a5f", "type": "tag" }

$ gh api repos/aaddrick/claude-desktop-debian/git/tags/b195154ddf73c761fd83e95ea3100481aaf24a5f --jq '.object.sha'
b8fe6b850266c25b6e588ac82202ea9cfb9294e3            ← the actual commit
```

Pinning the commit (`b8fe6b85`) is more precise than pinning the tag-object SHA.

## Local verification

```
$ nix flake lock --update-input claude-desktop-linux
(refreshes lockfile entry)

$ nix build --no-link --print-out-paths .#nixosConfigurations.razer.pkgs.claude-desktop-linux
/nix/store/...claude-desktop-...

$ file $OUT/bin/claude-desktop
ELF 64-bit LSB shared object, x86_64
```

## Test plan

- [x] Flake lock update succeeded
- [x] Build succeeded for razer's pkg attr
- [ ] CI `check-configurations (p620|razer|p510)` builds (p620 + razer enable claude-desktop; p510 doesn't, so no-op there)
- [ ] After merge + deploy on razer/p620: launch claude-desktop, About → reports 1.8555.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)