### PR TITLE
feat(ollama): add gemma4:12b to p620 + p510 on-demand models

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -369,7 +369,7 @@ in
     persistentModels = [ ]; # No persistent models to save VRAM
     # gemma4 for n8n; qwen2.5:7b for reliable strict-JSON audiobook metadata
     # extraction + tool-calling (audiobook-import / audiobook-mcp).
-    onDemandModels = [ "gemma4:e4b" "qwen2.5:7b" ];
+    onDemandModels = [ "gemma4:e4b" "qwen2.5:7b" "gemma4:12b" ];
     keepAlive = "5m"; # Evict from VRAM after 5 minutes of idle
   };
 

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -105,7 +105,7 @@ in
     enable = true;
     modelsDir = "/mnt/data/ollama/models";
     persistentModels = [ "qwen3:14b" ];
-    onDemandModels = [ "qwen2.5-coder:14b" "gemma4:e4b" ];
+    onDemandModels = [ "qwen2.5-coder:14b" "gemma4:e4b" "gemma4:12b" ];
   };
 
   # LiteLLM router — Anthropic-compat proxy fronting Ollama (Phase 2).


### PR DESCRIPTION
## Summary

- Add `gemma4:12b` to `onDemandModels` on **p620** (RX 7900 XTX / ROCm) and **p510** (NVIDIA / CUDA)
- Mid-size Gemma 4 (~7-8GB Q4) — fills the gap between `gemma4:e4b` (~3GB) and the 14B coder models
- `OLLAMA_MAX_LOADED_MODELS=1` still enforces single-resident VRAM, so no contention with `qwen3:14b` (p620 persistent) or `qwen2.5:7b` (p510 on-demand)

## Test plan

- [x] `just test-host p620` — build succeeded, only `ollama-model-loader` unit rebuilt
- [x] `just test-host p510` — build succeeded, only `ollama-model-loader` unit rebuilt
- [ ] Deploy + verify `ollama list | grep gemma4` shows `:e4b` and `:12b` on both hosts
- [ ] Smoke-test `ai-cli -p ollama -m gemma4:12b "say hi"`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>