### PR TITLE
feat(secrets): add Synechron GitHub API token (all hosts)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,78 @@
+name: Documentation
+
+# Builds the MkDocs Material site reproducibly with Nix (`nix build .#docs`)
+# and publishes it to GitHub Pages. Pages source must be set to "GitHub
+# Actions" — the configure-pages step below enables this automatically.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "mkdocs.yml"
+      - "docs/**"
+      - "docs_gen/**"
+      - "modules/**"
+      - "pkgs/**"
+      - "hosts/**"
+      - "lib/**"
+      - "overlays/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+# Least-privilege token plus the OIDC/pages permissions Pages deploy needs.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; let in-progress runs finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build documentation site
+        run: nix build .#docs --print-build-logs
+
+      - name: Stage site artifact
+        # Dereference the /nix/store symlink into a real, writable directory
+        # so upload-pages-artifact can package it.
+        run: |
+          cp -rL result public
+          chmod -R u+w public
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ themes/gruvbox-material-gtk/
 result
 result-*
 
+# MkDocs build output (site is built reproducibly via `nix build .#docs`)
+site/
+public/
+
 # Temporary files
 .tmp/
 *.tmp

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -10,7 +10,8 @@
       "kbd",
       "br",
       "details",
-      "summary"
+      "summary",
+      "div"
     ]
   },
   "MD041": false,

--- a/Justfile
+++ b/Justfile
@@ -1427,3 +1427,22 @@ deploy-all:
     @echo "🔹 Phase 2: Clients (Razer, P510)"
     @just deploy-all-parallel
     @echo "✅ Deployment Coordinator finished successfully."
+
+# === Documentation site (MkDocs Material) ===
+
+# Build the documentation site reproducibly with Nix (-> ./result)
+docs-build:
+    @echo "📚 Building documentation site with Nix..."
+    nix build .#docs --print-build-logs
+    @echo "✅ Site built. Open: file://$(readlink -f result)/index.html"
+
+# Serve the docs locally with live reload (requires: nix develop .#docs)
+docs-serve:
+    @echo "📚 Serving docs at http://127.0.0.1:8000 (Ctrl+C to stop)..."
+    nix develop .#docs --command mkdocs serve
+
+# Strict build to catch broken links / nav issues (used as a quality gate)
+docs-check:
+    @echo "🔍 Strict documentation build (fails on warnings)..."
+    nix develop .#docs --command mkdocs build --strict --site-dir /tmp/nixos-docs-check
+    @echo "✅ Strict build passed."

--- a/docs/Nixos/README.md
+++ b/docs/Nixos/README.md
@@ -1,10 +1,14 @@
 # NixOS Custom Commands Documentation
 
-Welcome to the NixOS custom commands documentation. This directory contains comprehensive guides for using specialized Claude Code slash commands designed for NixOS infrastructure management.
+Welcome to the NixOS custom commands documentation. This directory contains
+comprehensive guides for using specialized Claude Code slash commands designed
+for NixOS infrastructure management.
 
 ## Overview
 
-Custom slash commands automate complex NixOS workflows, embedding best practices, safety checks, and GitHub integration into repeatable, documented procedures.
+Custom slash commands automate complex NixOS workflows, embedding best
+practices, safety checks, and GitHub integration into repeatable, documented
+procedures.
 
 ## Available Commands
 
@@ -93,7 +97,7 @@ claude
 
 ## Documentation Structure
 
-```
+```text
 docs/Nixos/
 ├── README.md                          # This file
 ├── Command-System-Overview.md         # Complete command system guide
@@ -169,24 +173,24 @@ Commands integrate seamlessly with:
 
 ## Best Practices
 
-### Do's 
+### Do's
 
--  Use commands for all routine maintenance
--  Read command output carefully
--  Follow recommended schedules
--  Review generated documentation
--  Create GitHub issues for tracking
--  Monitor after deployments
--  Keep commands up-to-date
+- Use commands for all routine maintenance
+- Read command output carefully
+- Follow recommended schedules
+- Review generated documentation
+- Create GitHub issues for tracking
+- Monitor after deployments
+- Keep commands up-to-date
 
-### Don'ts 
+### Don'ts
 
--  Skip testing steps in commands
--  Ignore command warnings
--  Deploy without validation
--  Forget to monitor after changes
--  Skip GitHub workflow integration
--  Ignore rollback procedures
+- Skip testing steps in commands
+- Ignore command warnings
+- Deploy without validation
+- Forget to monitor after changes
+- Skip GitHub workflow integration
+- Ignore rollback procedures
 
 ## Common Workflows
 
@@ -274,8 +278,8 @@ cat .claude/commands/COMMAND_NAME.md
 
 - **Patterns**: [@docs/PATTERNS.md](../PATTERNS.md)
 - **Anti-patterns**: [@docs/NIXOS-ANTI-PATTERNS.md](../NIXOS-ANTI-PATTERNS.md)
-- **GitHub Workflow**: [@docs/GITHUB-WORKFLOW.md](../GITHUB-WORKFLOW.md)
-- **Roadmap**: [@.agent-os/product/roadmap.md](../../.agent-os/product/roadmap.md)
+- **GitHub Workflow**: [@docs/guides/GITHUB-WORKFLOW.md](../guides/GITHUB-WORKFLOW.md)
+- **Roadmap**: [@.agent-os/product/roadmap.md](https://github.com/olafkfreund/nixos_config/blob/main/.agent-os/product/roadmap.md)
 
 ## Support and Feedback
 
@@ -320,4 +324,5 @@ Planned command additions:
 
 ---
 
-**Remember**: Commands are tools to enhance your workflow, not replace understanding. Always know what the commands are doing and why.
+**Remember**: Commands are tools to enhance your workflow, not replace
+understanding. Always know what the commands are doing and why.

--- a/docs/architecture/feature-flags.md
+++ b/docs/architecture/feature-flags.md
@@ -1,0 +1,101 @@
+# Feature Flags
+
+## The problem
+
+Enabling a capability often means configuring several services together. Doing
+that inline in each host file produces copy-paste, drift, and no way to validate
+that prerequisites are met.
+
+## The solution
+
+Capabilities are exposed as **typed feature flags** under `features.*`. A host
+turns a dial; the module behind it wires up the actual services. The feature
+system (`lib/features.nix`) additionally validates **dependencies** and
+**conflicts** at evaluation time.
+
+```nix
+# In a host configuration.nix — declarative intent, not implementation
+features = {
+  development.enable = true;
+  virtualization = {
+    enable = true;
+    docker = true;
+  };
+  ai.enable = true;
+  media.enable = true;
+  syncthing.enable = true;
+};
+```
+
+## How a feature module is shaped
+
+Every module follows the same contract: declare options, then apply config only
+when enabled.
+
+```nix
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.features.myservice;
+in
+{
+  options.features.myservice = {
+    enable = lib.mkEnableOption "MyService";
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8080;
+      description = "Port MyService listens on.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.myservice = {
+      enable = true;
+      port = cfg.port;
+    };
+  };
+}
+```
+
+!!! warning "Never configure services directly in a host"
+    `services.foo = { … }` in `hosts/*/configuration.nix` defeats reuse and
+    testing. Wrap it in a module under `modules/` and expose a feature flag.
+    This is a hard rule — see [Anti-Patterns](../NIXOS-ANTI-PATTERNS.md).
+
+## Dependency and conflict validation
+
+`lib/features.nix` carries a small registry describing how features relate.
+When a host enables a feature, the system asserts its dependencies are present
+and that no conflicting feature is active:
+
+```nix
+development = {
+  dependencies = [ "networking" ];
+  conflicts = [ ];
+  description = "Development environment setup";
+};
+gaming = {
+  dependencies = [ "graphics" ];
+  conflicts = [ "server-minimal" ];
+};
+```
+
+If you enable a feature without its dependency, the build fails fast with a
+clear message — far better than a service silently misbehaving at runtime.
+
+## Feature profiles
+
+Common bundles are pre-composed so a host can opt into a whole role at once:
+
+| Profile | Enables |
+| --- | --- |
+| `workstation` | development, desktop, virtualization, security |
+| `gaming` | desktop, gaming, security |
+| `server` | virtualization, security, networking |
+| `minimal` | security |
+
+Explicit per-feature flags always take precedence over profile defaults.
+
+## Browsing what exists
+
+The full set of feature-flagged modules — every option, with its description
+and the source — is in the generated [Modules reference](../reference/modules/index.md).

--- a/docs/architecture/hardware-profiles.md
+++ b/docs/architecture/hardware-profiles.md
@@ -1,0 +1,57 @@
+# Hardware Profiles
+
+## The problem
+
+GPU support is the messiest part of any Linux host config: drivers, kernel
+modules, acceleration stacks, user groups, and environment variables all have to
+agree. Three hosts with three different GPU vendors should not each reinvent
+this.
+
+## The solution
+
+GPU stacks are abstracted into reusable **hardware profiles** under
+`hosts/common/hardware-profiles/`:
+
+| Profile | File | Used by |
+| --- | --- | --- |
+| AMD | `amd-gpu.nix` | p620 (Radeon RX 7900, ROCm) |
+| NVIDIA | `nvidia-gpu.nix` | p510, razer |
+| Intel integrated | `intel-integrated.nix` | hybrid-graphics hosts |
+
+A host's `variables.nix` imports the right profile and inherits its `gpu`,
+`acceleration`, `videoDrivers`, extra user groups, and environment variables:
+
+```nix
+# hosts/p620/variables.nix
+hardwareProfile = import ../common/hardware-profiles/amd-gpu.nix;
+# …
+gpu          = hardwareProfile.gpu;
+acceleration = hardwareProfile.acceleration;
+userGroups   = baseUserGroups ++ (hardwareProfile.extraGroups or [ ]);
+```
+
+## Why this matters per host
+
+### p620 (AMD)
+
+Radeon RX 7900 with the `amdgpu` driver and **ROCm** acceleration — this is what
+makes p620 viable as the local Ollama inference host. The profile adds the
+`render`/`video` groups and the ROCm environment so the GPU is usable from
+containers and CLI tools.
+
+### p510 (NVIDIA)
+
+Intel Xeon paired with an NVIDIA card. The profile pulls in the proprietary
+driver and the bits needed for **hardware transcoding** in Plex.
+
+### razer (NVIDIA + Intel)
+
+Hybrid Optimus graphics: the Intel iGPU drives the panel for battery life, the
+NVIDIA dGPU is available on demand. The profile handles the dual-driver setup;
+the laptop profile adds power management on top.
+
+## Source
+
+The exact contents of each profile — driver lists, groups, env vars — are in
+the generated [Host Manifests](../reference/hosts/index.md) under
+`hosts/common/`.

--- a/docs/architecture/home-manager.md
+++ b/docs/architecture/home-manager.md
@@ -1,0 +1,56 @@
+# Home Manager
+
+## The problem
+
+User-space configuration (shell, editors, dotfiles, desktop apps) needs to be
+declarative too — but if it is managed *separately* from the system, the two can
+fall out of step, and you have to remember to run two different activation
+commands.
+
+## The solution
+
+Home Manager is loaded as a **flake module** from `flake.nix`. User environments
+are activated **as part of the system rebuild** — there is no separate
+activation step.
+
+!!! danger "Do not run `home-manager switch`"
+    User environments are built and activated by the NixOS rebuild
+    (`just <host>` / `nixos-rebuild switch`). Running `home-manager switch`
+    directly will fight the flake-module integration. This is a hard rule for
+    this repository.
+
+## How it composes
+
+```mermaid
+flowchart LR
+    F[flake.nix] --> HM[home-manager.nixosModules]
+    HM --> U[Users/olafkfreund]
+    U --> P[home/profiles/*]
+    P --> PROG[home/ programs &amp; dotfiles]
+    style F fill:#5e35b1,color:#fff
+    style PROG fill:#00897b,color:#fff
+```
+
+- **`home/profiles/`** holds role-based profiles (e.g. `developer`,
+  `server-admin`) that bundle related programs.
+- **`Users/<name>/`** composes the profiles a given user wants, optionally with
+  host-specific home files.
+- **`home/`** contains the actual program configurations (shell, browsers,
+  desktop, media, development tooling).
+
+## Why a flake module instead of standalone
+
+- **One activation.** A single `nixos-rebuild switch` brings the system *and*
+  the user environment to the declared state together — they can never drift.
+- **Shared inputs.** Home Manager sees the same pinned nixpkgs and overlays as
+  the system, so versions match.
+- **`specialArgs` flow through.** Host variables and feature state are available
+  to home modules via `extraSpecialArgs`, so user config can react to the host
+  it runs on.
+
+## Adding user configuration
+
+1. Put the program config under `home/` (or a profile under
+   `home/profiles/`).
+2. Compose it for the user in `Users/<name>/`.
+3. Rebuild the host — the home generation is activated automatically.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,0 +1,77 @@
+# Architecture
+
+This section explains *how* the configuration is built and, more importantly,
+*why* each choice was made. Every page leads with the problem it solves.
+
+<div class="grid cards" markdown>
+
+- :material-thought-bubble: __[Philosophy & Why](philosophy.md)__
+
+    ---
+
+    The guiding principles: explicitness, thin hosts, trusting the module
+    system, security by default.
+
+- :material-file-tree: __[Host Template System](template-system.md)__
+
+    ---
+
+    One parameterised template builds every host. How `profile` selects
+    workstation vs laptop behaviour.
+
+- :material-flag: __[Feature Flags](feature-flags.md)__
+
+    ---
+
+    Typed feature toggles with dependency and conflict validation — the dials
+    that shape each host.
+
+- :material-expansion-card: __[Hardware Profiles](hardware-profiles.md)__
+
+    ---
+
+    AMD / NVIDIA / Intel GPU stacks abstracted into reusable profiles.
+
+- :material-layers-triple: __[Overlays](overlays.md)__
+
+    ---
+
+    How custom packages and upstream fixes are layered onto nixpkgs.
+
+- :material-palette: __[Theming (Stylix)](theming.md)__
+
+    ---
+
+    A single base16 palette driving colours across the whole desktop stack.
+
+- :material-key-variant: __[Secrets (agenix)](secrets.md)__
+
+    ---
+
+    Age-encrypted secrets committed to git and loaded at runtime, never at
+    evaluation.
+
+- :material-home-account: __[Home Manager](home-manager.md)__
+
+    ---
+
+    User environments as a flake module — activated by the system rebuild.
+
+</div>
+
+## The data flow
+
+```mermaid
+flowchart TD
+    A[flake.nix] -->|profile + hostUsers| B[lib/hostTypes.nix]
+    B --> C[hosts/templates/desktop.nix]
+    C -->|explicit imports| D[modules/ tree]
+    H[hosts/&lt;name&gt;/variables.nix] --> C
+    SV[shared-variables.nix] --> H
+    HP[hardware-profiles/*.nix] --> H
+    D -->|features.*| E[Enabled services & programs]
+    F[home/ profiles] -->|HM flake module| E
+    S[secrets/*.age] -->|runtime| E
+    style A fill:#5e35b1,color:#fff
+    style E fill:#00897b,color:#fff
+```

--- a/docs/architecture/overlays.md
+++ b/docs/architecture/overlays.md
@@ -1,0 +1,58 @@
+# Overlays
+
+## The problem
+
+Two recurring needs: packaging software that is not in nixpkgs (or is patched),
+and fixing upstream packages without waiting for a nixpkgs release. Both require
+modifying the package set — but a single monolithic overlay becomes an
+unreadable grab-bag.
+
+## The solution
+
+Overlays are **split by purpose** under `overlays/`, so each file has one job:
+
+| Overlay | Purpose |
+| --- | --- |
+| `default.nix` | Entry point — composes the others |
+| `custom-packages.nix` | Wires in the ~60 packages from `pkgs/` |
+| `upstream-fixes.nix` | Temporary patches for broken/lagging nixpkgs packages |
+| `cmake-compat.nix` | CMake compatibility shims |
+| `python-compat.nix` | Python packaging compatibility |
+| `citrix-workspace.nix` | Citrix Workspace (needs a manual tarball) |
+
+## Custom packages
+
+The `pkgs/` tree holds packages built from source or vendored: MCP servers,
+GNOME/COSMIC extensions, CLI tools, and desktop apps. `custom-packages.nix`
+exposes them on `pkgs.*` so any module or host can reference them like any other
+package.
+
+Browse them all — name, version, description, and source — in the generated
+[Custom Packages reference](../reference/packages.md).
+
+## A real example: nix-prefetch-git regression
+
+`nixpkgs-unstable` started naming the `nix-prefetch-git` binary
+`nix-prefetch-git-<version>`, which broke `fetchCargoVendor` for any Rust
+package with git dependencies. Rather than patch dozens of packages, a single
+overlay restores the expected binary name via `postFixup`:
+
+```nix
+# Illustrative — adds a stable `nix-prefetch-git` symlink
+nix-prefetch-git = prev.nix-prefetch-git.overrideAttrs (old: {
+  postFixup = (old.postFixup or "") + ''
+    ln -s $out/bin/nix-prefetch-git-* $out/bin/nix-prefetch-git
+  '';
+});
+```
+
+This is exactly what `upstream-fixes.nix` is for: contain the workaround in one
+place, document why, and remove it when nixpkgs catches up.
+
+## Why split overlays
+
+- **Readability** — each file is small and single-purpose.
+- **Lifecycle** — `upstream-fixes.nix` is meant to shrink over time; keeping it
+  separate makes stale workarounds obvious.
+- **Safety** — compatibility shims do not get tangled with first-party
+  packaging.

--- a/docs/architecture/philosophy.md
+++ b/docs/architecture/philosophy.md
@@ -1,0 +1,84 @@
+# Philosophy & Why
+
+The configuration is opinionated. These principles explain the trade-offs, so
+that future changes stay coherent with the existing design.
+
+## 1. Explicit over magic
+
+**Why.** Auto-discovery (`readDir` + dynamic imports) saves a few lines but
+hides *what actually loads*. When something breaks, you want to read one import
+list, not trace a directory walk.
+
+The template imports the module tree by hand. The cost is a visible list; the
+benefit is that the list **is** the documentation of what is active.
+
+```nix
+imports = [
+  ../../modules/core.nix
+  ../../modules/development.nix
+  ../../modules/desktop.nix
+  # … explicit, greppable, obvious
+];
+```
+
+## 2. Thin hosts, reusable modules
+
+**Why.** Three machines sharing 90%+ of their configuration should not copy it
+three times. Duplication drifts; abstraction stays in sync.
+
+A host file declares feature flags and the handful of things that are genuinely
+unique (GPU, monitors, host-specific services). Everything reusable lives in
+`modules/`. Shared constants (user, locale, network) live in
+`hosts/common/shared-variables.nix`.
+
+## 3. Trust the module system
+
+**Why.** NixOS already ignores disabled services. Wrapping enablement in
+`mkIf cond true` adds evaluation overhead and obscures intent.
+
+```nix
+# Anti-pattern — never do this
+services.foo.enable = mkIf cfg.enable true;
+
+# Correct — direct boolean
+services.foo.enable = cfg.enable;
+```
+
+This rule is enforced repo-wide. See [Anti-Patterns](../NIXOS-ANTI-PATTERNS.md).
+
+## 4. Security by default
+
+**Why.** A daemon that runs as root with full filesystem access is a liability,
+even at home.
+
+- Services run unprivileged (`DynamicUser`, `ProtectSystem`) where the upstream
+  module allows it.
+- Secrets are **never** read during evaluation (which would copy them into the
+  world-readable Nix store). They are decrypted at runtime by agenix. See
+  [Secrets](secrets.md).
+- The local firewall is intentionally delegated to Tailscale's trust model on
+  these hosts; access is gated at the mesh layer.
+
+## 5. Reproducibility end to end
+
+**Why.** "Works on my machine" is unacceptable for infrastructure.
+
+- `flake.lock` pins every input.
+- Binary caches (including a local `nix-serve` on p620) keep builds fast.
+- Even this documentation builds reproducibly via `nix build .#docs`, so the
+  published site is a deterministic function of the source.
+
+## 6. Keep changes small and reversible
+
+**Why.** NixOS generations make rollback trivial — but only if a change is
+scoped tightly enough to reason about.
+
+Prefer one feature flag, one module, one host at a time. Validate
+(`just validate`), build (`just test-host`), then switch. If it misbehaves,
+`nixos-rebuild switch --rollback`.
+
+---
+
+These principles are not aspirational — they are reflected throughout the
+[Best Practices](../PATTERNS.md) and enforced in the
+[Anti-Patterns](../NIXOS-ANTI-PATTERNS.md) checklist.

--- a/docs/architecture/secrets.md
+++ b/docs/architecture/secrets.md
@@ -1,0 +1,67 @@
+# Secrets (agenix)
+
+## The problem
+
+Secrets — API keys, passwords, tokens — must live somewhere. Two tempting
+approaches are both wrong:
+
+- **Plaintext in git** leaks the moment the repo is shared.
+- **`builtins.readFile` at evaluation** copies the secret into the
+  world-readable `/nix/store`, which is arguably worse.
+
+## The solution
+
+This repo uses **agenix**: secrets are **age-encrypted** files that are safe to
+commit, and they are decrypted to a runtime path **at activation**, never during
+evaluation.
+
+```nix
+# WRONG — secret ends up in the Nix store
+services.myservice.password = builtins.readFile "/secrets/pass";
+
+# CORRECT — reference a runtime path produced by agenix
+age.secrets."api-anthropic".file = ../secrets/api-anthropic.age;
+services.myservice.passwordFile = config.age.secrets."api-anthropic".path;
+```
+
+## How access control works
+
+`secrets/secrets.nix` maps each `.age` file to the public keys allowed to
+decrypt it — per host and per user. Only a host that holds the matching private
+key can read a secret destined for it.
+
+```nix
+# secrets/secrets.nix (shape)
+{
+  "api-anthropic.age".publicKeys = [ p620 razer olafkfreund ];
+  "user-password-olafkfreund.age".publicKeys = [ p620 p510 razer ];
+}
+```
+
+Encrypted `.age` files **are committed**; plaintext is **never** committed.
+
+## Managing secrets
+
+A helper script wraps the common operations:
+
+```bash
+./scripts/manage-secrets.sh status          # what exists, who can read it
+./scripts/manage-secrets.sh create NAME      # create + encrypt a new secret
+./scripts/manage-secrets.sh edit NAME        # decrypt, edit, re-encrypt
+./scripts/manage-secrets.sh rekey            # re-encrypt all to current keys
+```
+
+After adding a host or rotating a key, run `rekey` so every secret is encrypted
+to the new set of recipients.
+
+## Where secrets are used
+
+The most prominent consumers are the AI providers — `api-openai`,
+`api-anthropic`, `api-gemini` are loaded at runtime and exposed under
+`/run/agenix/`. User passwords follow the `user-password-<name>.age` convention.
+
+## Why agenix here
+
+- Secrets travel **with** the configuration (in git) without being exposed.
+- Decryption is **bound to host keys**, so a leaked repo is not a leaked secret.
+- It composes cleanly with NixOS `*File` options, keeping evaluation pure.

--- a/docs/architecture/template-system.md
+++ b/docs/architecture/template-system.md
@@ -1,0 +1,102 @@
+# Host Template System
+
+## The problem
+
+Three hosts, each historically carrying its own near-identical import list and
+boilerplate. Adding a module meant editing every host; the lists drifted.
+
+## The solution
+
+A **single parameterised template** at `hosts/templates/desktop.nix`, surfaced
+through `lib/hostTypes.nix` as two entry points:
+
+- `hostTypes.workstation` — used by **p620** and **p510**
+- `hostTypes.laptop` — used by **razer**
+
+The template takes one argument, `profile`, and imports the entire module tree.
+Profile-specific behaviour is applied with `lib.mkIf`.
+
+```nix
+{ profile ? "workstation" }:
+{ lib, ... }:
+{
+  imports = [
+    ../../modules/core.nix
+    ../../modules/development.nix
+    ../../modules/desktop.nix
+    ../../modules/virtualization.nix
+    ../../modules/performance.nix
+    ../../modules/email.nix
+    ../../modules/cloud.nix
+    ../../modules/programs.nix
+    ../../modules/common/ai-defaults.nix
+    ../../modules/windows/winboat.nix
+  ];
+
+  config = lib.mkMerge [
+    {
+      aiDefaults.enable = lib.mkDefault true;
+      services.openssh.enable = lib.mkDefault true;
+    }
+    (lib.mkIf (profile == "laptop") {
+      services.thermald.enable = lib.mkDefault true;
+      powerManagement = {
+        enable = lib.mkDefault true;
+        cpuFreqGovernor = lib.mkDefault "powersave";
+      };
+    })
+  ];
+}
+```
+
+## How a host wires in
+
+`lib/hostTypes.nix` wraps the template and layers on sensible feature defaults
+that a host can still override with `mkForce`:
+
+```nix
+workstation = {
+  imports = [ (desktopTemplate "workstation") ];
+  config = {
+    aiDefaults.profile = "workstation";
+    features = {
+      development.enable = lib.mkDefault true;
+      desktop.enable = lib.mkDefault true;
+      virtualization.enable = lib.mkDefault true;
+    };
+  };
+};
+```
+
+A host's `configuration.nix` then imports the host type and declares only what
+is unique to it.
+
+!!! note "Why `mkDefault` everywhere"
+    The template sets defaults, not hard values. A host that needs something
+    different (e.g. p510 running headless with no display manager) overrides
+    cleanly without fighting the template.
+
+## Headless from the same template
+
+p510 is a server, yet it uses the **workstation** template. Rather than
+maintain a separate `server` template (the old `server`/`hybrid`/`base`
+templates were removed), p510 simply:
+
+- sets `host.class = "workstation"`,
+- disables the display manager and desktop compositor,
+- enables GNOME Remote Desktop for the rare time a GUI is needed.
+
+This keeps one template instead of three and avoids the divergence that the
+template system exists to prevent.
+
+## Adding a new host
+
+1. Create `hosts/<name>/` with `variables.nix` and
+   `hardware-configuration.nix`.
+2. Import the appropriate host type (`hostTypes.workstation` or
+   `hostTypes.laptop`).
+3. Declare host-unique bits (GPU profile, monitors, host-specific features).
+4. Register it in `flake.nix` (`hostUsers`, `hardwareProfiles`).
+5. Add the host SSH key to `secrets/secrets.nix` and rekey.
+
+Full procedure: [Adding a Host](../guides/HOST_SETUP.md).

--- a/docs/architecture/theming.md
+++ b/docs/architecture/theming.md
@@ -1,0 +1,58 @@
+# Theming (Stylix)
+
+## The problem
+
+A consistent look across a desktop means keeping colours in sync across the
+compositor, terminals, editors, GTK/Qt, and every applet. Maintaining those
+palettes by hand guarantees they drift.
+
+## The solution
+
+Theming is centralised through **Stylix** using a single **base16** palette.
+Every surface derives its colours from `config.lib.stylix.colors` rather than
+hard-coding hex values.
+
+The shared theme is defined once in `hosts/common/shared-variables.nix`:
+
+```nix
+baseTheme = {
+  scheme = "gruvbox-dark";
+  wallpaper = ../../assets/wallpapers/amdgruvorange.png;
+  cursor = { name = "Bibata-Modern-Classic"; size = 16; };
+  font = {
+    mono = "Adwaita Mono";
+    sans = "Noto Sans";
+    serif = "Noto Serif";
+  };
+  opacity = { desktop = 1.0; terminal = 1.0; popups = 1.0; };
+};
+```
+
+## What derives from the palette
+
+Surfaces that cannot consume Stylix automatically are wired to it explicitly:
+
+- **GNOME Terminal** and **Zellij** — colours generated from
+  `config.lib.stylix.colors`.
+- **COSMIC** — a full RON palette (all 30 fields) is written from the same
+  source, so the COSMIC desktop matches everything else.
+
+Because they all read one palette, changing `scheme` re-themes the entire stack
+in a single rebuild.
+
+!!! note "nix-colors removed"
+    An earlier setup used a standalone `nix-colors` input. It was removed in
+    favour of deriving everything from Stylix directly — one source of truth,
+    one dependency fewer.
+
+## Opacity
+
+Terminal and popup opacity are pinned to `1.0`. Transparency was disabled
+deliberately: it caused rendering issues under COSMIC/GTK. The structure is kept
+so it can be re-enabled per host if a future desktop handles it cleanly.
+
+## Per-host wallpaper
+
+The base theme carries a single wallpaper. Hosts may override it in their
+`variables.nix`; the mechanism is intentionally minimal because the rest of the
+palette is shared.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,41 @@
+# Getting Started
+
+New to this repository? Start here.
+
+<div class="grid cards" markdown>
+
+- :material-map: __[Overview](overview.md)__
+
+    ---
+
+    What this configuration is, the design goals, and how the pieces fit
+    together at a glance.
+
+- :material-rocket-launch: __[Quick Start](quick-start.md)__
+
+    ---
+
+    Clone, validate, build, and deploy — the commands you will use every day.
+
+- :material-folder-tree: __[Repository Layout](repository-layout.md)__
+
+    ---
+
+    A guided tour of every top-level directory and what belongs where.
+
+</div>
+
+## Mental model in one minute
+
+- __One flake__ (`flake.nix`) defines all three hosts and the dev/CI outputs.
+- __One host template__ (`hosts/templates/desktop.nix`) is parameterised by a
+  `profile` (`workstation` or `laptop`) and imports the whole module tree.
+- __Feature flags__ (`features.*`) turn capabilities on per host instead of
+  duplicating service config.
+- __Home Manager__ runs as a flake module — user environments are activated by
+  the system rebuild, never by a separate `home-manager switch`.
+- __Stylix__ drives every colour from a single base16 palette.
+- __agenix__ keeps secrets encrypted in git and loads them at runtime.
+
+If you remember nothing else: __hosts are thin, modules are reusable, and
+features are the dials you turn.__

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -1,0 +1,51 @@
+# Overview
+
+This repository is a single Nix flake that builds and deploys three machines
+from one shared codebase. It favours **explicitness over magic**: modules are
+imported by hand, features are toggled with typed flags, and there is no
+auto-discovery to reason around.
+
+## Design goals
+
+| Goal | How it is achieved |
+| --- | --- |
+| **No per-host duplication** | One parameterised template + shared variables; hosts only declare what is genuinely unique. |
+| **Reproducibility** | Pinned `flake.lock`, `nixos-unstable`, binary caches, and a reproducible docs build (`nix build .#docs`). |
+| **Explicit imports** | The template imports the module tree directly — no `readDir`/auto-import. |
+| **Trust the module system** | Direct boolean assignment (`enable = cond`), never `mkIf cond true`. |
+| **Security by default** | Services run unprivileged where possible; secrets load at runtime via agenix. |
+| **Consistent look** | Stylix applies one base16 palette across the desktop and terminal stack. |
+
+## The three hosts
+
+| Host | Profile | Hardware | Role |
+| --- | --- | --- | --- |
+| [**p620**](../hosts/p620.md) | workstation | AMD Ryzen + Radeon RX 7900 (ROCm) | Primary development, local AI inference, binary cache |
+| [**p510**](../hosts/p510.md) | workstation (headless) | Intel Xeon + NVIDIA | Plex media server, *arr automation, k3s MicroVMs |
+| [**razer**](../hosts/razer.md) | laptop | Intel + NVIDIA (Optimus) | Mobile development, Secure Boot |
+
+!!! note "Decommissioned hosts"
+    `DEX5550` and `Samsung` have been removed from the configuration. Older
+    references in archived docs are stale.
+
+## What every host shares
+
+Regardless of role, all three hosts enable a common baseline:
+
+- **Development** environment (editors, languages, git tooling)
+- **Virtualisation** (libvirt; Docker where appropriate)
+- **AI** providers — local Ollama plus OpenAI / Anthropic / Gemini
+- **Syncthing** for file sync
+- **Tailscale** mesh networking (the local firewall is left to Tailscale's
+  trust model)
+- **agenix** secrets and the **gruvbox-dark** Stylix theme
+- User `olafkfreund`, `Europe/London`, `en_GB.UTF-8`
+
+The differences — GPU stack, display layout, which services run — are described
+on each host's page.
+
+## Where to go next
+
+- Want to build it? → [Quick Start](quick-start.md)
+- Want to understand *why* it is shaped this way? → [Architecture](../architecture/index.md)
+- Want the per-file reference? → [Reference](../reference/modules/index.md)

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,70 @@
+# Quick Start
+
+Everyday commands are wrapped in the `Justfile`. Run `just --list` to see them
+all; the essentials are below.
+
+## Clone
+
+```bash
+git clone https://github.com/olafkfreund/nixos_config.git ~/.config/nixos
+cd ~/.config/nixos
+```
+
+## Validate and test
+
+```bash
+just check-syntax        # fast Nix syntax check
+just validate            # full validation suite
+just test-host p620      # build a host without switching
+just quick-test          # build all hosts in parallel
+```
+
+## Deploy
+
+```bash
+just quick-deploy p620   # smart deploy — only if the build changed
+just p620                # optimised deploy to a specific host
+just deploy-all-parallel # deploy every host at once
+```
+
+!!! tip "Routine lock bumps"
+    For the idiot-proof *update + commit + deploy* flow, use the `nhs`
+    shortcut (or `just update-commit-deploy HOST SCOPE`). It runs
+    `nix flake update → test-build → commit + push → switch` atomically and
+    refuses to run on a dirty tree. See
+    [Update & Deploy](../UPDATE-DEPLOY.md).
+
+## Build the documentation
+
+This very site is a flake output:
+
+```bash
+nix build .#docs         # -> ./result (static site)
+just docs-serve          # live preview at http://127.0.0.1:8000
+just docs-check          # strict build — fails on broken links
+```
+
+## Secrets
+
+```bash
+./scripts/manage-secrets.sh status          # show secret state
+./scripts/manage-secrets.sh create NAME     # create a new secret
+./scripts/manage-secrets.sh edit NAME       # edit an existing secret
+```
+
+See [Secrets (agenix)](../architecture/secrets.md) for the model.
+
+## A note on Home Manager
+
+Home Manager is loaded as a **flake module**. Do **not** run
+`home-manager switch` — user environments are activated automatically by the
+system rebuild (`just <host>` / `nixos-rebuild switch`). See
+[Home Manager](../architecture/home-manager.md).
+
+## Rollback
+
+NixOS keeps every generation. If a deploy misbehaves:
+
+```bash
+sudo nixos-rebuild switch --rollback
+```

--- a/docs/getting-started/repository-layout.md
+++ b/docs/getting-started/repository-layout.md
@@ -1,0 +1,54 @@
+# Repository Layout
+
+A tour of the top-level directories. Each one links to the generated
+[Reference](../reference/modules/index.md) where relevant.
+
+```text
+nixos_config/
+├── flake.nix              # All host definitions + dev/CI/docs outputs
+├── Justfile               # Task runner: build, test, deploy, docs
+├── lib/                   # Flake helpers: features, host types, secrets, validation
+├── hosts/                 # Per-host config (thin) + shared template
+│   ├── templates/         #   desktop.nix — the single parameterised template
+│   ├── common/            #   shared variables + hardware GPU profiles
+│   ├── p620/  p510/  razer/
+├── modules/               # 200+ feature modules, imported explicitly
+│   ├── services/          #   the largest category — daemons & integrations
+│   ├── ai/  desktop/  development/  security/  virt/  …
+├── home/                  # Home Manager configs + role profiles
+│   └── profiles/          #   developer, server-admin, …
+├── Users/                 # Per-user composition (olafkfreund)
+├── pkgs/                  # ~60 custom/vendored packages
+├── overlays/              # Overlays: custom packages + upstream fixes
+├── secrets/               # agenix-encrypted .age files (safe to commit)
+├── assets/                # Wallpapers, themes, icons, certificates
+├── scripts/               # Management & install-helper scripts
+├── checks/                # Flake checks (quality gates)
+├── docs/                  # This documentation (MkDocs source)
+└── docs_gen/              # Reference generator + Nix site build
+```
+
+## What lives where
+
+| Directory | Purpose | Reference |
+| --- | --- | --- |
+| `lib/` | Pure helper functions wired into the flake | [Library Functions](../reference/lib.md) |
+| `hosts/` | Thin host configs; the heavy lifting is in the template | [Host Manifests](../reference/hosts/index.md) |
+| `modules/` | Reusable, feature-flagged building blocks | [Modules](../reference/modules/index.md) |
+| `pkgs/` | Packages not in nixpkgs (or patched) | [Custom Packages](../reference/packages.md) |
+| `overlays/` | Inject `pkgs/` + apply fixes to nixpkgs | [Overlays](../reference/overlays.md) |
+| `home/` | User-space programs and dotfiles via Home Manager | — |
+| `secrets/` | Encrypted secrets + `secrets.nix` access rules | [Secrets](../architecture/secrets.md) |
+
+## Conventions
+
+- **Modules are imported explicitly.** There is no auto-discovery; the import
+  list in the template is the single source of truth for what loads.
+- **Hosts stay thin.** A host file should mostly be feature flags and the few
+  things that are genuinely unique to that machine (display layout, GPU,
+  host-specific services).
+- **Services belong in `modules/`.** Never write `services.foo = { … }`
+  directly in a host file — wrap it in a module with a feature flag so it is
+  reusable and testable. See [Feature Flags](../architecture/feature-flags.md).
+- **Encrypted secrets are committed; plaintext is not.** `.age` files are safe
+  in git; the access rules live in `secrets/secrets.nix`.

--- a/docs/guides/GITHUB-WORKFLOW.md
+++ b/docs/guides/GITHUB-WORKFLOW.md
@@ -997,9 +997,9 @@ gh issue close 123
 
 ### Documentation
 
-- [PATTERNS.md](./PATTERNS.md) - NixOS best practices
-- [NIXOS-ANTI-PATTERNS.md](./NIXOS-ANTI-PATTERNS.md) - Anti-patterns to avoid
-- [CLAUDE.md](../CLAUDE.md) - Project configuration
+- [PATTERNS.md](../PATTERNS.md) - NixOS best practices
+- [NIXOS-ANTI-PATTERNS.md](../NIXOS-ANTI-PATTERNS.md) - Anti-patterns to avoid
+- [CLAUDE.md](https://github.com/olafkfreund/nixos_config/blob/main/CLAUDE.md) - Project configuration
 
 ### External Resources
 

--- a/docs/guides/HOST_SETUP.md
+++ b/docs/guides/HOST_SETUP.md
@@ -2,13 +2,13 @@
 
 This guide covers adding new hosts to the NixOS configuration with proper secrets management and user access.
 
-##  Prerequisites
+## Prerequisites
 
 - NixOS installed on the target system
 - SSH access to the new host
-- Secrets management already initialized (see [SECRETS_MANAGEMENT.md](SECRETS_MANAGEMENT.md))
+- Secrets management already initialized (see [Secrets (agenix)](../architecture/secrets.md))
 
-##  Quick Setup
+## Quick Setup
 
 ### 1. Create Host Configuration
 
@@ -127,7 +127,7 @@ nixos-rebuild switch --flake .#new-hostname --target-host root@new-hostname
 nixos-rebuild switch --flake .#new-hostname
 ```
 
-##  Hardware-Specific Configuration
+## Hardware-Specific Configuration
 
 ### AMD Systems (like P620)
 
@@ -202,7 +202,7 @@ nixos-rebuild switch --flake .#new-hostname
 }
 ```
 
-##  User Management for New Hosts
+## User Management for New Hosts
 
 ### Adding Users to New Host
 
@@ -245,7 +245,7 @@ nixos-rebuild switch --flake .#new-hostname
    ./scripts/manage-secrets.sh rekey
    ```
 
-##  Network Configuration
+## Network Configuration
 
 ### Standard Network Setup
 
@@ -297,7 +297,7 @@ nixos-rebuild switch --flake .#new-hostname
 }
 ```
 
-##  Security Configuration
+## Security Configuration
 
 ### SSH Hardening
 
@@ -337,7 +337,7 @@ nixos-rebuild switch --flake .#new-hostname
 }
 ```
 
-##  Monitoring and Logging
+## Monitoring and Logging
 
 ### Basic Monitoring
 
@@ -361,7 +361,7 @@ nixos-rebuild switch --flake .#new-hostname
 }
 ```
 
-##  Testing New Host
+## Testing New Host
 
 ### Pre-deployment Tests
 
@@ -395,7 +395,7 @@ ping 1.1.1.1
 lspci | grep -i gpu
 ```
 
-##  Host Migration
+## Host Migration
 
 ### Migrating from Existing Host
 
@@ -424,7 +424,7 @@ lspci | grep -i gpu
    # Update any hardcoded IP addresses or hostnames
    ```
 
-##  Reference
+## Reference
 
 ### Common Host Patterns
 
@@ -486,4 +486,6 @@ lspci | grep -i gpu
 - Check secret file permissions
 - Run recovery script: `./scripts/recover-secrets.sh`
 
-This guide should help you successfully add new hosts to your NixOS configuration with proper integration into the secrets management and user systems.
+This guide should help you successfully add new hosts to your NixOS
+configuration with proper integration into the secrets management and user
+systems.

--- a/docs/hosts/index.md
+++ b/docs/hosts/index.md
@@ -1,0 +1,63 @@
+# Hosts
+
+Three active machines, all built from the same flake and
+[host template](../architecture/template-system.md). This page compares them;
+each host has its own page with the full picture.
+
+<div class="grid cards" markdown>
+
+- :material-desktop-tower: __[p620](p620.md)__ — AMD Workstation
+
+    ---
+
+    Primary development + local AI inference + binary cache.
+
+- :material-server: __[p510](p510.md)__ — Media Server
+
+    ---
+
+    Headless Plex + *arr automation + k3s MicroVMs.
+
+- :material-laptop: __[razer](razer.md)__ — Laptop
+
+    ---
+
+    Mobile development with Secure Boot.
+
+</div>
+
+## At a glance
+
+| | p620 | p510 | razer |
+| --- | --- | --- | --- |
+| __Profile__ | workstation | workstation (headless) | laptop |
+| __CPU__ | AMD Ryzen | Intel Xeon | Intel mobile |
+| __GPU__ | Radeon RX 7900 (ROCm) | NVIDIA (transcode) | Intel + NVIDIA (Optimus) |
+| __Role__ | Dev / AI / cache | Media server | Mobile dev |
+| __Desktop__ | Yes | Headless (remote GNOME) | Yes (GNOME) |
+| __Secure Boot__ | No | No | Yes (lanzaboote) |
+| __Display__ | 2× 2560×1440@120 | 1× 4K@30 | eDP 1920×1080@120 |
+| __NFS export__ | `/extdisk` | `/mnt/data` | `/extdisk` |
+
+## Shared baseline
+
+Every host enables the same foundation, so only the differences are worth
+documenting per host:
+
+- __Development__, __virtualisation__, __AI__ (Ollama + cloud providers),
+  __media__ tooling, __Syncthing__
+- __Tailscale__ mesh networking (local firewall delegated to Tailscale)
+- __agenix__ secrets, __gruvbox-dark__ Stylix theme
+- User `olafkfreund`, `Europe/London`, `en_GB.UTF-8`, UK keyboard
+
+## What differs (and why)
+
+| Dimension | p620 | p510 | razer |
+| --- | --- | --- | --- |
+| __Why it exists__ | Daily driver + GPU compute | Always-on media + services | Portable workstation |
+| __Signature services__ | Ollama (ROCm), LiteLLM router, glance, binary cache | Plex, recyclarr, FlareSolverr, audiobook/*arr MCP, k3s | OpenRazer, power mgmt |
+| __Boot__ | Standard | Standard | Secure Boot (lanzaboote) |
+| __Docker__ | On | On | Off (libvirt + lxd/incus) |
+
+Reference-level per-host file manifests live under
+[Host Manifests](../reference/hosts/index.md).

--- a/docs/hosts/p510.md
+++ b/docs/hosts/p510.md
@@ -1,0 +1,64 @@
+# p510 — Media Server
+
+A headless Intel Xeon box that runs the media stack and a small k3s cluster. It
+uses the **workstation** template but runs without a local display.
+
+| | |
+| --- | --- |
+| **Profile** | `workstation` (headless) |
+| **GPU** | NVIDIA — proprietary driver, used for **hardware transcoding** |
+| **Display** | DP-2, 4K@30 (mostly unused; remote GNOME for occasional GUI) |
+| **NFS** | exports `/mnt/data` to `192.168.1.*` |
+| **Boot** | standard |
+| **Source** | [`hosts/p510/`](https://github.com/olafkfreund/nixos_config/tree/main/hosts/p510) |
+
+## Why this host is shaped the way it is
+
+p510 is the always-on **media server**. It pairs a power-efficient Xeon with an
+NVIDIA card specifically for Plex transcoding. Because it is headless, the
+desktop compositor and display manager are disabled — but it keeps GNOME
+available over **GNOME Remote Desktop** for the rare moment a GUI is needed,
+rather than maintaining a separate server template.
+
+## What runs here
+
+### Media stack
+
+- **Plex** media server with NVIDIA hardware transcoding.
+- **recyclarr-sync** — keeps *arr quality profiles in shape.
+- **FlareSolverr** — Cloudflare-challenge proxy for indexers.
+- **Audiobook automation** — `audiobookbay-automated`, an import pipeline
+  (`audiobook-import`), and the `audiobook-mcp` server.
+- **MCP servers** for Plex and the *arr suite (`plex-mcp`, `arr-suite-mcp`),
+  exposing media control to AI tooling.
+
+### Compute & virtualisation
+
+- **k3s MicroVMs** — a master plus two agents, defined under
+  `hosts/p510/nixos/microvm/`, giving a lightweight Kubernetes cluster.
+- **Ollama server** for local inference.
+- **Virtualisation** and **Syncthing** enabled.
+
+### Access
+
+- **GNOME Remote Desktop** (native) for occasional graphical access.
+- **Tailscale** mesh; local firewall delegated to Tailscale.
+- **NFS** export of `/mnt/data` (the media library) to the LAN.
+
+## Hardware notes
+
+Under `hosts/p510/nixos/`: NVIDIA setup (`nvidia.nix`), boot/CPU/memory/power
+tuning, the Plex configuration, recyclarr, and the MicroVM definitions. See the
+[p510 manifest](../reference/hosts/p510.md).
+
+!!! tip "Tautulli / Plex API"
+    Media-analytics integrations read from Plex/Tautulli on this host. If you
+    rotate the Tautulli API key, update the p510 configuration and redeploy.
+
+## Deploy
+
+```bash
+just test-host p510
+just quick-deploy p510
+just p510
+```

--- a/docs/hosts/p620.md
+++ b/docs/hosts/p620.md
@@ -1,0 +1,68 @@
+# p620 — AMD Workstation
+
+The primary machine: daily development, local AI inference, and the binary
+cache that speeds up the other hosts.
+
+| | |
+| --- | --- |
+| **Profile** | `workstation` |
+| **GPU** | AMD Radeon RX 7900 — `amdgpu` driver, **ROCm** acceleration |
+| **Displays** | DP-1 and DP-2, both 2560×1440@120 |
+| **NFS** | exports `/extdisk` to `192.168.1.*` |
+| **Boot** | standard |
+| **Source** | [`hosts/p620/`](https://github.com/olafkfreund/nixos_config/tree/main/hosts/p620) |
+
+## Why this host is shaped the way it is
+
+p620 has the only GPU in the fleet suitable for ML work (Radeon RX 7900 +
+ROCm), so it is the **local AI host**: it runs Ollama against the GPU and fronts
+it with a LiteLLM router. It is also powerful and always-on, which makes it the
+natural **binary cache server** — the other hosts pull builds from it instead of
+rebuilding.
+
+## What runs here
+
+### AI stack
+
+- **Ollama server** with ROCm acceleration — local model inference.
+- **LiteLLM router** — a unified OpenAI-compatible endpoint in front of local
+  and cloud models.
+- **AI providers** — OpenAI, Anthropic, and Gemini (keys via agenix), with
+  Ollama as the local provider.
+- **claude-router CLI**, **claude-hooks**, and the **PARR protocol** tooling.
+
+### Development & virtualisation
+
+- Full development environment (editors, languages, git tooling).
+- **Docker** virtualisation enabled.
+- **Syncthing** for file sync.
+- **Email** with `mbsync` and AI-assisted features + notifications.
+
+### Desktop & extras
+
+- Desktop environment (COSMIC disabled; Hyprland/GNOME stack).
+- **glance** dashboard, **scrcpy over Wi-Fi**, temperature dashboard.
+- Media tooling including the `yt-x` terminal YouTube browser.
+
+### Networking
+
+- **Tailscale** mesh; the local firewall is left to Tailscale's trust model.
+- **NFS** export of `/extdisk` to the LAN.
+
+## Hardware notes
+
+p620 carries a few hardware-specific tweaks under `hosts/p620/nixos/`:
+
+- AMD/ROCm setup (`amd.nix`), CPU and memory tuning, power.
+- An AQC107 NIC link pin and a USB power fix.
+- VFIO setup and DNS fallback for resilience.
+
+For the exact files, see the [p620 manifest](../reference/hosts/p620.md).
+
+## Deploy
+
+```bash
+just test-host p620      # build without switching
+just quick-deploy p620   # deploy only if the build changed
+just p620                # optimised deploy
+```

--- a/docs/hosts/razer.md
+++ b/docs/hosts/razer.md
@@ -1,0 +1,71 @@
+# razer — Laptop
+
+The portable workstation: a Razer laptop with hybrid graphics, Secure Boot, and
+power management. It is the only host on the `laptop` profile.
+
+| | |
+| --- | --- |
+| **Profile** | `laptop` |
+| **GPU** | Intel iGPU + NVIDIA dGPU (Optimus) |
+| **Display** | eDP-1, 1920×1080@120 |
+| **NFS** | exports `/extdisk` to `192.168.1.*` |
+| **Boot** | **Secure Boot** via lanzaboote |
+| **Source** | [`hosts/razer/`](https://github.com/olafkfreund/nixos_config/tree/main/hosts/razer) |
+
+## Why this host is shaped the way it is
+
+razer is a mobile machine, so it makes trade-offs the desktops do not: the
+**laptop profile** turns on `thermald` and a `powersave` CPU governor, the Intel
+iGPU drives the panel to save battery while the NVIDIA dGPU is available on
+demand, and the boot chain is locked down with **Secure Boot**. It still carries
+the full development environment so it is a first-class dev box on the move.
+
+## What runs here
+
+### Laptop specifics
+
+- **Secure Boot** via **lanzaboote** (`secure-boot.nix`, `shim.nix`).
+- **greetd** login manager; **GNOME** desktop.
+- **Power management** — `thermald`, `powersave` governor (from the laptop
+  profile).
+- **OpenRazer** for Razer peripheral support (the `openrazer` user group).
+- Wayland-forced environment (`NIXOS_OZONE_WL`, `MOZ_ENABLE_WAYLAND`, …).
+
+### Development & virtualisation
+
+- Full development environment.
+- **Virtualisation** via libvirt; Docker is **off** here, with **lxd** and
+  **incus** containers instead.
+- **Syncthing** enabled.
+- **claude-router CLI** and the **PARR protocol** tooling.
+
+### AI & media
+
+- **AI providers** (Ollama local + cloud providers via agenix).
+- **Media** tooling enabled.
+
+### Networking
+
+- **Tailscale** mesh; local firewall delegated to Tailscale.
+- **NFS** export of `/extdisk`.
+
+## Hardware notes
+
+Under `hosts/razer/nixos/`: NVIDIA/Optimus setup, the laptop tuning
+(`laptop.nix`), `greetd.nix`, boot/CPU/memory/power, and the Secure Boot chain
+(`secure-boot.nix`, `shim.nix`). See the
+[razer manifest](../reference/hosts/razer.md).
+
+!!! warning "Remote builds for heavy rebuilds"
+    Large razer rebuilds can be offloaded to p620:
+    `nixos-rebuild build --build-host olafkfreund@p620`, then
+    `sudo switch-to-configuration switch`. Build and switch are split because
+    root has no SSH key for p620.
+
+## Deploy
+
+```bash
+just test-host razer
+just quick-deploy razer
+just razer
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,107 @@
+---
+hide:
+  - navigation
+---
+
+# NixOS Infrastructure Hub
+
+A multi-host NixOS configuration built on flakes, a single parameterised host
+template, Home Manager as a flake module, and Stylix-driven theming. This site
+documents **every module, package, and host** — and explains the reasoning
+behind each architectural choice.
+
+[Get started](getting-started/overview.md){ .md-button .md-button--primary }
+[Browse the reference](reference/modules/index.md){ .md-button }
+[View on GitHub](https://github.com/olafkfreund/nixos_config){ .md-button }
+
+## The hosts
+
+<div class="grid cards" markdown>
+
+- :material-desktop-tower: **p620 — AMD Workstation**
+
+    ---
+
+    Primary development and AI workloads. Radeon RX 7900 with ROCm, local
+    inference, binary cache server.
+
+    [:octicons-arrow-right-24: Details](hosts/p620.md)
+
+- :material-server: **p510 — Media Server**
+
+    ---
+
+    Headless Intel Xeon server. Plex media stack, NVIDIA transcoding,
+    k3s MicroVMs.
+
+    [:octicons-arrow-right-24: Details](hosts/p510.md)
+
+- :material-laptop: **razer — Laptop**
+
+    ---
+
+    Mobile development. Hybrid Intel + NVIDIA graphics, Secure Boot via
+    lanzaboote, power management.
+
+    [:octicons-arrow-right-24: Details](hosts/razer.md)
+
+</div>
+
+## How it fits together
+
+<div class="grid cards" markdown>
+
+- :material-file-tree: **One host template**
+
+    ---
+
+    A single parameterised `desktop.nix` template selects between
+    `workstation` and `laptop` profiles. No per-host import duplication.
+
+    [:octicons-arrow-right-24: Template system](architecture/template-system.md)
+
+- :material-flag: **Feature flags**
+
+    ---
+
+    Modules are imported explicitly and gated by feature flags with
+    dependency and conflict validation.
+
+    [:octicons-arrow-right-24: Feature flags](architecture/feature-flags.md)
+
+- :material-palette: **Stylix theming**
+
+    ---
+
+    A single base16 palette drives colours everywhere — terminals, Zellij,
+    COSMIC — from `config.lib.stylix.colors`.
+
+    [:octicons-arrow-right-24: Theming](architecture/theming.md)
+
+- :material-key: **agenix secrets**
+
+    ---
+
+    Secrets are age-encrypted, committed safely, and loaded at runtime —
+    never read during evaluation.
+
+    [:octicons-arrow-right-24: Secrets](architecture/secrets.md)
+
+</div>
+
+## Build this site
+
+The documentation is built reproducibly with Nix — the same toolchain locally
+and in CI:
+
+```bash
+nix build .#docs          # -> ./result (static site)
+just docs-serve           # live preview at http://127.0.0.1:8000
+just docs-check           # strict build (fails on broken links)
+```
+
+!!! info "Always in sync"
+    The entire [Reference](reference/modules/index.md) section is generated
+    from the live Nix source at build time. It mirrors every file under
+    `modules/`, `pkgs/`, `hosts/`, `lib/`, and `overlays/`, so it can never
+    drift from the configuration.

--- a/docs_gen/gen_reference.py
+++ b/docs_gen/gen_reference.py
@@ -1,0 +1,385 @@
+"""Generate the auto-mirrored reference section of the docs site.
+
+Run by the mkdocs-gen-files plugin at build time (see mkdocs.yml). It walks
+the repository source — modules/, pkgs/, hosts/, lib/, overlays/ — and emits
+one in-memory Markdown page per area plus a literate-nav SUMMARY.md. Nothing
+is written to disk, so the generated reference never goes stale in git.
+
+Extraction is best-effort and source-of-truth-linked: every page links back
+to the exact file on GitHub, and the raw `options` block is shown verbatim
+(brace-matched) rather than re-parsed, so we never misrepresent a module.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import mkdocs_gen_files
+
+REPO_BLOB = "https://github.com/olafkfreund/nixos_config/blob/main"
+ROOT = Path(__file__).resolve().parent.parent
+
+nav = mkdocs_gen_files.Nav()
+
+# Human-friendly titles for module categories. Anything not listed falls back
+# to a title-cased directory name.
+CATEGORY_TITLES = {
+    "ai": "AI Providers",
+    "cloud": "Cloud",
+    "common": "Common",
+    "containers": "Containers",
+    "desktop": "Desktop",
+    "development": "Development",
+    "email": "Email",
+    "fonts": "Fonts",
+    "funny": "Fun",
+    "helpers": "Helpers",
+    "installer": "Live Installer",
+    "microvms": "MicroVMs",
+    "networking": "Networking",
+    "nix": "Nix Settings",
+    "nix-index": "Nix Index",
+    "nixos": "NixOS Core",
+    "obsidian": "Obsidian",
+    "office": "Office",
+    "overlays": "Overlay Hooks",
+    "packages": "Package Sets",
+    "pkgs": "Package Glue",
+    "programs": "Programs",
+    "scrcpy": "scrcpy",
+    "scripts": "Scripts",
+    "secrets": "Secrets",
+    "security": "Security",
+    "services": "Services",
+    "spell": "Spell Checking",
+    "storage": "Storage",
+    "system": "System",
+    "system-utils": "System Utilities",
+    "virt": "Virtualisation",
+    "webcam": "Webcam",
+    "windows": "Windows Interop",
+}
+
+
+# --------------------------------------------------------------------------
+# Extraction helpers (stdlib + regex only)
+# --------------------------------------------------------------------------
+def leading_comment(text: str) -> str:
+    """Return the top-of-file `#` comment block as prose."""
+    lines = []
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if stripped.startswith("#"):
+            lines.append(stripped.lstrip("#").strip())
+        elif stripped == "":
+            if lines:
+                break
+            continue
+        else:
+            break
+    # Drop empty trailing/leading entries.
+    return "\n".join(lines).strip()
+
+
+def match_braces(text: str, open_idx: int) -> int:
+    """Return index just past the brace that matches the `{` at open_idx.
+
+    Naive depth counter — good enough for Nix option blocks. Returns -1 if
+    unbalanced.
+    """
+    depth = 0
+    for i in range(open_idx, len(text)):
+        c = text[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+    return -1
+
+
+def extract_options_block(text: str) -> str | None:
+    """Extract the first `options[...] = { ... }` block, verbatim."""
+    m = re.search(r"(?m)^\s*options\b[^=\n]*=\s*", text)
+    if not m:
+        # Some modules write `options = { ... }` or `options.foo.bar = {`.
+        return None
+    brace = text.find("{", m.end() - 1)
+    if brace == -1:
+        return None
+    end = match_braces(text, brace)
+    if end == -1:
+        return None
+    block = text[m.start() : end]
+    return block
+
+
+def enable_options(text: str) -> list[str]:
+    """Return descriptions of any `mkEnableOption "..."` calls."""
+    return re.findall(r'mkEnableOption\s+"([^"]+)"', text)
+
+
+def option_names(block: str) -> list[str]:
+    """Best-effort list of declared option leaf names in an options block."""
+    names = re.findall(r"(?m)^\s*([A-Za-z_][\w-]*)\s*=\s*mkOption\b", block)
+    enable = re.findall(r"(?m)^\s*([A-Za-z_][\w-]*)\s*=\s*mkEnableOption\b", block)
+    # Preserve order, dedupe.
+    seen = {}
+    for n in enable + names:
+        seen.setdefault(n, None)
+    return list(seen)
+
+
+def nix_string(text: str, key: str) -> str | None:
+    """Extract `key = "value";` (double-quoted) from text."""
+    m = re.search(rf'\b{re.escape(key)}\s*=\s*"([^"]*)"', text)
+    return m.group(1) if m else None
+
+
+def truncate_block(block: str, max_lines: int = 90) -> tuple[str, bool]:
+    lines = block.splitlines()
+    if len(lines) <= max_lines:
+        return block, False
+    return "\n".join(lines[:max_lines]), True
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def source_link(path: Path) -> str:
+    r = rel(path)
+    return f"[:material-github: `{r}`]({REPO_BLOB}/{r})"
+
+
+# --------------------------------------------------------------------------
+# modules/  — one page per category, a subsection per .nix file
+# --------------------------------------------------------------------------
+def render_module_file(out, path: Path) -> None:
+    text = path.read_text(errors="replace")
+    print(f"### `{path.name}`\n", file=out)
+    print(f"{source_link(path)}\n", file=out)
+
+    comment = leading_comment(text)
+    if comment:
+        print(f"{comment}\n", file=out)
+
+    for desc in enable_options(text):
+        print(f"- **Enable option:** {desc}", file=out)
+    if enable_options(text):
+        print("", file=out)
+
+    block = extract_options_block(text)
+    if block:
+        names = option_names(block)
+        if names:
+            joined = ", ".join(f"`{n}`" for n in names)
+            print(f"**Options:** {joined}\n", file=out)
+        shown, truncated = truncate_block(block)
+        print('??? note "Options declaration (Nix)"\n', file=out)
+        print("    ```nix", file=out)
+        for line in shown.splitlines():
+            print(f"    {line}", file=out)
+        if truncated:
+            print("    # … truncated — see source link above", file=out)
+        print("    ```\n", file=out)
+    else:
+        print("_No option declarations; see source for implementation._\n", file=out)
+
+
+def gen_modules() -> None:
+    modules = ROOT / "modules"
+    categories = sorted(p for p in modules.iterdir() if p.is_dir())
+
+    # Category index landing page.
+    index_path = "reference/modules/index.md"
+    with mkdocs_gen_files.open(index_path, "w") as out:
+        print("# Modules\n", file=out)
+        print(
+            "Feature modules are imported explicitly by the host template and "
+            "gated by feature flags. Each category below documents every "
+            "`.nix` file it contains, with the raw option declarations and a "
+            "link to the source.\n",
+            file=out,
+        )
+        print("| Category | Files | Description |", file=out)
+        print("| --- | ---: | --- |", file=out)
+        for cat in categories:
+            nix_files = sorted(cat.rglob("*.nix"))
+            title = CATEGORY_TITLES.get(cat.name, cat.name.replace("-", " ").title())
+            print(
+                f"| [{title}](./{cat.name}.md) | {len(nix_files)} | "
+                f"`modules/{cat.name}/` |",
+                file=out,
+            )
+    nav["Modules", "Overview"] = "modules/index.md"
+
+    for cat in categories:
+        title = CATEGORY_TITLES.get(cat.name, cat.name.replace("-", " ").title())
+        nix_files = sorted(cat.rglob("*.nix"))
+        page = f"reference/modules/{cat.name}.md"
+        with mkdocs_gen_files.open(page, "w") as out:
+            print(f"# {title}\n", file=out)
+            print(f"Source directory: `modules/{cat.name}/`\n", file=out)
+            if not nix_files:
+                print("_No Nix files in this category._", file=out)
+            for nf in nix_files:
+                render_module_file(out, nf)
+        nav["Modules", title] = f"modules/{cat.name}.md"
+
+
+# --------------------------------------------------------------------------
+# pkgs/  — single sortable table + per-package detail
+# --------------------------------------------------------------------------
+def package_meta(pkg_dir: Path) -> dict:
+    candidates = [pkg_dir / "default.nix"]
+    candidates += sorted(pkg_dir.glob("*.nix"))
+    text = ""
+    used = None
+    for c in candidates:
+        if c.exists():
+            used = c
+            text = c.read_text(errors="replace")
+            break
+    return {
+        "name": pkg_dir.name,
+        "pname": nix_string(text, "pname") or pkg_dir.name,
+        "version": nix_string(text, "version") or "—",
+        "description": nix_string(text, "description") or "",
+        "homepage": nix_string(text, "homepage") or "",
+        "file": used,
+    }
+
+
+def gen_packages() -> None:
+    pkgs = ROOT / "pkgs"
+    pkg_dirs = sorted(p for p in pkgs.iterdir() if p.is_dir())
+    metas = [package_meta(p) for p in pkg_dirs]
+
+    page = "reference/packages.md"
+    with mkdocs_gen_files.open(page, "w") as out:
+        print("# Custom Packages\n", file=out)
+        print(
+            f"{len(metas)} packages live under `pkgs/`, wired in through the "
+            "overlays. Each is built from source or vendored and exposed to "
+            "every host. Packages flagged unfree require "
+            "`allowUnfree`.\n",
+            file=out,
+        )
+        print("| Package | Version | Description |", file=out)
+        print("| --- | --- | --- |", file=out)
+        for m in metas:
+            anchor = m["name"].lower().replace(".", "").replace("_", "-")
+            desc = m["description"].replace("|", "\\|")
+            print(f"| [`{m['name']}`](#{anchor}) | {m['version']} | {desc} |", file=out)
+        print("", file=out)
+
+        for m in metas:
+            print(f"## {m['name']}\n", file=out)
+            if m["file"] is not None:
+                print(f"{source_link(m['file'])}\n", file=out)
+            rows = [
+                ("Package name", f"`{m['pname']}`"),
+                ("Version", m["version"]),
+            ]
+            if m["homepage"]:
+                rows.append(("Homepage", f"<{m['homepage']}>"))
+            print("| | |", file=out)
+            print("| --- | --- |", file=out)
+            for k, v in rows:
+                print(f"| **{k}** | {v} |", file=out)
+            print("", file=out)
+            if m["description"]:
+                print(f"{m['description']}\n", file=out)
+    nav["Packages"] = "packages.md"
+
+
+# --------------------------------------------------------------------------
+# hosts/  — file manifest per host (complements the hand-written host pages)
+# --------------------------------------------------------------------------
+def gen_hosts() -> None:
+    hosts = ROOT / "hosts"
+    host_dirs = sorted(
+        p
+        for p in hosts.iterdir()
+        if p.is_dir() and p.name not in ("common", "templates")
+    )
+
+    index_path = "reference/hosts/index.md"
+    with mkdocs_gen_files.open(index_path, "w") as out:
+        print("# Host File Manifests\n", file=out)
+        print(
+            "Per-host file listings for the curious. For the narrative — what "
+            "each machine is for and how to run it — see the "
+            "[Hosts](../../hosts/index.md) section.\n",
+            file=out,
+        )
+        print("Shared host scaffolding lives in:", file=out)
+        for sub in ("common", "templates"):
+            d = hosts / sub
+            if d.exists():
+                print(f"\n- `hosts/{sub}/`", file=out)
+                for f in sorted(d.rglob("*.nix")):
+                    print(f"    - {source_link(f)}", file=out)
+    nav["Hosts", "Overview"] = "hosts/index.md"
+
+    for hd in host_dirs:
+        page = f"reference/hosts/{hd.name}.md"
+        with mkdocs_gen_files.open(page, "w") as out:
+            print(f"# `hosts/{hd.name}/`\n", file=out)
+            variables = hd / "variables.nix"
+            if variables.exists():
+                print(f"Host variables: {source_link(variables)}\n", file=out)
+            print("## Files\n", file=out)
+            for f in sorted(hd.rglob("*.nix")):
+                comment = leading_comment(f.read_text(errors="replace"))
+                first = comment.splitlines()[0] if comment else ""
+                print(
+                    f"- {source_link(f)}" + (f" — {first}" if first else ""), file=out
+                )
+        nav["Hosts", hd.name] = f"hosts/{hd.name}.md"
+
+
+# --------------------------------------------------------------------------
+# lib/ and overlays/  — small manifests with leading comments
+# --------------------------------------------------------------------------
+def gen_simple_dir(dir_name: str, title: str, blurb: str) -> None:
+    base = ROOT / dir_name
+    if not base.exists():
+        return
+    page = f"reference/{dir_name}.md"
+    with mkdocs_gen_files.open(page, "w") as out:
+        print(f"# {title}\n", file=out)
+        print(f"{blurb}\n", file=out)
+        for f in sorted(base.rglob("*.nix")):
+            print(f"## `{f.relative_to(base).as_posix()}`\n", file=out)
+            print(f"{source_link(f)}\n", file=out)
+            comment = leading_comment(f.read_text(errors="replace"))
+            if comment:
+                print(f"{comment}\n", file=out)
+    nav[title] = f"{dir_name}.md"
+
+
+# --------------------------------------------------------------------------
+# Drive everything + write the literate-nav SUMMARY.
+# --------------------------------------------------------------------------
+gen_modules()
+gen_packages()
+gen_hosts()
+gen_simple_dir(
+    "lib",
+    "Library Functions",
+    "Helper functions and builders consumed by the flake: feature system, "
+    "host types, secrets wiring, live-image builders, and validation.",
+)
+gen_simple_dir(
+    "overlays",
+    "Overlays",
+    "Overlays are split by purpose. They inject the custom `pkgs/` packages "
+    "and apply upstream fixes and compatibility shims.",
+)
+
+with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
+    nav_file.writelines(nav.build_literate_nav())

--- a/docs_gen/site.nix
+++ b/docs_gen/site.nix
@@ -1,0 +1,61 @@
+# Reproducible MkDocs Material build of the repository documentation.
+#
+# Build with:  nix build .#docs   ->  ./result is the static site
+# Preview with: nix develop .#docs ; mkdocs serve
+#
+# The source is filtered to only the inputs the site needs, so the huge
+# assets/ tree and node_modules are never copied into the Nix store.
+{ lib
+, stdenvNoCC
+, python3
+,
+}:
+let
+  pythonEnv = python3.withPackages (ps: [
+    ps.mkdocs
+    ps.mkdocs-material
+    ps.mkdocs-gen-files
+    ps.mkdocs-literate-nav
+    ps.pymdown-extensions
+  ]);
+
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../mkdocs.yml
+      ../docs
+      ../docs_gen
+      ../modules
+      ../pkgs
+      ../hosts
+      ../lib
+      ../overlays
+      ../README.md
+    ];
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "nixos-config-docs";
+  version = "1.0.0";
+
+  inherit src;
+
+  nativeBuildInputs = [ pythonEnv ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+    export HOME=$TMPDIR
+    mkdocs build --site-dir $out
+    runHook postBuild
+  '';
+
+  dontInstall = true;
+
+  meta = {
+    description = "MkDocs Material documentation site for the NixOS configuration";
+    homepage = "https://olafkfreund.github.io/nixos_config/";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -396,6 +396,9 @@
             };
           };
 
+          # Documentation site (MkDocs Material, built reproducibly)
+          docs = pkgs.callPackage ./docs_gen/site.nix { };
+
           # Live ISO images
           live-iso-razer = liveImages.liveImages.live-iso-razer.config.system.build.isoImage;
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,173 @@
+site_name: NixOS Infrastructure Hub
+site_description: >-
+  Multi-host NixOS configuration — flakes, a single parameterised host
+  template, Home Manager as a flake module, and Stylix-driven theming.
+  Documentation for every module, package, and host, with the reasoning
+  behind each architectural choice.
+site_author: olafkfreund
+site_url: https://olafkfreund.github.io/nixos_config/
+
+repo_url: https://github.com/olafkfreund/nixos_config
+repo_name: olafkfreund/nixos_config
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+
+copyright: >-
+  Built with MkDocs Material · Generated reproducibly with Nix
+  (<code>nix build .#docs</code>)
+
+theme:
+  name: material
+  language: en
+  features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.indexes
+    - navigation.top
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.tracking
+    - navigation.footer
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.tooltips
+    - toc.follow
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to system preference
+  font:
+    text: Inter
+    code: JetBrains Mono
+  icon:
+    repo: fontawesome/brands/github
+    edit: material/pencil
+    view: material/eye
+
+plugins:
+  - search
+  - gen-files:
+      scripts:
+        - docs_gen/gen_reference.py
+  - literate-nav:
+      nav_file: SUMMARY.md
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      permalink_title: Anchor link to this section
+  - pymdownx.betterem
+  - pymdownx.caret
+  - pymdownx.mark
+  - pymdownx.tilde
+  - pymdownx.details
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.smartsymbols
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+# README.md duplicates index.md at the docs root; keep it on disk for repo
+# browsing but exclude it from the built site. Design plans are source notes.
+exclude_docs: |
+  /README.md
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - getting-started/index.md
+      - Overview: getting-started/overview.md
+      - Quick Start: getting-started/quick-start.md
+      - Repository Layout: getting-started/repository-layout.md
+  - Architecture:
+      - architecture/index.md
+      - Philosophy & Why: architecture/philosophy.md
+      - Host Template System: architecture/template-system.md
+      - Feature Flags: architecture/feature-flags.md
+      - Hardware Profiles: architecture/hardware-profiles.md
+      - Overlays: architecture/overlays.md
+      - Theming (Stylix): architecture/theming.md
+      - Secrets (agenix): architecture/secrets.md
+      - Home Manager: architecture/home-manager.md
+  - Hosts:
+      - hosts/index.md
+      - "p620 — AMD Workstation": hosts/p620.md
+      - "p510 — Media Server": hosts/p510.md
+      - "razer — Laptop": hosts/razer.md
+  - Reference: reference/
+  - Guides:
+      - Deployment: guides/deployment-guide.md
+      - Update & Deploy: UPDATE-DEPLOY.md
+      - Update Workflow: guides/UPDATE-WORKFLOW.md
+      - Adding a Host: guides/HOST_SETUP.md
+      - GitHub Workflow: guides/GITHUB-WORKFLOW.md
+      - Cache Strategy: guides/CACHE-STRATEGY.md
+      - Cachix Analysis: guides/CACHIX-ANALYSIS.md
+      - Package System: guides/PACKAGE-SYSTEM-USAGE.md
+      - Gemini CLI: guides/GEMINI_CLI_FEATURE.md
+  - Patterns:
+      - Best Practices: PATTERNS.md
+      - Anti-Patterns: NIXOS-ANTI-PATTERNS.md
+      - MCP Servers: MCP-GUIDE.md
+  - Applications:
+      - Citrix Workspace: applications/CITRIX-WORKSPACE-SETUP.md
+      - Waydroid: applications/WAYDROID-SETUP.md
+      - FlareSolverr: applications/flaresolverr-deployment.md
+      - GitLab Runner: applications/GITLAB-RUNNER-SETUP.md
+      - VS Code Extensions: applications/VSCODE_EXTENSIONS.md
+      - COSMIC Screen Sharing: applications/screensharing_cosmic.md
+      - P620 BIOS / NUMA: applications/P620-BIOS-NUMA-Configuration.md
+  - Command System:
+      - Overview: Nixos/README.md
+      - Commands Index: Nixos/COMMANDS-INDEX.md
+      - System Overview: Nixos/Command-System-Overview.md
+      - Quick Reference: Nixos/Quick-Reference.md
+      - Update Checker: Nixos/Update-Checker-Guide.md
+  - Tooling:
+      - Claude Code Optimization: tooling/CLAUDE-CODE-OPTIMIZATION.md
+      - Claude Powerline: tooling/Claude-Powerline.md
+      - GitHub Spec-Kit: tooling/Github-spec-kit.md
+      - Claude Code 2.0.54: tooling/claude-code-update-2.0.54.md
+  - Design Notes:
+      - "Ollama / LiteLLM (p620)": plans/2026-05-22-ollama-p620-litellm-design.md

--- a/modules/secrets/api-keys.nix
+++ b/modules/secrets/api-keys.nix
@@ -75,6 +75,13 @@ in
         group = "users";
       };
 
+      synechron-github-api = {
+        file = ../../secrets/synechron-github-api.age;
+        mode = "0600";
+        owner = username;
+        group = "users";
+      };
+
       tailscale-auth-key = {
         file = ../../secrets/tailscale-auth-key.age;
         mode = "0600";
@@ -121,6 +128,10 @@ in
           # Export as GITHUB_API_TOKEN to avoid conflict with gh CLI credential management
           # gh CLI expects to manage its own credentials via 'gh auth login'
           echo "export GITHUB_API_TOKEN=\"$(cat /run/agenix/api-github-token)\""
+        fi
+
+        if [ -r "/run/agenix/synechron-github-api" ]; then
+          echo "export SYNECHRON_GITHUB_API_TOKEN=\"$(cat /run/agenix/synechron-github-api)\""
         fi
 
         # If no secrets are available, output nothing (safe for eval)

--- a/secrets.nix
+++ b/secrets.nix
@@ -23,6 +23,9 @@ in
   "secrets/api-gemini.age".publicKeys = allUsers ++ allHosts;
   "secrets/api-anthropic.age".publicKeys = allUsers ++ allHosts;
   "secrets/api-github-token.age".publicKeys = allUsers ++ allHosts;
+  # Synechron GitHub API token (PAT). All hosts; exported as
+  # SYNECHRON_GITHUB_API_TOKEN via load-api-keys. Edit: agenix -e secrets/synechron-github-api.age
+  "secrets/synechron-github-api.age".publicKeys = allUsers ++ allHosts;
   # gogcli refresh-token export (gog auth tokens export). Decrypted to
   # /run/agenix/gogcli-token, imported into gog's file keyring on every host.
   "secrets/gogcli-token.age".publicKeys = allUsers ++ allHosts;

--- a/secrets/synechron-github-api.age
+++ b/secrets/synechron-github-api.age
@@ -1,0 +1,11 @@
+age-encryption.org/v1
+-> ssh-ed25519 wgedHw FX7F2quiZ4VffPHrFhtHKWzRlLIY8w//IpB5Mv5ety0
+T1Sx1kLxYeMtDoZ1xVLkN29SIBUJQJbFtL9vwkj4rFc
+-> ssh-ed25519 NzeCSQ f8UamZXwY3DCOs/HcMJ5ZxI5cHtfUJ5276rYi/p6QA8
+gIKX3TMc40Y1XCjwCz31ALmZJo+SiV7uZXaBAJHKB+s
+-> ssh-ed25519 UT51fQ ONlANeiv9kxe/jH0gRM98FMRopIf/FpfD3iSIqPVTnU
+TX+lgzC4n5DRVHNZ/7Ot8f/JHiZGhbyPOq9S5xI6dTM
+-> ssh-ed25519 tbxj3w vO0OlreazWGSmyDXY9O66LnC1/Ut7q6Kt+337CIpqxQ
+6y8m31/q+QgmCf50LmhGijKaarLSpIQqna4IaYlNpmY
+--- UT0xr8T+IMazylujvmdebG0+VKFElmOx5e/RaB5vcyI
+”VÅ/®:„šò´c÷Øu‚I¨œçªÙ¨º·!TÒÆ¶0Y]—5y·éÇ[Êþ¢|FFƒ÷³Ä_j¨ÑxÑ.­Ë¬ApË

--- a/tools/docs.nix
+++ b/tools/docs.nix
@@ -4,6 +4,16 @@ pkgs.mkShell {
   name = "nixos-docs-environment";
 
   packages = with pkgs; [
+    # MkDocs Material site (matches `nix build .#docs`)
+    # Use `mkdocs serve` for live preview, `just docs-serve` as a shortcut.
+    (python3.withPackages (ps: [
+      ps.mkdocs
+      ps.mkdocs-material
+      ps.mkdocs-gen-files
+      ps.mkdocs-literate-nav
+      ps.pymdown-extensions
+    ]))
+
     # Documentation generation
     mdbook # Rust-based documentation
     mdbook-mermaid # Mermaid diagram support


### PR DESCRIPTION
## Summary

Adds a new agenix secret **`synechron-github-api.age`** (a GitHub PAT), available on all hosts.

- `secrets.nix`: `publicKeys = allUsers ++ allHosts` (encrypted to olafkfreund + p620/razer/p510).
- `modules/secrets/api-keys.nix`: declares `age.secrets.synechron-github-api` (mode 0600, owned by the user) and exports it as **`SYNECHRON_GITHUB_API_TOKEN`** via the `load-api-keys` shell hook, mirroring `api-github-token`.

Decrypts to `/run/agenix/synechron-github-api` on every host. Edit later with `agenix -e secrets/synechron-github-api.age`.

## Test plan

- [x] `just test-host p510` + `nix build` p620 + razer — all build
- [x] `.age` encrypted to 4 recipients (all users + hosts) verified
- [ ] Deploy all hosts; confirm `/run/agenix/synechron-github-api` decrypts

> Security: the token was shared in plaintext to set this up — consider rotating it if that channel isn't private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)