### PR TITLE
chore(claude-desktop): update to v2.0.16+claude1.9255.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,17 +116,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1779861875,
-        "narHash": "sha256-tzG7V3jixO/win+Es0Sf0R2qWHWoQ9LpR7uESODcPms=",
+        "lastModified": 1779932571,
+        "narHash": "sha256-vOHSgioMms0IHVryaofcIOw/5nY3SzBtRscRSRcINTA=",
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "5b2fb4141bccfc621da2356b5f978cd71cf96a51",
+        "rev": "5dd948e96d853ed37636bc0e2368fc2665cd1104",
         "type": "github"
       },
       "original": {
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "5b2fb4141bccfc621da2356b5f978cd71cf96a51",
+        "rev": "5dd948e96d853ed37636bc0e2368fc2665cd1104",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -71,17 +71,19 @@
     # Additional tools
     lan-mouse.url = "github:feschber/lan-mouse";
     zjstatus.url = "github:dj95/zjstatus";
-    # = tag v2.0.15+claude1.9255.0, commit 5b2fb414 (2026-05-27).
-    # Claude binary bump 1.8555.2 -> 1.9255.0. Picks up:
-    #   - #657 anchor tray-var extraction on .Tray() literal, resolving
-    #     the 1.9255.0 nix build failure reported in #654
+    # = tag v2.0.16+claude1.9255.2, commit 5dd948e9 (2026-05-28).
+    # Claude binary bump 1.9255.0 -> 1.9255.2. Picks up:
+    #   - #660 capture $-prefixed minified names in cowork spawn guard
+    #     (refinement to cowork patch from v2.0.15)
+    # Carries forward from v2.0.15:
+    #   - #657 anchor tray-var extraction on .Tray() literal
     #   - #650 filter .asar paths from --add-dir dispatch + session restore
     # Known caveat carried in: #605 (Electron holds systemd-inhibit
     # forever, blocking suspend while app runs). Razer-relevant.
     # Workaround: close claude-desktop entirely to release inhibitor,
     # or set CLAUDE_KEEP_AWAKE=0 (#645).
     # Bump via /update-claude-code.
-    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/5b2fb4141bccfc621da2356b5f978cd71cf96a51";
+    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/5dd948e96d853ed37636bc0e2368fc2665cd1104";
 
     # Claude Code skill catalogue (borghei). flake = false because it's a
     # plain markdown/assets catalogue, not a Nix flake. We symlink one


### PR DESCRIPTION
## Summary

- Bumps `claude-desktop-linux` flake input from `5b2fb4141b` (v2.0.15) to `5dd948e96d` (tag `v2.0.16+claude1.9255.2`, 2026-05-28).
- Claude binary bump `1.9255.0` → `1.9255.2`.
- Picks up upstream PR #660: capture `$`-prefixed minified names in cowork spawn guard (refinement to v2.0.15 cowork patch).

## Pre-flight checks (per /update-claude-code Section B)

- [x] Upstream open-bug scan: no `_svcLaunched`, no `optionalDependencies`, no `build.sh` regression flags.
- [x] Diff between pin and target: 4 commits, 4 files touched (CHANGELOG, upstream nix derivation, cowork patch refinement, host-detect script). No risk-surface changes.
- [x] Built FHS wrapper resolves to inner `claude-desktop-1.9255.2`.
- [x] `pty.node` verified ELF in `app.asar.unpacked/node_modules/node-pty/build/Release/`.
- [x] All three host configs build: p620, razer, p510.

**Note:** Our integration is now a thin passthrough on `inputs.claude-desktop-linux.packages.${system}.claude-desktop-fhs`; we don't carry an overlay sed on `build.sh`, so the skill's `grep -c "Copying node-pty native binaries"` check is N/A here.

## Test plan

- [ ] Deploy to razer post-merge: `ssh razer 'cd ~/.config/nixos && git pull && sudo nixos-rebuild switch --flake .#razer'`
- [ ] Confirm process tree picks up new inner hash: `ssh razer 'pgrep -af "claude-desktop-1\.[0-9]"'`
- [ ] Deploy to p620 after user OK (Electron will keep running old binary until pkill + relaunch).

## Idiot-proofing reminder

- claude-desktop processes keep running from the OLD store path until killed. After deploy, user must `pkill -f claude-desktop` and relaunch from app menu — this loses in-flight state.
- If post-restart launch fails with "VM service not running": `rm -rf ~/.config/Claude/vm_bundles/` and try again.

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)