### PR TITLE
feat(gogcli): Google Workspace CLI + splashboard agenda widgets

### DIFF
--- a/Users/olafkfreund/p510_home.nix
+++ b/Users/olafkfreund/p510_home.nix
@@ -198,4 +198,15 @@
     enable = true;
     nix-direnv.enable = true;
   };
+
+  # splashboard — renders on SSH shell startup. Headless server still benefits
+  # from the agenda panels when the admin logs in.
+  programs.splashboard.enable = true;
+
+  # gogcli-fed splashboard panels: Gmail unread, Google Tasks, Calendar events.
+  # Token provisioned headless via agenix (gog auth keyring=file import).
+  programs.gogDashboard = {
+    enable = true;
+    account = "olaf@freundcloud.com";
+  };
 }

--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -35,6 +35,13 @@
   # SPLASHBOARD_SILENT=1 or globally with NO_SPLASHBOARD=1.
   programs.splashboard.enable = true;
 
+  # gogcli-fed splashboard panels: Gmail unread, Google Tasks, Calendar events.
+  # Account email — confirm/adjust if your Google account differs.
+  programs.gogDashboard = {
+    enable = true;
+    account = "olaf@freundcloud.com";
+  };
+
   # Claude Code statusline with Gruvbox Dark theme
   programs.claude-powerline = {
     enable = true;

--- a/Users/olafkfreund/razer_home.nix
+++ b/Users/olafkfreund/razer_home.nix
@@ -24,6 +24,12 @@ in
   # splashboard — terminal splash screen on shell startup + cd. Same as p620.
   programs.splashboard.enable = true;
 
+  # gogcli-fed splashboard panels: Gmail unread, Google Tasks, Calendar events.
+  programs.gogDashboard = {
+    enable = true;
+    account = "olaf@freundcloud.com";
+  };
+
   # Windsurf theme derived from host variables (razer uses orange-desert variant)
   editor.windsurf.settings = {
     theme = lib.removePrefix "gruvbox-" vars.theme.scheme;

--- a/home/shell/default.nix
+++ b/home/shell/default.nix
@@ -6,6 +6,7 @@ _: {
     ./zsh.nix
     ./zsh-ai-cmd.nix # AI-powered shell command suggestions
     ./splashboard # Terminal splash screen on shell startup
+    ./gogcli # gogcli collector feeding splashboard email/tasks/events widgets
     ./starship/default.nix
     ./mail/default.nix
     ./fzf/default.nix

--- a/home/shell/gogcli/default.nix
+++ b/home/shell/gogcli/default.nix
@@ -1,0 +1,147 @@
+{ config, lib, pkgs, ... }:
+
+# gog-dashboard — feeds splashboard's read_store widgets with Gmail unread,
+# Google Tasks, and upcoming Calendar events via gogcli (`gog`).
+#
+# Splashboard has no command/exec fetcher; its escape hatch is `basic_read_store`,
+# which reads $HOME/.splashboard/store/<widget-id>.txt. A systemd user timer runs
+# `gog … -j` periodically and writes those store files atomically. When the token
+# isn't provisioned yet (or a fetch fails) the collector leaves the previous file
+# in place, so splashboard renders the panel empty/quiet rather than erroring.
+#
+# Token provisioning (headless-friendly, no keyring daemon):
+#   1. one-time on a workstation: `gog login <email>` (browser consent)
+#   2. `gog auth tokens export <email> <file>`; encrypt as secrets/gogcli-token.age
+#   3. agenix decrypts to tokenFile; the import oneshot below seeds the file-based
+#      keyring on every host (including p510) before the collector runs.
+let
+  inherit (lib) mkOption mkEnableOption mkIf mkPackageOption types getExe;
+  cfg = config.programs.gogDashboard;
+  storeDir = "${config.home.homeDirectory}/.splashboard/store";
+in
+{
+  options.programs.gogDashboard = {
+    enable = mkEnableOption "gogcli-fed splashboard email/tasks/events widgets";
+
+    package = mkPackageOption pkgs "gogcli" { };
+
+    account = mkOption {
+      type = types.str;
+      example = "you@gmail.com";
+      description = "Google account email passed to gog as --account.";
+    };
+
+    tokenFile = mkOption {
+      type = types.str;
+      default = "/run/agenix/gogcli-token";
+      description = ''
+        Path to the agenix-decrypted gogcli refresh-token export. Imported into
+        the file-based keyring by the gog-token-import user service. Read at
+        runtime only — never enters the Nix store.
+      '';
+    };
+
+    interval = mkOption {
+      type = types.str;
+      default = "10m";
+      description = "How often the collector refreshes the store files (systemd time span).";
+    };
+
+    maxItems = mkOption {
+      type = types.ints.positive;
+      default = 6;
+      description = "Max lines written to each store file (also cap the widget max_items).";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package pkgs.jq ];
+
+    # GOG_HOME keeps gogcli's config/data/state under a stable per-user root so
+    # the file-based keyring and the import are deterministic across services.
+    home.sessionVariables.GOG_HOME = "${config.home.homeDirectory}/.config/gogcli";
+
+    # Seed the file-based keyring from the agenix token. Idempotent: re-imports
+    # on each activation/boot; no-op (no failure) when the token isn't present.
+    systemd.user.services.gog-token-import = {
+      Unit.Description = "Import gogcli refresh token into the file keyring";
+      Service = {
+        Type = "oneshot";
+        Environment = [ "GOG_HOME=${config.home.homeDirectory}/.config/gogcli" ];
+        ExecStart = getExe (pkgs.writeShellScriptBin "gog-token-import" ''
+          set -u
+          tok="${cfg.tokenFile}"
+          [ -r "$tok" ] || { echo "gog token not present at $tok; skipping import"; exit 0; }
+          ${getExe cfg.package} auth keyring set file >/dev/null 2>&1 || true
+          ${getExe cfg.package} auth tokens import "$tok" >/dev/null 2>&1 || true
+        '');
+      };
+      Install.WantedBy = [ "default.target" ];
+    };
+
+    # Collector: pull the three feeds and write store files atomically.
+    # NOTE: the jq field paths below are a best-effort mapping; confirm them
+    # against real `gog … -j` output once the account is authorized (one-line
+    # tweak each). Lenient jq → on shape mismatch it emits nothing, leaving the
+    # prior file so splashboard stays quiet.
+    systemd.user.services.gog-dashboard = {
+      Unit = {
+        Description = "Refresh splashboard gog store (gmail/tasks/events)";
+        After = [ "gog-token-import.service" ];
+      };
+      Service = {
+        Type = "oneshot";
+        Environment = [ "GOG_HOME=${config.home.homeDirectory}/.config/gogcli" ];
+        ExecStart = getExe (pkgs.writeShellScriptBin "gog-dashboard-refresh" ''
+          set -u
+          GOG=${getExe cfg.package}
+          JQ=${getExe pkgs.jq}
+          ACCT=${lib.escapeShellArg cfg.account}
+          N=${toString cfg.maxItems}
+          STORE=${lib.escapeShellArg storeDir}
+          mkdir -p "$STORE"
+
+          # $1 = store id, $2... = gog argv (after `gog -a ACCT`), reads stdin jq prog last
+          emit() {
+            id="$1"; shift
+            prog="$1"; shift
+            out="$STORE/$id.txt"
+            tmp="$out.tmp.$$"
+            if "$GOG" -a "$ACCT" --no-input -j "$@" 2>/dev/null \
+                 | "$JQ" -r "$prog" 2>/dev/null | head -n "$N" > "$tmp" \
+               && [ -s "$tmp" ]; then
+              mv -f "$tmp" "$out"
+            else
+              rm -f "$tmp"
+            fi
+          }
+
+          # Upcoming events: "HH:MM  Summary"
+          emit gog_events \
+            '(.result // .events // .items // .) | (if type=="array" then .[] else empty end) | "\((.start.dateTime // .start.date // .start // "")|tostring|.[11:16]) \(.summary // .title // "(no title)")"' \
+            calendar events
+
+          # Tasks from the default list: "☐ Title"
+          emit gog_tasks \
+            '(.result // .tasks // .items // .) | (if type=="array" then .[] else empty end) | select((.status // "") != "completed") | "☐ \(.title // .name // "(untitled)")"' \
+            tasks list @default
+
+          # Unread inbox: "● Subject"
+          emit gog_email \
+            '(.result // .messages // .threads // .items // .) | (if type=="array" then .[] else empty end) | "● \(.subject // .snippet // .title // "(no subject)")"' \
+            gmail search "is:unread in:inbox"
+        '');
+      };
+    };
+
+    systemd.user.timers.gog-dashboard = {
+      Unit.Description = "Periodic splashboard gog refresh";
+      Timer = {
+        OnStartupSec = "30s";
+        OnUnitActiveSec = cfg.interval;
+        Persistent = true;
+      };
+      Install.WantedBy = [ "timers.target" ];
+    };
+  };
+}

--- a/home/shell/splashboard/home.dashboard.toml
+++ b/home/shell/splashboard/home.dashboard.toml
@@ -129,6 +129,28 @@ id = "on_this_day"
 fetcher = "wikipedia_on_this_day"
 render = { type = "list_links", max_items = 5 }
 
+# Personal agenda — fed by the gog-dashboard systemd user timer (gogcli).
+# basic_read_store reads $HOME/.splashboard/store/<id>.txt; file_format="text"
+# turns one line into one TextBlock row. Files are absent until the gog OAuth
+# token is provisioned, in which case the panels render empty (quiet).
+[[widget]]
+id = "gog_events"
+fetcher = "basic_read_store"
+file_format = "text"
+render = { type = "list_plain", max_items = 6 }
+
+[[widget]]
+id = "gog_tasks"
+fetcher = "basic_read_store"
+file_format = "text"
+render = { type = "list_plain", max_items = 6 }
+
+[[widget]]
+id = "gog_email"
+fetcher = "basic_read_store"
+file_format = "text"
+render = { type = "list_plain", max_items = 6 }
+
 # ── Layout ─────────────────────────────────────────────────────────
 #
 # Hero band sits on `bg = "subtle"` so the date masthead / greeting / almanac strip read as
@@ -194,6 +216,34 @@ flex = "center"
 [[row]]
 height = { length = 1 }
 bg = "subtle"
+
+[[row]]
+height = { length = 1 }
+
+# Agenda row — Events | Tasks | Email from gogcli. 100-cell band (32×3 + gap2×2);
+# 6 items + 1 border = 7. Sits above the news feeds as the daily briefing.
+[[row]]
+height = { length = 7 }
+flex = "center"
+gap = 2
+  [[row.child]]
+  widget = "gog_events"
+  width = { length = 32 }
+  border = "top"
+  title = "  TODAY  "
+  title_align = "center"
+  [[row.child]]
+  widget = "gog_tasks"
+  width = { length = 32 }
+  border = "top"
+  title = "  TASKS  "
+  title_align = "center"
+  [[row.child]]
+  widget = "gog_email"
+  width = { length = 32 }
+  border = "top"
+  title = "  UNREAD  "
+  title_align = "center"
 
 [[row]]
 height = { length = 1 }

--- a/modules/secrets/api-keys.nix
+++ b/modules/secrets/api-keys.nix
@@ -81,6 +81,18 @@ in
         owner = "root";
         group = "root";
       };
+    }
+    # gogcli refresh-token export — wired only once the encrypted file exists
+    # (the user runs `gog login` + `gog auth tokens export` first), so builds
+    # pass before the one-time OAuth. Owned by the user so the gog-token-import
+    # user service can read it.
+    // lib.optionalAttrs (builtins.pathExists ../../secrets/gogcli-token.age) {
+      gogcli-token = {
+        file = ../../secrets/gogcli-token.age;
+        mode = "0600";
+        owner = username;
+        group = "users";
+      };
     };
 
     # Note: System environment variables removed - use shell initialization instead

--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -20,6 +20,10 @@ final: _prev: {
 
   gemini-cli = final.callPackage ../home/development/gemini-cli { };
 
+  # gogcli — Google Workspace CLI (`gog`). Built from the canonical openclaw
+  # repo at the latest tag rather than nixpkgs' older steipete 0.11.0.
+  gogcli = final.callPackage ../pkgs/gogcli { };
+
   # GNOME Shell extensions not packaged in nixpkgs. Pinned to the
   # extensions.gnome.org ZIP for the exact version currently active on
   # p620, so the snapshot is byte-stable. Source-of-truth for the UUID +

--- a/pkgs/gogcli/default.nix
+++ b/pkgs/gogcli/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+,
+}:
+
+# gogcli — "Google Workspace in your terminal" (gmail, calendar, tasks,
+# contacts, drive). Binary is `gog`. nixpkgs ships an older 0.11.0 under the
+# original `steipete` owner; we track the canonical openclaw repo at the
+# latest tag so the auth tokens export/import + service-account surface is
+# available (needed to provision the OAuth token onto the headless p510 via
+# agenix). The Go module path is still `github.com/steipete/gogcli`, so the
+# version ldflags target that path even though the source lives at openclaw.
+buildGoModule (finalAttrs: {
+  pname = "gogcli";
+  version = "0.19.0";
+
+  src = fetchFromGitHub {
+    owner = "openclaw";
+    repo = "gogcli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8+ojZUNsmAzFQbdTG0eE/FG6nbptq49QZqjrCP1RhE4=";
+  };
+
+  vendorHash = "sha256-fkvMTJmYRsknDDffrZq2L2GRYDozwPX0yv7K84n5a84=";
+
+  subPackages = [ "cmd/gog" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/steipete/gogcli/internal/cmd.version=v${finalAttrs.version}"
+    "-X github.com/steipete/gogcli/internal/cmd.commit=${finalAttrs.src.rev}"
+    "-X github.com/steipete/gogcli/internal/cmd.date=1970-01-01T00:00:00Z"
+  ];
+
+  meta = {
+    description = "Google Workspace in your terminal (Gmail, Calendar, Tasks, Contacts, Drive)";
+    homepage = "https://gogcli.sh";
+    changelog = "https://github.com/openclaw/gogcli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "gog";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/secrets.nix
+++ b/secrets.nix
@@ -23,6 +23,9 @@ in
   "secrets/api-gemini.age".publicKeys = allUsers ++ allHosts;
   "secrets/api-anthropic.age".publicKeys = allUsers ++ allHosts;
   "secrets/api-github-token.age".publicKeys = allUsers ++ allHosts;
+  # gogcli refresh-token export (gog auth tokens export). Decrypted to
+  # /run/agenix/gogcli-token, imported into gog's file keyring on every host.
+  "secrets/gogcli-token.age".publicKeys = allUsers ++ allHosts;
   "secrets/obsidian-api-key.age".publicKeys = allUsers ++ workstations;
   "secrets/api-linkedin-cookie.age".publicKeys = allUsers ++ workstations;
 


### PR DESCRIPTION
## Summary

Installs **gogcli** (`gog`, openclaw/gogcli) on p620/razer/p510 and feeds **splashboard** a daily-agenda row: Gmail unread, Google Tasks, and Calendar events.

- **`pkgs/gogcli/default.nix`** — gogcli **0.19.0** via `buildGoModule` (nixpkgs ships the older steipete 0.11.0; we track the canonical openclaw repo for the `auth tokens export/import` + file-keyring surface needed for the headless p510). Overlay-wired. Builds & runs (`gog v0.19.0`, ELF OK).
- **`home/shell/gogcli/`** — `programs.gogDashboard`: a systemd **user timer** runs `gog gmail/tasks/calendar -j` and writes `~/.splashboard/store/{gog_events,gog_tasks,gog_email}.txt` **atomically**. A token-import oneshot seeds gog's **file-based keyring** from the agenix token (no keyring daemon → works headless). Any fetch/auth failure leaves the prior file in place, so splashboard stays quiet.
- **`home.dashboard.toml`** — 3 `basic_read_store` panels (TODAY / TASKS / UNREAD) as the top agenda row; `file_format="text"` → TextBlock → `list_plain`.
- **agenix** — `gogcli-token` secret declared; the `age.secrets` entry is `pathExists`-guarded so the build passes before the encrypted token exists.
- **Enabled on all 3 hosts**; p510 also gains splashboard.

## Test plan
- [x] gogcli 0.19.0 builds & runs (version + ELF verified)
- [x] `nixosConfigurations.{p620,razer,p510}.config.system.build.toplevel` all build
- [x] builds pass with the token absent (panels render empty)
- [ ] **one-time auth (user):** `gog login <email>` on p620 → `gog auth tokens export` → `manage-secrets.sh create gogcli-token` (encrypt the export)
- [ ] confirm the `jq` field mapping in `home/shell/gogcli/default.nix` against real `gog … -j` output (one line each — couldn't verify without auth)
- [ ] confirm the `account` email (`olaf@freundcloud.com`) matches your Google account
- [ ] deploy + verify panels populate

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)