### PR TITLE
fix(catalog): add /tree/main/ to source-location — unbreaks TechDocs build

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -82,7 +82,7 @@ metadata:
   annotations:
     github.com/project-slug: olafkfreund/nixos_config
     backstage.io/techdocs-ref: dir:.
-    backstage.io/source-location: url:https://github.com/olafkfreund/nixos_config
+    backstage.io/source-location: url:https://github.com/olafkfreund/nixos_config/tree/main/
     backstage.io/view-url: https://github.com/olafkfreund/nixos_config
     backstage.io/edit-url: https://github.com/olafkfreund/nixos_config/edit/main/
     github.com/project-readme-path: README.md


### PR DESCRIPTION
## Problem

The NixOS Infrastructure Hub TechDocs tab in Backstage showed:

- Top banner: \`Request failed for https://api.github.com/repos/olafkfreund, 404 Not Found\`
- Body: \`ERROR 404: NotFoundError: Page not found... no index.md file in the root of the docs directory\`

## Root cause

\`backstage.io/techdocs-ref: dir:.\` is resolved against \`backstage.io/source-location\` via \`scmIntegrations.resolveUrl\` (standard URL semantics). With source-location \`url:https://github.com/olafkfreund/nixos_config\` (no trailing slash), \`nixos_config\` is parsed as a filename, and \`.\` resolves to the *parent dir* \`https://github.com/olafkfreund/\`. GithubUrlReader then sees \`owner=olafkfreund, repo=''\` and calls \`/repos/olafkfreund\` → 404. TechDocs build never starts.

Confirmed by reading the live container's:
- \`/app/node_modules/@backstage/plugin-techdocs-node/dist/stages/prepare/dir.cjs.js\` (DirectoryPreparer)
- \`/app/node_modules/@backstage/plugin-techdocs-node/dist/helpers.cjs.js\` (transformDirLocation → resolveUrl)

## Fix

Append \`/tree/main/\` to make source-location unambiguous. \`resolveUrl({url: '.', base: '.../nixos_config/tree/main/'})\` returns the repo-root tree URL, and the build succeeds.

## Test plan

- [x] Read DirectoryPreparer + helpers source from running container — confirmed URL-resolution behavior
- [ ] After merge: catalog refresh on Backstage, visit \`/catalog/default/component/nixos_config\` → TechDocs tab loads
- [ ] Container journal: no more \`Request failed for https://api.github.com/repos/olafkfreund\` errors

Note: \`component:default/backstage\` shows the same failure pattern — likely the same fix applies to its catalog-info.yaml (separate repo, separate PR).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>