### PR TITLE
fix(backstage): seed catalog Groups (group:olafkfreund + group:admins)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -26,7 +26,33 @@ spec:
   profile:
     displayName: Olaf K. Freund
     email: olaf@freundcloud.com
-  memberOf: []
+  memberOf: [admins]
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: admins
+  description: Backstage administrators — currently a one-member group.
+spec:
+  type: team
+  children: []
+  members: [olafkfreund]
+
+---
+# Same-name Group as the User so `spec.owner: olafkfreund` in any
+# onboarded catalog-info.yaml resolves cleanly. Backstage interprets
+# bare owner names as Group refs, and the catalog-onboard workflow
+# emits `owner: olafkfreund` without a namespace prefix.
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: olafkfreund
+  description: Owner alias for olafkfreund — one-member group containing the User of the same name.
+spec:
+  type: team
+  children: []
+  members: [olafkfreund]
 
 ---
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
Backstage warns on every entity page: `Entities not found are: group:default/olafkfreund`.

Every onboarded catalog-info.yaml uses `spec.owner: olafkfreund` (no namespace). Backstage interprets bare owner names as Group refs and looks up `group:default/olafkfreund` — which didn't exist in main's seed catalog.

This commit adds the two Group entities so the relations resolve cleanly. Group entities were on the feature branch but the squash-merge of PR #737 to main happened before they were added. This brings the gap closed.

After merge, Backstage's Location processor re-fetches catalog-info.yaml and ingests the Groups within ~5 min.

## Test plan

- [x] Local YAML structure valid
- [ ] After merge: `curl /api/catalog/entities?filter=kind=group` returns olafkfreund + admins
- [ ] After merge: orange warning on entity pages disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)