### PR TITLE
fix(flake): align nixpkgs original.ref + force --refresh to defeat the fetcher cache

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -942,8 +942,8 @@
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/scripts/update-commit-deploy.sh
+++ b/scripts/update-commit-deploy.sh
@@ -111,28 +111,51 @@ old_date=$(jq -r --arg n "$nixpkgs_node" '.nodes[$n].locked.lastModified | todat
 log "current nixpkgs pin: ${old_rev:0:10} (${old_date})"
 
 # --- 3. Update --------------------------------------------------------------
+# Why we do nixpkgs + nixpkgs-unstable separately with --refresh:
+#
+# `nix flake update` consults `~/.cache/nix/fetcher-cache-v4.sqlite` for the
+# URL→storepath mapping of github branch endpoints. That cache has a TTL —
+# within it, nix uses the cached resolution rather than re-querying github.
+# If the cached entry was written when nixos-unstable HEAD was X, every
+# subsequent update inside the TTL window returns X even if upstream has
+# moved on.
+#
+# Empirically observed on this machine: the TTL window held a 10-month-old
+# nixos-unstable rev (59e69648, Aug 2025) when actual HEAD was 64c08a7c
+# (May 2026). Bulk `nix flake update` honored the cache; only a NAMED
+# `nix flake update <input> --refresh` bypassed it.
+#
+# So for the `all` scope we do the bulk update FIRST (efficient for the
+# many small inputs, fine when they're already current), then explicitly
+# re-update nixpkgs + nixpkgs-unstable with --refresh to overwrite any
+# cached-stale rev the bulk step would otherwise leave behind.
 case "$SCOPE" in
   all)
-    log "nix flake update  (all inputs)"
+    log "nix flake update  (all inputs, bulk)"
     nix flake update
+    log "nix flake update nixpkgs --refresh        (overwrite cache-regression)"
+    nix flake update nixpkgs --refresh
+    log "nix flake update nixpkgs-unstable --refresh"
+    nix flake update nixpkgs-unstable --refresh
     ;;
   nixpkgs)
-    log "nix flake update nixpkgs"
-    nix flake update nixpkgs
+    log "nix flake update nixpkgs --refresh"
+    nix flake update nixpkgs --refresh
     ;;
   *)
-    log "nix flake lock --update-input $SCOPE"
-    nix flake lock --update-input "$SCOPE"
+    log "nix flake update $SCOPE --refresh"
+    nix flake update "$SCOPE" --refresh
     ;;
 esac
 
 # --- 3b. Regression guard: nixpkgs + nixpkgs-unstable must move forward -----
 #
-# Why: a local nix tooling quirk (probably a stale entry in
-# ~/.cache/nix/binary-cache-v7.sqlite or similar) can make
-# `nix flake update` silently rewrite the nixpkgs lock entry to a much
-# older commit. We caught this once when `nix flake update` happily wrote
-# a rev from 2025-08 over a perfectly-current 2026-05 pin.
+# Belt-and-braces on top of --refresh above. Even with the targeted refresh
+# step, the fetcher cache could in theory still serve a stale resolution if
+# the cache invalidation logic itself has a bug, or if a future code path
+# stops honoring --refresh. If EITHER of {nixpkgs, nixpkgs-unstable} comes
+# out of the update step with an older lastModified than HEAD's, restore
+# that node from HEAD. Cheap and bulletproof.
 #
 # Strategy: for each of {nixpkgs, nixpkgs-unstable}, compare the new
 # lastModified epoch against the old one. If it went backward, restore


### PR DESCRIPTION
## Summary

Properly root-causes and fixes the nixpkgs-regresses-on-flake-update bug we've been wrestling with all day. Two cooperating causes; both fixed.

## Root cause #1 — `original.ref` drift

The `flake.lock`'s `nixpkgs` node had `original.ref = "nixos-25.05"` while `flake.nix` line 32 declares `inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable"`. The lock is the source of truth for `nix flake update`'s URL resolution — it ignored flake.nix and resolved the 25.05 release branch instead.

**Verified by direct lockfile read.** The sibling `nixpkgs-unstable` input correctly has `original.ref = "nixos-unstable"`, which is why it locked correctly — proof that the bug is per-node, not systemic.

## Root cause #2 — fetcher cache TTL

After fixing root cause #1, `nix flake update nixpkgs` STILL returned the wrong rev. Investigation:

- `~/.cache/nix/fetcher-cache-v4.sqlite` has table `Cache` with `domain="file"` rows mapping `https://api.github.com/repos/nixos/nixpkgs/commits/<ref>` URLs to cached storepaths containing JSON responses
- Within the cache TTL, `nix flake update` returns the cached resolution rather than re-querying github
- Empirically: the cache held a 10-month-old `nixos-unstable` rev (`59e69648`, Aug 2025) when actual HEAD was `64c08a7c` (May 2026)
- `nix flake metadata --refresh <URL>` correctly bypassed the cache. `nix flake update <name> --refresh` also bypassed it. **Bulk `nix flake update`, even with `--refresh`, did NOT bypass for nixpkgs specifically.**

So the only reliable shape: bulk update for cheap inputs, then targeted `nix flake update nixpkgs --refresh` + same for `nixpkgs-unstable` to overwrite any stale rev.

## Changes

- **`flake.lock`**: patched `nodes.nixpkgs.original.ref` `"nixos-25.05" → "nixos-unstable"`, `owner` `"NixOS" → "nixos"` (case match with flake.nix). `.locked` regenerated via `nix flake update nixpkgs --refresh`.
- **`scripts/update-commit-deploy.sh`**:
  - `all` scope: bulk `nix flake update`, then `nix flake update nixpkgs --refresh`, then `nix flake update nixpkgs-unstable --refresh`
  - Specific scope: `nix flake update <name> --refresh`
  - Comments rewritten with the *real, evidence-based* cause (not my earlier speculation about "stale entry in binary-cache-v7.sqlite or similar" — that was wrong; it's fetcher-cache-v4.sqlite specifically, on `domain="file"` rows for github API URLs)

The regression guard added in PR #686 stays — still useful as belt-and-braces.

## Verification

- `nix build .#nixosConfigurations.{razer,p620,p510}.config.system.build.toplevel` — all exit 0
- `jq -r '.nodes.nixpkgs.locked.rev' flake.lock` == `gh api repos/NixOS/nixpkgs/branches/nixos-unstable --jq .commit.sha` ✓

## Test plan

- [ ] After merge: `nhs` should report no lock changes (already at HEAD)
- [ ] Wait a few days, run `nhs` again — nixpkgs should bump *forward* to whatever new HEAD is, never backward
- [ ] `git log -S '59e69648' -- flake.lock` should never see new occurrences of the bad rev

## What I got wrong earlier today

My PR #686 said the cache was probably `binary-cache-v7.sqlite or similar` — that was a guess and turned out to be wrong. The actual file is `fetcher-cache-v4.sqlite`. Honest about it in this commit's comments.