### PR TITLE
chore(claude-desktop): bump to v2.0.18+claude1.11187.4 (#780)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,17 +116,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1780624122,
-        "narHash": "sha256-NeajPGABECK+ltSKT8MTy0+h760aHyRpzFKtfZqc8Ms=",
+        "lastModified": 1780710221,
+        "narHash": "sha256-UWuDKE1O1PeKnlNzAGmRREwOOZR6F+cOYOiFT7o2KoM=",
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "4b6ff35236598725ba02bfb5acd57b4e531ee07f",
+        "rev": "d99cdbd0e054fc04eb2ccfaf31777f11e89416c3",
         "type": "github"
       },
       "original": {
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "4b6ff35236598725ba02bfb5acd57b4e531ee07f",
+        "rev": "d99cdbd0e054fc04eb2ccfaf31777f11e89416c3",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -83,8 +83,10 @@
     # Workaround: close claude-desktop entirely to release inhibitor,
     # or set CLAUDE_KEEP_AWAKE=0 (#645).
     # Bump via /update-claude-code.
-    # = tag v2.0.18+claude1.11187.1 (commit 4b6ff35236, 2026-06-05)
-    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/4b6ff35236598725ba02bfb5acd57b4e531ee07f";
+    # = tag v2.0.18+claude1.11187.4 (commit d99cdbd0e0, 2026-06-06)
+    # Delta from previous pin: bubblewrap added to FHS targetPkgs for cowork
+    # sandbox + Claude binary URLs bumped to 1.11187.4.
+    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/d99cdbd0e054fc04eb2ccfaf31777f11e89416c3";
 
     # Claude Code skill catalogue (borghei). flake = false because it's a
     # plain markdown/assets catalogue, not a Nix flake. We symlink one


### PR DESCRIPTION
## Summary

Bump `claude-desktop-linux` flake input from `4b6ff35236` (tag `v2.0.18+claude1.11187.1`) to `d99cdbd0e0` (tag `v2.0.18+claude1.11187.4`).

Closes #780.

## Delta (3 commits)

| SHA | Message |
|---|---|
| `b94aec10` | fix(nix): add bubblewrap to FHS targetPkgs for cowork sandbox |
| `1b31a418` | Merge PR #698 (the bubblewrap fix) |
| `d99cdbd0` | Update Claude Desktop download URLs to version 1.11187.4 |

The bubblewrap addition is a net win — improves cowork sandbox reliability.

## Pre-flight (per `update-claude-code` skill)

- [x] No `_svcLaunched` (Cowork daemon recovery) regression in upstream open issues
- [x] Our overlay is a thin pass-through of upstream's `claude-desktop-fhs`; no sed pattern to verify
- [x] FHS wrapper builds clean
- [x] Inner derivation resolves to `claude-desktop-1.11187.4` (matches target tag)
- [x] `pty.node` is `ELF 64-bit LSB shared object` (mandatory check)
- [x] All three host closures build clean (p620, razer, p510 — p510 cached, doesn't install but is in build matrix)
- [ ] Deploy razer first (primary claude-desktop host); restart the app to pick up the new binary
- [ ] Deploy p620 after; restart the app to pick up the new binary

## Post-deploy idiot-proofing

claude-desktop is usually running. `nixos-rebuild switch` activates the new generation, but the Electron process keeps running from the OLD store path until killed. Skill warns: don't `pkill` without explicit OK from the user. After deploy, verify:

\`\`\`bash
ssh razer 'pgrep -af "claude-desktop-1\\.[0-9]" | head -3'
# Should show 1.11187.4 hash after user restarts the app
\`\`\`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>