### PR TITLE
chore(claude-code): update to 2.1.153

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.152";
+  version = "2.1.153";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-UVW9yif3VKug0v4vgDNvX9R5MiRWHCNKcj8MzvZUqOg=";
+      hash = "sha256-IU9gPzGUIWLayaZfGNQ7OsZGriFSQPrUgcSq1sYPLjg=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-Ne8mhcT2ebXEYQ71azCmgLbVlblYtPpewL+ihSGV80U=";
+      hash = "sha256-Ynf7vqciKKBp5HGfw+X6NvFnSSR6IyHFINrpPoPpLZw=";
     };
   };
 


### PR DESCRIPTION
## Summary

- Bumps `claude-code-native` 2.1.152 → 2.1.153 (Anthropic GCS `latest` channel).
- Refreshes both `x86_64-linux` and `aarch64-linux` SRI hashes.

## Test plan

- [x] `./scripts/update-claude-code-native.sh 2.1.153` resolved hashes cleanly.
- [x] `nix build .#claude-code-native` → `result/bin/claude --version` = `2.1.153 (Claude Code)`.
- [x] `ldd result/bin/claude` → no "not found" entries.
- [x] All three host configs build: p620, razer, p510.
- [ ] Deploy to p620 post-merge.

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)