### PR TITLE
fix(voice-input): wtype -> ydotool + fix dconf keybind-list path

### DIFF
--- a/home/applications/voice-input.nix
+++ b/home/applications/voice-input.nix
@@ -58,7 +58,10 @@ let
       sox # mic recording with VAD
       curl
       libnotify # notify-send
-      wtype # Wayland keyboard typing
+      ydotool # kernel-level (/dev/uinput) keystroke injection — works on
+      # GNOME Wayland where wtype fails (Mutter declines to implement the
+      # virtual_keyboard_v1 protocol). ydotoold must be running; enabled
+      # via `programs.ydotool.enable = true;` on the host.
       coreutils # mktemp, tr
     ];
     text = ''
@@ -104,8 +107,10 @@ let
 
       # Type into the focused window. 50 ms warm-up gives the focused widget
       # time to receive keystrokes cleanly after the notification dismisses.
+      # ydotool requires ydotoold running; the script picks up YDOTOOL_SOCKET
+      # if exported, otherwise uses the default /tmp/.ydotool_socket.
       sleep 0.05
-      wtype -- "$TEXT"
+      ydotool type --delay 5 -- "$TEXT"
       notify-send -t 2000 -a voice-input "🎙️ Typed" "$TEXT"
     '';
   };
@@ -174,25 +179,10 @@ in
 
     home.packages = [ voiceInputScript ];
 
-    # GNOME custom keybinding — additive (home-manager merges dconf settings
-    # across modules). Named slot "voice-input" avoids colliding with the
-    # numeric custom0..N list in home/desktop/gnome/keybindings.nix.
-    dconf.settings = {
-      "org/gnome/settings-daemon/plugins/media-keys" = {
-        custom-keybindings = [
-          "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/"
-          "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/"
-          "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/"
-          "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/"
-          "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/voice-input/"
-        ];
-      };
-
-      "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/voice-input" = {
-        name = "Voice input (whisper → wtype, ${cfg.backend})";
-        binding = cfg.hotkey;
-        command = "${voiceInputScript}/bin/voice-input";
-      };
-    };
+    # The GNOME custom keybinding for SUPER+SHIFT+SPACE → `voice-input` is
+    # defined in `home/desktop/gnome/keybindings.nix` (slot custom4). It's
+    # owned there because that file is the single source of truth for the
+    # `custom-keybindings` list — two modules writing to the same dconf
+    # list-valued key was previously dropping entries silently.
   };
 }

--- a/home/desktop/gnome/keybindings.nix
+++ b/home/desktop/gnome/keybindings.nix
@@ -153,13 +153,18 @@ in
         search = [ "XF86Search" "<Super>f" ];
       };
 
-      # Custom keybindings
-      "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings" = {
-        custom-keybinding-list = [
+      # Custom keybindings — list of slot paths that gnome-settings-daemon
+      # actually reads. The correct schema key is `custom-keybindings`
+      # under `.../media-keys` (NOT `custom-keybinding-list` under
+      # `.../media-keys/custom-keybindings` — that was a previous bug that
+      # silently dropped the list, leaving only whatever dconf had cached).
+      "org/gnome/settings-daemon/plugins/media-keys" = {
+        custom-keybindings = [
           "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/"
           "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/"
           "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/"
           "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/"
+          "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4/"
         ];
       };
 
@@ -189,6 +194,16 @@ in
         binding = "<Super>comma";
         command = "gnome-control-center";
         name = "Open Settings";
+      };
+
+      # Voice input — hold-to-talk dictation. Configured by
+      # home/applications/voice-input.nix; this slot just wires the GNOME
+      # keybind. SUPER+SHIFT+SPACE is push-to-start (sox VAD auto-stops
+      # the recording on 2s of silence).
+      "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4" = {
+        binding = "<Super><Shift>space";
+        command = "voice-input";
+        name = "Voice input (whisper → ydotool)";
       };
 
       # # Input method keybindings

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -630,6 +630,12 @@ in
   # Windows app integration - Re-enabled after upstream fix (v0.9.0)
   # programs.winboat.enable = true; # DISABLED: Go 1.26 cross-compilation broken with mingw32 GCC 15
 
+  # ydotoold — kernel-level keystroke injection daemon. Used by the
+  # voice-input client to type transcripts into focused windows on GNOME
+  # Wayland (Mutter doesn't implement the virtual_keyboard_v1 protocol that
+  # wtype needs). NixOS adds the user to the ydotool group automatically.
+  programs.ydotool.enable = true;
+
   # Package configurations
   nixpkgs.config = {
     allowBroken = true;

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -465,6 +465,11 @@ in
     "/etc/ssh/ssh_host_rsa_key" # Host key (RSA fallback)
   ];
 
+  # ydotoold — kernel-level keystroke injection daemon. Used by the
+  # voice-input client to type transcripts on GNOME Wayland where wtype
+  # fails (Mutter doesn't implement virtual_keyboard_v1).
+  programs.ydotool.enable = true;
+
   nixpkgs.config = {
     allowBroken = true;
     permittedInsecurePackages = [


### PR DESCRIPTION
wtype fails on GNOME Mutter (no virtual_keyboard_v1). Switched to ydotool (kernel uinput). Also fixed a pre-existing typo in keybindings.nix where the list was being written to a non-existent dconf key (custom-keybinding-list at the subkey path instead of custom-keybindings at the parent). Added custom4 entry for voice-input. Enabled programs.ydotool on razer + p620.