### PR TITLE
fix(gstreamer): ship coreelements (fakesink/identity/queue/…) by adding gstreamer.out

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -542,7 +542,16 @@ in
     # codecs reliably (GNOME pulls these in transitively but only
     # exposes them inside app wrappers, not on the system GST_PLUGIN_PATH).
     # Tracks nixpkgs-unstable's current GStreamer 1.26.x stable.
+    #
+    # NOTE: `gstreamer` itself has `meta.outputsToInstall = ["bin"]` —
+    # the default add gives ONLY the gst-* CLI tools, NOT the core
+    # plugins (coreelements: fakesink, identity, queue, tee, …). We must
+    # explicitly add `gstreamer.out` to get libgstcoreelements.so onto
+    # GST_PLUGIN_SYSTEM_PATH_1_0. Without it, anything using `fakesink`
+    # (e.g. YetAnotherRadio's playbin3 video-sink stub) fails with
+    # "GStreamer plugin missing".
     gstreamer
+    gstreamer.out
     gst-plugins-base
     gst-plugins-good
     gst-plugins-bad

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -461,7 +461,16 @@ in
     # codecs reliably (GNOME pulls these in transitively but only
     # exposes them inside app wrappers, not on the system GST_PLUGIN_PATH).
     # Tracks nixpkgs-unstable's current GStreamer 1.26.x stable.
+    #
+    # NOTE: `gstreamer` itself has `meta.outputsToInstall = ["bin"]` —
+    # the default add gives ONLY the gst-* CLI tools, NOT the core
+    # plugins (coreelements: fakesink, identity, queue, tee, …). We must
+    # explicitly add `gstreamer.out` to get libgstcoreelements.so onto
+    # GST_PLUGIN_SYSTEM_PATH_1_0. Without it, anything using `fakesink`
+    # (e.g. YetAnotherRadio's playbin3 video-sink stub) fails with
+    # "GStreamer plugin missing".
     gstreamer
+    gstreamer.out
     gst-plugins-base
     gst-plugins-good
     gst-plugins-bad


### PR DESCRIPTION
Follow-up to #721. gstreamer's default output is 'bin' (gst-* CLI), not 'out' (libgstcoreelements.so) — listing just `gstreamer` left core elements off GST_PLUGIN_SYSTEM_PATH_1_0. BuddySirJava/YetAnotherRadio (and anything using fakesink/identity/queue/etc) breaks on launch.

## Verified
- ✅ `just test-host p620` green; closure contains `gstreamer-1.26.11` (the .out path)
- ✅ `just test-host razer` green

## Test plan
- [ ] Deploy
- [ ] `gst-inspect-1.0 fakesink` returns Factory Details on both hosts
- [ ] YetAnotherRadio launches without 'GStreamer plugin missing'

🤖 Generated with [Claude Code](https://claude.com/claude-code)