### PR TITLE
chore(flake): bump gnome-quick-web-apps to 0.1.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -743,11 +743,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780391650,
-        "narHash": "sha256-svrR+EOILckQTOvJUNfKHBu+ttfXMFxAI7SFpA9eaCg=",
+        "lastModified": 1780394778,
+        "narHash": "sha256-cr3RIMpuWi1wen+CZWwpUTl3dG1Q5ZCpdTPGwiVz+rs=",
         "owner": "olafkfreund",
         "repo": "gnome-quick-web-apps",
-        "rev": "5c1dce705276bc11c60adda7e5f96d358a878669",
+        "rev": "2691e42eb04439a9be34415c11aece0ef95293b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Bumps `inputs.gnome-quick-web-apps` from `5c1dce70` (0.1.4) → `2691e42e` (commit message: `chore(release): v0.1.5`), same-day follow-up to #709.

## Verified

- ✅ `just test-host razer` — green, closure contains `gnome-quick-web-apps-0.1.5`
- ✅ `just test-host p620` — green, identical store path (`7qihd1qcc9na...`)

## Test plan

- [x] Build both hosts
- [ ] Deploy
- [ ] Launch app from GNOME app grid post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)