### PR TITLE
chore(flake): bump gnome-quick-web-apps to 0.1.7

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -743,11 +743,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780404386,
-        "narHash": "sha256-B65Q8CRLpzLGeszOMH0bxgT54kHLjeXjYc7aL8AEy2E=",
+        "lastModified": 1780410656,
+        "narHash": "sha256-KXjf1CJHJtFEoAFjRup78/Iak0Vi7HR/lWFgQARm1/g=",
         "owner": "olafkfreund",
         "repo": "gnome-quick-web-apps",
-        "rev": "6309e096533753c78b31bbfd70c9c645b57013f8",
+        "rev": "fe6c43ebc8100172a2e93ce90fc110c67aec7f13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Bumps `inputs.gnome-quick-web-apps` `6309e0965` (0.1.6 + 1 docs) → `fe6c43ebc8` (= v0.1.7 tag).

## Verified

- ✅ `just test-host razer` — green
- ✅ `just test-host p620` — green
- ✅ Both closures: `/nix/store/nfhipdk8icdbk3zzw1i17fz1c6mpwp8l-gnome-quick-web-apps-0.1.7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)