### PR TITLE
fix(k3d): add git to bootstrap script's runtime inputs

### DIFF
--- a/modules/containers/k3d.nix
+++ b/modules/containers/k3d.nix
@@ -62,6 +62,11 @@ let
       jq
       coreutils
       docker-client
+      # `kubectl apply -k` against a remote git URL shells out to `git`.
+      # Without this, the bootstrap fails the GitOps step with
+      # "no 'git' program on path: exec: \"git\": executable file not
+      # found in $PATH" — observed in first deploy.
+      git
     ];
     text = ''
       set -euo pipefail


### PR DESCRIPTION
Without this, kubectl apply -k against the remote factory-gitops URL
fails the GitOps step in first-time bootstrap:

  error: no 'git' program on path: exec: "git": executable file not
  found in $PATH

kubectl's kustomize integration shells out to git to fetch remote
refs. writeShellApplication puts only the listed runtimeInputs on
PATH; git wasn't there.

Observed on first p510 deploy (post #788 merge). Worked around by
running `kubectl apply -k …` manually from a host shell (which has
git in PATH). This patch closes the loop.
