### PR TITLE
fix(git): set GIT_OPTIONAL_LOCKS=0 to stop index.lock races

### DIFF
--- a/hosts/common/nixos/envvar.nix
+++ b/hosts/common/nixos/envvar.nix
@@ -6,5 +6,10 @@ in
 {
   environment.sessionVariables = sharedVars.baseEnvironment // {
     QT_QPA_PLATFORMTHEME = lib.mkForce "qt5ct";
+    # Skip git's optional index-refresh lock so background tools (editors,
+    # MCP git daemons running `git status`/`diff`) don't grab .git/index.lock
+    # and race a concurrent `git commit` (e.g. pre-commit's write-tree).
+    # Required locks (commit/add/write-tree) are unaffected.
+    GIT_OPTIONAL_LOCKS = "0";
   };
 }


### PR DESCRIPTION
## Summary
Local `git commit` was failing with `Unable to create '.git/index.lock': File exists` whenever pre-commit hooks ran. Investigation showed this is **not** a git 2.54 or pre-commit bug.

**Root cause:** concurrent git tooling — editors and the harness-launched `mcp-server-git` daemons from other Claude Code sessions — run `git status`/`diff`, which refresh and rewrite the index as a side effect, taking `.git/index.lock`. During a normal commit, pre-commit's first op (`git write-tree`) runs for several seconds and collides with that lock. `--no-verify` only worked because its window is sub-second.

**Fix:** `GIT_OPTIONAL_LOCKS=0` in the shared session environment (`hosts/common/nixos/envvar.nix`). This tells git to skip the *optional* index-refresh lock that `status`/`diff` take — the same setting editors like VS Code use — while leaving *required* locks (commit/add/write-tree) intact. PAM-propagated to the graphical session, so harness-launched git daemons inherit it.

## Evidence
- Clean `/tmp` repo on the same git 2.54: hooked commit succeeds, no lock during hook → git/pre-commit innocent
- Real repo, 20s idle (zero git from me): `.git/index.lock` appeared 6×, held by `mcp-server-git` daemons
- `git --no-optional-locks` / `GIT_OPTIONAL_LOCKS=0` verified supported & honored on git 2.54

## Tradeoffs
- `git status` no longer auto-refreshes the stat cache (well-accepted; editors do this routinely). Commits/adds unaffected.
- Takes effect for new sessions — running daemons need a Claude app restart / re-login.

## Test plan
- [x] `nix-instantiate --parse` on envvar.nix → OK
- [x] pre-commit hooks run manually on the file → all Passed
- [ ] CI green (all host config builds)
- [ ] Deployed to p620

> Committed with `--no-verify` because the lock race still blocks hooked commits until this fix is deployed and the daemons restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)