### PR TITLE
fix(media-bot): use LoadCredential for users-file (DynamicUser permission)

### DIFF
--- a/modules/services/media-bot.nix
+++ b/modules/services/media-bot.nix
@@ -92,17 +92,20 @@ in
       wantedBy = [ "multi-user.target" ];
 
       environment = {
-        # Non-secret paths handed to the bot. (BOT_USERS_FILE intentionally
-        # NOT in the env file: the path is module-controlled, not a secret,
-        # and pointing it at the agenix-decrypted location decouples the
-        # bot from where agenix happens to write the file.)
-        BOT_USERS_FILE = cfg.usersFile;
+        # BOT_USERS_FILE points into the systemd Credentials Directory
+        # populated by LoadCredential below — agenix decrypts the YAML
+        # as root to /run/agenix/media-bot-users (0400 root-owned), then
+        # systemd copies it into /run/credentials/media-bot.service/
+        # readable by the DynamicUser-spawned bot process. Same pattern
+        # plex-mcp uses for PLEX_TOKEN.
+        BOT_USERS_FILE = "/run/credentials/media-bot.service/users-file";
         WEBHOOK_PORT = toString cfg.port;
       };
 
       serviceConfig = {
         ExecStart = "${lib.getExe pkgs.customPkgs.media-bot}";
         EnvironmentFile = cfg.environmentFile;
+        LoadCredential = [ "users-file:${cfg.usersFile}" ];
 
         DynamicUser = true;
         StateDirectory = "media-bot";


### PR DESCRIPTION
## Summary

Hotfix to PR #665. First deploy of media-bot crashed in a restart loop with:

\`\`\`
PermissionError: [Errno 13] Permission denied: '/run/agenix/media-bot-users'
\`\`\`

Root cause: \`age.secrets.\"media-bot-users\".mode = \"0400\"\` (root-owned) plus
\`DynamicUser = true\` on the service. The dynamic user can't read the agenix
file directly.

## Fix

Use systemd's \`LoadCredential\` mechanism — same pattern \`plex-mcp.nix\`
uses for \`PLEX_TOKEN\`. systemd reads the agenix file as root, copies it
into \`/run/credentials/media-bot.service/\` owned by the spawned dynamic
user, and \`BOT_USERS_FILE\` points the bot at that location.

## Test plan

- [x] \`nix build .#nixosConfigurations.p510.config.system.build.toplevel\` clean
- [ ] Post-merge: \`just quick-deploy p510\` → \`systemctl is-active media-bot\` → \`active (running)\`, NRestarts=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)