### PR TITLE
chore(flake): bump gnome-quick-web-apps to 0.1.17

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -743,11 +743,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780434135,
-        "narHash": "sha256-urs1vlI/Mx8O7wFCz/4OTO8MencYRAvGRw6b9MQ1ssk=",
+        "lastModified": 1780446092,
+        "narHash": "sha256-Kwur5erh2nGS3He8GquKFtW8zAXAHWS26LBISk7SQCg=",
         "owner": "olafkfreund",
         "repo": "gnome-quick-web-apps",
-        "rev": "5c8db2ea80406e22f6bc457be0dda22e60741f12",
+        "rev": "7724117fbeb897748e8dfdefb5fbd5e54b7a86a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `inputs.gnome-quick-web-apps` `5c8db2ea80` (0.1.11) → `7724117fbe` (= v0.1.17 tag, per-app dock icon fix). Skips 0.1.12 (startup crash from premature DRM enablement, since reverted across 0.1.13-0.1.16).

Verified: `just test-host` green on razer + p620, identical closure path `/nix/store/97bcvq6sdw1zrinzrck7ivh42rz3ixv9-gnome-quick-web-apps-0.1.17` on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)