### PR TITLE
fix(audit): set GH_TOKEN at job scope so the audit script can call gh

### DIFF
--- a/.github/workflows/nixos-issue-audit.yml
+++ b/.github/workflows/nixos-issue-audit.yml
@@ -31,6 +31,12 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # GH_TOKEN at job scope: every step shells out to `gh` (audit script
+    # uses it for nixpkgs queries; later steps use it for issue writes).
+    # Per-step env was an easy thing to miss — first dispatched run on
+    # 2026-06-06 failed exactly here.
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -42,8 +48,6 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: Ensure required labels exist
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           # Idempotent: gh label create fails if exists; suppress that.
@@ -63,8 +67,6 @@ jobs:
           head -30 audit-out/report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upsert rolling Nightly Audit issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           # Find the most recent open issue with label nightly-audit. If
@@ -89,8 +91,6 @@ jobs:
           fi
 
       - name: Open tracking issues for CRITICAL + REGRESSION findings
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           # Iterate over the JSONL findings. Dedup by the upstream issue


### PR DESCRIPTION
## Summary

First dispatched run of \`nixos-issue-audit.yml\` (run #27048323711, see [logs](https://github.com/olafkfreund/nixos_config/actions/runs/27048323711)) failed at the **Run audit** step:

\`\`\`
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
\`\`\`

The audit script shells out to \`gh api\` to fetch nixpkgs issues. The label-create / upsert / per-finding steps each set \`GH_TOKEN\` explicitly, but the run-audit step didn't.

## Fix

Lift \`GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}\` to job scope so all steps inherit it. Drop the now-redundant per-step env blocks. Net: -3 \`env:\` blocks, +1 at job scope.

## Why this slipped through

Pre-commit hooks (shellcheck, yaml-lint, spelling) all passed. CI on the original PR passed too. There's no static check that catches \"this step shells to \`gh\` without setting \`GH_TOKEN\`\" — only a runtime check.

## Verification

After merge I'll re-trigger the workflow manually (\`gh workflow run\`). Expected: \"Run audit\" succeeds, rolling issue created with label \`nightly-audit\`, one tracking issue created for nixpkgs#528030 (the pipewire+bluetooth 🟠 finding).