### PR TITLE
feat(voice-input): hold-to-talk dictation → focused window (razer + p620)

### DIFF
--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -13,6 +13,7 @@ in
     ../../home/default.nix
     ../../home/games/steam.nix
     ../../home/media/reddit.nix
+    ../../home/applications/voice-input.nix
     ./private.nix
   ];
 

--- a/home/applications/voice-input.nix
+++ b/home/applications/voice-input.nix
@@ -1,0 +1,96 @@
+# voice-input — hold-to-talk dictation that types into the focused window.
+#
+# How it works: GNOME custom keybind (SUPER+SHIFT+SPACE by default) runs the
+# `voice-input` script. The script:
+#   1. Notifies "Listening…"
+#   2. Records mic via sox with VAD: starts when sound > 1%, auto-stops after
+#      2 s of silence, hard cap 30 s.
+#   3. POSTs the .wav to whisper-server (running on p620 over the tailnet).
+#   4. Types the returned transcript into the focused window via `wtype`.
+#
+# Works with any focused app — that includes claude-code, codex, antigravity,
+# copilot in a terminal, plus your normal browser/editor windows.
+#
+# To rebind the hotkey, edit `binding` below.
+{ pkgs, ... }:
+let
+  # Default whisper-server endpoint — Tailscale Magic DNS resolves `p620`.
+  serverUrl = "http://p620:9300/inference";
+
+  voiceInputScript = pkgs.writeShellApplication {
+    name = "voice-input";
+    runtimeInputs = with pkgs; [
+      sox # mic recording with VAD
+      curl
+      libnotify # notify-send
+      wtype # Wayland keyboard typing
+      coreutils # mktemp, tr
+    ];
+    text = ''
+      set -euo pipefail
+      TMP=$(mktemp --suffix=.wav)
+      trap 'rm -f "$TMP"' EXIT
+
+      notify-send -t 1500 -a voice-input "🎙️ Listening" "Speak now (auto-stops on silence)"
+
+      # VAD recording: 16 kHz mono is what Whisper wants.
+      #   `silence 1 0.1 1%` : start when audio > 1% for 100 ms
+      #   `1 2.0 1%`         : stop after 2 s of audio < 1%
+      #   `trim 0 30`        : hard cap at 30 s
+      # Errors to /dev/null because sox is chatty about VAD on stderr.
+      sox -q -d -r 16000 -c 1 "$TMP" \
+        silence 1 0.1 1% 1 2.0 1% trim 0 30 2>/dev/null
+
+      # If the file is < 0.5 s, there was no real speech — bail.
+      DUR_MS=$(sox --i -D "$TMP" 2>/dev/null | awk '{printf "%d", $1 * 1000}')
+      if [ "''${DUR_MS:-0}" -lt 500 ]; then
+        notify-send -t 1500 -a voice-input "🎙️ Voice input" "(no speech)"
+        exit 0
+      fi
+
+      TEXT=$(curl -sS --max-time 20 \
+        -F "file=@$TMP" \
+        -F "response_format=text" \
+        -F "temperature=0" \
+        "${serverUrl}" | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+      if [ -z "''${TEXT:-}" ]; then
+        notify-send -u critical -t 3000 -a voice-input "🎙️ Voice input failed" \
+          "Empty response from whisper-server. Check: systemctl status whisper-server on p620."
+        exit 1
+      fi
+
+      # Type into the focused window. wtype handles Wayland natively under
+      # GNOME 45+. A 50 ms warm-up gives the focused widget time to receive
+      # the keystroke stream cleanly after the notification dismisses.
+      sleep 0.05
+      wtype -- "$TEXT"
+      notify-send -t 2000 -a voice-input "🎙️ Typed" "$TEXT"
+    '';
+  };
+in
+{
+  home.packages = [ voiceInputScript ];
+
+  # GNOME custom keybinding — additive to the existing list (home-manager
+  # merges dconf settings across modules). The slot identifier here
+  # ("voice-input") deliberately uses a name rather than a custom<N> index
+  # so it can't collide with the numeric slots in home/desktop/gnome/keybindings.nix.
+  dconf.settings = {
+    "org/gnome/settings-daemon/plugins/media-keys" = {
+      custom-keybindings = [
+        "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/"
+        "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/"
+        "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/"
+        "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/"
+        "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/voice-input/"
+      ];
+    };
+
+    "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/voice-input" = {
+      name = "Voice input (whisper → wtype)";
+      binding = "<Super><Shift>space";
+      command = "${voiceInputScript}/bin/voice-input";
+    };
+  };
+}

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -41,6 +41,7 @@ in
     ../../modules/services/skill-pool.nix # local skill-pool registry portal
     ../../modules/services/ollama.nix # local Ollama coding-model server (RX 7900 XTX, ROCm)
     ../../modules/services/litellm-router.nix # Anthropic-compat proxy → Ollama (Phase 2)
+    ../../modules/services/whisper-server.nix # voice-input transcription HTTP API (port 9300, tailnet only)
   ];
   host.class = "workstation";
 
@@ -110,6 +111,14 @@ in
   features.litellm-router = {
     enable = true;
     listenLanInterface = "enp1s0";
+  };
+
+  # Whisper.cpp HTTP transcription server — backend for the `voice-input`
+  # client on razer + p620. Reachable on tailnet only (port 9300).
+  # First-start downloads ggml-base.en (~150MB) into /var/lib/whisper.
+  features.whisper-server = {
+    enable = true;
+    model = "base.en";
   };
 
   # Claude Code managed-settings baseline (read-only at /etc/claude-code).

--- a/modules/services/whisper-server.nix
+++ b/modules/services/whisper-server.nix
@@ -1,0 +1,108 @@
+# whisper-server — local Whisper transcription HTTP API
+#
+# Wraps `whisper-server` from pkgs.whisper-cpp. Used by `voice-input` clients
+# on razer + p620 to convert speech-to-text via a hold-to-talk hotkey.
+#
+# Default deployment: p620 hosts the server (it has the CPU/GPU budget),
+# razer reaches it over the tailnet. p510 is irrelevant — headless.
+#
+# Service surface:
+#   POST http://p620:9300/inference  multipart  file=@audio.wav  →  transcript
+#
+# Designed to be cheap to run idle: the binary memory-maps the model and
+# only burns CPU when a request comes in.
+{ config
+, lib
+, pkgs
+, ...
+}:
+let
+  cfg = config.features.whisper-server;
+in
+{
+  options.features.whisper-server = {
+    enable = lib.mkEnableOption "Whisper.cpp HTTP transcription server";
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 9300;
+      description = "TCP port for the HTTP inference endpoint.";
+    };
+
+    model = lib.mkOption {
+      type = lib.types.str;
+      default = "base.en";
+      example = "small.en";
+      description = ''
+        ggml model name (passed to whisper-cpp-download-ggml-model). Sizes:
+          tiny.en   ≈  40 MB, fastest, lowest accuracy
+          base.en   ≈ 150 MB, good balance for short dictation
+          small.en  ≈ 500 MB, more accurate, slower
+          medium.en ≈ 1.5 GB
+      '';
+    };
+
+    openFirewallOnTailscale = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Open the service port on the tailscale0 interface only.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.whisper-server = {
+      description = "whisper.cpp HTTP inference server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      # Download the model into StateDirectory on first run; subsequent
+      # starts are zero-cost.
+      preStart = ''
+        cd /var/lib/whisper
+        if [ ! -f ggml-${cfg.model}.bin ]; then
+          ${pkgs.whisper-cpp}/bin/whisper-cpp-download-ggml-model ${cfg.model} .
+        fi
+      '';
+
+      serviceConfig = {
+        ExecStart = ''
+          ${pkgs.whisper-cpp}/bin/whisper-server \
+            --model /var/lib/whisper/ggml-${cfg.model}.bin \
+            --host 0.0.0.0 \
+            --port ${toString cfg.port} \
+            --threads 4
+        '';
+
+        # Hardening — typical NixOS-best-practices defaults.
+        DynamicUser = true;
+        StateDirectory = "whisper";
+        StateDirectoryMode = "0750";
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = false; # whisper-cpp JITs
+        NoNewPrivileges = true;
+        SystemCallFilter = [ "@system-service" "~@privileged" ];
+
+        # Sized for base.en — bump if you switch to small/medium.
+        MemoryMax = "1G";
+        TasksMax = 64;
+
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+    };
+
+    networking.firewall.interfaces.tailscale0 = lib.mkIf cfg.openFirewallOnTailscale {
+      allowedTCPPorts = [ cfg.port ];
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Hit `SUPER+SHIFT+SPACE` anywhere on razer or p620 → speak → transcript types into the focused window via `wtype`. Works with **claude-code, codex, antigravity, copilot** in a terminal — they're all just apps receiving keystrokes.

## Architecture

| Piece | Where | What |
|---|---|---|
| `modules/services/whisper-server.nix` | p620 system module | Wraps `whisper-server` from `pkgs.whisper-cpp`. Listens on `:9300`, firewall open on `tailscale0` only. DynamicUser + standard systemd hardening. Auto-downloads `ggml-base.en` (~150 MB) into `/var/lib/whisper` on first start. |
| `home/applications/voice-input.nix` | razer + p620 home module | `voice-input` script: sox VAD record → POST `.wav` to `p620:9300` → `wtype` the transcript. GNOME custom keybinding via dconf (additive named slot so it can't collide with the existing `custom0..custom3`). |
| `Users/olafkfreund/profile.nix` | razer + p620 (not p510) | Imports the new home module. |
| `hosts/p620/configuration.nix` | p620 system | Imports the service module + enables it. |

## UX details

- **Sox VAD**: starts recording when audio > 1% for 100 ms, stops after 2 s of silence, 30 s hard cap. No "release the key" event needed — GNOME custom keybinds are press-only.
- **notify-send progress**: "🎙️ Listening" → "🎙️ Typed: <transcript>" or "(no speech)" if recording was too short to bother.
- **Audio**: 16 kHz mono, what Whisper expects natively.

## Verification

- `nix build .#nixosConfigurations.{razer,p620,p510}.config.system.build.toplevel` — all exit 0
- Both modules use the explicit-import pattern (no auto-discovery), DynamicUser systemd hardening, follow the repo's existing patterns

## Test plan

After merge:

- [ ] `nhs p620` then check `systemctl status whisper-server` — should be `active (running)`, model downloaded
- [ ] Curl smoke test from p620: `curl -F 'file=@/tmp/test.wav' -F 'response_format=text' http://localhost:9300/inference`
- [ ] `nhs razer` to deploy the client
- [ ] Press `SUPER+SHIFT+SPACE` in a terminal running `claude`
- [ ] Say "what's in the current directory"
- [ ] Verify the text types into the prompt, hit Enter, claude responds

## Future tweaks (out of scope here)

- A "release detection" mode using `gsettings`/keyboard hooks if push-to-talk feels cleaner than VAD.
- Larger model selection per-host (razer might want `small.en` for accuracy; p620 can run it fine).
- TTS reply (Piper) for hands-free use — would shift toward the Shape C architecture I described pre-build; not what we picked.