### PR TITLE
feat(inotify): raise watch/instance/queue limits to 2097152 fleet-wide

### DIFF
--- a/hosts/common/nixos/inotify-limits.nix
+++ b/hosts/common/nixos/inotify-limits.nix
@@ -1,0 +1,11 @@
+_: {
+  # Inotify limits — headroom for heavy multi-project dev (VSCode,
+  # watchexec, multiple node_modules trees, file-watching dev servers).
+  # Nixpkgs' sysctl.nix sets these to 524288 via mkDefault; we override
+  # at normal priority for 4× margin across all hosts.
+  boot.kernel.sysctl = {
+    "fs.inotify.max_user_watches" = 2097152;
+    "fs.inotify.max_user_instances" = 2097152;
+    "fs.inotify.max_queued_events" = 2097152;
+  };
+}

--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -23,6 +23,7 @@ in
       ../common/nixos/i18n.nix
       ../common/nixos/envvar.nix
       ../common/nixos/host-class.nix
+      ../common/nixos/inotify-limits.nix
       ./nixos/cpu.nix
       ./nixos/memory.nix
       ../common/nixos/hosts.nix

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -26,6 +26,7 @@ in
     ../common/nixos/hosts.nix
     ../common/nixos/envvar.nix
     ../common/nixos/host-class.nix
+    ../common/nixos/inotify-limits.nix
     ./nixos/cpu.nix
     ./nixos/memory.nix
     ./nixos/load.nix

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -23,6 +23,7 @@ in
     ../common/nixos/hosts.nix
     ../common/nixos/envvar.nix
     ../common/nixos/host-class.nix
+    ../common/nixos/inotify-limits.nix
     ./nixos/cpu.nix
     ./nixos/laptop.nix
     ./nixos/memory.nix


### PR DESCRIPTION
## Summary

Raise inotify limits across all 3 active hosts from the kernel/systemd default of 524288 to 2097152 (4× margin).

\`\`\`
fs.inotify.max_user_watches   = 2097152
fs.inotify.max_user_instances = 2097152
fs.inotify.max_queued_events  = 2097152
\`\`\`

## Why

Nothing in this repo previously pinned these — the 524288 effective values came from \`nixos/modules/config/sysctl.nix\` upstream at priority 1000 (\`mkDefault\`). A future systemd/kernel default change could have silently drifted us down. Pinning explicitly removes that risk and provides headroom for heavy multi-project dev (multiple VSCode windows + watchexec + node_modules trees + file-watching dev servers).

## Implementation

- New file: \`hosts/common/nixos/inotify-limits.nix\` (the shared sysctl block).
- One import line added to each of \`p620\`, \`razer\`, \`p510\` configurations.

## Verification

\`\`\`bash
nix eval --no-eval-cache .#nixosConfigurations.{p620,razer,p510}.config.boot.kernel.sysctl."fs.inotify.max_user_watches"
# → 2097152 on all three

nix build .#nixosConfigurations.{p620,razer,p510}.config.system.build.toplevel
# → all green
\`\`\`

Becomes active after \`nh os switch\` / \`nhs <host>\` on each machine; current running kernels stay on 524288 until then.