### PR TITLE
fix(rescreenshot-mcp): skip configure unit for users other than cfg.user

### DIFF
--- a/modules/services/rescreenshot-mcp.nix
+++ b/modules/services/rescreenshot-mcp.nix
@@ -101,11 +101,25 @@ in
       ];
     };
 
-    # Configure Claude Desktop for the user
+    # Configure Claude Desktop for the user.
+    # systemd.user.services are loaded for EVERY user's systemd-user instance
+    # by default — including system users like gdm-greeter. Without the
+    # ConditionUser gate, gdm-greeter's systemd-user (UID 60578) tries to
+    # start this unit, fails with exit 216/GROUP because it can't switch
+    # to User=cfg.user, and spams the journal once per gdm display attempt:
+    #   configure-rescreenshot-mcp.service: Failed to determine supplementary
+    #   groups: Operation not permitted
+    #   Failed at step GROUP spawning ...: Operation not permitted
+    #   Main process exited, code=exited, status=216/GROUP
+    # ConditionUser=cfg.user skips the unit cleanly for any user except the
+    # configured one, so only the intended user's systemd-user instance ever
+    # tries to run it.
     systemd.user.services.configure-rescreenshot-mcp = mkIf cfg.autoConfigureClaudeDesktop {
       description = "Configure Claude Desktop with rescreenshot-mcp";
       wantedBy = [ "default.target" ];
       after = [ "graphical-session.target" ];
+
+      unitConfig.ConditionUser = cfg.user;
 
       serviceConfig = {
         Type = "oneshot";


### PR DESCRIPTION
## Summary

Add `ConditionUser=cfg.user` to `configure-rescreenshot-mcp.service` so it only runs on the intended user's systemd-user instance.

## Why

`systemd.user.services.*` are loaded for **every** user's systemd-user instance by default — including system users like `gdm-greeter` (UID 60578). Without the `ConditionUser` gate, gdm-greeter's systemd-user tries to start `configure-rescreenshot-mcp.service`, fails with exit 216/GROUP because it can't switch to `User=cfg.user`, and spams the journal on every gdm display attempt:

```
configure-rescreenshot-mcp.service: Failed to determine supplementary groups: Operation not permitted
Failed at step GROUP spawning ...: Operation not permitted
Main process exited, code=exited, status=216/GROUP
```

`ConditionUser=cfg.user` makes systemd skip the unit cleanly on any user-systemd instance that isn't the configured one, so only the intended user ever tries to run it.

## Test plan

- [x] Eval-tested: `nix eval --raw .#nixosConfigurations.razer.config.system.build.toplevel.outPath`
- [x] Deployed to razer; new generation activated cleanly; no more 216/GROUP errors from gdm-greeter's systemd-user instance
- [x] Affects all hosts that import `services.rescreenshot-mcp` (currently p620, razer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)