### PR TITLE
feat(terminals): enable ghostty on razer and p510

### DIFF
--- a/Users/olafkfreund/p510_home.nix
+++ b/Users/olafkfreund/p510_home.nix
@@ -28,7 +28,11 @@
       enable = lib.mkForce false; # Completely disable desktop framework for headless server
     };
 
-    # Disable GUI terminals for headless operation - override profile conflicts
+    # Disable GUI terminals for headless operation - override profile conflicts.
+    # Ghostty is kept available below (via direct ghostty.enable) so SSH'd
+    # users that occasionally open a graphical session over RDP / X11
+    # forwarding have a modern terminal; the feature gate stays off so we
+    # don't drag in the full GUI terminal stack.
     terminals = {
       enable = lib.mkForce false;
       alacritty = lib.mkForce false;
@@ -92,6 +96,12 @@
       zellij = true;
     };
   };
+
+  # Ghostty: bypass the disabled terminals feature gate above to install
+  # ghostty directly. Useful for occasional graphical sessions over RDP /
+  # X11-forwarding, and for shipping the same primary terminal across
+  # every host without flipping the whole headless-mode posture.
+  ghostty.enable = lib.mkForce true;
 
   # P510 development server specific packages
   home.packages = with pkgs; [

--- a/Users/olafkfreund/razer_home.nix
+++ b/Users/olafkfreund/razer_home.nix
@@ -1,5 +1,4 @@
 { lib
-, pkgs
 , ...
 }:
 let
@@ -12,6 +11,10 @@ in
 
   # Laptop: enable zellij (session management for mobile use)
   features.multiplexers.zellij = true;
+
+  # Ghostty: profile.nix defaults this off ("workstation only"); razer wants
+  # it too as the primary terminal alongside the existing wave/warp/foot/etc.
+  features.terminals.ghostty = true;
 
   # Laptop: flameshot works fine on Razer (single-monitor Wayland)
   features.desktop.flameshot = true;


### PR DESCRIPTION
## Summary

Brings ghostty (previously p620-only) to razer and p510.

## Why each host needs a different change

- **razer**: \`profile.nix\` defaults \`features.terminals.ghostty\` to \`mkDefault false\` with a "workstation only" comment. razer just overrides the default. Also drops the now-unused \`pkgs\` argument that deadnix caught.
- **p510**: \`features.terminals.enable\` is force-disabled (headless server). Setting \`features.terminals.ghostty = true\` won't take effect because the feature impl gates everything on \`terminals.enable\`. Bypassed with a direct \`ghostty.enable = lib.mkForce true\` so the rest of the headless posture (no alacritty, no kitty, no firefox, etc.) is preserved.

## Test plan

- [x] \`nix eval .#nixosConfigurations.{razer,p510,p620}.config.home-manager.users.olafkfreund.programs.ghostty.enable\` all return \`true\`
- [x] Both razer and p510 toplevel rebuild cleanly
- [ ] Deploy + smoke (run \`ghostty --version\` on each host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)