### PR TITLE
feat(kometa): flip dry_run to false (Phase 1b — first live run)

### DIFF
--- a/modules/services/kometa/config.yml
+++ b/modules/services/kometa/config.yml
@@ -68,7 +68,7 @@ settings:
   custom_repo:
   overlay_artwork_filetype: jpg
   overlay_artwork_quality: 75
-  dry_run: true   # <-- Phase 1a: dry-run only. Flip to false for live runs.
+  dry_run: false  # <-- Phase 1b: live. Collections are actually created in Plex.
   verify_ssl: false
   delete_unmanaged_collections: false
 


### PR DESCRIPTION
One-line config flip. Phase 1a dry-run produced clean output (28 / 5 / 0 films across the three IMDb default collections). Live run will create them in the Films library on next Monday or whenever the container is restarted with a manual --run.