### PR TITLE
feat(stylix): add YAMIS monochrome icon theme (via Stylix icons target)

### DIFF
--- a/modules/desktop/stylix-theme.nix
+++ b/modules/desktop/stylix-theme.nix
@@ -44,6 +44,20 @@ in
         size = vars.baseTheme.cursor.size;
       };
 
+      # YAMIS — monochrome icon theme with FollowsColorScheme=true, so the
+      # same theme name works for both light and dark polarity (Stylix flips
+      # the polarity via dconf; the theme adapts automatically).
+      # Falls back to Papirus-Dark / breeze-dark / Cosmic / Adwaita for any
+      # icon YAMIS doesn't ship — see pkgs/yet-another-monochrome-icons.
+      # Note: use the modern `stylix.icons` namespace; the old
+      # `stylix.iconTheme` is deprecated and emits a warning.
+      icons = {
+        enable = true;
+        package = pkgs.yet-another-monochrome-icons;
+        dark = "yet-another-monochrome-icon-set";
+        light = "yet-another-monochrome-icon-set";
+      };
+
       targets = {
         chromium.enable = false;
 

--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -34,4 +34,9 @@ final: _prev: {
   # for rationale). Source-of-truth for UUID + version is the metadata.json
   # baked into the upstream commit we pin.
   gnome-ext-forge = final.callPackage ../pkgs/gnome-ext-forge { };
+
+  # YAMIS — monochrome icon theme with FollowsColorScheme + multi-theme
+  # fallback chain. Wired via Stylix in modules/desktop/stylix-theme.nix
+  # so it applies wherever Stylix's GTK / GNOME targets are enabled.
+  yet-another-monochrome-icons = final.callPackage ../pkgs/yet-another-monochrome-icons { };
 }

--- a/pkgs/yet-another-monochrome-icons/default.nix
+++ b/pkgs/yet-another-monochrome-icons/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenvNoCC
+, fetchgit
+, gtk3
+}:
+# YAMIS — Yet Another Monochrome Icon Set.
+# Freedesktop-spec-compliant monochromatic icon theme with FollowsColorScheme,
+# so a single theme name renders correctly under both light and dark
+# polarity (Stylix handles the polarity switch via dconf).
+#
+# Upstream: https://bitbucket.org/dirn-typo/yet-another-monochrome-icon-set
+# License: GPL-3.0
+# Inherits: Papirus-Dark, breeze-dark, Cosmic, Adwaita, hicolor — so any
+# icon YAMIS doesn't ship falls back through that chain. Adwaita is in
+# nixpkgs by default, so the fallback never produces missing-icon glyphs;
+# Papirus-Dark would improve visual completeness if you ever add it.
+#
+# Not in nixpkgs (verified 2026-05-24 via mcp-nixos), so packaged here
+# alongside the existing custom-icon-set / gnome-ext-* style.
+stdenvNoCC.mkDerivation rec {
+  pname = "yet-another-monochrome-icons";
+  version = "unstable-2026-05-22";
+
+  src = fetchgit {
+    url = "https://bitbucket.org/dirn-typo/yet-another-monochrome-icon-set.git";
+    rev = "3d9dc63386f35618cd8570767ade43ff0edab7a7";
+    hash = "sha256-KzAWx+ls4Y0WzaFIdCjtarkr68/uE9jyeRreLyPcziw=";
+  };
+
+  # gtk-update-icon-cache lives in gtk3 — needed so apps don't have to
+  # rescan the (large) theme tree on every launch.
+  nativeBuildInputs = [ gtk3 ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    target="$out/share/icons/yet-another-monochrome-icon-set"
+    install -d "$target"
+
+    # Copy the theme metadata and every freedesktop-spec context directory
+    # that's actually present at the repo root.
+    cp index.theme "$target/"
+    for dir in actions apps categories devices emblems mimetypes places preferences status; do
+      [ -d "$dir" ] && cp -r "$dir" "$target/"
+    done
+
+    # Build the GTK icon cache so apps don't pay the per-launch scan cost.
+    # `|| true` because a missing-cache failure shouldn't fail the build
+    # outright — apps fall back to direct directory scanning.
+    gtk-update-icon-cache --force --quiet "$target" || true
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "YAMIS — monochrome icon theme with Papirus-Dark / breeze-dark / Cosmic / Adwaita fallback chain";
+    homepage = "https://bitbucket.org/dirn-typo/yet-another-monochrome-icon-set";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
## Summary

Packages [Yet Another Monochrome Icon Set (YAMIS)](https://bitbucket.org/dirn-typo/yet-another-monochrome-icon-set) and wires it as the system icon theme via Stylix's icons target.

## Why YAMIS

- Freedesktop-spec compliant — GTK / GNOME Shell recognize it natively
- `FollowsColorScheme=true` → single theme name renders correctly for both light + dark polarity (Stylix flips polarity via dconf; theme adapts automatically)
- Inherits `Papirus-Dark,breeze-dark,Cosmic,Adwaita,hicolor` → any icon YAMIS doesn't ship falls back through that chain. No missing-icon glyphs.
- GPL-3.0, ~10 MB, last updated 2026-05-22 (3 days ago — actively maintained)

## Files touched

| File | Change |
|---|---|
| `pkgs/yet-another-monochrome-icons/default.nix` | **NEW.** `fetchgit` (Bitbucket, not GitHub) pinned to commit `3d9dc6338`. Simple copy install + `gtk-update-icon-cache`. |
| `overlays/custom-packages.nix` | Register at top-level `pkgs.*` (matches `gnome-ext-*` / `gnome-ext-forge` pattern; HM modules can reference unqualified via `with pkgs;`) |
| `modules/desktop/stylix-theme.nix` | Add `stylix.icons` block. Uses the **modern** option namespace; the old `stylix.iconTheme` is deprecated and emits a warning. |

## Scope

Stylix's gtk + gnome targets are enabled on **p620 + razer**. p510's `host.class = "headless-rdp"` disables the gnome target (this was already in the shared module), so YAMIS will install but won't take effect on p510 — fine, p510 doesn't have a user-facing desktop session anyway.

## Verified locally

```
$ nix-build -E 'with import <nixpkgs> {}; callPackage ./pkgs/yet-another-monochrome-icons { }' --no-out-link
/nix/store/0bd0k6c7...yet-another-monochrome-icons-unstable-2026-05-22

$ ls /nix/store/.../share/icons/yet-another-monochrome-icon-set/
actions apps categories devices emblems index.theme mimetypes places preferences status

$ head -3 /nix/store/.../share/icons/yet-another-monochrome-icon-set/index.theme
[Icon Theme]
Name=yet-another-monochrome-icon-set
Inherits=Papirus-Dark,breeze-dark,Cosmic,Adwaita,hicolor

$ nix eval --raw '.#nixosConfigurations.p620.pkgs.yet-another-monochrome-icons.outPath'
/nix/store/0bd0k6c7...                                ← flake wiring intact

$ nix eval --raw '.#nixosConfigurations.p620.config.stylix.icons.dark'
yet-another-monochrome-icon-set                       ← Stylix sees it, no deprecation warning
```

## Caveats called out in the file

- Monochrome icons can look austere at small sizes — try for a day before committing if you're unsure
- App tray icons (AppIndicator) ignore the system icon theme by design — taskbar won't go monochrome from this alone
- The Inherits chain references `Papirus-Dark` first; if you ever want fewer fallbacks-to-color, install `pkgs.papirus-icon-theme` so that fallback path provides matching dark icons too

## Test plan

- [x] Local `nix-build` clean
- [x] Through-flake eval of both the package and `stylix.icons.\*` attrs resolves
- [x] No Stylix deprecation warning
- [ ] CI `check-configurations (p620|razer|p510)` builds
- [ ] After deploy + a fresh shell (no logout needed for GTK theme; new apps pick it up immediately): file manager, system menu, and apps show YAMIS-styled icons

## Follow-ups

- Could add a complementary `pkgs.papirus-icon-theme` for full fallback coverage if any icons feel "wrong"
- If you ever want to revert: comment out the `stylix.icons` block and the previous Adwaita default returns. Or drop `enable = true → false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)