### PR TITLE
feat: claude-code 2.1.158, MCP bug fixes, HM warning cleanups, /blog command

### DIFF
--- a/Users/common/base-home.nix
+++ b/Users/common/base-home.nix
@@ -60,11 +60,17 @@
   gtk.gtk4.theme = null;
   programs.git.signing.format = null;
 
+  # We intentionally chase nixos-unstable for nixpkgs; HM/Stylix master often
+  # advance to the next release cycle before nixpkgs unstable does, producing
+  # "mismatched versions" nags at HM profile evaluation. The system-level
+  # stylix.enableReleaseChecks in modules/desktop/stylix-theme.nix only silences
+  # the NixOS-level check; the HM-profile check needs its own opt-out here.
+  home.enableNixpkgsReleaseCheck = false;
+  stylix.enableReleaseChecks = false;
+
   programs.home-manager.enable = true;
 
-  # Stylix theming targets (Home Manager level).
-  # `enableReleaseChecks = false` is set once in modules/desktop/stylix-theme.nix
-  # at the system level — no need to repeat it here. GTK is enabled fleet-wide
+  # Stylix theming targets (Home Manager level). GTK is enabled fleet-wide
   # because COSMIC's GTK theme sync is off on every host; cosmic-comp does not
   # clobber ~/.config/gtk-{3,4}.0/gtk.css at runtime.
   stylix.targets = {

--- a/home/development/claude-code-commands/blog.md
+++ b/home/development/claude-code-commands/blog.md
@@ -1,0 +1,126 @@
+---
+description: Draft, stage, and publish a post to the freundcloud Jekyll blog (GitHub Pages)
+argument-hint: "[--draft|--publish <slug>|--list] <title or notes>"
+allowed-tools: Bash(*), Read, Write, Edit
+---
+
+# Blog publishing command
+
+You write and publish posts for **www.freundcloud.com**, a Jekyll site
+deployed to GitHub Pages from the repo `olafkfreund/WWW-Freundcloud`.
+Posts are Markdown files in `_posts/`; pushing to `main` triggers the
+`pages.yml` GitHub Action which builds the site and deploys it. Drafts
+live in `_drafts/` and are never built/deployed until promoted.
+
+Your input:
+
+$ARGUMENTS
+
+## Step 0 — Locate the blog repository
+
+Find the repo root before doing anything else. In order:
+
+1. If the current working directory is inside a git repo whose `origin`
+   remote matches `WWW-Freundcloud` (case-insensitive), use that root:
+   `git rev-parse --show-toplevel`.
+2. Otherwise try `~/Source/GitHub/www-freundcloud`.
+3. If neither exists, stop and tell me where the repo is (do **not**
+   clone or guess). All file paths below are relative to this root.
+
+Confirm you found a Jekyll blog: `_config.yml`, `_posts/`, and
+`_layouts/post.html` must all exist. If not, stop and say so.
+
+## Step 1 — Parse the mode from `$ARGUMENTS`
+
+- `--list` → **List drafts.** Print the files in `_drafts/` (name +
+  first-line title). Do nothing else.
+- `--publish <slug>` → **Promote a draft.** Go to Step 4 with the draft
+  `_drafts/<slug>.md`.
+- `--draft <rest>` → **Draft only.** Write to `_drafts/`, no date, no
+  push. Go to Step 2 then Step 3 (draft variant).
+- anything else (plain text) → **Publish-ready.** Treat the text as the
+  title/topic/notes. Go to Step 2 then Step 3 then Step 4.
+
+## Step 2 — Gather what you need
+
+From the input, derive: **title**, **angle**, **tags** (2–4, lowercase,
+from the site's themes: devops, platform, cicd, nixos, ai, agents,
+multicloud, meta, kubernetes, …), and a one-to-two-sentence **excerpt**.
+
+Only ask me questions for fields you genuinely cannot infer. If the
+input is a rich set of notes, infer everything and proceed — don't
+interrogate. If it's just a bare title, ask for the angle and the tags
+in a single batch, then continue.
+
+Derive the **slug**: lowercase the title, replace non-alphanumerics with
+single hyphens, trim leading/trailing hyphens. (e.g. "Moving a bank off
+Bamboo" → `moving-a-bank-off-bamboo`.)
+
+## Step 3 — Write the post
+
+**Match the house voice.** Read `_posts/2026-05-29-welcome-to-the-blog.md`
+first and mirror it: first-person, opinionated, working-out-loud, dry
+wit, concrete over abstract, short paragraphs, `##` section headings,
+fenced code blocks with a language where useful, occasional inline links
+using Jekyll's `relative_url` filter for internal links
+(e.g. `[the KB]({{ '/kb/' | relative_url }})`). No marketing fluff, no
+"In today's fast-paced world" openers. Write something I'd actually post.
+
+Length: aim 400–900 words unless the notes clearly want more or less.
+
+**Front matter** — every field is required and read by the templates:
+
+```yaml
+---
+layout: post
+title: "<title>"
+date: <YYYY-MM-DD HH:MM:SS +0100>
+permalink: /blog/<slug>/
+tags: [<tag>, <tag>]
+comments: true
+excerpt: >-
+  <one-to-two sentence summary; shown on the blog index and in RSS>
+---
+```
+
+For the **publish-ready** path: set `date` using real local time —
+get it from `date "+%Y-%m-%d %H:%M:%S +0100"` — and write the file to
+`_posts/<YYYY-MM-DD>-<slug>.md` (date prefix from `date +%F`).
+
+For the **--draft** path: write to `_drafts/<slug>.md` and omit the
+`date:` line entirely (Jekyll assigns the date at publish time). Do not
+go to Step 4 — instead report the draft path and remind me I can publish
+it later with `/blog --publish <slug>`.
+
+**Safety:** if the target file already exists, stop and warn — never
+overwrite an existing post or draft. Show me the proposed file (front
+matter + body) and wait for my go-ahead before the publish step.
+
+## Step 4 — Publish (publish-ready and --publish paths only)
+
+1. If promoting a draft: read `_drafts/<slug>.md`, add a `date:` line
+   with the current local time, write it to
+   `_posts/<YYYY-MM-DD>-<slug>.md`, and `git rm` the draft.
+2. **Validate locally** before pushing — run, from the repo root:
+   `bundle exec jekyll build` (set `JEKYLL_ENV=production`). If the
+   build fails, stop, show me the error, and do **not** push. This
+   catches YAML/Liquid breakage that would otherwise fail the deploy.
+3. Stage **only** the new post file (and the removed draft, if any) —
+   never `git add -A`. Confirm with `git status` that nothing unexpected
+   is staged.
+4. Commit: `git commit -m "post: <title>"`.
+5. Push: `git push origin main`. Never force-push.
+6. Report the result: the live URL
+   `https://www.freundcloud.com/blog/<slug>/`, the commit hash, and a
+   note that the Pages Action takes ~1–2 minutes to build and deploy
+   (link to the Actions tab so I can watch it).
+
+## Notes
+
+- Comments use giscus and are enabled per-post via `comments: true`, but
+  live comments need the one-time giscus repo/category IDs filled into
+  `_includes/giscus.html` (currently placeholders). Mention this once if
+  relevant; it's outside this command's job.
+- This command never edits already-published posts and never touches
+  files other than the single new post (+ the promoted draft). For
+  anything beyond that, tell me explicitly.

--- a/home/development/claude-code-commands/blog.md
+++ b/home/development/claude-code-commands/blog.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(*), Read, Write, Edit
 
 # Blog publishing command
 
-You write and publish posts for **www.freundcloud.com**, a Jekyll site
+You write and publish posts for **<www.freundcloud.com>**, a Jekyll site
 deployed to GitHub Pages from the repo `olafkfreund/WWW-Freundcloud`.
 Posts are Markdown files in `_posts/`; pushing to `main` triggers the
 `pages.yml` GitHub Action which builds the site and deploys it. Drafts

--- a/home/development/claude-code-commands/default.nix
+++ b/home/development/claude-code-commands/default.nix
@@ -176,8 +176,8 @@ in
   options.programs.claude-code-commands = {
     enable = mkEnableOption ''
       Declarative Claude Code user-level slash commands at
-      ~/.claude/commands/. Adds /team and /crew — see source file for
-      details.
+      ~/.claude/commands/. Adds /team, /crew and /blog — see source file
+      for details.
     '';
 
     endpoint = mkOption {
@@ -210,5 +210,10 @@ in
   config = mkIf cfg.enable {
     home.file.".claude/commands/team.md".text = teamCommand;
     home.file.".claude/commands/crew.md".text = crewCommand;
+    # /blog — bundled as a source file rather than inline text because the
+    # command body is full of shell ${...} and Liquid {{ }} braces that a
+    # Nix '' string would try to interpolate. Deploys to every host that
+    # enables this module (p620, p510, razer).
+    home.file.".claude/commands/blog.md".source = ./blog.md;
   };
 }

--- a/home/media/music.nix
+++ b/home/media/music.nix
@@ -1,6 +1,6 @@
 { pkgs, spicetify-nix, ... }:
 let
-  spicePkgs = spicetify-nix.legacyPackages.${pkgs.system};
+  spicePkgs = spicetify-nix.legacyPackages.${pkgs.stdenv.hostPlatform.system};
 in
 {
   home.packages = [

--- a/pkgs/arr-suite-mcp/default.nix
+++ b/pkgs/arr-suite-mcp/default.nix
@@ -25,10 +25,38 @@ python3Packages.buildPythonApplication rec {
 
   # Upstream's pyproject only lists the top-level package, so setuptools omits
   # the clients/routers/utils subpackages (ModuleNotFoundError at runtime).
+  #
+  # ProwlarrClient also forgets to override `_api_version`, so it inherits "v3"
+  # from BaseArrClient and every request 404s (Prowlarr only exposes /api/v1).
+  # Patch mirrors overseerr.py's existing override idiom.
+  #
+  # OverseerrClient inherits BaseArrClient.get_system_status() which hits
+  # /api/v1/system/status, but Overseerr exposes the equivalent at /api/v1/status
+  # (already implemented as get_status). Override to delegate so arr_get_system_status
+  # stops reporting Overseerr as offline.
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail 'packages = ["arr_suite_mcp"]' \
         'packages = ["arr_suite_mcp", "arr_suite_mcp.clients", "arr_suite_mcp.routers", "arr_suite_mcp.utils"]'
+
+    substituteInPlace arr_suite_mcp/clients/prowlarr.py \
+      --replace-fail \
+        '    """Client for interacting with Prowlarr API."""' \
+        '    """Client for interacting with Prowlarr API."""
+
+        def __init__(self, base_url: str, api_key: str, timeout: int = 30, max_retries: int = 3):
+            """Initialize Prowlarr client (uses v1 API)."""
+            super().__init__(base_url, api_key, timeout, max_retries)
+            self._api_version = "v1"  # Prowlarr uses v1'
+
+    substituteInPlace arr_suite_mcp/clients/overseerr.py \
+      --replace-fail \
+        '    async def get_status(self) -> dict[str, Any]:' \
+        '    async def get_system_status(self) -> dict[str, Any]:
+            """Overseerr exposes status at /status, not /system/status."""
+            return await self.get("status")
+
+        async def get_status(self) -> dict[str, Any]:'
   '';
 
   build-system = [ python3Packages.setuptools ];

--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.156";
+  version = "2.1.158";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-bYPNImRFDF5U/JiL4QMsKIz0GO5gQpSs+4/ErCj196M=";
+      hash = "sha256-3ScAis1CcAusV2JlLsg/9gS/muB4bU3eVdV6aGYBf74=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-ftldCpOutA4rmOI0t2DZKVtwRO9njGLbjR9eFL/VeHg=";
+      hash = "sha256-mIB2daPtW3t3X36qge2jLLooELl+nbn2+Y171ljOwA4=";
     };
   };
 


### PR DESCRIPTION
## Summary

Bundles five small, independent changes that accumulated this session.

| # | Commit | Scope |
|---|---|---|
| 1 | `fix(arr-suite-mcp): patch upstream client bugs for Prowlarr & Overseerr` | MCP integration |
| 2 | `chore(claude-code): update to 2.1.158` | CLI bump (closes #661, #662) |
| 3 | `fix(home): silence HM/Stylix release-check and pkgs.system deprecations` | Eval warnings |
| 4 | `feat(claude-code-commands): add /blog slash command` | New command |
| 5 | `style(claude-code-commands): apply markdownlint auto-fix to /blog` | Lint fix-up |

### Details

**1. arr-suite-mcp** — Two upstream client bugs in `shaktech786/arr-suite-mcp-server @ 96665c1`: `ProwlarrClient` inherits `_api_version="v3"` but Prowlarr only exposes `/api/v1` (every call 404s); `OverseerrClient.get_system_status()` hits non-existent `/api/v1/system/status` instead of `/api/v1/status`. Both patched via `postPatch` in `pkgs/arr-suite-mcp/default.nix`.

**2. claude-code 2.1.158** — Anthropic GCS channel bump from 2.1.156. Built artifact reports the expected version; ldd clean on x86_64-linux.

**3. HM/Stylix warnings** — `pkgs.system` is deprecated (now `pkgs.stdenv.hostPlatform.system`). HM-profile-level checks for HM-version-vs-nixpkgs and Stylix-version-vs-HM keep firing despite the system-level Stylix disable, because they look at HM-profile config; add the equivalent opt-outs at the profile level in `Users/common/base-home.nix`.

**4. /blog slash command** — Jekyll publishing helper for www.freundcloud.com. Bundled as a source file (not inline string) because the body mixes shell `${...}` and Liquid `{{ }}` braces.

**5. Lint fix-up** — `markdownlint` MD034 auto-fix on the bare URL in `/blog`'s preamble.

## Test plan

- [x] `nix build .#claude-code-native` → reports `2.1.158`, `ldd` clean
- [x] `nix build .#nixosConfigurations.{p620,p510,razer}.config.system.build.toplevel` → clean, no warnings
- [x] arr-suite-mcp service rebuilt and restarted on p510; Prowlarr + Overseerr verified online via MCP tools
- [ ] Post-merge: deploy to all hosts and verify `claude --version` reports `2.1.158`

🤖 Generated with [Claude Code](https://claude.com/claude-code)