### PR TITLE
chore: lockfile bumps — nixpkgs to unstable HEAD, antigravity to 1.0.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -931,16 +931,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754028485,
-        "narHash": "sha256-IiiXB3BDTi6UqzAZcf2S797hWEPCRZOwyNThJIYhUfk=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "59e69648d345d6e8fef86158c555730fa12af9de",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.0.2-6109799369277440";
+  version = "1.0.3-6260531212976128";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.2-6109799369277440/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-9sfKgNUJkzO/IpZ2RzvREeDapqDY23xTKt9lA7Dqrck=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.3-6260531212976128/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-BH02Ndl7Su7MDcM79SfYQRF50VRDAwA+ifw8uDsNBGI=";
   };
 
   # Tarball contains a single file `antigravity` at the root.

--- a/pkgs/google-antigravity-py/default.nix
+++ b/pkgs/google-antigravity-py/default.nix
@@ -25,15 +25,15 @@
 # Upstream: https://github.com/google-antigravity/antigravity-sdk-python
 buildPythonPackage rec {
   pname = "google-antigravity";
-  version = "0.1.0";
+  version = "0.1.1";
   format = "wheel";
 
   # fetchPypi gets the URL wrong for this package (constructs
   # google-antigravity- instead of google_antigravity-), so use fetchurl
   # with the canonical PyPI download URL.
   src = fetchurl {
-    url = "https://files.pythonhosted.org/packages/df/70/812e0ef107fa1b71c3079eab7162928b0695ce59646e19ea32bfb2a21ab7/google_antigravity-0.1.0-py3-none-manylinux_2_17_x86_64.whl";
-    hash = "sha256-KRsHLAwp34brbDyID8Vgb5E74GKQBmXGvUgkZtbUhz0=";
+    url = "https://files.pythonhosted.org/packages/f3/21/9c3b3b59943b2f0c89c35282c8838b691a1e6b39f3801f40a23882ea45f6/google_antigravity-0.1.1-py3-none-manylinux_2_17_x86_64.whl";
+    hash = "sha256-ZMzXHZuaUIJ8aOTf20YFV1R9G6qr7OhD1OrlbBu7Ve4=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Summary

Two small, independent maintenance commits batched together.

| Commit | What |
|---|---|
| `1be1655e0` | `nixpkgs` lock advanced from `59e69648d3` (2025-08-01, recorded `original.ref=nixos-25.05`) → `64c08a7ca0` (2026-05-23, `nixos-unstable` HEAD). flake.nix already declared `nixos-unstable`; the lock had drifted. Force-resolved via `nix flake prefetch`. |
| `6142aad3b` | `antigravity-cli` 1.0.2 → 1.0.3 (matches upstream antigravity-nix flake), `google-antigravity-py` 0.1.0 → 0.1.1. |

## Why

- The `nixpkgs` drift was making `nix flake update nixpkgs` silently no-op. This restores the channel intent declared in flake.nix.
- Antigravity-cli was behind upstream's 1.0.3 release (announced in antigravity-nix flake commit `e857f976b3`); the python pkg had a new PyPI release.

## Test plan

- [x] `nix build --no-link .#nixosConfigurations.{p620,p510,razer}.config.system.build.toplevel` — all three clean, zero warnings
- [x] `nix build .#nixosConfigurations.p620.pkgs.customPkgs.antigravity-cli` — builds to 1.0.3 artifact
- [x] `system.nixos.release` stays `26.05`; `gnome-shell.version` stays `50.1`
- [ ] Post-merge: deploy via `nhs <host>` per usual

## Notes

- `nixpkgs` jumped ~10 months of unstable history but most of the closure was already cached on p510 (build wall-time was 31s). Real impact is small.
- Antigravity-ide (the larger sibling) was already at upstream's pinned 2.0.3-6242596486512640; no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)