### PR TITLE
fix(ci): authenticate nix github: fetches to avoid API 403 rate-limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
             accept-flake-config = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       # NB: `nix flake check` is intentionally skipped here.
       #
@@ -101,6 +102,7 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
             accept-flake-config = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate secrets structure
         run: |
@@ -195,6 +197,7 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: Nix formatting check
         run: |
@@ -245,6 +248,7 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: Run pre-commit hooks
         run: |


### PR DESCRIPTION
## Summary
CI's `check-configurations` jobs fetch `github:` flake inputs (`mcp-nixos`, etc.) via GitHub's API, which is rate-limited to **60 req/hr per IP when unauthenticated**. On a cold runner this returns **HTTP 403** and fails the build — exactly what broke #621 (p620 + razer failed fetching the `mcp-nixos` tarball; p510 got through by luck/cache).

Add `access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}` to all four `cachix/install-nix-action` `extra_nix_config` blocks so nix fetches authenticated (**5000 req/hr**). `GITHUB_TOKEN` is injected automatically by Actions — no secret setup needed.

## Why this, not a per-package change
`mcp-nixos` is a flake input (`mcp-nixos.url = "github:utensils/mcp-nixos"`); the 403 affects *every* `github:` input on a cold runner, so the fix belongs in the workflow's nix config, not in any single package.

## Test plan
- [x] `Lint GitHub Actions` (actionlint) via pre-commit → Passed
- [x] All 4 `extra_nix_config` blocks updated (verified count == 4)
- [ ] CI green (blocked: GitHub Actions currently degraded — workflow_dispatch returns HTTP 500)

> Hold for merge until GitHub Actions recovers. Once merged, re-run #621's failed jobs (`gh run rerun 26447327858 --failed`) to clear main's red and validate this fix end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)