### PR TITLE
fix(razer): patch openrazer for kernel 7.0.9+ hid_report_raw_event signature

### DIFF
--- a/hosts/razer/nixos/boot.nix
+++ b/hosts/razer/nixos/boot.nix
@@ -52,7 +52,18 @@
   # known-good (gen 2438, currently running). 6.17/6.19 are EOL'd in nixpkgs.
   # If 7.0.1 also fails to boot, fall back to pinning 6.18.22 via a separate
   # nixpkgs flake input. See: https://github.com/nixos/nixpkgs/issues/493618
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+  # Patch openrazer's kernel module: 3.12.2 calls hid_report_raw_event() with
+  # 5 args, but kernel 7.0.9+ added a bufsize argument (torvalds/linux@2c85c61,
+  # backported to 7.0.9). Apply the upstream fix (openrazer@ff30624) until it
+  # lands in nixpkgs. The version-gated #if matches our 7.0.10 kernel.
+  # See: https://github.com/openrazer/openrazer/issues/2808
+  boot.kernelPackages = pkgs.linuxPackages_latest.extend (_kfinal: kprev: {
+    openrazer = kprev.openrazer.overrideAttrs (old: {
+      patches = (old.patches or [ ]) ++ [
+        ./patches/openrazer-kernel-7.0.9-hid-report-raw-event.patch
+      ];
+    });
+  });
 
   boot.plymouth.enable = true;
   boot.kernel.sysctl."vm.nr_hugepages" = 1024;

--- a/hosts/razer/nixos/patches/openrazer-kernel-7.0.9-hid-report-raw-event.patch
+++ b/hosts/razer/nixos/patches/openrazer-kernel-7.0.9-hid-report-raw-event.patch
@@ -1,0 +1,54 @@
+From ff3062498c6b3fc6fcb703627034598a3a5fbb59 Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca@z3ntu.xyz>
+Date: Sat, 16 May 2026 23:32:03 +0200
+Subject: [PATCH] razerkbd: Adjust to hid_report_raw_event() signature change
+
+With the Linux release 7.1-rc4
+
+(and backported to future 7.0.9 and
+6.18.32), the signature of hid_report_raw_event() adding a bufsize
+argument. Also pass the size of xdata to it.
+
+Note, that Arch Linux has backported this patch to their 7.0.8 kernel,
+but I haven't found any way to account for that with a preprocessor
+macro.
+---
+ driver/razerkbd_driver.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/driver/razerkbd_driver.c b/driver/razerkbd_driver.c
+index 557c3ab7b..5bdadcf8d 100644
+--- a/driver/razerkbd_driver.c
++++ b/driver/razerkbd_driver.c
+@@ -11,6 +11,7 @@
+ #include <linux/hid.h>
+ #include <linux/dmi.h>
+ #include <linux/input-event-codes.h>
++#include <linux/version.h>
+ 
+ #include "usb_hid_keys.h"
+ 
+@@ -4835,11 +4836,23 @@ static int razer_raw_event_bitfield(struct hid_device *hdev, struct razer_kbd_us
+ 
+                             // report key down
+                             xdata[1] = cur_value;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0) || \
++        (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 9) && LINUX_VERSION_CODE < KERNEL_VERSION(7, 1, 0)) || \
++        (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 32) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 19, 0))
++                            hid_report_raw_event(hdev, HID_INPUT_REPORT, xdata, sizeof(xdata), sizeof(xdata), 0);
++#else
+                             hid_report_raw_event(hdev, HID_INPUT_REPORT, xdata, sizeof(xdata), 0);
++#endif
+ 
+                             // report key up
+                             xdata[1] = 0x00;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0) || \
++        (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 9) && LINUX_VERSION_CODE < KERNEL_VERSION(7, 1, 0)) || \
++        (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 32) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 19, 0))
++                            hid_report_raw_event(hdev, HID_INPUT_REPORT, xdata, sizeof(xdata), sizeof(xdata), 0);
++#else
+                             hid_report_raw_event(hdev, HID_INPUT_REPORT, xdata, sizeof(xdata), 0);
++#endif
+                         }
+                     }
+                 }


### PR DESCRIPTION
## Summary

Razer's `nixos-rebuild` was failing: openrazer 3.12.2's out-of-tree kernel module wouldn't compile against kernel 7.0.10.

**Root cause:** Kernel 7.0.9+ added a `bufsize` argument to `hid_report_raw_event()` ([torvalds/linux@2c85c61](https://github.com/torvalds/linux/commit/2c85c61d1332e1e16f020d76951baf167dcb6f7a), backported to 7.0.9). openrazer 3.12.2 still made the old 5-arg call → `too few arguments to function 'hid_report_raw_event'; expected 6, have 5`. Tracked as [openrazer#2808](https://github.com/openrazer/openrazer/issues/2808). nixpkgs has not yet shipped the fix.

## Changes Made

- Vendored the upstream fix commit [`ff30624`](https://github.com/openrazer/openrazer/commit/ff3062498c6b3fc6fcb703627034598a3a5fbb59) as `hosts/razer/nixos/patches/openrazer-kernel-7.0.9-hid-report-raw-event.patch`.
- Extended `boot.kernelPackages` (`linuxPackages_latest`) to apply the patch to `openrazer`. The `hardware.openrazer` module picks up the patched module automatically. The patch is version-gated (`>= KERNEL_VERSION(7,0,9)`), matching the 7.0.10 kernel.

## Testing

- `nix build .#nixosConfigurations.razer.config.boot.kernelPackages.openrazer` → builds (`openrazer-3.12.2-7.0.10`)
- `nix build .#nixosConfigurations.razer.config.system.build.toplevel` → builds `nixos-system-razer`
- pre-commit hooks passed

## Follow-up

Remove the patch + the `.extend` block once nixpkgs ships an openrazer release containing `ff30624`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)