### PR TITLE
feat(gnome-ext-rudra): pin master for v8 features (AI, clipboard, plugins, calculator)

### DIFF
--- a/pkgs/gnome-ext-rudra/default.nix
+++ b/pkgs/gnome-ext-rudra/default.nix
@@ -1,50 +1,89 @@
 { lib
 , stdenvNoCC
-, fetchurl
-, unzip
+, fetchFromGitHub
 , glib
-, jq
 }:
+# Rudra — keyboard-driven productivity launcher for GNOME Shell.
+# Upstream: https://github.com/NarkAgni/rudra
+#
+# Pinned to a master commit (not a release tag / extensions.gnome.org ZIP)
+# because the maintainer hasn't published v8 yet. The latest ZIP on
+# extensions.gnome.org is still the original v7 (February 2026), which is
+# missing nearly every interesting feature that has since landed in master:
+#   - AI Assistant with multi-provider dropdown (Gemini / Groq / Ollama /
+#     Perplexity / Cohere), triggered with `?`
+#   - Inline AI shortcuts: `px` (Perplexity) and `co` (Cohere) for quick answers
+#   - Clipboard history manager, triggered with `cb`
+#   - Developer plugins (Python / Bash), triggered with `p`
+#   - Inline calculator (math expressions evaluate live, Enter copies result)
+#   - DuckDuckGo search alongside Google + YouTube
+#   - v8 UI overhaul, native settings icon, outside-click-to-close toggle
+#   - Native GNOME 50 / 50.1 support in metadata.json (so no need for our
+#     jq-patching workaround that the previous v7 ZIP fetcher used)
+#
+# When upstream cuts a real v8 release on extensions.gnome.org, this can be
+# simplified back to a fetchurl-of-ZIP — but as long as that hasn't
+# happened, the master pin is how we get the actually-shipped features.
+#
+# Install convention mirrors the upstream Makefile's `install` target,
+# minus the user-local destination (we install to the Nix store and let
+# Home Manager symlink it into ~/.local).
 stdenvNoCC.mkDerivation rec {
   pname = "gnome-ext-rudra";
-  version = "7";
+  version = "unstable-2026-03-25";
   uuid = "rudra@narkagni";
 
-  src = fetchurl {
-    url = "https://extensions.gnome.org/extension-data/rudranarkagni.v${version}.shell-extension.zip";
-    sha256 = "0mpbakxs440rbl5h596zxqskva90dbzqg2xqlgm1ll8lb29vapvm";
+  src = fetchFromGitHub {
+    owner = "NarkAgni";
+    repo = "rudra";
+    rev = "ecc3abd5b52f0cd1e698967dbdacbebad264bbbe";
+    hash = "sha256-ddy0oEohJHbA09pAuFYFmo418bupQcAJIeVrjnaafEw=";
   };
 
-  nativeBuildInputs = [ unzip glib jq ];
+  nativeBuildInputs = [ glib ];
 
-  dontUnpack = true;
+  dontConfigure = true;
   dontBuild = true;
 
   installPhase = ''
     runHook preInstall
-    install -d "$out/share/gnome-shell/extensions/${uuid}"
-    unzip -q "$src" -d "$out/share/gnome-shell/extensions/${uuid}"
+    target="$out/share/gnome-shell/extensions/${uuid}"
+    install -d "$target"
 
-    # GNOME 50 compat patch: the published v7 ZIP's metadata.json declares
-    # shell-version up to "49" only, so GNOME Shell silently disables rudra
-    # on GNOME 50+. Upstream's master HEAD has already added "50" to the
-    # array (https://github.com/NarkAgni/rudra/blob/master/metadata.json)
-    # but hasn't pushed a v8 to extensions.gnome.org. Patch the metadata
-    # in place until then — drop this block when a newer ZIP with "50"
-    # baked in lands upstream.
-    meta="$out/share/gnome-shell/extensions/${uuid}/metadata.json"
-    jq '.["shell-version"] |= (. + ["50"] | unique)' "$meta" > "$meta.tmp"
-    mv "$meta.tmp" "$meta"
+    # Compile gsettings schemas before copying so the .compiled lands in place.
+    glib-compile-schemas schemas
 
-    if [ -d "$out/share/gnome-shell/extensions/${uuid}/schemas" ]; then
-      glib-compile-schemas "$out/share/gnome-shell/extensions/${uuid}/schemas"
-    fi
+    # Mirror the upstream Makefile's install target.
+    cp metadata.json   "$target/"
+    cp extension.js    "$target/"
+    cp prefs.js        "$target/"
+    cp stylesheet.css  "$target/"
+    cp LICENSE         "$target/"
+    cp -r icons        "$target/"
+    cp -r schemas      "$target/"
+
+    # src/ subdirs. Using `cp -r src` rather than per-subdir copies (the
+    # Makefile does per-subdir but the net effect is identical and this
+    # form survives upstream adding new subdirs without a derivation bump).
+    cp -r src          "$target/"
+
     runHook postInstall
   '';
 
   meta = with lib; {
-    description = "Lightning-fast keyboard-centric launcher for GNOME Shell";
-    homepage = "https://github.com/narkagni/rudra";
+    description = "Keyboard-driven productivity launcher for GNOME Shell with AI / clipboard / plugins";
+    longDescription = ''
+      Rudra is a modern, deeply integrated launcher designed to replace the
+      default GNOME overview. Pinned to upstream master (v8-in-development)
+      until the maintainer publishes v8 to extensions.gnome.org — see the
+      file header for the feature gap between the master HEAD and the latest
+      published v7 ZIP.
+
+      Default trigger: Ctrl + Shift + Space. Mode prefixes inside the
+      launcher: `?` AI assistant, `cb` clipboard, `p` plugins, `.` files,
+      `g`/`yt` web search, `>` command runner.
+    '';
+    homepage = "https://github.com/NarkAgni/rudra";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ ];


### PR DESCRIPTION
## Summary

Switches `pkgs/gnome-ext-rudra/default.nix` from `fetchurl` of extensions.gnome.org v7 ZIP → `fetchFromGitHub` of upstream master commit `ecc3abd5b5` (2026-03-25, message "Major v8 UI overhaul, AI upgrades & community requests").

## Why now

The published v7 ZIP on extensions.gnome.org is a February 2026 snapshot. Master HEAD has had ~10 commits of feature work since then that ARE NOT in the published ZIP:

| Feature | v7 ZIP | master HEAD |
|---|---|---|
| AI Assistant with multi-provider dropdown (Gemini / Groq / Ollama / Perplexity / Cohere) | ❌ | ✅ |
| Inline AI shortcuts (`px`, `co`) | ❌ | ✅ |
| Clipboard history manager (`cb`) | ❌ | ✅ |
| Developer plugins (Python/Bash) (`p`) | ❌ | ✅ |
| Inline calculator with clipboard copy | ❌ | ✅ |
| DuckDuckGo search | ❌ | ✅ |
| v8 UI overhaul + native settings icon | ❌ | ✅ |
| Native GNOME 50 in metadata.json | ❌ (we jq-patched) | ✅ |

The previous setup (v7 ZIP + jq patch to fake GNOME 50 support) loaded but was missing all v8 features that users would actually notice. This was the source of "rudra installed but the dropdown menu and AI agent are missing" friction.

## Approach

Same pattern as Forge (PR #599):
- `fetchFromGitHub` with a specific commit SHA (reproducible)
- Manual `installPhase` mirroring upstream's Makefile `install` target (minus the user-local destination — we install to the Nix store)
- Drops `nativeBuildInputs = [ unzip jq ]` (no ZIP unpack, no metadata patching needed)

## Local verification

```
$ nix-build -E 'with import <nixpkgs> {}; callPackage ./pkgs/gnome-ext-rudra { }' --no-out-link
/nix/store/n3p8a59m...gnome-ext-rudra-unstable-2026-03-25

$ jq '.["shell-version"]' /nix/store/.../metadata.json
["45","46","47","48","49","50"]                ← natively, no patch

$ ls /nix/store/.../src/
browsers  core  data  prefs  search  services  ui    ← all 7 subdirs

$ grep -r perplexity /nix/store/.../src/ | head -3
src/ui/LauncherInput.js: getTrigger(ctx._settings, 'trigger-perplexity'),
…                                                  ← v8 AI code is really there

$ nix eval --raw '.#nixosConfigurations.p620.pkgs.gnome-ext-rudra.outPath'
/nix/store/n3p8a59m...gnome-ext-rudra-unstable-2026-03-25  ← flake wiring intact
```

## Migration

Same as for Forge:
- After merge + redeploy: `gnome-extensions show rudra@narkagni` should report v7 (upstream still self-reports as v7 — see Makefile, version bump pending) but the BINARY is the v8-in-development codebase
- The same `~/.local/share/gnome-shell/extensions/rudra@narkagni` user-local override caveat applies; `rm -rf` it before relog if you previously installed via web UI

## How to keep this fresh

When upstream lands new features you want, bump:
1. `rev` to a newer commit SHA
2. `hash` from `nix-prefetch-url --unpack --type sha256 https://github.com/NarkAgni/rudra/archive/<SHA>.tar.gz | xargs -I{} nix-hash --type sha256 --to-sri sha256:{}`
3. `version` date stamp

When upstream finally publishes v8 to extensions.gnome.org, swap back to the simpler `fetchurl` of the ZIP + plain hash.

## Test plan

- [x] Local `nix-build` clean
- [x] `shell-version` includes `"50"` natively (no jq workaround needed)
- [x] All Makefile-installed files present in the store path
- [x] AI / clipboard / plugin code grep-confirmed in `src/ui/` + `src/services/`
- [x] Through-flake eval resolves to the same store path
- [ ] CI `check-configurations (p620|razer|p510)` builds
- [ ] After deploy + `rm ~/.local/share/.../rudra@narkagni` + relog: `Ctrl+Shift+Space` opens v8 UI; type `?` for AI dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)