### PR TITLE
chore(flake): bump gnome-quick-web-apps to 0.1.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -743,11 +743,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780394778,
-        "narHash": "sha256-cr3RIMpuWi1wen+CZWwpUTl3dG1Q5ZCpdTPGwiVz+rs=",
+        "lastModified": 1780404386,
+        "narHash": "sha256-B65Q8CRLpzLGeszOMH0bxgT54kHLjeXjYc7aL8AEy2E=",
         "owner": "olafkfreund",
         "repo": "gnome-quick-web-apps",
-        "rev": "2691e42eb04439a9be34415c11aece0ef95293b7",
+        "rev": "6309e096533753c78b31bbfd70c9c645b57013f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Bumps `inputs.gnome-quick-web-apps` `2691e42e` (0.1.5) → `6309e0965` — main HEAD = v0.1.6 + 1 docs commit, package version `0.1.6`.

## Verified

- ✅ `just test-host razer` — green
- ✅ `just test-host p620` — green
- ✅ Both closures: `/nix/store/5vs85kyzn717a0kjay30w7pjqpxld211-gnome-quick-web-apps-0.1.6` (identical store path on both hosts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)