### PR TITLE
fix(k3d): bind API to p510's tailnet IP, not 0.0.0.0

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -326,11 +326,15 @@ in
     enable = true;
     argocd.enable = true;
     tailscaleAuthKey.enable = true;
-    # Bind kube API to all interfaces so kubectl from the laptop (over
-    # the tailnet) can drive the cluster directly. Default-open ACL +
-    # host firewall disabled make this equivalent posture to loopback.
-    # Auth is the bearer token in the kubeconfig.
-    apiHostBind = "0.0.0.0";
+    # Bind kube API to p510's tailnet IP so kubectl from any tailnet
+    # device can drive the cluster directly (`kubectl get nodes` against
+    # https://100.118.96.32:6443). k3d 5.x's port-publishing logic
+    # doesn't honour `0.0.0.0` correctly (empty Docker PortBindings),
+    # so an explicit IP is required. Posture: tailnet ACL is default-
+    # open + host firewall disabled; auth gates on the kubeconfig
+    # bearer token. p510's tailnet IP is stable per-device — Tailscale
+    # doesn't renumber unless you delete + re-add the node.
+    apiHostBind = "100.118.96.32";
   };
 
   # Claude Code managed-settings baseline (mirrors p620 + razer): PARR


### PR DESCRIPTION
k3d 5.x's `--api-port 0.0.0.0:PORT` produces empty Docker
PortBindings — the cluster comes up but the API is unreachable from
the host. Reproduced live: serverlb container shows no published
ports until an explicit IP is given. Switching to 100.118.96.32
(p510's stable tailnet IP) gives:

  k3d-factory-serverlb  Up  100.118.96.32:6443->6443/tcp

After which `kubectl --server https://100.118.96.32:6443 get nodes`
works from any tailnet device.

The IP is hardcoded because Tailscale assigns it deterministically
per-device (re-issued only if the node is removed + re-added).
Future improvement: derive at runtime via a systemd
ExecStartPre that reads `tailscale ip -4`, but that adds complexity
the homelab doesn't currently need.
