### PR TITLE
fix(voice-input): YDOTOOL_SOCKET + add user to ydotool group

### DIFF
--- a/home/applications/voice-input.nix
+++ b/home/applications/voice-input.nix
@@ -107,10 +107,12 @@ let
 
       # Type into the focused window. 50 ms warm-up gives the focused widget
       # time to receive keystrokes cleanly after the notification dismisses.
-      # ydotool requires ydotoold running; the script picks up YDOTOOL_SOCKET
-      # if exported, otherwise uses the default /tmp/.ydotool_socket.
+      # YDOTOOL_SOCKET is set explicitly here because the system-managed
+      # ydotoold (programs.ydotool.enable) listens at /run/ydotoold/socket,
+      # not the per-user XDG default the client looks for. The user must be
+      # in the `ydotool` group (added via host configs) to access the socket.
       sleep 0.05
-      ydotool type --delay 5 -- "$TEXT"
+      YDOTOOL_SOCKET=/run/ydotoold/socket ydotool type --delay 5 -- "$TEXT"
       notify-send -t 2000 -a voice-input "🎙️ Typed" "$TEXT"
     '';
   };

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -633,8 +633,12 @@ in
   # ydotoold — kernel-level keystroke injection daemon. Used by the
   # voice-input client to type transcripts into focused windows on GNOME
   # Wayland (Mutter doesn't implement the virtual_keyboard_v1 protocol that
-  # wtype needs). NixOS adds the user to the ydotool group automatically.
+  # wtype needs).
   programs.ydotool.enable = true;
+  # The NixOS programs.ydotool module does NOT auto-add users to the
+  # ydotool group; we have to do it explicitly. Without this the user
+  # can't write to /run/ydotoold/socket (mode 0660 root:ydotool).
+  users.users.olafkfreund.extraGroups = [ "ydotool" ];
 
   # Package configurations
   nixpkgs.config = {

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -469,6 +469,7 @@ in
   # voice-input client to type transcripts on GNOME Wayland where wtype
   # fails (Mutter doesn't implement virtual_keyboard_v1).
   programs.ydotool.enable = true;
+  users.users.olafkfreund.extraGroups = [ "ydotool" ];
 
   nixpkgs.config = {
     allowBroken = true;


### PR DESCRIPTION
Two follow-ups after PR #695. (1) Script sets YDOTOOL_SOCKET=/run/ydotoold/socket — the NixOS system service listens there, not the per-user XDG default. (2) Adds user to ydotool group — programs.ydotool.enable doesn't auto-add. After deploy + a one-time log-out/log-in, the hotkey works.