### PR TITLE
chore(docker): move data-root to /mnt/data/docker

### DIFF
--- a/modules/containers/docker.nix
+++ b/modules/containers/docker.nix
@@ -47,6 +47,7 @@ in
       # Explicitly disable Docker Swarm
       daemon.settings = {
         swarm-default-advertise-addr = "";
+        data-root = "/mnt/data/docker";
       };
     };
 


### PR DESCRIPTION
## Summary

Relocate Docker's data directory from `/var/lib/docker` (on `/`) to `/mnt/data/docker` to keep the overlayfs tree off the root filesystem.

## Context

`/` was sitting at 92% used on p620. Reclamation done in three phases:

1. **Phase 1 — Docker prune** (in-place, no config change): `builder prune -af` + `image prune -f` + `volume prune -f` → reclaimed **141 GB** with all running containers untouched.
2. **Phase 2 — `~/Source` migration**: `~/Source` (272 GB) → `/mnt/data/Source-home/`, with `~/Source` becoming a symlink. Old tree kept aside as `~/Source.old-2026-06-01` for rollback.
3. **Phase 3 — this PR**: Docker data-root → `/mnt/data/docker`. `nixos-rebuild switch` re-mounted overlayfs cleanly; skillai-app's bind mount naturally re-resolved through the new `~/Source` symlink at restart.

## Change

One line in `modules/containers/docker.nix`:

```nix
daemon.settings = {
  swarm-default-advertise-addr = "";
+ data-root = "/mnt/data/docker";
};
```

## Test plan

- [x] `sudo nixos-rebuild switch --flake .#p620` succeeded (generation 26 active)
- [x] `docker info` reports `Docker Root Dir: /mnt/data/docker`
- [x] All previously-running containers came back healthy on the new data-root
- [x] skillai-app `/app` bind mount resolves through `~/Source` symlink → `/mnt/data/Source-home/GitHub/SkillAi`
- [x] Pre-commit + pre-push hooks pass

## Rollback

Original tree preserved at `/var/lib/docker.old-2026-06-01`. Revert this PR and `nixos-rebuild switch` would re-point at `/var/lib/docker`; rename `.old-…` back to clean up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)