### PR TITLE
feat(voice-input): wire Groq Whisper-Large-v3 via agenix

### DIFF
--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -17,6 +17,15 @@ in
     ./private.nix
   ];
 
+  # Voice dictation → Groq Whisper-Large-v3 (~200-400 ms, cheap, accurate).
+  # API key is decrypted by agenix to /run/agenix/api-groq (mode 0644 via
+  # modules/secrets/api-keys.nix). Falls back to the local whisper-server
+  # on p620:9300 if you flip back to backend = "local".
+  programs.voice-input = {
+    backend = "groq";
+    apiKeyFile = "/run/agenix/api-groq";
+  };
+
   # Terminal app desktop entries
   programs.k9s.desktopEntry.enable = lib.mkForce true;
   programs.claude-code.desktopEntry.enable = lib.mkForce true;

--- a/modules/secrets/api-keys.nix
+++ b/modules/secrets/api-keys.nix
@@ -54,6 +54,13 @@ in
         group = "users";
       };
 
+      api-groq = {
+        file = ../../secrets/api-groq.age;
+        mode = "0644";
+        owner = "root";
+        group = "users";
+      };
+
       # api-qwen = {
       #   file = ../../secrets/api-qwen.age;
       #   mode = "0644";
@@ -124,6 +131,10 @@ in
           echo "export GEMINI_API_KEY=\"$(cat /run/agenix/api-gemini)\""
         fi
 
+        if [ -r "/run/agenix/api-groq" ]; then
+          echo "export GROQ_API_KEY=\"$(cat /run/agenix/api-groq)\""
+        fi
+
         if [ -r "/run/agenix/api-github-token" ]; then
           # Export as GITHUB_API_TOKEN to avoid conflict with gh CLI credential management
           # gh CLI expects to manage its own credentials via 'gh auth login'
@@ -147,6 +158,7 @@ in
         [ -n "$OPENAI_API_KEY" ] && echo "✅ OpenAI: Available" || echo "❌ OpenAI: Not available"
         [ -n "$GEMINI_API_KEY" ] && echo "✅ Gemini: Available" || echo "❌ Gemini: Not available"
         [ -n "$ANTHROPIC_API_KEY" ] && echo "✅ Anthropic: Available" || echo "❌ Anthropic: Not available"
+        [ -n "$GROQ_API_KEY" ] && echo "✅ Groq: Available" || echo "❌ Groq: Not available"
         [ -n "$LANGCHAIN_API_KEY" ] && echo "✅ LangChain: Available" || echo "❌ LangChain: Not available"
         [ -n "$GITHUB_API_TOKEN" ] && echo "✅ GitHub API Token: Available" || echo "❌ GitHub API Token: Not available"
 

--- a/secrets.nix
+++ b/secrets.nix
@@ -22,6 +22,7 @@ in
   "secrets/api-openai.age".publicKeys = allUsers ++ allHosts;
   "secrets/api-gemini.age".publicKeys = allUsers ++ allHosts;
   "secrets/api-anthropic.age".publicKeys = allUsers ++ allHosts;
+  "secrets/api-groq.age".publicKeys = allUsers ++ allHosts;
   "secrets/api-github-token.age".publicKeys = allUsers ++ allHosts;
   # Synechron GitHub API token (PAT). All hosts; exported as
   # SYNECHRON_GITHUB_API_TOKEN via load-api-keys. Edit: agenix -e secrets/synechron-github-api.age

--- a/secrets/api-groq.age
+++ b/secrets/api-groq.age
@@ -1,0 +1,14 @@
+age-encryption.org/v1
+-> ssh-ed25519 wgedHw elfk0PzHb+z/kCQL6Bu8YmCSIo2xITM0k21BRaTITQA
+ps/dIBiXi8dOfmEJxITTQvsLm17+ENekBqoHwJsg6y4
+-> ssh-ed25519 NzeCSQ eE08a+7xKtFyQJi2kubrgvRwzwcUl4uqJLrhWsX7tWY
+/C14HrOKdYLSOO/X4lB+oe6xQJLvz5GSWQKi/1c21hA
+-> ssh-ed25519 UT51fQ rH7fuNTR/Lz0qy/D8kjeOtRjPQTSaiA6Zb8RT7i1/A0
+uUXh44wrTfprmEH4Q1/E0M2wP1uDYAQ7bkGfJyitFZE
+-> ssh-ed25519 tbxj3w UIZ0z2h6YgCDGAUxkMnfQdxk8XRzVd9d76Afz9sOayw
+qByvQRFr5FQnTntDkDNfaIT20AMNk0pnXvBpNNq2X58
+-> j+|&]ry5-grease :ZI|# ]yiS <o,m"/ y/gv
+rmVvNDJ4/zR2eGKzF4yjayfPs6bhLwDM1iqxvivexDrac+6b4DUivF57E6no
+--- RRnn4k5c8Q/gKZAluWqQzl84IoLYhJ+cikwIWZ2BLNM
+ïìà=ˆ\ç·Ìþô) …²SŠƒÂ€°*²qc{ýQ]Ë-$ˆGÊóhœ.xÅ
+!CïS¥4ÊÑËS	ecQ*oõâ4ÎvìJ¨pãéÕŒÑ§“~þì]R


### PR DESCRIPTION
Adds the Groq API key as an agenix secret and flips razer + p620 to use it. ~200-400ms transcription latency, essentially free. Local whisper-server on p620 stays running as fallback. p510 untouched. All three host closures build clean.