### PR TITLE
chore(claude-code): update to 2.1.160

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.158";
+  version = "2.1.160";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-3ScAis1CcAusV2JlLsg/9gS/muB4bU3eVdV6aGYBf74=";
+      hash = "sha256-K4TMLgRjNhnqsCufd+0ApWtkaCtPp7MmcUnunrH+z8c=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-mIB2daPtW3t3X36qge2jLLooELl+nbn2+Y171ljOwA4=";
+      hash = "sha256-H88oUZSg6gxeCZc8TFkQ9xxav0UZMPC5x5RB11Aawik=";
     };
   };
 


### PR DESCRIPTION
## Summary

Bumps `claude-code-native` from **2.1.158 → 2.1.160** (Anthropic GCS distribution channel).

Closes #706 (watcher-opened issue for 2.1.160).
Supersedes #701 (watcher's earlier 2.1.159 — now obsolete).

## Diff

`pkgs/claude-code-native/default.nix`: version + two SRI hashes.

## Verification

- ✅ `nix build .#claude-code-native` → `claude --version` reports `2.1.160 (Claude Code)`
- ✅ `ldd` clean — no missing libs (autoPatchelfHook resolved everything)
- ✅ Host matrix all green (p620 / razer / p510)

## Test plan

- [x] Build claude-code-native
- [x] Verify version output matches target
- [x] Verify ldd has no missing libraries
- [x] Build all 3 hosts
- [ ] Deploy p620 (local)
- [ ] Deploy razer (remote)

p510 doesn't ship the package (not in its closure) — no deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)