### PR TITLE
chore(flaresolverr): replace stale "testing fix" comment

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -27,7 +27,7 @@ in
       ./nixos/memory.nix
       ../common/nixos/hosts.nix
       ./nixos/plex.nix
-      ./flaresolverr.nix # Re-enabled: Testing fix for xvfbwrapper Python 3.13 build error
+      ./flaresolverr.nix # Cloudflare-bypass proxy for Prowlarr (used by 1337x and any other CF-protected indexer)
 
       # P510-specific server modules (media server)
       ../../modules/development/default.nix


### PR DESCRIPTION
Third stack-hardening defect investigated and closed. Py3.13 build issue is resolved upstream; service is active, NRestarts=0, actively serving Prowlarr 1337x indexer. Just cleaning up the misleading import comment.