### PR TITLE
fix(whisper-server): bump TasksMax 64 -> 256 (fix EAGAIN crash)

### DIFF
--- a/modules/services/whisper-server.nix
+++ b/modules/services/whisper-server.nix
@@ -92,9 +92,13 @@ in
         NoNewPrivileges = true;
         SystemCallFilter = [ "@system-service" "~@privileged" ];
 
-        # Sized for base.en — bump if you switch to small/medium.
+        # Sized for base.en — bump MemoryMax if you switch to small/medium.
+        # TasksMax needs to be generous: whisper-server spawns a thread
+        # pool for HTTP serving plus worker threads; a tight cap (e.g. 64)
+        # causes std::terminate("Resource temporarily unavailable") when
+        # pthread_create returns EAGAIN.
         MemoryMax = "1G";
-        TasksMax = 64;
+        TasksMax = 256;
 
         Restart = "on-failure";
         RestartSec = 5;


### PR DESCRIPTION
Service crashed with `std::system_error: Resource temporarily unavailable` on every start. Diagnosis: `pthread_create` returning `EAGAIN` because TasksMax=64 is too low for whisper-server's HTTP + worker-thread pool. Bumped to 256 — empirically enough. Tested by rebuild + restart on p620: service now stays `active (running)`.