### PR TITLE
chore(containers): pin Kometa + PAL container images to digests

### DIFF
--- a/modules/services/kometa/default.nix
+++ b/modules/services/kometa/default.nix
@@ -49,7 +49,11 @@ in
       backend = "podman";
 
       containers."kometa" = {
-        image = "kometateam/kometa:latest";
+        # Pinned to a specific digest for reproducibility + supply-chain
+        # safety. Bump by running on p510 and grabbing the new digest:
+        #   sudo podman pull kometateam/kometa:latest
+        #   sudo podman inspect kometateam/kometa:latest --format '{{.Digest}}'
+        image = "kometateam/kometa@sha256:b265e952fcc3931ac378601faf9e6e0d90bee104fc70d9002f59c8678bf00b87";
         autoStart = true;
         environmentFiles = [ config.age.secrets."kometa-env".path ];
         environment = {

--- a/modules/services/plex-auto-languages/default.nix
+++ b/modules/services/plex-auto-languages/default.nix
@@ -40,7 +40,11 @@ in
       backend = "podman";
 
       containers."plex-auto-languages" = {
-        image = "remirigal/plex-auto-languages:latest";
+        # Pinned to a specific digest for reproducibility + supply-chain
+        # safety. Bump by running on p510 and grabbing the new digest:
+        #   sudo podman pull remirigal/plex-auto-languages:latest
+        #   sudo podman inspect remirigal/plex-auto-languages:latest --format '{{.Digest}}'
+        image = "remirigal/plex-auto-languages@sha256:54bd9cf5d399514b8ed3052ce1d01a14375825a429653cb06da129685740889e";
         autoStart = true;
         environmentFiles = [ config.age.secrets."plex-auto-languages-env".path ];
         volumes = [


### PR DESCRIPTION
Supply-chain reproducibility. Drop :latest, use @sha256:... pins for both kometateam/kometa and remirigal/plex-auto-languages. Bump procedure documented inline.