### PR TITLE
feat(docs): wire custom domain nixos.freundcloud.com

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+nixos.freundcloud.com

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_description: >-
   Documentation for every module, package, and host, with the reasoning
   behind each architectural choice.
 site_author: olafkfreund
-site_url: https://olafkfreund.github.io/nixos_config/
+site_url: https://nixos.freundcloud.com/
 
 repo_url: https://github.com/olafkfreund/nixos_config
 repo_name: olafkfreund/nixos_config


### PR DESCRIPTION
## Summary
- `+ docs/CNAME` — contains `nixos.freundcloud.com`, ships at the site root so each deploy preserves the custom-domain setting in Pages config (otherwise an artifact without CNAME can clear it).
- `~ mkdocs.yml` — `site_url` flipped from `https://olafkfreund.github.io/nixos_config/` → `https://nixos.freundcloud.com/`. Fixes canonical `<link>`, `sitemap.xml`, and `og:url`.

## Verification
`nix build .#docs`:
- `$OUT/CNAME` → `nixos.freundcloud.com` (22 bytes, present at site root)
- `$OUT/sitemap.xml` URLs start with `https://nixos.freundcloud.com/`

## Test plan
- [ ] Merge → `docs.yml` redeploys with the new artifact
- [ ] User adds CNAME record at GoDaddy: `nixos  CNAME  olafkfreund.github.io`
- [ ] After DNS propagates (5–60 min), GitHub Pages "InvalidDNSError" warning clears and `https://nixos.freundcloud.com/` serves the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)