### PR TITLE
fix(home): drop preemptive gtk.gtk4.theme = null (stylix collision)

### DIFF
--- a/Users/common/base-home.nix
+++ b/Users/common/base-home.nix
@@ -57,7 +57,6 @@
   };
 
   # Adopt new Home Manager defaults (silence deprecation warnings)
-  gtk.gtk4.theme = null;
   programs.git.signing.format = null;
 
   # We intentionally chase nixos-unstable for nixpkgs; HM/Stylix master often


### PR DESCRIPTION
## Summary

Resolves a `home-manager.users.olafkfreund.gtk.gtk4.theme` option collision triggered by a recent stylix bump.

## Background

\`Users/common/base-home.nix\` originally set:

\`\`\`nix
gtk.gtk4.theme = null;
\`\`\`

…to silence a Home Manager deprecation warning. Recent stylix releases now populate \`gtk.gtk4.theme\` with a derived value from the active base16 palette, producing:

\`\`\`
error: The option \`home-manager.users.olafkfreund.gtk.gtk4.theme\`
is defined both null and not null, in '…/modules/gtk/hm.nix' (stylix)
and '…/Users/common/base-home.nix' (ours).
\`\`\`

## Fix

Drop the line. GTK theming is enabled fleet-wide via stylix (per the comment block immediately below in the same file). Stylix providing an explicit non-null value is the intended behavior, and any explicit value satisfies HM's deprecation check — so the original nag won't return.

## Verification

\`\`\`bash
nix eval --raw .#nixosConfigurations.p620.config.system.build.toplevel.outPath  # ✓
nix eval --raw .#nixosConfigurations.razer.config.system.build.toplevel.outPath # ✓
nix eval --raw .#nixosConfigurations.p510.config.system.build.toplevel.outPath  # ✓
\`\`\`

Discovered via \`just update-commit\` failing at the post-update freshness check.