### PR TITLE
feat(desktop): add Aerion email client

### DIFF
--- a/Users/common/features-impl.nix
+++ b/Users/common/features-impl.nix
@@ -63,6 +63,7 @@ in
         evince.enable = cfg.desktop.evince;
         kdeconnect.enable = cfg.desktop.kdeconnect;
         slack.enable = cfg.desktop.slack;
+        aerion.enable = cfg.desktop.aerion;
       };
 
       # File managers

--- a/Users/common/features.nix
+++ b/Users/common/features.nix
@@ -45,6 +45,7 @@ let inherit (lib) mkEnableOption; in {
       evince = mkEnableOption "Enable Evince document viewer";
       kdeconnect = mkEnableOption "Enable KDE Connect";
       slack = mkEnableOption "Enable Slack";
+      aerion = mkEnableOption "Enable Aerion email client";
       lanmouse = mkEnableOption "Enable LAN Mouse";
 
       # Desktop shell (experimental)

--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -14,6 +14,7 @@
 
   # Workstation-specific desktop flags
   features.desktop.obsidian = true;
+  features.desktop.aerion = true;
   features.desktop.waylandScreenshots = true;
   features.desktop.quickshell = true;
 

--- a/Users/olafkfreund/razer_home.nix
+++ b/Users/olafkfreund/razer_home.nix
@@ -19,6 +19,8 @@ in
   # Laptop: flameshot works fine on Razer (single-monitor Wayland)
   features.desktop.flameshot = true;
 
+  features.desktop.aerion = true;
+
   # obsidian stays disabled — see #370 (electron-39 build broken upstream)
 
   # splashboard — terminal splash screen on shell startup + cd. Same as p620.

--- a/flake.nix
+++ b/flake.nix
@@ -341,6 +341,7 @@
         in
         {
           # Custom applications
+          aerion = pkgs.callPackage ./pkgs/aerion { };
           claude-code = import ./home/development/claude-code {
             inherit (pkgs) lib buildNpmPackage fetchurl nodejs makeWrapper writeShellScriptBin;
           };

--- a/home/desktop/aerion/default.nix
+++ b/home/desktop/aerion/default.nix
@@ -1,0 +1,19 @@
+{ lib
+, config
+, pkgs
+, ...
+}:
+let
+  inherit (lib) mkIf mkEnableOption mkPackageOption;
+  cfg = config.programs.aerion;
+in
+{
+  options.programs.aerion = {
+    enable = mkEnableOption "Aerion lightweight email client";
+    package = mkPackageOption pkgs "aerion" { };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+  };
+}

--- a/home/desktop/default.nix
+++ b/home/desktop/default.nix
@@ -15,6 +15,7 @@
     ./neofetch/default.nix
     ./kdeconnect/default.nix
     ./slack/default.nix
+    ./aerion/default.nix
     ./obs/default.nix
     ./flameshot/default.nix
     ./screenshots/wayland-native.nix

--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -1,4 +1,5 @@
 final: _prev: {
+  aerion = final.callPackage ../pkgs/aerion { };
   glim = final.callPackage ./glim { };
   intune-portal = final.callPackage ../pkgs/intune-portal { };
   zsh-ai-cmd = final.callPackage ../pkgs/zsh-ai-cmd { };

--- a/pkgs/aerion/default.nix
+++ b/pkgs/aerion/default.nix
@@ -1,0 +1,93 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, makeWrapper
+, webkitgtk_4_1
+, gtk3
+, glib
+, cairo
+, pango
+, gdk-pixbuf
+, libsoup_3
+, libGL
+, libdrm
+, mesa
+, alsa-lib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "aerion";
+  version = "0.2.5";
+
+  src = fetchurl {
+    url = "https://github.com/hkdb/aerion/releases/download/v${version}/aerion-linux-amd64.tar.gz";
+    hash = "sha256-rFoZ9gVLfHxJDqoV04NiW5ptpPS9dh+TswoU6b9ZAec=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    webkitgtk_4_1
+    gtk3
+    glib
+    cairo
+    pango
+    gdk-pixbuf
+    libsoup_3
+    libGL
+    libdrm
+    mesa
+    alsa-lib
+    stdenv.cc.cc.lib
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 aerion $out/bin/aerion
+    install -Dm644 io.github.hkdb.Aerion.png \
+      $out/share/icons/hicolor/256x256/apps/io.github.hkdb.Aerion.png
+    install -Dm644 io.github.hkdb.Aerion.desktop \
+      $out/share/applications/io.github.hkdb.Aerion.desktop
+
+    substituteInPlace $out/share/applications/io.github.hkdb.Aerion.desktop \
+      --replace-quiet "/usr/local/bin/aerion" "$out/bin/aerion" \
+      --replace-quiet "/usr/bin/aerion" "$out/bin/aerion" \
+      --replace-quiet "Exec=aerion" "Exec=$out/bin/aerion"
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/aerion \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs}
+  '';
+
+  meta = {
+    description = "Lightweight cross-platform email client (Wails + Svelte)";
+    longDescription = ''
+      Aerion is an open-source, lightweight email client inspired by Geary.
+      Supports IMAP/SMTP, Gmail, Microsoft 365/Outlook, Proton (via Bridge),
+      iCloud, Fastmail, and more. Features unified inbox, conversation
+      threads, WYSIWYG composer, PGP & S/MIME, and CardDav contact sync.
+
+      This package wraps the upstream prebuilt amd64 Linux binary; OAuth
+      client IDs (Gmail/Outlook) are whatever upstream baked in at release.
+    '';
+    homepage = "https://github.com/hkdb/aerion";
+    changelog = "https://github.com/hkdb/aerion/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "aerion";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Summary

- Package Aerion v0.2.5 ([hkdb/aerion](https://github.com/hkdb/aerion)), a lightweight Wails (Go + Svelte) email client not in nixpkgs, by wrapping the upstream prebuilt amd64 tarball with `autoPatchelfHook` against webkit2gtk_4_1 / gtk3 / etc. Apache-2.0, x86_64-linux only.
- Plumb through the existing features pipeline: new `features.desktop.aerion` option in `Users/common/features.nix`, mapping in `Users/common/features-impl.nix`, and per-user toggles in `Users/olafkfreund/{p620,razer}_home.nix`. P510 is headless and skipped.
- Add a small Home Manager module at `home/desktop/aerion/default.nix` exposing `programs.aerion.enable`.
- Wire `pkgs.aerion` via `overlays/custom-packages.nix` and expose as flake output `aerion`.

## Test plan

- [x] `nix build .#aerion` succeeds; `ldd result/bin/.aerion-wrapped` shows 0 "not found" entries.
- [x] `.desktop` Exec paths rewritten to the store path; icon installed at `share/icons/hicolor/256x256/apps/io.github.hkdb.Aerion.png`.
- [x] `just test-host p620` and `just test-host razer` both succeed.
- [x] Deployed to p620: `which aerion` → `/etc/profiles/per-user/olafkfreund/bin/aerion`, `aerion --version` → `0.2.5`.
- [ ] Deploy to razer (post-merge): `just quick-deploy razer`.
- [ ] Smoke-test GUI launch from the application menu.

## Notes

- OAuth client IDs for Gmail / Microsoft 365 are whatever upstream baked into v0.2.5. If those don't work, swapping to a source build is the workaround.
- Version bumps: change `version` in `pkgs/aerion/default.nix`, set `hash = lib.fakeHash;`, run `nix build .#aerion`, copy the reported hash back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)