### PR TITLE
feat(home): manage syncthing .stignore declaratively

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -11,6 +11,7 @@
     ./media/music.nix
     ./media/spice_themes.nix
     ./files.nix
+    ./syncthing-stignore.nix
   ];
 
   # Enable Claude Code via home-manager's built-in module.

--- a/home/syncthing-stignore.nix
+++ b/home/syncthing-stignore.nix
@@ -1,0 +1,82 @@
+# Syncthing .stignore — declarative allowlists for ~/.claude and ~/.gemini
+#
+# Both folders are synced cluster-wide via Syncthing (folders claude-config
+# and gemini-config). We restrict what actually syncs to a small curated
+# allowlist: skills/commands/agents/plugins/CLAUDE.md for claude;
+# config/skills/commands/agents/hooks/extensions/GEMINI.md/settings.json
+# for gemini. Everything else (session transcripts, file-history, caches,
+# antigravity runtime, ...) is excluded by a trailing `*` catch-all.
+#
+# force = true: Syncthing wrote these files imperatively before we
+# Nixified them, so the first activation must clobber the on-disk copies.
+# After that they're symlinks to the Nix store and Syncthing reloads them
+# automatically on change (verified — see folder.fsWatcher).
+#
+# To change patterns, edit this file and re-deploy. Do NOT edit ~/.claude/
+# .stignore or ~/.gemini/.stignore directly — your edits would be reverted
+# on the next nixos-rebuild switch.
+{ ... }:
+{
+  home.file.".claude/.stignore" = {
+    force = true;
+    text = ''
+      // ~/.claude/.stignore — allowlist mode (managed by home/syncthing-stignore.nix)
+      // Only paths matched by "!" rules below are synced.
+      // Everything else is ignored by the final catch-all.
+
+      // ─── Sensitive: never sync, even by accident ───
+      .credentials.json
+
+      // ─── Sync-conflict litter: drop everywhere ───
+      *sync-conflict*
+
+      // ─── ALLOWLIST: only these sync ───
+      !CLAUDE.md
+      !skills/**
+      !commands/**
+      !agents/**
+      !plugins/**
+
+      // ─── Catch-all: ignore everything else ───
+      *
+    '';
+  };
+
+  home.file.".gemini/.stignore" = {
+    force = true;
+    text = ''
+      // ~/.gemini/.stignore — allowlist mode (managed by home/syncthing-stignore.nix)
+      // Only paths matched by "!" rules below are synced.
+      // Everything else is ignored by the final catch-all.
+
+      // ─── Sensitive: never sync, even by accident ───
+      oauth_creds.json
+      google_accounts.json
+
+      // ─── Per-machine state: never useful cross-host ───
+      installation_id
+      user_id
+      state.json
+      projects.json
+      trustedFolders.json
+      settings.json.orig
+      settings.nix
+
+      // ─── Sync-conflict litter: drop everywhere ───
+      *sync-conflict*
+
+      // ─── ALLOWLIST: only these sync ───
+      !GEMINI.md
+      !settings.json
+      !config/**
+      !skills/**
+      !commands/**
+      !agents/**
+      !hooks/**
+      !extensions/**
+
+      // ─── Catch-all: ignore everything else ───
+      *
+    '';
+  };
+}


### PR DESCRIPTION
## Summary

- New Home Manager module `home/syncthing-stignore.nix` that writes `~/.claude/.stignore` and `~/.gemini/.stignore` from a Nix source-of-truth.
- Bakes the **allowlist** content that was deployed imperatively earlier today (only curated paths sync: skills, commands, agents, plugins, CLAUDE.md for claude; config, skills, commands, agents, hooks, extensions, GEMINI.md, settings.json for gemini).
- Sync-conflict litter dropped by pattern; everything else caught by a trailing `*`.
- `force = true` on both `home.file` entries — the on-disk copies were imperatively written before; first activation clobbers them. Subsequent runs replace store symlinks atomically; syncthing's fsWatcher reloads on change.
- Imported unconditionally from `home/default.nix` (no enable flag — `.claude/` and `.gemini/` exist on every host that runs Claude Code / Gemini CLI).

## Test plan

- [x] `just test-host p620` → exit 0
- [x] `just test-host razer` → exit 0
- [x] `just test-host p510` → exit 0
- [ ] Deploy to each host post-merge; verify `readlink ~/.claude/.stignore` points at `/nix/store/...` and syncthing's parsed ignore list still shows the allowlist.

## Notes

- To change ignore patterns in the future: edit `home/syncthing-stignore.nix`, rebuild, deploy. Do NOT hand-edit `~/.claude/.stignore` or `~/.gemini/.stignore` — your changes would be reverted on the next switch.
- Module rationale and prior context: see today's discussion thread on cluster-wide syncthing tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)