### PR TITLE
chore: bump claude-desktop + antigravity tooling

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778836484,
-        "narHash": "sha256-DN6FpQFdT1ik/FDsdq7PM7yLogejjJerq7HcNHH+UPA=",
+        "lastModified": 1779821672,
+        "narHash": "sha256-v0hkFV4IPMruDNqmc1G2ft3XYId8w42WLBKY9qzpIck=",
         "owner": "jacopone",
         "repo": "antigravity-nix",
-        "rev": "db285f7d21f691407ea9264ee8b4ad58f82064fa",
+        "rev": "d6e05bbcf2d1048184709dcbcf064bc8e16af0b0",
         "type": "github"
       },
       "original": {
@@ -116,17 +116,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1779760459,
-        "narHash": "sha256-woTHicw3feGdE4AmnHKDocoga3ZTNkFkzfRhug98oMo=",
+        "lastModified": 1779861875,
+        "narHash": "sha256-tzG7V3jixO/win+Es0Sf0R2qWHWoQ9LpR7uESODcPms=",
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "98232dbd81591eae64d565fff856e80c5c6ef08b",
+        "rev": "5b2fb4141bccfc621da2356b5f978cd71cf96a51",
         "type": "github"
       },
       "original": {
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "98232dbd81591eae64d565fff856e80c5c6ef08b",
+        "rev": "5b2fb4141bccfc621da2356b5f978cd71cf96a51",
         "type": "github"
       }
     },
@@ -1260,11 +1260,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1779791314,
-        "narHash": "sha256-swOfYziwniQanEVwAvv4xQ2KKIkM2tohsHWKRSh/0+M=",
+        "lastModified": 1779820287,
+        "narHash": "sha256-60CmolwNpkNeLOTa8pV20bPzy/iI3cLOk0TNTWjRYyI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "57839ab0fbf7c902c90f37c6534b645625ac9783",
+        "rev": "b0b588262f254eac430bb6f5a074798e92832cd9",
         "type": "github"
       },
       "original": {
@@ -1860,11 +1860,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779762401,
-        "narHash": "sha256-D6QRZJxfIMF8gLyDmnPWTQKhAF/8sMAUb6VUpmosfMA=",
+        "lastModified": 1779799513,
+        "narHash": "sha256-nFoZcccgnQsWZKB+9/37vQk/gJttVpzgOzjvXL4edt0=",
         "owner": "Benexl",
         "repo": "yt-x",
-        "rev": "02375d19e1f7915af5e063fb7429240c79e9e9a9",
+        "rev": "eefdca1e093a51ccbcc9afa68c5fe9fd20d0a778",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -71,23 +71,17 @@
     # Additional tools
     lan-mouse.url = "github:feschber/lan-mouse";
     zjstatus.url = "github:dj95/zjstatus";
-    # = tag v2.0.14+claude1.8555.2, commit 98232dbd (2026-05-25).
-    # Wrapper/packaging-only bump from v2.0.12+claude1.8555.2 (b8fe6b85);
-    # the claude binary is unchanged at 1.8555.2. Picks up:
-    #   - #401 fix(node-pty): clean upstream Windows binaries before
-    #     staging the Linux build
-    #   - #645 powerSaveBlocker logging shim + CLAUDE_KEEP_AWAKE=0 escape
-    #     hatch (mitigates the #605 inhibitor caveat below)
-    #   - #424 exec before Electron to fix signal forwarding
-    #   - #580 F11 fullscreen toggle for Linux parity
-    #   - #643 preserve mcpServers across config writes
-    #   - #648 align WM_CLASS / StartupWMClass to claude-desktop
+    # = tag v2.0.15+claude1.9255.0, commit 5b2fb414 (2026-05-27).
+    # Claude binary bump 1.8555.2 -> 1.9255.0. Picks up:
+    #   - #657 anchor tray-var extraction on .Tray() literal, resolving
+    #     the 1.9255.0 nix build failure reported in #654
+    #   - #650 filter .asar paths from --add-dir dispatch + session restore
     # Known caveat carried in: #605 (Electron holds systemd-inhibit
     # forever, blocking suspend while app runs). Razer-relevant.
     # Workaround: close claude-desktop entirely to release inhibitor,
-    # or set CLAUDE_KEEP_AWAKE=0 (new in #645).
+    # or set CLAUDE_KEEP_AWAKE=0 (#645).
     # Bump via /update-claude-code.
-    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/98232dbd81591eae64d565fff856e80c5c6ef08b";
+    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/5b2fb4141bccfc621da2356b5f978cd71cf96a51";
 
     # Claude Code skill catalogue (borghei). flake = false because it's a
     # plain markdown/assets catalogue, not a Nix flake. We symlink one

--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.0.0-5288553236791296";
+  version = "1.0.2-6109799369277440";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.0-5288553236791296/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-cAljQFdPr8SgbE08gFcxTiLUdc4cgg0K1R/wf7fpnrY=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.2-6109799369277440/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-9sfKgNUJkzO/IpZ2RzvREeDapqDY23xTKt9lA7Dqrck=";
   };
 
   # Tarball contains a single file `antigravity` at the root.

--- a/pkgs/antigravity-ide/package.nix
+++ b/pkgs/antigravity-ide/package.nix
@@ -103,11 +103,11 @@ let
 in
 stdenv.mkDerivation {
   pname = "antigravity-ide";
-  version = "2.0.2-5949548972081152";
+  version = "2.0.3-6242596486512640";
 
   src = fetchurl {
-    url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.0.2-5949548972081152/linux-x64/Antigravity%20IDE.tar.gz";
-    hash = "sha256-SVKYKDn8TH4ST4X+rkR54mXK4pVxjPlsfJ5Esu9qME4=";
+    url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.0.3-6242596486512640/linux-x64/Antigravity%20IDE.tar.gz";
+    hash = "sha256-ALX9cJ/vAsn4GrTt136NW6+LhYQsxlT6AW19BJLN6AM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.150";
+  version = "2.1.152";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-bAhqD1+/aE1BSLtpYpJotPUQlJjBp751es8YxR/QT0s=";
+      hash = "sha256-UVW9yif3VKug0v4vgDNvX9R5MiRWHCNKcj8MzvZUqOg=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-IFKUlUPqB24rXNpEwDGys0/DA9uY3FatZYO34KQX6+s=";
+      hash = "sha256-Ne8mhcT2ebXEYQ71azCmgLbVlblYtPpewL+ihSGV80U=";
     };
   };
 


### PR DESCRIPTION
## Summary
- **claude-desktop** `v2.0.14` → `v2.0.15` (claude binary `1.8555.2` → `1.9255.0`). Pulls in #657 tray-var extraction fix, which resolves the 1.9255.0 nix build failure reported in #654.
- **antigravity-ide** `2.0.2-5949548972081152` → `2.0.3-6242596486512640` (VS Code base unchanged at 1.107.0).
- **antigravity-cli (`agy`)** `1.0.0-5288553236791296` → `1.0.2-6109799369277440`.
- **antigravity-nix** input `db285f7d` → `d6e05bbc`.
- **google-antigravity-py** already at the only/latest PyPI version (`0.1.0`) — no change.

## Notes
- `flake.lock` also carries pre-existing working-tree drift for the `nur` and `yt-x` inputs (not separable within a single file; accepted).
- This branch is stacked on #634 (claude-code 2.1.152), so that commit appears in the diff until #634 merges to main.

## Test plan
- [x] `claude-desktop` FHS builds; inner pkg = `claude-desktop-1.9255.0`; `pty.node` is ELF (confirms #654 regression is resolved at this commit)
- [x] `antigravity-ide` builds, binary present + executable
- [x] `antigravity-cli` builds (exit 0, hash matched)
- [x] `p620`/`razer`/`p510` toplevel closures all build
- [ ] Deploy to razer + p620 (claude-desktop/antigravity are GUI; p510 is headless). claude-desktop needs quit-and-relaunch to pick up the new binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)