### PR TITLE
chore(backstage): bump image to obsidian-bridge build (sha-efbf61f)

### DIFF
--- a/modules/services/backstage.nix
+++ b/modules/services/backstage.nix
@@ -51,7 +51,7 @@ in
 
     image = lib.mkOption {
       type = lib.types.str;
-      default = "ghcr.io/olafkfreund/backstage@sha256:c2bee00f32aa787aa88d44d8dbbf7d62ccdb349d380acb1f33e48ab97d64ec8b";
+      default = "ghcr.io/olafkfreund/backstage@sha256:33a836eb6a7b8d45e5ef240e973ba2dd1856e377a31b1c952fa244b2d3dd70bc";
       example = "ghcr.io/olafkfreund/backstage@sha256:abc123...";
       description = ''
         OCI image to pull for the Backstage backend. MUST be pinned to a


### PR DESCRIPTION
## Summary

Bumps the pinned Backstage backend image digest to bring in the version that has \`mkdocs-obsidian-bridge\` baked in.

- Old: \`sha256:c2bee00f3...\` (2026-06-04)
- New: \`sha256:33a836eb6...\` (2026-06-06, from olafkfreund/backstage#28 source commit \`efbf61f\`)

## Why now

Unblocks olafkfreund/calitii_vault#3 — that PR adds symlinks under \`docs/\` so the whole vault renders, but the wikilinks (\`[[Path/File|Display]]\`) only resolve to real anchors if the running Backstage backend has the \`mkdocs-obsidian-bridge\` MkDocs plugin available. The old image doesn't ship it.

## Verification

- \`nix build .#nixosConfigurations.p510.config.system.build.toplevel\` succeeds (47s) ✅
- New image was built and pushed by olafkfreund/backstage's CI run #27048769249 ✅

## Test plan

- [ ] CI green (all 3 host configs, lint, pre-commit)
- [ ] Merge
- [ ] \`just p510\` to deploy
- [ ] Confirm \`podman exec backstage pip list | grep obsidian\` shows \`mkdocs-obsidian-bridge\` on p510
- [ ] Refresh \`calitii_vault\` in Backstage UI → Docs tab renders the NixOS notes with working wikilinks