### PR TITLE
fix(backstage): bump to 32f566e (convertLegacyPlugin for entity tabs)

### DIFF
--- a/modules/services/backstage.nix
+++ b/modules/services/backstage.nix
@@ -51,7 +51,7 @@ in
 
     image = lib.mkOption {
       type = lib.types.str;
-      default = "ghcr.io/olafkfreund/backstage@sha256:cc024bb3f729d7b9f7e7e14a06be0baf5e5eeaa624871f9c57bd4379e83b4b1f";
+      default = "ghcr.io/olafkfreund/backstage@sha256:3458fc58849e5cd70821f326ba57c28b483660fac37950b6965bf5e01ebb6731";
       example = "ghcr.io/olafkfreund/backstage@sha256:abc123...";
       description = ''
         OCI image to pull for the Backstage backend. MUST be pinned to a


### PR DESCRIPTION
Pulls olafkfreund/backstage#16. Fixes routeRef-not-discovered errors on Actions/Insights/PRs/Security entity tabs.