### PR TITLE
chore(claude-code): update CLI to 2.1.152

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.150";
+  version = "2.1.152";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-bAhqD1+/aE1BSLtpYpJotPUQlJjBp751es8YxR/QT0s=";
+      hash = "sha256-UVW9yif3VKug0v4vgDNvX9R5MiRWHCNKcj8MzvZUqOg=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-IFKUlUPqB24rXNpEwDGys0/DA9uY3FatZYO34KQX6+s=";
+      hash = "sha256-Ne8mhcT2ebXEYQ71azCmgLbVlblYtPpewL+ihSGV80U=";
     };
   };
 


### PR DESCRIPTION
## Summary
- Bump `claude-code-native` from **2.1.150 → 2.1.152** (latest channel)
- Update x86_64 and aarch64 SRI hashes in `pkgs/claude-code-native/default.nix`

## Test plan
- [x] `nix build .#claude-code-native` → `claude --version` reports `2.1.152`, `ldd` shows no missing libs
- [x] `nixosConfigurations.{p620,razer,p510}.config.system.build.toplevel` all build
- [ ] Deploy to p620 (local), then razer/p510

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)