### PR TITLE
fix(ydotool): merge ydotool into existing extraGroups (PR #696 had duplicate users.users)

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -396,6 +396,7 @@ in
       "wheel"
       "networkmanager"
       "render"
+      "ydotool" # /run/ydotoold/socket access for the voice-input client
     ];
     shell = pkgs.zsh;
     # Run user services even when not logged in so headless user units
@@ -635,10 +636,10 @@ in
   # Wayland (Mutter doesn't implement the virtual_keyboard_v1 protocol that
   # wtype needs).
   programs.ydotool.enable = true;
-  # The NixOS programs.ydotool module does NOT auto-add users to the
-  # ydotool group; we have to do it explicitly. Without this the user
-  # can't write to /run/ydotoold/socket (mode 0660 root:ydotool).
-  users.users.olafkfreund.extraGroups = [ "ydotool" ];
+  # User membership in the `ydotool` group (required for
+  # /run/ydotoold/socket mode 0660 root:ydotool access) is added to the
+  # `users.users = lib.genAttrs hostUsers ...` block earlier in this file —
+  # programs.ydotool.enable does NOT auto-add users.
 
   # Package configurations
   nixpkgs.config = {

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -396,6 +396,7 @@ in
     extraGroups = [
       "wheel"
       "networkmanager"
+      "ydotool" # /run/ydotoold/socket access for the voice-input client
     ];
     shell = pkgs.zsh;
     # Only use secret-managed password if the secret exists
@@ -469,7 +470,8 @@ in
   # voice-input client to type transcripts on GNOME Wayland where wtype
   # fails (Mutter doesn't implement virtual_keyboard_v1).
   programs.ydotool.enable = true;
-  users.users.olafkfreund.extraGroups = [ "ydotool" ];
+  # User group membership for /run/ydotoold/socket access is added in the
+  # `users.users = lib.genAttrs hostUsers ...` block above.
 
   nixpkgs.config = {
     allowBroken = true;


### PR DESCRIPTION
PR #696 caused an eval-fail because it added a second users.users top-level attribute. Folding ydotool into the genAttrs extraGroups list fixes it.