### PR TITLE
feat(backstage): bump image to e52253e (4 templates + 4 widgets)

### DIFF
--- a/modules/services/backstage.nix
+++ b/modules/services/backstage.nix
@@ -51,7 +51,7 @@ in
 
     image = lib.mkOption {
       type = lib.types.str;
-      default = "ghcr.io/olafkfreund/backstage@sha256:7c31bc488e01d4fcf3e0dd6d454490dcc9c52412f6451e897b8c202b0da3979a";
+      default = "ghcr.io/olafkfreund/backstage@sha256:adefc7778b7695cfd054bbcfd837384c187c45488ab34c46ac040223d0815bdb";
       example = "ghcr.io/olafkfreund/backstage@sha256:abc123...";
       description = ''
         OCI image to pull for the Backstage backend. MUST be pinned to a


### PR DESCRIPTION
## Summary

Bumps the pinned Backstage image digest to pull in [olafkfreund/backstage#2](https://github.com/olafkfreund/backstage/pull/2).

### Image
- Old: \`sha256:7c31bc4…\` (sha-c27d09f, rust-service template only)
- New: \`sha256:adefc77…\` (sha-e52253e, +4 templates +4 widgets)

### What lands on p510
4 new software templates (each appears in \`/create\`):
- **python-service** — FastAPI + uv + pytest + Claude skill
- **typescript-service** — Fastify + vitest + ESLint + Prettier + OpenAPI dump + Claude skill
- **cosmic-applet** — libcosmic + iced applet + .desktop file + Claude skill
- **nixos-module** — Reusable module + example host + Claude skill

4 new HomePage widgets (GitHub-authed, 5-min refresh):
- **OrgOpenPrs** — my open PRs, oldest-first, with review state
- **ReviewRequested** — PRs waiting on my review
- **RecentActivity** — last 20 events from my events feed
- **OpenIssues** — issues assigned to me

## Test plan
- [x] \`just check-syntax\` clean
- [ ] \`just p510\` deploys without rollback
- [ ] All 4 templates appear in \`/create\`
- [ ] All 4 widgets render on home page after GitHub OAuth
- [ ] Existing rust-service template still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)