### PR TITLE
chore(warp-terminal): bump to v0.2026.05.27.15.44.stable_01

### DIFF
--- a/pkgs/warp-terminal/versions.json
+++ b/pkgs/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "linux_x86_64": {
-    "hash": "sha256-ca50kA30ABbaLk/9ro6QFzQGoKn9oCvMsGTSlu/1NlE=",
-    "version": "0.2026.05.20.09.21.stable_03"
+    "hash": "sha256-dvD9s1zVGlvWrc2TmARp5njCHKH0FvocRxg642R2tQc=",
+    "version": "0.2026.05.27.15.44.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-C4UqgVGzdU/9KSIhLPlTdyEcMuSWGNVSgGCqen4Uf10=",
-    "version": "0.2026.05.20.09.21.stable_03"
+    "hash": "sha256-HOZwnG7ebq0PJIP5xalHDP5BpAMA6BY0k6V1QmvuFB8=",
+    "version": "0.2026.05.27.15.44.stable_01"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `pkgs/warp-terminal/versions.json` from `v0.2026.05.20.09.21.stable_03` → `v0.2026.05.27.15.44.stable_01` (one week newer)
- Both arches (x86_64 + aarch64) bumped in lock-step

## Verification
- `nix build .#nixosConfigurations.p620.pkgs.warp-terminal` → clean
- ELF check on `$OUT/opt/warpdotdev/warp-terminal/warp` → OK
- `nix eval` of `.version` reports `0.2026.05.27.15.44.stable_01` ✓
- Full p620 toplevel closure build → clean (47s with warm cache)

## Test plan
- [ ] Merge, then `just quick-deploy p620` and `just quick-deploy razer`
- [ ] Launch a fresh Warp window on each — version line in About should reflect the new build
- [ ] p510 (headless) skipped — Warp is desktop-only and not in p510's closure

🤖 Generated with [Claude Code](https://claude.com/claude-code)