### PR TITLE
fix(backstage): bump to a574f01 (drop broken visits widgets)

### DIFF
--- a/modules/services/backstage.nix
+++ b/modules/services/backstage.nix
@@ -51,7 +51,7 @@ in
 
     image = lib.mkOption {
       type = lib.types.str;
-      default = "ghcr.io/olafkfreund/backstage@sha256:c707f8d912965459fb5faa3bc653a54adb31516bc2de651232989a52dbc6f969";
+      default = "ghcr.io/olafkfreund/backstage@sha256:9082e1296894f18fb173136b7cc7589dc9c8333064581dd3a962989ffc0a37f4";
       example = "ghcr.io/olafkfreund/backstage@sha256:abc123...";
       description = ''
         OCI image to pull for the Backstage backend. MUST be pinned to a


### PR DESCRIPTION
Pulls in olafkfreund/backstage#5. Removes the two error-throwing widgets from the home page.