### PR TITLE
feat(home): newsboat + reddit-tui + headlines on razer + p620

### DIFF
--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -1,7 +1,6 @@
 { config
 , lib
 , pkgs
-, antigravity-nix
 , ...
 }:
 let
@@ -13,6 +12,7 @@ in
     ../common/default.nix
     ../../home/default.nix
     ../../home/games/steam.nix
+    ../../home/media/reddit.nix
     ./private.nix
   ];
 

--- a/home/media/reddit.nix
+++ b/home/media/reddit.nix
@@ -1,0 +1,51 @@
+# Reddit on the desktop — declarative newsboat feeds + a TUI client + a GTK
+# client. Read-only by design (post-2023 Reddit API meltdown killed most
+# write/vote flows for third-party clients unless you wire your own OAuth
+# app — not worth the maintenance burden for a feed reader).
+#
+# Imported from Users/olafkfreund/profile.nix, so this lands on razer + p620
+# but NOT on p510 (which uses a different home profile composition).
+{ pkgs, ... }:
+{
+  # newsboat — TUI RSS reader. Reddit serves RSS at <subreddit>/.rss, so
+  # subscribing is just listing the URLs here. `tags` are used by newsboat's
+  # filter view (press `t` then a tag name).
+  programs.newsboat = {
+    enable = true;
+    autoReload = true;
+    reloadTime = 30; # minutes
+    urls = [
+      { url = "https://www.reddit.com/r/NixOS/.rss"; tags = [ "reddit" "nix" ]; title = "r/NixOS"; }
+      { url = "https://www.reddit.com/r/unixporn/.rss"; tags = [ "reddit" "ricing" ]; title = "r/unixporn"; }
+      { url = "https://www.reddit.com/r/ClaudeAI/.rss"; tags = [ "reddit" "ai" ]; title = "r/ClaudeAI"; }
+      { url = "https://www.reddit.com/r/ClaudeCode/.rss"; tags = [ "reddit" "ai" ]; title = "r/ClaudeCode"; }
+      { url = "https://www.reddit.com/r/tui/.rss"; tags = [ "reddit" "tui" ]; title = "r/tui"; }
+      { url = "https://www.reddit.com/r/gnome/.rss"; tags = [ "reddit" "desktop" ]; title = "r/gnome"; }
+      { url = "https://www.reddit.com/r/linux/.rss"; tags = [ "reddit" "linux" ]; title = "r/linux"; }
+    ];
+    # Sensible defaults: open links in the user's preferred browser via
+    # xdg-open, cache feeds for offline browsing, and skip the (admittedly
+    # cute) startup splash so it shows the article list immediately.
+    extraConfig = ''
+      browser "xdg-open"
+      auto-reload yes
+      max-items 100
+      show-read-feeds no
+      show-read-articles no
+      confirm-mark-feed-read no
+      external-url-viewer "urlview"
+      bind-key j down
+      bind-key k up
+      bind-key J next-feed
+      bind-key K prev-feed
+    '';
+  };
+
+  # Standalone clients alongside newsboat:
+  #   - reddit-tui : modern Go-based read-only browser (uses public JSON)
+  #   - headlines  : GTK4 / Libadwaita GUI client when you want a window
+  home.packages = with pkgs; [
+    reddit-tui
+    headlines
+  ];
+}

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -627,6 +627,7 @@ in
     permittedInsecurePackages = [
       "olm-3.2.16"
       "python3.12-youtube-dl-2021.12.17"
+      "python3.13-youtube-dl-2021.12.17" # newsboat (RSS reader) pulls youtube-dl for URL extraction
       "libsoup-2.74.3" # Temporary: Required by some GNOME packages until migration to libsoup-3
       "electron-35.7.5" # Temporary: Required until upstream packages migrate to newer electron
     ];

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -470,6 +470,7 @@ in
     permittedInsecurePackages = [
       "olm-3.2.16"
       "python3.12-youtube-dl-2021.12.17"
+      "python3.13-youtube-dl-2021.12.17" # newsboat (RSS reader) pulls youtube-dl for URL extraction
       "libsoup-2.74.3" # Temporary: Required by some GNOME packages until migration to libsoup-3
       "electron-35.7.5" # Temporary: Required until upstream packages migrate to newer electron
     ];


### PR DESCRIPTION
## Summary

Declarative Reddit-via-RSS on the two daily-driver hosts.

### New `home/media/reddit.nix`

- `programs.newsboat` enabled with 7 subreddit RSS feeds (tagged for filter view): `NixOS`, `unixporn`, `ClaudeAI`, `ClaudeCode`, `tui`, `gnome`, `linux`
- Defaults: 30-min auto-reload, `xdg-open` for thread browsing, show-unread-only, vim-style nav keybinds
- Packages: `reddit-tui` (Go, read-only) + `headlines` (GTK4/Libadwaita)

### Scoping

Imported via `Users/olafkfreund/profile.nix`, which only razer + p620 use. p510 untouched.

### Insecure-package permit

newsboat pulls `python3.13-youtube-dl-2021.12.17` for URL extraction. p510 already permitted the 3.12 variant; razer + p620 needed the 3.13 entry added.

### Drive-by cleanup

`profile.nix` had a dead `antigravity-nix` lambda arg — removed (deadnix pre-push hook flagged it on my touched file).

## Why read-only

Post-2023 Reddit API meltdown: full write/vote flows require your own OAuth app + paid API access. Not worth the maintenance churn for a feed reader. Comment via a Chromium `--app=` window when needed.

## Verification

- All 7 subreddit `.rss` URLs return HTTP 200 (preflighted)
- `nix build .#nixosConfigurations.{razer,p620,p510}.config.system.build.toplevel` — all exit 0
- p510 sanity-checked: closure unchanged by this work (already had newsboat transitively)