### PR TITLE
chore(claude-code): update to 2.1.156

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.154";
+  version = "2.1.156";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-Z/bKt+bBJAEPYqwY+AeLwJ4NtqW56K6HTp5zAzxFF5M=";
+      hash = "sha256-bYPNImRFDF5U/JiL4QMsKIz0GO5gQpSs+4/ErCj196M=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-n3Mt4nj3rcYdKf1bBV3a8brjuybXX+bgahJWAlZXd6g=";
+      hash = "sha256-ftldCpOutA4rmOI0t2DZKVtwRO9njGLbjR9eFL/VeHg=";
     };
   };
 


### PR DESCRIPTION
## Summary
- Bump `claude-code-native` from `2.1.154` → `2.1.156` (Anthropic GCS `latest` channel; skips 2.1.155 — upstream jumped directly to .156)
- Updates `version` + both x86_64-linux / aarch64-linux SRI hashes in `pkgs/claude-code-native/default.nix`

## Verification
- `nix build .#claude-code-native` → `claude --version` reports `2.1.156 (Claude Code)`
- `ldd` on the patched binary — no missing libraries
- Host matrix `nix build --no-link .#nixosConfigurations.<host>.config.system.build.toplevel` all pass:
  - p620 ✅ (49s)
  - razer ✅ (49s)
  - p510 ✅ (39s)

## Test plan
- [ ] Merge + deploy p620 (`just quick-deploy p620`), confirm `claude --version` → 2.1.156
- [ ] Deploy razer (p510 doesn't ship claude-code; deploy still rolls flake.lock parity)

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)