### PR TITLE
chore(flake): bump gnome-quick-web-apps to 0.1.8

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -743,11 +743,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780410656,
-        "narHash": "sha256-KXjf1CJHJtFEoAFjRup78/Iak0Vi7HR/lWFgQARm1/g=",
+        "lastModified": 1780412935,
+        "narHash": "sha256-5lT3ehEJitgjL37hMejwt4BNT4TYfTcXN0jJTYHYZHY=",
         "owner": "olafkfreund",
         "repo": "gnome-quick-web-apps",
-        "rev": "fe6c43ebc8100172a2e93ce90fc110c67aec7f13",
+        "rev": "7601a63a00092708bee6746af1c6361a75cfbef9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `inputs.gnome-quick-web-apps` `fe6c43ebc8` (0.1.7) → `7601a63a00` (= v0.1.8 tag).

Verified: `just test-host` green on razer + p620, identical closure path `/nix/store/c9cc4crj41cq9h88l4zgphn5yzqn7hnm-gnome-quick-web-apps-0.1.8` on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)