### PR TITLE
feat(scripts): add deploy-to-host.sh wrapper for non-TTY remote deploys

### DIFF
--- a/scripts/deploy-to-host.sh
+++ b/scripts/deploy-to-host.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# deploy-to-host — TTY-safe wrapper around `nixos-rebuild --target-host` for
+# cross-host activation from a non-interactive context (background tasks, CI,
+# automation).
+#
+# Why this exists: `nh os switch --target-host HOST` invokes sudo on the
+# remote unconditionally trying to read a password, which requires a TTY.
+# Even with NOPASSWD configured on the remote, nh fails with
+#
+#   Error: Failed to read sudo password / The input device is not a TTY
+#
+# whenever run from a non-interactive shell. `nixos-rebuild --target-host
+# --use-remote-sudo` handles this correctly — it uses sudo's -S mode and
+# doesn't need a TTY when NOPASSWD applies.
+#
+# Use this instead of `nh os switch --target-host HOST` whenever the caller
+# might not have a TTY (background jobs, CI, scripted automation). For
+# interactive use from your terminal, nh still works fine.
+#
+# Usage:
+#   ./scripts/deploy-to-host.sh <HOST>          # build + switch on remote
+#   ./scripts/deploy-to-host.sh <HOST> build    # build only, no activation
+#   ./scripts/deploy-to-host.sh <HOST> boot     # activate on next boot only
+#   ./scripts/deploy-to-host.sh <HOST> dry      # plan only, no changes
+#
+# Example:
+#   ./scripts/deploy-to-host.sh p510
+#   ./scripts/deploy-to-host.sh razer build
+
+set -u
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+log() { echo ">> $*" >&2; }
+
+# ---- args ----
+
+HOST="${1:-}"
+ACTION="${2:-switch}"
+
+[ -n "$HOST" ] || die "usage: $0 <HOST> [switch|build|boot|dry]"
+
+case "$ACTION" in
+  switch | build | boot)
+    ;;
+  dry)
+    ACTION="dry-build"
+    ;;
+  *)
+    die "unknown action '$ACTION' (expected: switch | build | boot | dry)"
+    ;;
+esac
+
+# ---- preflight ----
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+[ -f "$REPO_ROOT/flake.nix" ] || die "no flake.nix at $REPO_ROOT"
+
+if ! ssh -o ConnectTimeout=5 -o BatchMode=yes "$HOST" "true" 2>/dev/null; then
+  die "host '$HOST' unreachable via SSH (BatchMode, no password). " \
+    "Check ~/.ssh/config and that your key is authorized on the target."
+fi
+
+# Sanity: confirm NOPASSWD sudo is actually live on the target so we don't
+# silently hang waiting for a password later.
+if ! ssh -o BatchMode=yes "$HOST" "sudo -n true" 2>/dev/null; then
+  die "host '$HOST' does not have NOPASSWD sudo for the SSH user. " \
+    "Either fix security.sudo.wheelNeedsPassword on the host, or run " \
+    "this from a real terminal so sudo can prompt."
+fi
+
+# ---- deploy ----
+
+log "deploying ${REPO_ROOT}#${HOST} to ${HOST} (action=${ACTION})"
+log "command: nixos-rebuild ${ACTION} --target-host olafkfreund@${HOST} --sudo --flake ${REPO_ROOT}#${HOST}"
+
+cd "$REPO_ROOT" || die "cannot cd to $REPO_ROOT"
+exec nixos-rebuild "$ACTION" \
+  --target-host "olafkfreund@$HOST" \
+  --sudo \
+  --flake "$REPO_ROOT#$HOST"


### PR DESCRIPTION
## Summary

Adds `scripts/deploy-to-host.sh` — a small focused wrapper around `nixos-rebuild --target-host --sudo` for cross-host activation from contexts where `nh os switch --target-host` fails (no TTY available for sudo prompt).

## Background

This session uncovered a quiet bug: `nh os switch --hostname p510 --target-host olafkfreund@p510` was reporting exit 0 but never creating a new generation on p510. Three deploys to p510 today silently no-op'd. The buried error in the output:

```
> Copied closure to remote host 'olafkfreund@p510'
Error:
   0: Activation (switch) failed
   1: Failed to read sudo password
   2: The input device is not a TTY
Location: crates/nh-remote/src/remote.rs:1257
```

nh's `--target-host` calls sudo on the remote in a way that unconditionally tries to read a password from stdin — fails when stdin isn't a TTY, **even with NOPASSWD configured** (verified live: `sudo -n true` returns 0 on both razer and p510). Bug is in nh's sudo invocation, not the remote's sudo policy.

`nixos-rebuild --target-host --sudo` handles this correctly.

## What this PR ships

`scripts/deploy-to-host.sh` — single ~85-line script that:

1. Parses `<HOST> [switch|build|boot|dry]` (defaults to switch)
2. Pre-flights:
   - SSH reachability (BatchMode — fails fast with clear error if key auth doesn't work)
   - NOPASSWD sudo on target (fails fast if it would hang later)
3. Execs `nixos-rebuild ACTION --target-host olafkfreund@HOST --sudo --flake REPO#HOST`

No automation rewrites in this PR — opt-in tool.

## When to use which

| Context | Use |
|---|---|
| Interactive deploy from your terminal | `nhs` / `nh os switch` |
| Background jobs, CI, automation, agent scripts | `./scripts/deploy-to-host.sh HOST` |

## Verified locally

- shellcheck: clean
- pre-push hooks: pass (after fixing SC2164 + nixos-rebuild --sudo deprecation that the hooks caught)
- Usage / error paths: print clear messages
- Dry-run against p510: nixos-rebuild dry-build actually runs

## Test plan

- [x] shellcheck clean
- [x] usage / error / dry-run smoke tests
- [ ] CI `check-configurations` (script not consumed by any module — no-op expected)

## Follow-ups (intentionally NOT in this PR)

- `scripts/update-commit-deploy.sh` uses `nh os switch --target-host` and has the same non-TTY bug; should be updated to call this wrapper for the remote path
- File issue upstream on nh-remote/src/remote.rs:1257 sudo handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)