### PR TITLE
chore(flake): bump nixpkgs (waydroid 1.6.3) + p620 audible-sync

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1260,11 +1260,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -43,6 +43,7 @@ in
     ../../modules/services/litellm-router.nix # Anthropic-compat proxy → Ollama (Phase 2)
     ../../modules/services/whisper-server.nix # voice-input transcription HTTP API (port 9300, tailnet only)
     ../../modules/services/meeting-transcribe.nix # meet CLI: record → whisperX → Ollama summary
+    ../../modules/services/audible-sync.nix # audible-sync: download + decrypt Audible library to .m4b
   ];
   host.class = "workstation";
 
@@ -141,6 +142,10 @@ in
     userName = "Olaf";
     userEmail = "olaf@freundcloud.com";
   };
+
+  # Audible-sync — download + decrypt your Audible library locally on p620.
+  # One-time setup after deploy: `audible quickstart`, then `audible-sync`.
+  features.audibleSync.enable = true;
 
   # Claude Code managed-settings baseline (read-only at /etc/claude-code).
   # Enables PARR hook + lets the router CLI inject apiKeyHelper (Phase 3).
@@ -671,6 +676,7 @@ in
       "python3.13-youtube-dl-2021.12.17" # newsboat (RSS reader) pulls youtube-dl for URL extraction
       "libsoup-2.74.3" # Temporary: Required by some GNOME packages until migration to libsoup-3
       "electron-35.7.5" # Temporary: Required until upstream packages migrate to newer electron
+      "electron-39.8.10" # Newly marked EOL after nixpkgs bump on 2026-06-01 — still pulled in by some upstream package, audit + drop later
     ];
   };
 }

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -528,6 +528,7 @@ in
       "python3.13-youtube-dl-2021.12.17" # newsboat (RSS reader) pulls youtube-dl for URL extraction
       "libsoup-2.74.3" # Temporary: Required by some GNOME packages until migration to libsoup-3
       "electron-35.7.5" # Temporary: Required until upstream packages migrate to newer electron
+      "electron-39.8.10" # Newly marked EOL after nixpkgs bump on 2026-06-01 — still pulled in by some upstream package, audit + drop later
     ];
   };
   system.stateVersion = "25.11";

--- a/hosts/razer/nixos/boot.nix
+++ b/hosts/razer/nixos/boot.nix
@@ -52,18 +52,15 @@
   # known-good (gen 2438, currently running). 6.17/6.19 are EOL'd in nixpkgs.
   # If 7.0.1 also fails to boot, fall back to pinning 6.18.22 via a separate
   # nixpkgs flake input. See: https://github.com/nixos/nixpkgs/issues/493618
-  # Patch openrazer's kernel module: 3.12.2 calls hid_report_raw_event() with
-  # 5 args, but kernel 7.0.9+ added a bufsize argument (torvalds/linux@2c85c61,
-  # backported to 7.0.9). Apply the upstream fix (openrazer@ff30624) until it
-  # lands in nixpkgs. The version-gated #if matches our 7.0.10 kernel.
+  # Razer needs the latest kernel for hardware support (eGPU, Optimus, etc).
+  # The previous override on this line also patched the openrazer kernel
+  # module for the kernel-7.0.9 hid_report_raw_event() API change
+  # (openrazer @ff30624). That fix has now landed in nixpkgs' packaged
+  # openrazer, so reapplying our patch on top fails with "Reversed (or
+  # previously applied) patch detected". Override slimmed to just the
+  # kernel selection.
   # See: https://github.com/openrazer/openrazer/issues/2808
-  boot.kernelPackages = pkgs.linuxPackages_latest.extend (_kfinal: kprev: {
-    openrazer = kprev.openrazer.overrideAttrs (old: {
-      patches = (old.patches or [ ]) ++ [
-        ./patches/openrazer-kernel-7.0.9-hid-report-raw-event.patch
-      ];
-    });
-  });
+  boot.kernelPackages = pkgs.linuxPackages_latest;
 
   boot.plymouth.enable = true;
   boot.kernel.sysctl."vm.nr_hugepages" = 1024;

--- a/modules/desktop/stylix-theme.nix
+++ b/modules/desktop/stylix-theme.nix
@@ -61,6 +61,12 @@ in
       targets = {
         chromium.enable = false;
 
+        # kmscon: stylix's kmscon target still sets the removed-in-nixpkgs-50
+        # `services.kmscon.fonts` option, which now fails the build. We don't
+        # theme the Linux text console anyway (Wayland sessions are what
+        # matters here), so disable the target until upstream stylix updates.
+        kmscon.enable = false;
+
         # COSMIC's GTK theme sync is disabled on this fleet, so cosmic-comp
         # does NOT clobber ~/.config/gtk-{3,4}.0/gtk.css at runtime. Stylix
         # can own that file safely and theme GTK3 / non-libadwaita GTK4 apps

--- a/modules/services/audible-sync.nix
+++ b/modules/services/audible-sync.nix
@@ -1,0 +1,171 @@
+# audible-sync — download + decrypt your Audible library to local .m4b files.
+#
+# UX: one command, `audible-sync`, after a one-time interactive login.
+# Pipeline: library export → bulk download (.aaxc/.aax) → decrypt to .m4b
+# → organise into one folder per book under `outputDir`. Re-runnable;
+# already-downloaded books and already-decrypted files are skipped.
+#
+# Per-host wiring (currently p620 only):
+#
+#   features.audibleSync = {
+#     enable = true;
+#     outputDir = "~/audiobooks/audible";  # default
+#   };
+#
+# One-time setup (run interactively on p620 AFTER deploy):
+#   1. audible quickstart      # picks marketplace, handles 2FA in browser
+#   2. audible library list    # confirm your books are visible
+#   3. audible-sync            # downloads + decrypts everything
+#
+# Legal note: stripping DRM violates Audible's ToS. Personal-use only.
+{ config
+, lib
+, pkgs
+, ...
+}:
+let
+  cfg = config.features.audibleSync;
+
+  audibleSync = pkgs.writeShellApplication {
+    name = "audible-sync";
+    # SC2088 (tilde in single quotes won't expand) is a false positive here —
+    # `lib.escapeShellArg` below emits `'~/...'`, and the very next line uses
+    # bash parameter expansion to substitute `~` with `$HOME` at runtime.
+    excludeShellChecks = [ "SC2088" ];
+    runtimeInputs = with pkgs; [
+      audible-cli
+      ffmpeg
+      jq
+      coreutils
+      findutils
+    ];
+    text = ''
+            set -euo pipefail
+
+            OUTPUT_DIR=${lib.escapeShellArg cfg.outputDir}
+            OUTPUT_DIR="''${OUTPUT_DIR/#\~/$HOME}"
+            STAGING_DIR="''${XDG_CACHE_HOME:-$HOME/.cache}/audible-sync/staging"
+
+            mkdir -p "$OUTPUT_DIR" "$STAGING_DIR"
+
+            echo "==> Checking audible-cli login state..."
+            # Fail loud (no stdin) so a missing login is obvious on first run.
+            if ! audible profile list </dev/null >/dev/null 2>&1; then
+              cat >&2 <<'EOF'
+      audible-cli is not logged in.
+
+      One-time setup (run interactively on this host):
+        $ audible quickstart        # picks marketplace, handles 2FA in a browser
+        $ audible library list      # confirm your books are visible
+      Then re-run: audible-sync
+      EOF
+              exit 1
+            fi
+
+            echo "==> Fetching activation bytes (for legacy .aax decryption)..."
+            ACTIVATION_BYTES="$(audible activation-bytes 2>/dev/null || true)"
+
+            echo "==> Bulk download into $STAGING_DIR"
+            # --ignore-existing makes this safe to re-run. </dev/null fails loud
+            # if a future audible-cli version starts prompting.
+            audible download \
+              --all \
+              --output-dir "$STAGING_DIR" \
+              --aax-fallback \
+              --quality best \
+              --cover \
+              --chapter \
+              --ignore-existing \
+              </dev/null
+
+            echo "==> Decrypting .aaxc files..."
+            decrypted=0; skipped=0; failed=0
+            while IFS= read -r -d "" aaxc; do
+              base="''${aaxc%.aaxc}"
+              m4b="$base.m4b"
+              voucher="$base.voucher"
+              if [ -e "$m4b" ]; then
+                skipped=$((skipped+1)); continue
+              fi
+              if [ ! -f "$voucher" ]; then
+                echo "  [skip] no voucher for $(basename "$aaxc")" >&2
+                failed=$((failed+1)); continue
+              fi
+              key=$(jq -r '.content_license.license_response.key // empty' "$voucher")
+              iv=$(jq -r '.content_license.license_response.iv  // empty' "$voucher")
+              if [ -z "$key" ] || [ -z "$iv" ]; then
+                echo "  [skip] no key/iv in $(basename "$voucher") — voucher schema may have changed" >&2
+                failed=$((failed+1)); continue
+              fi
+              echo "  [decrypt aaxc] $(basename "$aaxc")"
+              ffmpeg -nostdin -hide_banner -loglevel error -y \
+                -audible_key "$key" -audible_iv "$iv" \
+                -i "$aaxc" -c copy "$m4b"
+              decrypted=$((decrypted+1))
+            done < <(find "$STAGING_DIR" -type f -name '*.aaxc' -print0)
+
+            echo "==> Decrypting .aax files (legacy)..."
+            while IFS= read -r -d "" aax; do
+              base="''${aax%.aax}"
+              m4b="$base.m4b"
+              if [ -e "$m4b" ]; then
+                skipped=$((skipped+1)); continue
+              fi
+              if [ -z "$ACTIVATION_BYTES" ]; then
+                echo "  [skip] no activation bytes (run: audible activation-bytes)" >&2
+                failed=$((failed+1)); continue
+              fi
+              echo "  [decrypt aax]  $(basename "$aax")"
+              ffmpeg -nostdin -hide_banner -loglevel error -y \
+                -activation_bytes "$ACTIVATION_BYTES" \
+                -i "$aax" -c copy "$m4b"
+              decrypted=$((decrypted+1))
+            done < <(find "$STAGING_DIR" -type f -name '*.aax' -print0)
+
+            echo "==> Organising into $OUTPUT_DIR/<book>/ ..."
+            # audible-cli writes "<Author> - <Title>.<ext>" flat in the staging
+            # dir. We copy the .m4b plus its cover/chapter sidecar into one
+            # folder per book — Audiobookshelf's preferred layout.
+            organised=0
+            while IFS= read -r -d "" m4b; do
+              dir="$(dirname "$m4b")"
+              base="$(basename "$m4b" .m4b)"
+              target="$OUTPUT_DIR/$base"
+              if [ -e "$target/$base.m4b" ]; then continue; fi
+              mkdir -p "$target"
+              cp -n "$m4b" "$target/$base.m4b"
+              for ext in jpg jpeg png chapters.json; do
+                src="$dir/$base.$ext"
+                [ -e "$src" ] && cp -n "$src" "$target/" || true
+              done
+              organised=$((organised+1))
+            done < <(find "$STAGING_DIR" -maxdepth 1 -type f -name '*.m4b' -print0)
+
+            echo
+            echo "Done. decrypted=$decrypted  skipped=$skipped  failed=$failed  organised=$organised"
+            echo "  Library:  $OUTPUT_DIR"
+            echo "  Staging:  $STAGING_DIR   (encrypted originals kept — delete after verifying)"
+    '';
+  };
+in
+{
+  options.features.audibleSync = {
+    enable = lib.mkEnableOption "audible-sync — download + decrypt Audible library to .m4b";
+
+    outputDir = lib.mkOption {
+      type = lib.types.str;
+      default = "~/audiobooks/audible";
+      description = ''
+        Destination for decrypted, organised .m4b files (one folder per book).
+        Tilde is expanded at runtime against the invoking user's $HOME.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      pkgs.audible-cli # `audible` CLI for one-time login + ad-hoc commands
+      audibleSync # `audible-sync` end-to-end pipeline
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

Two related changes bundled because they need each other to land cleanly:

1. **Bump nixpkgs** to `nixos-unstable` HEAD (`331800de`, 2026-05-31). Headline change: **waydroid 1.6.2 → 1.6.3** (upstream release 4 days ago). Picked up automatically by both razer and p620 via `features.virtualization.waydroid`.

2. **Add `audible-sync` feature on p620** — one-command pipeline to download + decrypt your Audible library to .m4b files, organised one folder per book under `~/audiobooks/audible`.

## Churn fixes triggered by the bump

| File | Fix |
|---|---|
| `modules/desktop/stylix-theme.nix` | Disable `stylix.targets.kmscon` — upstream stylix still sets the removed-in-26.11 `services.kmscon.fonts` option |
| `hosts/razer/configuration.nix` | Permit newly-EOL'd `electron-39.8.10` |
| `hosts/p620/configuration.nix` | Same `electron-39.8.10` permit |
| `hosts/razer/nixos/boot.nix` | Drop our local `openrazer-kernel-7.0.9-hid-report-raw-event.patch` — the fix has landed in nixpkgs' packaged openrazer 3.12.3, our patch now refuses to re-apply. Kept `linuxPackages_latest` (kernel 7.0.10). |

## Why the previous "bump all" PR (#703) left nixpkgs unchanged

`scripts/update-commit-deploy.sh` does try to bump nixpkgs via a `gh api` splice against the `nixos-unstable` branch HEAD. When PR #703 ran, the channel branch had been stuck at `64c08a7c` since 2026-05-23 — Hydra hadn't promoted a fresh commit yet. By the time this PR was prepared (~9 hours after #703 merged), Hydra had advanced the channel to `331800de`. The "(nixpkgs unchanged)" in #703's title was literal: there was nothing newer to advance to at that moment.

## audible-sync notable details

- Implemented as `pkgs.writeShellApplication` with `runtimeInputs = [ audible-cli ffmpeg jq coreutils findutils ]`.
- Suppresses **SC2088** (tilde in single quotes — false positive; `lib.escapeShellArg` emits `'~/...'` and the next line does the `~`→`$HOME` substitution at runtime).
- Adds **`-nostdin`** to ffmpeg invocations — fixes a real bug where ffmpeg would swallow stdin inside the `while read` decryption loop and silently truncate the batch.
- Legal note in module header: personal-use only; stripping DRM violates Audible's ToS.

## Test plan

- [x] `just test-host razer` — green, final derivation `nixos-system-razer-26.11.20260531.331800d`
- [x] `just test-host p620` — green, final derivation `nixos-system-p620-26.11.20260531.331800d`
- [x] Razer closure contains `waydroid-1.6.3` + `openrazer-3.12.3-7.0.10` (kernel 7.0.10)
- [x] Razer kernel resolves to 7.0.10 (`linuxPackages_latest`)
- [ ] Deploy razer + p620
- [ ] `audible-sync` end-to-end after one-time `audible quickstart` on p620

## Files NOT touched (pre-existing user WIP, left alone)

- `home/development/claude-code-commands/*` (dns command WIP)
- `home/development/claude-code-skills/dns/*` (dns skill WIP)
- `home/media/music.nix`
- `secrets.nix`, `secrets/api-godaddy.age`, `secrets/godaddy-account.age` (godaddy WIP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)