### PR TITLE
chore(claude-code): bump native binary to 2.1.167 (#779)

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.165";
+  version = "2.1.167";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-00sMqt0l64LY4IyhA7ZIKRtN7+9TGT9XKEenNuKq9Ng=";
+      hash = "sha256-1tKZW/yj+FOdnpqlE/9Dw9qg1VbW0a8Hxt9oHgUOUiw=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-/y4GCCf58CFKdxMyBsRTmmR37B9P3bSSsCJVoGeWQv0=";
+      hash = "sha256-uPOD3x3KVX3I+4F+TnYzVjn5SgqMe4A8ovWu8S03Pwk=";
     };
   };
 


### PR DESCRIPTION
## Summary

Bump `pkgs.claude-code-native` from 2.1.165 → **2.1.167** to track Anthropic's `latest` channel.

- Closes #779 (target version 2.1.167)
- Closes #773 (superseded — targeted 2.1.166)

## Test plan

- [x] `./scripts/update-claude-code-native.sh 2.1.167` — hashes resolved from GCS manifest
- [x] `nix build .#claude-code-native` → binary reports `2.1.167 (Claude Code)`
- [x] `ldd` — no missing libs
- [x] All three host closures build cleanly: p620, razer, p510
- [ ] Deploy p620 + razer; verify `claude --version` reports 2.1.167

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>