### PR TITLE
chore(docker): move data-root to /mnt/img_pool/docker

### DIFF
--- a/modules/containers/docker.nix
+++ b/modules/containers/docker.nix
@@ -47,7 +47,12 @@ in
       # Explicitly disable Docker Swarm
       daemon.settings = {
         swarm-default-advertise-addr = "";
-        data-root = "/mnt/data/docker";
+        # Docker data-root on /mnt/img_pool — the 870GB pool — so container
+        # layers + volumes don't eat the 226GB system disk. Especially
+        # important for k3d (modules/containers/k3d.nix) whose cluster
+        # state lives in Docker volumes; before this move, an idle 226GB
+        # disk would fill up over weeks of cluster operation.
+        data-root = "/mnt/img_pool/docker";
       };
     };
 


### PR DESCRIPTION
## Summary

Move Docker's `data-root` from `/mnt/data/docker` (which is just a directory on `/`, the 226 GB system disk) to `/mnt/img_pool/docker` (the dedicated 916 GB pool with ~870 GB free).

Motivation: the new k3d cluster (from #788) stores its cluster state in Docker volumes. Combined with the system closure + media-stack state, the 226 GB system disk would fill up over weeks of normal cluster operation. /mnt/img_pool is sized for this.

## Migration

**Zero cost.** `/mnt/data/docker` currently holds 212 K — empty directory tree, no containers, no volumes. Docker is enabled on p510 but the production services run as systemd units / podman. After deploy, the old empty `/mnt/data/docker` can be removed.

## Test plan

- [x] `git diff` — one-line config change
- [x] Pre-commit hooks ✅
- [ ] CI green
- [ ] `just quick-deploy p510`
- [ ] `docker info | grep "Docker Root Dir"` shows `/mnt/img_pool/docker`