### PR TITLE
revert: gemma4:12b — requires newer ollama runtime (HTTP 412 on manifest pull)

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -369,7 +369,7 @@ in
     persistentModels = [ ]; # No persistent models to save VRAM
     # gemma4 for n8n; qwen2.5:7b for reliable strict-JSON audiobook metadata
     # extraction + tool-calling (audiobook-import / audiobook-mcp).
-    onDemandModels = [ "gemma4:e4b" "qwen2.5:7b" "gemma4:12b" ];
+    onDemandModels = [ "gemma4:e4b" "qwen2.5:7b" ];
     keepAlive = "5m"; # Evict from VRAM after 5 minutes of idle
   };
 

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -105,7 +105,7 @@ in
     enable = true;
     modelsDir = "/mnt/data/ollama/models";
     persistentModels = [ "qwen3:14b" ];
-    onDemandModels = [ "qwen2.5-coder:14b" "gemma4:e4b" "gemma4:12b" ];
+    onDemandModels = [ "qwen2.5-coder:14b" "gemma4:e4b" ];
   };
 
   # LiteLLM router — Anthropic-compat proxy fronting Ollama (Phase 2).


### PR DESCRIPTION
## Summary

Reverts #781. The tag `gemma4:12b` IS published, but pulling its manifest fails with HTTP 412 against our currently-pinned `pkgs.ollama-rocm` / `ollama-cuda` versions:

> The model you are attempting to pull requires a newer version of Ollama.

On p620 this left `ollama-model-loader.service` in an auto-restart fail loop. Reverting restores the prior known-good model list (`qwen3:14b` persistent + `qwen2.5-coder:14b` / `gemma4:e4b` on-demand on p620; `gemma4:e4b` / `qwen2.5:7b` on-demand on p510). p510 was never deployed with #781 so this revert only matters for p620.

## Follow-up

To actually land `gemma4:12b`, bump nixpkgs to pull a newer `ollama-rocm` / `ollama-cuda`:

\`\`\`bash
nhs               # bump nixpkgs and redeploy current host
# or
just update-input nixpkgs && just quick-deploy p620 && ssh p510 ...
\`\`\`

Then re-introduce the model entries.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>