### PR TITLE
fix(syncthing): remove imperative .stignore writer (follow-up to #649)

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -1,7 +1,7 @@
 { config, lib, ... }:
 
 let
-  inherit (lib) mkOption mkIf mkEnableOption types optionalString listToAttrs filter;
+  inherit (lib) mkOption mkIf mkEnableOption types listToAttrs filter;
   cfg = config.features.syncthing;
 
   # Host device IDs - obtained from each host's Syncthing installation
@@ -29,62 +29,6 @@ let
       };
     })
     otherHosts);
-
-  # Common ignore patterns for Claude config
-  claudeIgnorePatterns = ''
-    // Sensitive files - never sync
-    .credentials.json
-
-    // Large/runtime files - per machine
-    history.jsonl
-    stats-cache.json
-
-    // Cache and temporary directories
-    cache
-    debug
-    shell-snapshots
-    session-env
-    paste-cache
-    file-history
-    statsig
-    telemetry
-    todos
-    ide
-
-    // Home Manager managed files (symlinks to nix store)
-    settings.json
-    settings.local.json
-    MCP-README.md
-    plugins/custom-marketplace
-
-    // Backup files
-    *.bak
-    *.backup
-    *~
-    .*.swp
-  '';
-
-  # Common ignore patterns for Gemini config
-  geminiIgnorePatterns = ''
-    // Sensitive files - never sync
-    oauth_creds.json
-    google_accounts.json
-
-    // Per-machine identifiers
-    installation_id
-    user_id
-    state.json
-
-    // Browser profile and temp
-    antigravity-browser-profile
-    tmp
-
-    // Backup files
-    *.bak
-    *.backup
-    *~
-    .*.swp
-  '';
 
 in
 {
@@ -225,32 +169,8 @@ in
       };
     };
 
-    # Create .stignore files for each synced folder
-    systemd.services.syncthing-stignore = {
-      description = "Create Syncthing ignore files";
-      wantedBy = [ "multi-user.target" ];
-      after = [ "syncthing.service" ];
-      serviceConfig = {
-        Type = "oneshot";
-        User = cfg.user;
-        Group = "users";
-      };
-      script = ''
-        # Create .stignore for Claude config
-        ${optionalString cfg.syncClaude ''
-          cat > /home/${cfg.user}/.claude/.stignore << 'EOF'
-        ${claudeIgnorePatterns}
-        EOF
-        ''}
-
-        # Create .stignore for Gemini config
-        ${optionalString cfg.syncGemini ''
-          cat > /home/${cfg.user}/.gemini/.stignore << 'EOF'
-        ${geminiIgnorePatterns}
-        EOF
-        ''}
-      '';
-    };
+    # NOTE: .stignore files are now managed declaratively by Home Manager
+    # via home/syncthing-stignore.nix — no oneshot writer here.
 
     # Firewall configuration
     networking.firewall = mkIf cfg.openFirewall {


### PR DESCRIPTION
## Summary

Follow-up to #649. The pre-existing `systemd.services.syncthing-stignore` in `modules/services/syncthing.nix` writes `~/.claude/.stignore` and `~/.gemini/.stignore` imperatively. After #649, those paths became read-only nix-store symlinks via Home Manager, so the imperative writer now fails with `EROFS`:

```
syncthing-stignore-start: /home/olafkfreund/.claude/.stignore: Read-only file system
syncthing-stignore.service: Failed with result 'exit-code'
```

The switch still completes (`switch-to-configuration` exits 4 = non-essential service failure), but the unit fails on every `nixos-rebuild` and pollutes journalctl.

## Changes

- Drop `systemd.services.syncthing-stignore`
- Drop the now-orphaned `claudeIgnorePatterns` + `geminiIgnorePatterns` let-bindings (they were only used by the deleted service)
- Drop unused `optionalString` from the `inherit (lib) …`
- Keep `syncClaude` / `syncGemini` options + folder definitions (still used at L171 / L194)

Net -83 lines.

## Test plan

- [x] `nix build .#nixosConfigurations.p620.config.system.build.toplevel` — clean
- [ ] Deploy p620 after merge; verify `systemctl status syncthing-stignore.service` returns "unit not found" and the deploy returns exit 0.
- [ ] Verify `~/.claude/.stignore` remains a symlink into `/nix/store/<...>-home-manager-files/`.
- [ ] Deploy razer + p510 same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)