### PR TITLE
chore(claude-code): update to 2.1.162

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.161";
+  version = "2.1.162";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-H2oi84ejvOSWtthpOJo13/taacl9mDGDPzvW3A5sbCg=";
+      hash = "sha256-lHpJsN6GiPanSm51PCR3H/Pd0Xsqba6F82ME7FFOYdE=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-ffoKeaL8nzMgV83AMC+AjLpj33t14sy1p8GrYmOYBOM=";
+      hash = "sha256-7KKmA9/rw0JqhGnL55f535UkVzi8HCDshC/I+Ar0AQ0=";
     };
   };
 


### PR DESCRIPTION
## Summary

Bump `claude-code-native` from `2.1.161` → `2.1.162`.

## Changes

- `pkgs/claude-code-native/default.nix`:
  - `version`: `2.1.161` → `2.1.162`
  - x86_64-linux hash refreshed
  - aarch64-linux hash refreshed

## Verification

- `nix build .#claude-code-native` ✅ — `claude --version` reports `2.1.162`
- `ldd` clean — no missing libs
- Host closures build green on all 3 active hosts:
  - p620 ✅
  - razer ✅
  - p510 ✅ (builds even though it doesn't install claude-code)

## Deploy plan

- p620 (local) — primary
- razer (remote via SSH)
- p510 — skip; `claude-code-native` is not in its closure

Closes #724