### PR TITLE
fix(kometa): drop fictional agenix.service dependency

### DIFF
--- a/modules/services/kometa/default.nix
+++ b/modules/services/kometa/default.nix
@@ -87,8 +87,9 @@ in
       description = "Render Kometa config.yml from template + agenix secrets";
       wantedBy = [ "podman-kometa.service" ];
       before = [ "podman-kometa.service" ];
-      requires = [ "agenix.service" ];
-      after = [ "agenix.service" ];
+      # agenix on NixOS decrypts secrets in an activation script (not a
+      # systemd unit), so /run/agenix/<name> is already present by the
+      # time any service starts. No explicit dependency needed.
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = false;


### PR DESCRIPTION
agenix decrypts in an activation script (not a systemd unit) so the requires/after were referring to a non-existent unit, silently blocking kometa-config-render from starting.