### PR TITLE
fix(p510): auto-import audiobooks from SABnzbd (Usenet path)

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -398,6 +398,13 @@ in
   # under /mnt/media/Media/Audiobooks/<Author>/[<Series>/]<Title>/.
   features.audiobook-import = {
     enable = true;
+    # ABB torrents land here; SABnzbd (audiobook-only on p510 — the *arr stack
+    # uses NZBGet/Transmission) completes Usenet grabs here. Both are watched
+    # so NZBGeek audiobooks import too.
+    watchDirs = [
+      "/mnt/media/downloads/torrents/audiobooks"
+      "/mnt/media/downloads/sabnzbd/complete"
+    ];
   };
 
   # Audiobook acquisition + library MCP (SSE on :3012). Exposes search_abb,


### PR DESCRIPTION
## Summary

`audiobook-import` only watched the AudioBookBay torrents dir, so NZBGeek/Usenet grabs that complete in `sabnzbd/complete` were downloaded but never auto-imported into Audiobookshelf. Add `sabnzbd/complete` to `watchDirs`.

Safe: SABnzbd is **audiobook-only** on p510 — Radarr/Sonarr use NZBGet + Transmission (verified via Radarr's download-client list), so nothing else lands in that dir.

## Test plan

- [x] `just test-host p510` + deployed
- [x] Triggered import on two completed Usenet grabs (Robopocalypse, Robogenesis) — qwen2.5 parsed author/title correctly and m4b-tool is merging into `Audiobooks/Daniel H Wilson/<Title>/<Title>.m4b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)