### PR TITLE
fix(backstage): bump to 21db7e6 (revert broken legacy entity tabs)

### DIFF
--- a/modules/services/backstage.nix
+++ b/modules/services/backstage.nix
@@ -51,7 +51,7 @@ in
 
     image = lib.mkOption {
       type = lib.types.str;
-      default = "ghcr.io/olafkfreund/backstage@sha256:3458fc58849e5cd70821f326ba57c28b483660fac37950b6965bf5e01ebb6731";
+      default = "ghcr.io/olafkfreund/backstage@sha256:149315cd0ec744cd0db4d74f9e89bf9dc0794be3340180635f062e6deceff0ca";
       example = "ghcr.io/olafkfreund/backstage@sha256:abc123...";
       description = ''
         OCI image to pull for the Backstage backend. MUST be pinned to a


### PR DESCRIPTION
Pulls olafkfreund/backstage#17. Removes errored Actions/PRs/Security tabs; routable legacy plugins deferred to olafkfreund/backstage#18.