### PR TITLE
fix(docs): correct Tailscale sidecar image pin

### DIFF
--- a/docs/guides/factory-gitops.md
+++ b/docs/guides/factory-gitops.md
@@ -119,7 +119,7 @@ spec:
             - containerPort: 8080
         # ── Tailscale sidecar ──────────────────────────────────────
         - name: tailscale
-          image: ghcr.io/tailscale/tailscale:v1.74.0
+          image: docker.io/tailscale/tailscale:v1.98.4
           env:
             - name: TS_AUTHKEY
               valueFrom:
@@ -236,7 +236,7 @@ spec:
           image: ghcr.io/olafkfreund/aifactory:0.1.0
           ports: [ { containerPort: 8080 } ]
         - name: tailscale
-          image: ghcr.io/tailscale/tailscale:v1.74.0
+          image: docker.io/tailscale/tailscale:v1.98.4
           env:
             - { name: TS_AUTHKEY, valueFrom: { secretKeyRef: { name: tailscale-auth-key, key: TS_AUTHKEY } } }
             - { name: TS_HOSTNAME, value: aifactory }


### PR DESCRIPTION
ghcr.io/tailscale/tailscale:v1.74.0 doesn't exist (verified: GHCR
returns 404; Docker Hub is Tailscale's canonical registry).

Bumps both sidecar-template snippets in docs/guides/factory-gitops.md
to docker.io/tailscale/tailscale:v1.98.4 — the current stable tag.

Matches the equivalent fix in factory-gitops (3ca90b1) so users
copy-pasting the template from either doc get a working pull.
