### PR TITLE
fix(home): reach p510 with declarative .stignore (follow-up to #649)

### DIFF
--- a/Users/common/imports.nix
+++ b/Users/common/imports.nix
@@ -13,5 +13,10 @@
 
     # Development environment modules
     ../../home/development/default.nix
+
+    # Syncthing .stignore — managed declaratively for every host
+    # (p510 doesn't import home/default.nix via profile.nix, so this
+    # is the common bind site that reaches all three host_home.nix files).
+    ../../home/syncthing-stignore.nix
   ];
 }


### PR DESCRIPTION
## Summary

Follow-up fix for #649 / #650. The new HM module from #649 was imported only from `home/default.nix`, which is reached by `Users/olafkfreund/profile.nix` — but p510's `p510_home.nix` doesn't import profile.nix (it goes directly to `server-admin` + `developer` profiles). So p510 never saw the module after #649; its `~/.claude/.stignore` and `~/.gemini/.stignore` stayed as the regular files we SCP'd in earlier, not as nix-store symlinks.

## Fix

Add `../../home/syncthing-stignore.nix` to `Users/common/imports.nix`, which IS pulled in by all three host_home.nix files via `Users/common/default.nix → ./imports.nix`.

The duplicate import via `home/default.nix` on p620/razer is harmless — Nix's module system merges duplicate imports without issue.

## Test plan

- [x] `nix build .#nixosConfigurations.p510.config.system.build.toplevel` → exit 0
- [ ] Deploy p510 after merge; verify `~/.claude/.stignore` and `~/.gemini/.stignore` are now symlinks into `/nix/store/<hash>-home-manager-files/`.
- [ ] Syncthing still healthy on p510 (state=idle, errors=0, ignorePatterns=true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)