### PR TITLE
chore(claude-desktop): update to v2.0.18+claude1.11187.1 (#739)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,17 +116,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1779932571,
-        "narHash": "sha256-vOHSgioMms0IHVryaofcIOw/5nY3SzBtRscRSRcINTA=",
+        "lastModified": 1780624122,
+        "narHash": "sha256-NeajPGABECK+ltSKT8MTy0+h760aHyRpzFKtfZqc8Ms=",
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "5dd948e96d853ed37636bc0e2368fc2665cd1104",
+        "rev": "4b6ff35236598725ba02bfb5acd57b4e531ee07f",
         "type": "github"
       },
       "original": {
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "5dd948e96d853ed37636bc0e2368fc2665cd1104",
+        "rev": "4b6ff35236598725ba02bfb5acd57b4e531ee07f",
         "type": "github"
       }
     },
@@ -1207,11 +1207,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1779536132,
-        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
+        "lastModified": 1780030872,
+        "narHash": "sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL+WNQD0rJfJZQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
+        "rev": "e9a7635a57597d9754eccebdfc7045e6c8600e6b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,8 @@
     # Workaround: close claude-desktop entirely to release inhibitor,
     # or set CLAUDE_KEEP_AWAKE=0 (#645).
     # Bump via /update-claude-code.
-    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/5dd948e96d853ed37636bc0e2368fc2665cd1104";
+    # = tag v2.0.18+claude1.11187.1 (commit 4b6ff35236, 2026-06-05)
+    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/4b6ff35236598725ba02bfb5acd57b4e531ee07f";
 
     # Claude Code skill catalogue (borghei). flake = false because it's a
     # plain markdown/assets catalogue, not a Nix flake. We symlink one


### PR DESCRIPTION
## Summary

- Bumps `aaddrick/claude-desktop-debian` flake input from \`5dd948e9\` (v2.0.18+claude1.10628.2, 2026-05-28) to \`4b6ff352\` (v2.0.18+claude1.11187.1, 2026-06-05).
- Underlying Claude binary: 1.10628.2 → 1.11187.1 (26 upstream commits).
- Our overlay (\`overlays/default.nix:13-15\`) is a plain pass-through to upstream's \`claude-desktop-fhs\`, so there's no local sed/patch to re-anchor.

## Verification

- ✅ Razer FHS wrapper builds; inner derivation is \`claude-desktop-1.11187.1\`.
- ✅ \`pty.node\` at the standard path is ELF 64-bit x86-64 (\`file\` check).
- ✅ p620 / razer / p510 nixos-system toplevels all build (p510 cached — no claude-desktop in its closure).

## Test plan

- [ ] Deploy razer first (primary desktop host): \`ssh razer 'cd ~/.config/nixos && git pull && sudo nixos-rebuild switch --flake .#razer'\`
- [ ] Verify on razer post-deploy: \`pgrep -af "claude-desktop-1\\.[0-9]"\` shows new \`1.11187.1\` inner hash after relaunch
- [ ] Deploy p620 second (user confirmation expected — known idiot-proofing: any running claude-desktop processes keep the OLD store path until \`pkill -f claude-desktop\` + relaunch)

Closes #739