### PR TITLE
feat(bazarr): subtitle automation for Sonarr/Radarr/Lidarr on p510

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -39,6 +39,7 @@ in
       ../../modules/services/audiobook-import.nix # Completed downloads → Audiobookshelf (LLM + m4b)
       ../../modules/services/audiobook-mcp.nix # Audiobook acquisition + library MCP (SSE)
       ../../modules/services/media-bot.nix # Household media Telegram bot (Ollama NL + webhooks)
+      ../../modules/services/bazarr.nix # Subtitle automation for Sonarr/Radarr/Lidarr
       # Desktop-specific imports (needed for GNOME):
       # ./nixos/greetd.nix      # Display manager - using GDM instead
       ./nixos/screens.nix # Display configuration - needed for desktop
@@ -432,5 +433,15 @@ in
   # then `sudo systemctl reload media-bot` on p510 to hot-reload.
   features.media-bot = {
     enable = true;
+  };
+
+  # Bazarr — subtitle manager for Sonarr/Radarr/Lidarr. Runs on :6767;
+  # exposed on tailnet0 + eno1 LAN. First-deploy: open the UI, wire it
+  # to Sonarr/Radarr by hand (one-time), set Default Language Profile
+  # to Norwegian Bokmål (nb) + English (en) fallback. See the module
+  # for the full first-run checklist.
+  features.bazarr = {
+    enable = true;
+    listenLanInterface = "eno1";
   };
 }

--- a/modules/services/bazarr.nix
+++ b/modules/services/bazarr.nix
@@ -1,0 +1,67 @@
+# Bazarr — subtitle manager for Sonarr/Radarr/Lidarr on p510.
+#
+# Thin wrapper over nixpkgs's services.bazarr. We add a feature flag for
+# consistency with the other media services, plus narrow the firewall
+# opening to tailscale0 (and optionally a named LAN interface) instead
+# of using `openFirewall = true` which would expose the port globally.
+#
+# Storage: nixpkgs default `/var/lib/bazarr` (small config + SQLite db).
+# Subtitle .srt files are written *next to* the video files in
+# `/mnt/media`, not into Bazarr's own data dir — no extra config needed.
+#
+# First-deploy UX (one-time, in the Bazarr web UI at http://p510:6767):
+#   1. Settings → Sonarr → add: localhost:8989 + SONARR_API_KEY
+#   2. Settings → Radarr → add: localhost:7878 + RADARR_API_KEY
+#      (API keys can be found in arr-suite-mcp-env.age — pasted via UI;
+#       Bazarr stores them in its own DB after that)
+#   3. Settings → Languages → enable Norwegian Bokmål (nb) + English (en)
+#   4. Settings → Languages → Default Profile:
+#        a. Norwegian Bokmål  (forced=False)
+#        b. English           (forced=False)
+#   5. Settings → Providers → enable OpenSubtitles.com (anonymous works;
+#      authenticate later for higher daily quota)
+#   6. Tick "use embedded subs" if present (saves a download when the
+#      release already has subs muxed in)
+#
+# Phase 2 candidate: declarative initial-config via Bazarr's REST API at
+# first deploy, similar to the *arr webhook wiring for media-bot.
+{ config
+, lib
+, ...
+}:
+let
+  cfg = config.features.bazarr;
+  port = 6767; # nixpkgs default
+in
+{
+  options.features.bazarr = {
+    enable = lib.mkEnableOption "Bazarr subtitle manager";
+
+    listenLanInterface = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "eno1";
+      description = ''
+        LAN interface to also open the Bazarr port on, in addition to
+        tailscale0. null exposes the service only via Tailscale (the
+        recommended setting; Bazarr's UI is fine over the tailnet).
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.bazarr = {
+      enable = true;
+      # We open the firewall ourselves below (tailnet + optional LAN);
+      # nixpkgs's `openFirewall = true` would open it on every interface.
+      openFirewall = false;
+    };
+
+    networking.firewall.interfaces = lib.mkMerge [
+      { "tailscale0".allowedTCPPorts = [ port ]; }
+      (lib.mkIf (cfg.listenLanInterface != null) {
+        "${cfg.listenLanInterface}".allowedTCPPorts = [ port ];
+      })
+    ];
+  };
+}


### PR DESCRIPTION
First sub-project from the Library QoL bucket of the media-stack brainstorm. Thin module wrapping `services.bazarr` from nixpkgs.

## Decisions

- Port: 6767 (nixpkgs default)
- Firewall: tailscale0 + eno1 (not global; matches other *arr services on p510)
- Storage: /var/lib/bazarr (nixpkgs default; small sqlite db; .srt files land next to videos in /mnt/media)
- Language profile: Norwegian Bokmål → English fallback (configured in UI on first deploy)
- No new agenix secrets (Bazarr auto-generates its own API key; Sonarr/Radarr keys pasted via UI on first deploy)

## Test plan

- [x] All 3 hosts build clean
- [ ] Post-merge: `just quick-deploy p510` → `systemctl is-active bazarr` → active
- [ ] Open http://p510:6767 → first-run wizard → wire Sonarr+Radarr per module docstring
- [ ] Trigger a Sonarr search for a series with missing English subs → Bazarr should grab .srt within minutes

## Out of scope

- Declarative Sonarr/Radarr wiring via Bazarr's REST API (Phase 2 candidate; mirrors the media-bot webhook pattern)
- Plex-Auto-Languages / Kometa / Maintainerr (separate sub-projects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)