### PR TITLE
razer: add gscratch + work around Optimus headless GDM-greeter bug

### DIFF
--- a/Users/olafkfreund/razer_home.nix
+++ b/Users/olafkfreund/razer_home.nix
@@ -1,4 +1,6 @@
 { lib
+, pkgs
+, inputs
 , ...
 }:
 let
@@ -8,6 +10,15 @@ in
   imports = [ ./profile.nix ];
 
   desktop.gnome.profile = "laptop";
+
+  # gscratch — i3/Sway-style scratchpad for GNOME (testing on razer first).
+  # Configure bindings via: gnome-extensions prefs scratchpad@wastedintelligence.com
+  programs.gnome-shell = {
+    enable = true;
+    extensions = [
+      { package = inputs.gscratch.packages.${pkgs.system}.default; }
+    ];
+  };
 
   # Laptop: enable zellij (session management for mobile use)
   features.multiplexers.zellij = true;

--- a/flake.lock
+++ b/flake.lock
@@ -734,6 +734,26 @@
         "type": "github"
       }
     },
+    "gscratch": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780320187,
+        "narHash": "sha256-Z7pvZGhYtoPXzv7eXC3Ws8RJ+81DgP17OpWDdHWnCNE=",
+        "owner": "olafkfreund",
+        "repo": "gscratch",
+        "rev": "2a8245a862eed1f02bc4e2caaa7d31542ef64710",
+        "type": "github"
+      },
+      "original": {
+        "owner": "olafkfreund",
+        "repo": "gscratch",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -1366,6 +1386,7 @@
         "cosmic-ext-web-apps": "cosmic-ext-web-apps",
         "cosmic-music-player": "cosmic-music-player",
         "flake-utils": "flake-utils_5",
+        "gscratch": "gscratch",
         "home-manager": "home-manager_2",
         "lan-mouse": "lan-mouse",
         "lanzaboote": "lanzaboote",

--- a/flake.nix
+++ b/flake.nix
@@ -155,6 +155,13 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # gscratch — i3/Sway-style scratchpad for GNOME Shell (any window, toggle
+    # via global shortcut). Consumed by Users/olafkfreund/razer_home.nix.
+    gscratch = {
+      url = "github:olafkfreund/gscratch";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
   };
 
   outputs =

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -273,7 +273,42 @@ in
   # cosmic module; the unified DM module defaults to "none" without it).
   # NOTE: must live at top-level, NOT inside the features = {...} block above —
   # the option path is `desktop.displayManager`, not `features.desktop.displayManager`.
+  # No autoLogin here — this is NVIDIA Optimus PRIME-sync hardware where any
+  # greeter respawn after first boot ("Unable to run session" → GdmLocal-
+  # DisplayFactory gives up after 8 retries → black screen) is broken.
+  # Keeping the boot-time greeter alive is the only reliable local UX, so
+  # autologin loops are off. Trade-off: cold-RDP needs a physical login
+  # first (see comment on `gnome.gnome-remote-desktop` below). p510 enables
+  # autoLogin because p510 is pure NVIDIA without PRIME — greeter respawn
+  # works there; not here.
   desktop.displayManager.backend = "gdm";
+
+  # GDM greeter visual baseline — dark colour scheme + 24h clock so it
+  # doesn't render as a near-blank Adwaita-light surface over RDP.
+  programs.dconf.profiles.gdm.databases = [{
+    settings = {
+      "org/gnome/desktop/interface" = {
+        clock-format = "24h";
+        color-scheme = "prefer-dark";
+      };
+    };
+  }];
+
+  # Disable system-mode GRD on razer. The GDM-greeter spawn path it uses
+  # (`gdm-wayland-session: Unable to run session`) is broken on this host's
+  # NVIDIA Optimus PRIME-sync hardware — verified by side-by-side journal
+  # comparison with p510 (pure NVIDIA), where the same path succeeds. With
+  # system-mode off, port 3389 frees up and the user-mode GRD daemon
+  # binds it instead. User-mode requires a live olafkfreund session, so
+  # the RDP flow is: physically log in once after each boot, then `razer:3389`
+  # serves your desktop for the rest of that uptime.
+  services.gnome.gnome-remote-desktop.enable = lib.mkForce false;
+  systemd.services.grd-bootstrap.enable = lib.mkForce false;
+  # The shared module unconditionally adds wantedBy=[graphical.target] to
+  # gnome-remote-desktop.service; with the service body gone (line above),
+  # that orphan wantedBy makes systemd reject the partial unit ("bad unit
+  # file setting"). Clear it.
+  systemd.services.gnome-remote-desktop.wantedBy = lib.mkForce [ ];
 
   # Citrix Workspace for client project remote access
   # Disabled — no longer needed. Module + overlay + package retained so this


### PR DESCRIPTION
## Summary

Two razer-specific changes bundled into one PR:

- **feat: gscratch** — install `olafkfreund/gscratch` (i3/Sway-style GNOME scratchpad) via Home Manager on razer for testing. Pinned as a flake input.
- **fix: RDP black screen** — work around an NVIDIA Optimus PRIME-sync hardware bug where headless GDM-greeter spawns die immediately (`gdm-wayland-session: Unable to run session`), making system-mode GRD RDP land on a blank framebuffer. p510 (pure NVIDIA) doesn't hit this; razer does.

## Diagnosis

Confirmed by side-by-side journal comparison with p510:
- razer: `GdmLocalDisplayFactory: maximum number of display failures reached. Giving up.` after 8 retries
- p510: greeter session ran for 46s without errors

Root cause is the PRIME-sync rendering path on Optimus hardware — headless Mutter has nothing to bind to without an attached display output.

## Fix shape

- Disable `services.gnome.gnome-remote-desktop` (system-mode daemon) — lets user-mode GRD bind the default port 3389.
- Clear the orphan `wantedBy=[graphical.target]` left on the shared module's `gnome-remote-desktop.service` (otherwise systemd rejects the empty unit).
- Defensive dark dconf for the GDM greeter.
- Deliberately **not** enabling `autoLogin` (unlike p510): the same Optimus bug breaks any greeter respawn, so autologin would turn local "log out" into an instant black-screen lockout until reboot.

## RDP flow on razer (new)

1. Boot → GDM greeter (boot-time spawn works — it's the respawn path that's broken)
2. Log in physically as olafkfreund
3. user-mode GRD daemon binds 3389 automatically
4. `xfreerdp /v:razer:3389 /u:olafkfreund` lands directly in the live desktop

## Test plan

- [x] Build: `just test-host razer` (clean)
- [x] Deploy: applied; confirmed live state on razer
- [x] gscratch installed in razer's system closure (`gnome-shell-extension-scratchpad-2a8245a`)
- [x] User-mode GRD daemon bound to port 3389
- [x] RDP into razer:3389 lands directly in olafkfreund's session (user confirmed in-session)
- [ ] Verify after reboot: GDM greeter shows, physical login works, RDP works for rest of uptime

🤖 Generated with [Claude Code](https://claude.com/claude-code)