### PR TITLE
chore(flake): bump gnome-quick-web-apps to 0.1.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -743,11 +743,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780430294,
-        "narHash": "sha256-66I1KTEMTSA0APOo5OfGuM2hIVY4pxIEfK6wS7WihEI=",
+        "lastModified": 1780434135,
+        "narHash": "sha256-urs1vlI/Mx8O7wFCz/4OTO8MencYRAvGRw6b9MQ1ssk=",
         "owner": "olafkfreund",
         "repo": "gnome-quick-web-apps",
-        "rev": "6689512660b2bf5ae8d6812dfded0d132dbe19b8",
+        "rev": "5c8db2ea80406e22f6bc457be0dda22e60741f12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `inputs.gnome-quick-web-apps` `6689512660` (0.1.10) → `5c8db2ea80` (= v0.1.11 tag, DRM 'protected content' runtime fix).

Verified: `just test-host` green on razer + p620, identical closure path `/nix/store/0qyrr8bjjpp08am6cwf62gvvsyah04sr-gnome-quick-web-apps-0.1.11` on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)