### PR TITLE
chore(zoxide): silence the periodic doctor-warning nag

### DIFF
--- a/home/shell/zoxide/default.nix
+++ b/home/shell/zoxide/default.nix
@@ -22,6 +22,12 @@ in
       options = [ "--cmd cd" ];
     };
 
+    # Silence the `zoxide doctor` periodic-nag that prints multi-line
+    # warnings on every shell invocation when it detects "issues" (newer
+    # db version, missing shell hook, etc). Documented escape hatch in
+    # zoxide's source: https://github.com/ajeetdsouza/zoxide
+    home.sessionVariables._ZO_DOCTOR = "0";
+
     # Manually initialize zoxide at the very end of zsh configuration
     # This ensures it loads after all hooks and other integrations
     programs.zsh.initContent = mkAfter ''


### PR DESCRIPTION
## Summary

Sets `_ZO_DOCTOR=0` via Home Manager session vars so zoxide stops printing its multi-line "Disable this message by setting _ZO_DOCTOR=0" warning on every shell invocation.

This is the documented escape hatch in zoxide's source.

## Test plan

- [x] `just test-host p620` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)