### PR TITLE
fix(gnome): restore logout button on single-user GNOME 50

### DIFF
--- a/home/desktop/gnome/extensions.nix
+++ b/home/desktop/gnome/extensions.nix
@@ -22,6 +22,12 @@ in
     dconf.settings = {
       "org/gnome/shell" = {
         disable-user-extensions = false;
+        # Restore the logout entry in the system menu on single-user GNOME 50+.
+        # GNOME 50 hid logout by default on single-user systems ("nothing to log
+        # out to"), but it's still useful for forcing a fresh shell session
+        # after extension changes / login-time tweaks. Re-enabling here makes
+        # the entry visible in the power menu next to Restart / Shut Down.
+        always-show-log-out = true;
         # UUIDs verified against gnomeExtensions.<name>.passthru.extensionUuid
         # (for nixpkgs entries) or against metadata.json of the manual zips
         # we re-package in pkgs/gnome-ext-*. Each UUID must have either a


### PR DESCRIPTION
## Summary

GNOME 50 redesigned the system menu and hides the "Log Out" entry on single-user systems — the heuristic being "if there's only one user, what would you log out to?". The entry is still useful in practice:
- Forcing a fresh shell session after toggling GNOME extensions
- Applying gsettings/dconf changes that only take effect on next login
- Switching between Wayland and X11 sessions

Set `org.gnome.shell.always-show-log-out = true` declaratively so the entry is back in the power menu next to Restart / Shut Down. Equivalent to running `gsettings set org.gnome.shell always-show-log-out true` but persists across deploys.

## Diff

One key added to the existing `dconf.settings."org/gnome/shell"` block in `home/desktop/gnome/extensions.nix`:

```diff
 "org/gnome/shell" = {
   disable-user-extensions = false;
+  always-show-log-out = true;
   enabled-extensions = [ ... ];
 };
```

Plus a comment explaining the why.

## Local verification

```
$ nix eval '.#nixosConfigurations.p620.config.home-manager.users.olafkfreund.dconf.settings."org/gnome/shell"."always-show-log-out"'
true
```

(Using the eval-the-actual-attr-path pattern from PR #601's post-mortem — "don't just check that the module loads, check that the attr you want actually resolves".)

## Scope

Applies to **p620 + razer** (both enable `home/desktop/gnome/extensions.nix` via the desktop-user profile). No-op on **p510** (GNOME extensions not enabled there).

## Test plan

- [x] Local `nix eval` of the dconf attr returns `true`
- [ ] CI `check-configurations (p620|razer|p510)` builds
- [ ] After deploy + relog: power menu shows "Log Out" next to Restart / Shut Down

🤖 Generated with [Claude Code](https://claude.com/claude-code)