### PR TITLE
feat(p510): rebind kube API + move Ollama + enable Claude

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -154,7 +154,11 @@ in
     ai = {
       enable = true;
       antigravity-cli = true;
-      claude-desktop = false; # Disable GUI app on media server
+      # claude-desktop is a GUI app — p510 has GNOME via the workstation
+      # template (RDP'd, since host.class = "headless-rdp"), so it CAN
+      # run here and is useful for driving the k3d cluster from p510 via
+      # RDP when off-LAN.
+      claude-desktop = true;
     };
 
     programs = {
@@ -322,6 +326,19 @@ in
     enable = true;
     argocd.enable = true;
     tailscaleAuthKey.enable = true;
+    # Bind kube API to all interfaces so kubectl from the laptop (over
+    # the tailnet) can drive the cluster directly. Default-open ACL +
+    # host firewall disabled make this equivalent posture to loopback.
+    # Auth is the bearer token in the kubeconfig.
+    apiHostBind = "0.0.0.0";
+  };
+
+  # Claude Code managed-settings baseline (mirrors p620 + razer): PARR
+  # protocol reminder hook + apiKeyHelper baseline. Read-only at
+  # /etc/claude-code; user ~/.claude/settings.json remains writable.
+  modules.programs.claude-code-managed = {
+    enable = true;
+    parrProtocol.enable = true;
   };
 
   # Network-specific overrides that go beyond the network profile
@@ -380,7 +397,10 @@ in
   features.ollama-server = {
     enable = true;
     package = pkgs.ollama-cuda; # NVIDIA CUDA GPU package
-    modelsDir = "/mnt/media/ollama/models"; # Stored on the large media pool disk
+    # Stored on the dedicated 916GB compute pool (870GB free), not the
+    # media pool. Models share IOPS with nothing else, and we leave
+    # /mnt/media for Plex transcodes + library scans.
+    modelsDir = "/mnt/img_pool/ollama/models";
     persistentModels = [ ]; # No persistent models to save VRAM
     # gemma4 for n8n; qwen2.5:7b for reliable strict-JSON audiobook metadata
     # extraction + tool-calling (audiobook-import / audiobook-mcp).

--- a/modules/containers/k3d.nix
+++ b/modules/containers/k3d.nix
@@ -81,9 +81,9 @@ let
 
       # 1. Create cluster if missing
       if ! k3d cluster list -o json | jq -e --arg n "$CLUSTER" '.[] | select(.name==$n)' >/dev/null; then
-        echo "[k3d-bootstrap] Creating cluster $CLUSTER (api 127.0.0.1:$API_PORT, storage $STORAGE_DIR)"
+        echo "[k3d-bootstrap] Creating cluster $CLUSTER (api ${cfg.apiHostBind}:$API_PORT, storage $STORAGE_DIR)"
         k3d cluster create "$CLUSTER" \
-          --api-port "127.0.0.1:$API_PORT" \
+          --api-port "${cfg.apiHostBind}:$API_PORT" \
           --servers 1 \
           --agents 0 \
           --k3s-arg "--disable=traefik@server:*" \
@@ -176,9 +176,26 @@ in
       type = types.port;
       default = 6443;
       description = ''
-        Host port for the kube API server. Bound to 127.0.0.1 only — never
-        published to the LAN or tailnet directly. Use `kubectl --kubeconfig
-        ${"$"}{kubeconfigPath}` from the host or `kubectl port-forward`.
+        Host port for the kube API server. Use `kubectl --kubeconfig
+        ${"$"}{kubeconfigPath}` from the host, or set `apiHostBind` to
+        a non-loopback address to reach it from elsewhere.
+      '';
+    };
+
+    apiHostBind = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      example = "0.0.0.0";
+      description = ''
+        Host IP the kube API server binds to.
+
+        Defaults to `127.0.0.1` — loopback only, requires SSH tunnel /
+        port-forward for off-host kubectl. Set to `0.0.0.0` (or a
+        specific interface IP) to expose the API to the LAN/tailnet so
+        kubectl can connect directly. With a default-open Tailscale
+        ACL and a disabled host firewall, `0.0.0.0` and `127.0.0.1`
+        are equivalent reachability-wise — the API is gated by the
+        bearer token in the kubeconfig regardless.
       '';
     };
 


### PR DESCRIPTION
## Summary

Three coordinated p510 changes wrapping up the user-facing follow-ups after #788/#789/#790:

1. **k3d API binding** — new `modules.containers.k3d.apiHostBind` option (default `127.0.0.1`); set to `0.0.0.0` on p510 so `kubectl` from any tailnet device can drive the cluster directly. Same security posture as before (default-open ACL + disabled host firewall + bearer-token auth in kubeconfig).
2. **Ollama models on /mnt/img_pool** — `modelsDir = "/mnt/img_pool/ollama/models"` (was `/mnt/media/ollama/models` but blobs never actually migrated and lived at `/var/lib/private/ollama/models/blobs`).
3. **Claude on p510** — `features.ai.claude-desktop = true` + `modules.programs.claude-code-managed = { enable = true; parrProtocol.enable = true; }` mirroring p620 / razer.

## Test plan

- [x] `nix-instantiate --parse` both files
- [ ] CI host-config builds
- [ ] `just quick-deploy p510`
- [ ] Post-deploy:
  - [ ] Recreate the cluster (`k3d cluster delete factory && systemctl restart k3d-cluster-bootstrap`) so the API binding takes effect
  - [ ] Verify `kubectl --server https://p510.tail833f7.ts.net:6443 get nodes` works from the laptop
  - [ ] `rsync -av /var/lib/private/ollama/ /mnt/img_pool/ollama/` then `chown -R ollama:ollama /mnt/img_pool/ollama` + restart ollama; verify `ollama list` shows models
  - [ ] `ssh p510 which claude` returns a path