### PR TITLE
chore(deps): bump skill-pool v0.2.2 → v0.3.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1521,16 +1521,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1779371251,
-        "narHash": "sha256-9H3RdlozdXXNybDLfZzUBnFczmQ3Axv/jiEJDMY40QI=",
+        "lastModified": 1779718025,
+        "narHash": "sha256-F1v5cETdgTqkPq/Tv8BTQAaz/EogdrCLk5PFlfGLHPc=",
         "owner": "olafkfreund",
         "repo": "skill_pool",
-        "rev": "67d7509a31524be1c3a66a6d1d36f86a5ef38b23",
+        "rev": "3839972f9ca7c5e60f9686d3203ae5b76652b691",
         "type": "github"
       },
       "original": {
         "owner": "olafkfreund",
-        "ref": "v0.2.2",
+        "ref": "v0.3.2",
         "repo": "skill_pool",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -150,10 +150,10 @@
     };
 
     # skill-pool — self-hosted Claude Code skill/agent/command registry.
-    # Pinned to the v0.2.2 tagged release; consumed by
+    # Pinned to the v0.3.2 tagged release; consumed by
     # modules/services/skill-pool.nix on p620.
     skill-pool = {
-      url = "github:olafkfreund/skill_pool/v0.2.2";
+      url = "github:olafkfreund/skill_pool/v0.3.2";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
## Summary

Routine version bump of the \`skill-pool\` flake input from v0.2.2 to v0.3.2.

## Why

Latest tagged release of [olafkfreund/skill_pool](https://github.com/olafkfreund/skill_pool). Consumed by \`modules/services/skill-pool.nix\` on p620 only.

## Test plan

- [x] \`nix eval --raw .#nixosConfigurations.p620.config.system.build.toplevel.outPath\` produces a fresh store hash (no NixOS module API regressions)
- [ ] Deploy p620 (\`./scripts/deploy-to-host.sh p620\` or \`nh os switch\`) to pick up the bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)