### PR TITLE
fix(k3d): pin modern k3s image to fix Postgres SIGBUS on cluster

### DIFF
--- a/modules/containers/k3d.nix
+++ b/modules/containers/k3d.nix
@@ -83,6 +83,7 @@ let
       if ! k3d cluster list -o json | jq -e --arg n "$CLUSTER" '.[] | select(.name==$n)' >/dev/null; then
         echo "[k3d-bootstrap] Creating cluster $CLUSTER (api ${cfg.apiHostBind}:$API_PORT, storage $STORAGE_DIR)"
         k3d cluster create "$CLUSTER" \
+          --image "${cfg.k3sImage}" \
           --api-port "${cfg.apiHostBind}:$API_PORT" \
           --servers 1 \
           --agents 0 \
@@ -165,6 +166,27 @@ in
     enable = mkEnableOption "k3d (k3s in Docker) cluster bootstrap";
 
     package = mkPackageOption pkgs "k3d" { };
+
+    k3sImage = mkOption {
+      type = types.str;
+      default = "rancher/k3s:v1.31.5-k3s1";
+      description = ''
+        k3s node image k3d boots the cluster from (passed to
+        `k3d cluster create --image`).
+
+        Pin this explicitly rather than relying on the k3d binary's
+        built-in default: that default was an ancient `v1.21.7-k3s1`
+        whose bundled containerd/runc mishandles shared-memory page
+        faults on modern host kernels, making every PostgreSQL pod die
+        during `initdb` with `Bus error (core dumped)`. A current k3s
+        ships a runc that handles this correctly.
+
+        NOTE: this only takes effect on cluster *creation*. To adopt a
+        new image on an existing cluster, delete and recreate it:
+        `k3d cluster delete ${"$"}{clusterName}` then re-run the
+        bootstrap unit (`systemctl start k3d-cluster-bootstrap`).
+      '';
+    };
 
     clusterName = mkOption {
       type = types.str;


### PR DESCRIPTION
## Problem

Every PostgreSQL pod on the p510 `factory` k3d cluster (rolehunter-db pg16, skillai-db pg17) crashes during `initdb` with **`Bus error (core dumped)`** — while the *same* image runs fine via plain `docker run` on the host.

Root cause: `k3d cluster create` had **no `--image`**, so it fell back to the k3d binary's built-in default, which resolved to an ancient **`rancher/k3s:v1.21.7-k3s1`**. That k3s's bundled containerd/runc mishandles shared-memory page faults on the host's modern kernel (6.18), SIGBUSing Postgres's shared-memory allocation during bootstrap.

## Fix

- Add a `modules.containers.k3d.k3sImage` option (default `rancher/k3s:v1.31.5-k3s1`).
- Pass it to `k3d cluster create --image`.

## Validation (on p510)

Spun up a throwaway k3d cluster on `v1.31.5-k3s1` and ran `pgvector/pgvector:pg16` — Postgres reached **"ready to accept connections"** cleanly. On `v1.21.7` the identical pod SIGBUSes during `initdb`. (Tested non-destructively in a separate `shmtest` cluster, since deleted.)

## Applying

Takes effect on cluster **creation** only. To adopt on the live cluster:
```
k3d cluster delete factory
systemctl start k3d-cluster-bootstrap   # recreates with the new image, reinstalls ArgoCD
```
Then re-seed any non-agenix Secrets (e.g. `rolehunter-db`/`rolehunter-app`). No data loss — the cluster carries no persistent app data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)