### PR TITLE
chore(flake): bump secondary inputs + drop redundant GDM greeter-env workaround

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1779683360,
-        "narHash": "sha256-fbATm7+/O10x7XdcfLNxMoECZYh2KIg4OcsdnfigBxE=",
+        "lastModified": 1779733940,
+        "narHash": "sha256-3DhS32jHm6znzblqBWNJJ28wmFXcx9+2EYgtC75+kZ0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0680daade6db6b2bc60408f1f02917ac6d48c7a9",
+        "rev": "c7704e4387f66c07a9ce2c76f5081848c61a3f1c",
         "type": "github"
       },
       "original": {
@@ -762,11 +762,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779678629,
-        "narHash": "sha256-gHcIFg0mm+KFsg7iZQt67kni3+qR5U3PhEC9P7vKlZ4=",
+        "lastModified": 1779726696,
+        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "612bbe3b405ad5f71d7bf9edecc04b678a061652",
+        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
         "type": "github"
       },
       "original": {
@@ -954,11 +954,11 @@
         "parts": "parts"
       },
       "locked": {
-        "lastModified": 1779691207,
-        "narHash": "sha256-WsU0WcM2tlg3WjbiBMca57u1fmlomGZy/gRXfYc7hvM=",
+        "lastModified": 1779775878,
+        "narHash": "sha256-HQywaHoBXkOvQFWfeEOqZ9D4ockQIZu40WMr+D2xNoY=",
         "owner": "moni-dz",
         "repo": "nixpkgs-f2k",
-        "rev": "b4ccc67575d49198ede108bd9de77a9b1a04cdf2",
+        "rev": "a40b04ff9a23d860140ede806f6f9adfac9507d6",
         "type": "github"
       },
       "original": {
@@ -1084,11 +1084,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1779508470,
-        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "29916453413845e54a65b8a1cf996842300cd299",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
@@ -1224,11 +1224,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1779508470,
-        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "29916453413845e54a65b8a1cf996842300cd299",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
@@ -1240,11 +1240,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1779689814,
-        "narHash": "sha256-eTdYWNN3Jy7civCYpmQ154fHR901aZDRY2EisHzsbbQ=",
+        "lastModified": 1779774786,
+        "narHash": "sha256-q9Jr7zDlFTxmbJ4H0VM2RX1ypzYtPckGE7osuKk5PTU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c03ba07ec4c5e92d79b23f237d73e02d6c1c85aa",
+        "rev": "84d837c27c9ff39df2bc822827ad1e70f476194f",
         "type": "github"
       },
       "original": {
@@ -1260,11 +1260,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1779713358,
-        "narHash": "sha256-1Ai5G8e8dT8fq45USayiYNE+WqApwcmMT9gA7fZZbSA=",
+        "lastModified": 1779785452,
+        "narHash": "sha256-vQIy+mJejR9E5MRVNkTGXoRGbRCO74UH/ikfjjGkfsE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "65e2b0ee404b1f39cd43a949b0459de70d4d987d",
+        "rev": "08425bf67d4a8f802e105a9269ced406be85d165",
         "type": "github"
       },
       "original": {
@@ -1479,11 +1479,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779679233,
-        "narHash": "sha256-qSIAAfK66X6waos6alIYxVze1ZU3C/WPp7NlN4ooP54=",
+        "lastModified": 1779765539,
+        "narHash": "sha256-2QxuD5gJcfCFsnqv54LGEHQKvd+K+DW/ecERwAvuA7w=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "47ab6c7b3c6a68beac60067490240efa32ae344c",
+        "rev": "09889992e640378f7008c3302b9d4892579df610",
         "type": "github"
       },
       "original": {
@@ -1610,11 +1610,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1779378391,
-        "narHash": "sha256-IsDb9erotvx9npI94UDosvMeYQK17p7/vmU2v9batrY=",
+        "lastModified": 1779768303,
+        "narHash": "sha256-glV4wcBH6fWub101jWj3c577T5Af8jOg6CdZPKKi4N8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "c1456cc4ba3c9485e7b4158c909eeca5a752cd59",
+        "rev": "8fbb6e8561ee72b57916c4ffd0e173fa42070dc2",
         "type": "github"
       },
       "original": {
@@ -1860,11 +1860,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779571927,
-        "narHash": "sha256-7xYf0TMcUsVqYBdySkHNnXP49rwslsN+3mbozcKlIB0=",
+        "lastModified": 1779762401,
+        "narHash": "sha256-D6QRZJxfIMF8gLyDmnPWTQKhAF/8sMAUb6VUpmosfMA=",
         "owner": "Benexl",
         "repo": "yt-x",
-        "rev": "f734867903b39dd4dd14c9e970568cbc3b1d0a76",
+        "rev": "02375d19e1f7915af5e063fb7429240c79e9e9a9",
         "type": "github"
       },
       "original": {

--- a/modules/desktop/display-manager.nix
+++ b/modules/desktop/display-manager.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, ... }:
 let
   inherit (lib) mkEnableOption mkIf mkOption types;
   cfg = config.desktop.displayManager;
@@ -55,28 +55,6 @@ in
           user = cfg.autoLogin.user;
         };
       };
-    };
-
-    # Workaround for nixpkgs#523332 — GDM 50's greeter session is a
-    # gnome-shell kiosk that exec's `gnome-session`, but the
-    # gdm-launch-environment PAM session does NOT inherit PATH /
-    # XDG_DATA_DIRS from display-manager.service. So gdm-wayland-session
-    # exits with exit 70 ("Unable to run session") and the greeter never
-    # registers — "GdmDisplay: Session never registered, failing".
-    # Hosts where the GNOME desktop module already pulls gnome-session
-    # into environment.systemPackages can luck into a working PATH, but
-    # any host that ever restarts display-manager after the GNOME 50
-    # upgrade hits this. Drop this block once PR #523948 lands upstream
-    # (we're pinned to nixpkgs 2025-08-01 which predates it).
-    security.pam.services.gdm-launch-environment.rules.session.env-greeter-path = mkIf (cfg.backend == "gdm") {
-      order = 10350; # after the existing env-greeter (10300), before systemd (10400)
-      control = "required";
-      modulePath = "${config.security.pam.package}/lib/security/pam_env.so";
-      settings.conffile = pkgs.writeText "gdm-launch-environment-env-conf" ''
-        PATH          DEFAULT="''${PATH}:${pkgs.gnome-session}/bin"
-        XDG_DATA_DIRS DEFAULT="''${XDG_DATA_DIRS}:${config.services.displayManager.generic.environment.XDG_DATA_DIRS}"
-      '';
-      settings.readenv = 0;
     };
   };
 }


### PR DESCRIPTION
## Summary

Two related changes now that nixpkgs is at `64c08a7c` (the GDM 50 / `services/display-managers` refactor):

1. **`chore(flake): bump secondary inputs`** — forward-bump of transitive/secondary inputs (emacs-overlay, home-manager_2, nixpkgs-f2k, nur, rust-overlay, stylix, yt-x, transitive nixpkgs pins). Root `nixpkgs` (`64c08a7c`) and root `home-manager` unchanged.
2. **`refactor(desktop): drop redundant GDM greeter-env workaround`** — removes the `gdm-launch-environment` `env-greeter-path` PAM injection in `modules/desktop/display-manager.nix`.

## Why the workaround is now redundant

It existed for nixpkgs#523332 (GNOME 50 greeter exited 70 because the `gdm-launch-environment` PAM session lacked `gnome-session` in PATH / correct `XDG_DATA_DIRS`). The upstream fix (PR #523948) is present in `64c08a7c`: the new gdm module sets these on `display-manager.service`, which the greeter inherits.

**Verified** on razer's built `display-manager.service`:
- `PATH=…/gnome-session-50.0/bin:…`
- `XDG_DATA_DIRS=…/gdm-50.0/share:…/desktops/share:…gnome-control-center…:adwaita…:hicolor…`

The new `gdm-launch-environment.pam` keeps only the generic `env` rule; nothing references the removed file.

## Testing

- `nix build .#nixosConfigurations.razer.config.system.build.toplevel` → builds (`nixos-system-razer`)
- Inspected `display-manager.service` env + greeter PAM as above
- pre-commit hooks passed

## Note

GDM 50 also drops the `gdm-greeter-env` PAM file (it only set `DCONF_PROFILE=gdm`); GDM 50 manages the greeter dconf profile itself (`gdm-config`). razer has no `programs.dconf.profiles.gdm` customizations, so no effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)