### PR TITLE
feat(backstage): MCP Actions server + secret + image bump

### DIFF
--- a/modules/services/backstage.nix
+++ b/modules/services/backstage.nix
@@ -51,7 +51,7 @@ in
 
     image = lib.mkOption {
       type = lib.types.str;
-      default = "ghcr.io/olafkfreund/backstage@sha256:8ad50a3479b6b6a08037bc01cdaa17212f25a783ac6cd59a9ecc6b82ef71e59c";
+      default = "ghcr.io/olafkfreund/backstage@sha256:a5af10f004e7aee92acd8543e08f859927306af39a873f5930c9678a4ff20810";
       example = "ghcr.io/olafkfreund/backstage@sha256:abc123...";
       description = ''
         OCI image to pull for the Backstage backend. MUST be pinned to a
@@ -143,6 +143,10 @@ in
       file = ../../secrets/backstage-gitlab-token.age;
       mode = "0400";
     };
+    age.secrets.backstage-mcp-token = {
+      file = ../../secrets/backstage-mcp-token.age;
+      mode = "0400";
+    };
 
     # ---------------------------------------------------------------------
     # Persistent state.
@@ -203,6 +207,7 @@ in
         GH_OAUTH_ID=$(cat ${agenixPath "backstage-github-oauth-client-id"})
         GH_OAUTH_SECRET=$(cat ${agenixPath "backstage-github-oauth-client-secret"})
         GL_TOKEN=$(cat ${agenixPath "backstage-gitlab-token"})
+        MCP_TOKEN=$(cat ${agenixPath "backstage-mcp-token"})
 
         cat > ${envDir}/env-postgres <<EOF
         POSTGRES_USER=${cfg.pgUser}
@@ -225,6 +230,7 @@ in
         AUTH_GITHUB_CLIENT_ID=$GH_OAUTH_ID
         AUTH_GITHUB_CLIENT_SECRET=$GH_OAUTH_SECRET
         GITLAB_TOKEN=$GL_TOKEN
+        MCP_TOKEN=$MCP_TOKEN
         EOF
 
         chmod 0400 ${envDir}/env-postgres ${envDir}/env-backstage

--- a/secrets.nix
+++ b/secrets.nix
@@ -85,6 +85,7 @@ in
   "secrets/backstage-github-oauth-client-id.age".publicKeys = allUsers ++ [ p510 ];
   "secrets/backstage-github-oauth-client-secret.age".publicKeys = allUsers ++ [ p510 ];
   "secrets/backstage-gitlab-token.age".publicKeys = allUsers ++ [ p510 ];
+  "secrets/backstage-mcp-token.age".publicKeys = allUsers ++ [ p510 ];
 
   # SABnzbd confidential settings (ConfigObj INI) merged via
   # services.sabnzbd.secretFiles on p510 — holds the Easynews news-server

--- a/secrets/backstage-mcp-token.age
+++ b/secrets/backstage-mcp-token.age
@@ -1,0 +1,8 @@
+age-encryption.org/v1
+-> ssh-ed25519 wgedHw HJdTz25hCZcZ2L+voqmZKg1X8GRl8Yulcxm3w4zaVUs
+l+LTWijcoMLwalJpmbNhji2SnBb3Wd1tvGOPQrhBMTs
+-> ssh-ed25519 tbxj3w ftMjYiN2HYpqP/zx06lPV800rkNQf1ZoPhKANH5hIWw
+HP7dGT/wwR0Hx6R4k4cPw5yH5NoT49kT2mvNulN7Tn0
+--- OJl/bEz5gd46uB8Tlt0tXpZFywSHv7U9geklecNTX6Y
+ÖšŸs+m€>Ó›Õ>N/y<Mb9Ùèq@H‘8cÜc£×7èÌ°HÌjñ¨ÎAÑç ÄÝ
+9“¼öO&ù


### PR DESCRIPTION
Enables Backstage's MCP server for AI agents. Token via agenix; reachable at https://p510.tail833f7.ts.net/backstage/api/mcp-actions/v1.