### PR TITLE
chore(deps): bump skill-pool v0.3.2 → v0.3.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1521,16 +1521,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1779718025,
-        "narHash": "sha256-F1v5cETdgTqkPq/Tv8BTQAaz/EogdrCLk5PFlfGLHPc=",
+        "lastModified": 1779719595,
+        "narHash": "sha256-SiD2ZAPuH2abWZ3g24Xnr6gqcq8ovMQSNHq1Y21kA0c=",
         "owner": "olafkfreund",
         "repo": "skill_pool",
-        "rev": "3839972f9ca7c5e60f9686d3203ae5b76652b691",
+        "rev": "9688e052ac5006a4a2a3a91701afd7cbbcc807d0",
         "type": "github"
       },
       "original": {
         "owner": "olafkfreund",
-        "ref": "v0.3.2",
+        "ref": "v0.3.4",
         "repo": "skill_pool",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -150,10 +150,10 @@
     };
 
     # skill-pool — self-hosted Claude Code skill/agent/command registry.
-    # Pinned to the v0.3.2 tagged release; consumed by
+    # Pinned to the v0.3.4 tagged release; consumed by
     # modules/services/skill-pool.nix on p620.
     skill-pool = {
-      url = "github:olafkfreund/skill_pool/v0.3.2";
+      url = "github:olafkfreund/skill_pool/v0.3.4";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
## Summary

Routine flake input bump — \`skill-pool\` v0.3.2 → v0.3.4.

## Why

Latest tagged release of [olafkfreund/skill_pool](https://github.com/olafkfreund/skill_pool). Consumed by \`modules/services/skill-pool.nix\` on p620 only.

## Test plan

- [x] \`nix eval --raw .#nixosConfigurations.p620.config.system.build.toplevel.outPath\` evals to a fresh store hash (no NixOS module API regressions)
- [ ] Deploy p620 to pick up the bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)