### PR TITLE
chore(claude-code): update to 2.1.154

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.153";
+  version = "2.1.154";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-IU9gPzGUIWLayaZfGNQ7OsZGriFSQPrUgcSq1sYPLjg=";
+      hash = "sha256-Z/bKt+bBJAEPYqwY+AeLwJ4NtqW56K6HTp5zAzxFF5M=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-Ynf7vqciKKBp5HGfw+X6NvFnSSR6IyHFINrpPoPpLZw=";
+      hash = "sha256-n3Mt4nj3rcYdKf1bBV3a8brjuybXX+bgahJWAlZXd6g=";
     };
   };
 


### PR DESCRIPTION
## Summary
- Bump `claude-code-native` from 2.1.153 → 2.1.154 (Anthropic GCS `latest` channel)
- Updates `version` + both linux-x64 / linux-arm64 SRI hashes in `pkgs/claude-code-native/default.nix`

## Verification
- `nix build .#claude-code-native` → `claude --version` reports `2.1.154 (Claude Code)`
- `ldd` on the patched binary — no missing libraries
- Host matrix `nix build --no-link .#nixosConfigurations.<host>.config.system.build.toplevel` all pass:
  - p620 ✅ (76s)
  - razer ✅ (230s)
  - p510 ✅ (51s)

## Test plan
- [ ] Deploy p620 (`just quick-deploy p620`) and confirm `claude --version` → 2.1.154
- [ ] Deploy razer + p510

🤖 Generated with [Claude Code](https://claude.com/claude-code)