### PR TITLE
feat(backstage): bump image to c91e7f5 (6 cloud templates + UX fixes)

### DIFF
--- a/modules/services/backstage.nix
+++ b/modules/services/backstage.nix
@@ -51,7 +51,7 @@ in
 
     image = lib.mkOption {
       type = lib.types.str;
-      default = "ghcr.io/olafkfreund/backstage@sha256:adefc7778b7695cfd054bbcfd837384c187c45488ab34c46ac040223d0815bdb";
+      default = "ghcr.io/olafkfreund/backstage@sha256:c707f8d912965459fb5faa3bc653a54adb31516bc2de651232989a52dbc6f969";
       example = "ghcr.io/olafkfreund/backstage@sha256:abc123...";
       description = ''
         OCI image to pull for the Backstage backend. MUST be pinned to a


### PR DESCRIPTION
Bumps Backstage image to pull in olafkfreund/backstage#3 + #4.

### Image
- Old: \`sha256:adefc77…\` (sha-e52253e)
- New: \`sha256:c707f8d…\` (sha-c91e7f5, latest)

### What lands on p510
**#3 — Custom HomePage actually renders**: the override id was wrong (\`page:home/home\` vs default's \`page:home\`), so it was registering as a duplicate route, not replacing. The default empty 'Add widget' page was winning. Now the 4 GitHub-data widgets + the 4 existing cards finally show up.

**#4 — 6 new cloud templates** appear in \`/create\` (devenv flake, mkdocs, Claude skill, CI each):
- terraform-aws / terraform-gcp / terraform-azure
- kubernetes-aws-eks / kubernetes-azure-aks / kubernetes-gcp-gke

**#4 — Catalog Graph deep-link**: \`qs.parse\` needs \`?rootEntityRefs[]=\` array form. Switched root from User to Group (Group is in default kinds filter + has 79 ownerOf relations). Also set initialState via app.extensions so direct navigation works too.

## Test plan
- [x] just check-syntax clean
- [ ] just p510 deploys without rollback
- [ ] /home shows 4 widgets + 4 cards instead of empty grid
- [ ] /create shows 11 templates (5 existing + 6 new)
- [ ] Sidebar 'Catalog Graph' click lands on populated graph