### PR TITLE
docs(ingress): Cloudflare Tunnel public-ingress + sidecar deprecation

### DIFF
--- a/docs/applications/cloudflared-tunnel.md
+++ b/docs/applications/cloudflared-tunnel.md
@@ -1,0 +1,253 @@
+# Cloudflare Tunnel — Operator Runbook (Host Side)
+
+The host-side Cloudflare Tunnel exposes services that live directly on
+the homelab host (developer portal, media stack) to the public internet
+under our home domain. For the cluster-side tunnel and overall design
+rationale, see [Public Ingress Architecture](../architecture/public-ingress.md).
+
+> Throughout this page, `<home-domain>` is our public domain;
+> `<name>.<home-domain>` is one exposed service hostname;
+> `<tunnel-id>` is a Cloudflare Tunnel UUID. We don't enumerate real
+> values — the source of truth is the host's NixOS configuration
+> and the agenix-encrypted credentials in `secrets/`.
+
+## TL;DR
+
+```bash
+# Is it running?
+ssh <host> systemctl is-active cloudflared-tunnel-<tunnel-id>
+
+# Logs (most recent connections + ingress lookups)
+ssh <host> sudo journalctl -u cloudflared-tunnel-<tunnel-id> -fb
+
+# Quick health check on the public side
+curl -sI https://<name>.<home-domain> | head -1
+# expect HTTP/2 200 / 302 / 401 / 403 depending on the service
+```
+
+## What the module does
+
+`modules/services/cloudflared.nix` is a thin feature-flag wrapper over
+the upstream `services.cloudflared`. It pins one tunnel by UUID, points
+the credentials and account-certificate paths at agenix secrets, and
+declares an `ingress` map of `<hostname> → <local URL>` pairs.
+
+```nix
+features.cloudflared = {
+  enable = true;
+  tunnelId = "<tunnel-id>";
+  ingress = {
+    "<name1>.<home-domain>" = "http://localhost:<port>";
+    "<name2>.<home-domain>" = "http://localhost:<port>";
+    # ...
+  };
+};
+```
+
+The module then materialises a systemd unit named
+`cloudflared-tunnel-<tunnel-id>.service`. The unit is `DynamicUser=true`,
+loads credentials via systemd's `LoadCredential=`, and connects out
+over QUIC to Cloudflare's edge. No inbound port is opened on the host.
+
+## First-time bootstrap (~10 min, one-time)
+
+Done already for the current tunnel. Repeat only if you're standing up
+a new tunnel on a new host.
+
+1. **Add the public domain as a Cloudflare zone** (free tier is enough).
+   Switch the domain's nameservers at its registrar to the two values
+   Cloudflare gives you. Wait for propagation (`dig NS <home-domain>` —
+   should return Cloudflare NS values).
+2. **On a workstation** with browser access (NOT the headless host):
+
+   ```bash
+   nix-shell -p cloudflared
+   cloudflared login
+   # → browser opens; choose the domain; saves ~/.cloudflared/cert.pem
+   cloudflared tunnel create <name>
+   # → prints the tunnel UUID; saves ~/.cloudflared/<uuid>.json
+   ```
+
+3. **Put both files into agenix**:
+
+   ```bash
+   ./scripts/manage-secrets.sh edit cloudflared-cert         # paste cert.pem contents
+   ./scripts/manage-secrets.sh edit cloudflared-credentials  # paste credentials.json contents
+   ```
+
+4. **Wire the tunnel UUID + first route** in the host configuration
+   (`features.cloudflared.tunnelId`, `ingress`), commit, deploy.
+5. **Create the first Cloudflare DNS CNAME**:
+
+   ```bash
+   cloudflared tunnel route dns <name> <name>.<home-domain>
+   ```
+
+## Adding a new service (the common path)
+
+1. Append a route to the host configuration's `features.cloudflared.ingress`
+   attrset.
+2. Commit, push, merge, deploy.
+3. On the host (cert.pem is now decrypted into `/run/agenix/cloudflared-cert`),
+   create the Cloudflare DNS CNAME:
+
+   ```bash
+   export TUNNEL_ORIGIN_CERT=/run/agenix/cloudflared-cert
+   /run/current-system/sw/bin/cloudflared tunnel route dns \
+     <tunnel-name> <name>.<home-domain>
+   ```
+
+   (or — same thing — run it from a workstation that has its own
+   cert.pem.)
+4. Smoke test:
+
+   ```bash
+   curl -sI --doh-url https://1.1.1.1/dns-query https://<name>.<home-domain> | head -1
+   ```
+
+   Anything other than `HTTP/2 5xx` is success (`200`, `302`, `401`,
+   `403` all mean the request reached the service and the service
+   responded — its own auth then takes over).
+
+## Authentication note
+
+Cloudflare Tunnel does **not** add an authentication layer. Whatever
+auth the service ships with applies:
+
+- The developer portal: GitHub OAuth (configured in its own
+  app-config).
+- The *arr stack (Sonarr, Radarr, Lidarr): API-key / session cookie.
+  Their UIs return `401` until you set the API key in headers or log
+  in.
+- NZBGet / SABnzbd: control password from their respective config.
+- Plex: a Plex token.
+
+For services that ship no UI auth (or weak auth), gate at the
+Cloudflare edge: **Cloudflare Zero Trust → Access → Applications** in
+the dashboard. Free tier covers 50 users. Each Access policy is
+scoped to one hostname and gates the connection before it reaches the
+tunnel.
+
+## Rotation
+
+### Auth-key / credentials rotation
+
+If `credentials.json` is ever compromised:
+
+```bash
+# On the workstation:
+cloudflared tunnel delete <name>
+cloudflared tunnel create <name>  # NEW UUID
+# Re-route every existing DNS entry to the new UUID:
+for HOST in <list of hostnames>; do
+  cloudflared tunnel route dns <name> $HOST
+done
+
+# Refresh agenix secrets:
+./scripts/manage-secrets.sh edit cloudflared-credentials
+
+# Update tunnelId in host config to the new UUID, deploy.
+```
+
+### Account-cert (cert.pem) rotation
+
+Same flow but starts with `cloudflared login` to re-issue cert.pem.
+The cert.pem grants the ability to create new tunnels and route DNS
+— it does NOT carry the per-tunnel connector credentials. Rotate
+separately.
+
+## Troubleshooting
+
+### `curl` returns nothing / DNS lookup fails
+
+Check the Cloudflare CNAME exists. From the host:
+
+```bash
+# Direct CF API check — needs the cert.pem
+sudo TUNNEL_ORIGIN_CERT=/run/agenix/cloudflared-cert \
+  /run/current-system/sw/bin/cloudflared tunnel route dns \
+  <tunnel-name> <name>.<home-domain>
+```
+
+This is idempotent — running it on an existing record is a no-op that
+prints the same `Added CNAME …` line. If you get an error about the
+tunnel UUID or auth, the cert.pem is wrong or the tunnel doesn't
+exist.
+
+### `HTTP/2 502` from the public URL
+
+The tunnel is healthy (we got an HTTP response from Cloudflare) but
+cloudflared couldn't reach the origin service. Common causes:
+
+1. Service binds to a non-loopback interface. Check the route in
+   the module config — `http://localhost:<port>` only works if the
+   service is bound to `127.0.0.1` or `0.0.0.0`. If the service
+   binds to a LAN IP only, change the route to that IP.
+2. Service is down. `systemctl status <service>` on the host.
+3. Wrong port. Verify with `curl http://localhost:<port>` from the
+   host.
+
+### `HTTP/2 1033` — "Cloudflare Tunnel error"
+
+Cloudflare's edge sees the DNS record but no connector is currently
+registered. Either cloudflared isn't running on the host, or it can't
+reach Cloudflare's edge:
+
+```bash
+systemctl status cloudflared-tunnel-<tunnel-id>
+journalctl -u cloudflared-tunnel-<tunnel-id> -b --no-pager | tail -50
+# Expect to see "Registered tunnel connection" lines.
+```
+
+### "redirect_uri is not associated with this application" — GitHub OAuth
+
+Not a Cloudflare problem. The developer portal's GitHub OAuth App has
+an outdated callback URL. Update it at
+`github.com/settings/developers` → OAuth Apps → your portal app →
+`https://<name>.<home-domain>/api/auth/github/handler/frame`.
+
+### The service redirect-loops with `307 → 307 → …`
+
+The service is trying to redirect HTTP to HTTPS at the application
+layer, but cloudflared's loopback hop is plain HTTP. Either:
+
+- Configure the service to trust `X-Forwarded-Proto: https` (most
+  app servers have a `behind-proxy` toggle).
+- Or terminate TLS inside the service and proxy via
+  `https://localhost:<port>` from cloudflared (set
+  `originRequest.noTLSVerify = true` to accept self-signed certs).
+
+### Resetting a tunnel from scratch
+
+If everything's broken and you just want a clean slate:
+
+```bash
+# Stop the unit
+systemctl stop cloudflared-tunnel-<tunnel-id>
+
+# On a workstation:
+cloudflared tunnel delete <name> --force
+cloudflared tunnel create <name>
+# Re-route every DNS entry (loop above)
+# Edit agenix creds, update tunnelId in host config, deploy
+```
+
+## What's NOT documented here
+
+- **In-cluster** cloudflared (for the Factory suite / ArgoCD /
+  Keycloak): same daemon, different deployment (Kubernetes Deployment
+  in the `factory` namespace), different tunnel UUID. Its config
+  lives in the `factory-gitops` repo under `infra/cloudflared/`.
+  Adding a route there means a commit + ArgoCD sync, then the same
+  DNS-route command. Cross-reference:
+  [Public Ingress Architecture](../architecture/public-ingress.md).
+- **Cloudflare Zero Trust access policies**: configured in the
+  Cloudflare dashboard, not in code. Document them where the access
+  policy itself lives (Cloudflare's UI) rather than duplicating
+  here.
+
+## Cross-references
+
+- Architecture rationale: [Public Ingress Architecture](../architecture/public-ingress.md)
+- Cluster-side tunnel + manifests location: [k3d Cluster Operations](k3d-cluster.md)
+- GitOps workflow for adding a public cluster service: [Factory GitOps](../guides/factory-gitops.md)

--- a/docs/applications/k3d-cluster.md
+++ b/docs/applications/k3d-cluster.md
@@ -1,5 +1,16 @@
 # k3d Cluster on p510 — Operations
 
+> **Public ingress note (2026-06-07):** services on this cluster are
+> now exposed via **Cloudflare Tunnel** under our home domain
+> (`<name>.<home-domain>`), not via Tailscale sidecars or tailnet
+> hostnames. The Tailscale auth-key / sidecar machinery described
+> further down this page is being decommissioned. For current public
+> ingress design + how to add a new service, see
+> [Public Ingress Architecture](../architecture/public-ingress.md)
+> and [Cloudflared Tunnel](cloudflared-tunnel.md). The rest of this
+> page covers cluster substrate (k3d, storage, bootstrap unit,
+> kubeconfig) which is unchanged.
+
 Single-node k3s-in-Docker cluster on p510, running ArgoCD + the Tailscale
 Kubernetes Operator. For design rationale see
 [architecture/k3d-architecture.md](../architecture/k3d-architecture.md).
@@ -110,17 +121,15 @@ kubectl -n argocd get secret argocd-initial-admin-secret \
   -o jsonpath='{.data.password}' | base64 -d; echo
 ```
 
-Once the Tailscale sidecar on `argocd-server` has registered (≈ 30 s
-after the Pod is Ready):
+Once the in-cluster Cloudflare Tunnel has the ArgoCD route in its
+ConfigMap and the matching DNS record exists:
 
-- ArgoCD UI: `https://argocd.tail833f7.ts.net`
+- ArgoCD UI: `argocd.<home-domain>`
 - Login: `admin` + the password from above
 
-Confirm registration:
-
-```bash
-kubectl -n argocd logs deploy/argocd-server -c tailscale | grep -iE 'success|registered|hostname'
-```
+(The Tailscale-sidecar exposure path that this section previously
+described is deprecated; see the public-ingress note at the top of
+this page.)
 
 If the sidecar isn't running yet (first cluster bring-up takes a few
 minutes), fall back to a port-forward:

--- a/docs/architecture/k3d-architecture.md
+++ b/docs/architecture/k3d-architecture.md
@@ -36,7 +36,31 @@ path-based routing (`p510.tail833f7.ts.net/sonarr`, etc.). The k3d cluster
 - Persistent volumes live under `/mnt/img_pool/k3d/storage` — off
   `/mnt/media` so PVCs don't fight Plex for IOPS.
 
-## Why sidecars and not the Tailscale Kubernetes Operator
+## Public exposure: Cloudflare Tunnel (current)
+
+Services running in the cluster are exposed to the public internet by
+an **in-cluster `cloudflared` Deployment** living in the `factory`
+namespace, with routes managed via the GitOps repo's
+`infra/cloudflared/` ConfigMap. Each route maps one hostname under
+our home domain (`<name>.<home-domain>`) to one in-cluster Service by
+FQDN (`<svc>.<ns>.svc.cluster.local:<port>`).
+
+The full architecture — why Cloudflare over Tailscale, what we
+accept by routing through someone else's edge, how to add a new
+service — lives in [Public Ingress Architecture](public-ingress.md).
+That's the canonical reference for anything touching public URLs.
+
+The remainder of this file documents the cluster substrate (k3d,
+storage, bootstrap unit, etc.). Tailscale sidecars — described
+below — are deprecated and being decommissioned.
+
+## Why sidecars and not the Tailscale Kubernetes Operator (legacy)
+
+> **Deprecated.** This section documents the original design decision
+> from the cluster's first iteration. The cluster has since moved to
+> Cloudflare Tunnel for public exposure (see
+> [Public Ingress Architecture](public-ingress.md)). The sidecar
+> still wraps `argocd-server` at time of writing but is being removed.
 
 The operator is the "obviously right" answer in most Kubernetes contexts —
 one annotation on a Service and the operator handles everything. We
@@ -199,9 +223,23 @@ Auth key setup (one-time, in the Tailscale admin console):
   `secrets.nix`; the contents are now a raw auth key. Future
   migration to the operator is a value-shape change + module option
   swap; nothing structural breaks.
+- **2026-06-07** — **Pivoted again, from Tailscale sidecars to Cloudflare
+  Tunnel.** Sidecar pattern bit us three times: (1) every pod restart
+  rotated the tailnet identity, suffixing the canonical hostname; (2)
+  deleting stale devices in the admin orphaned the cached node key
+  and tailscaled wedged in a `404 node not found` retry loop; (3) per-Pod
+  boilerplate didn't scale. Two `cloudflared` connectors (one
+  host-side, one in-cluster) now route `<name>.<home-domain>` to local
+  services and in-cluster Service FQDNs respectively. TLS terminates at
+  Cloudflare's edge with real Let's Encrypt certs for our domain. Sidecar
+  still wraps `argocd-server` while decommission is queued. Full design
+  rationale + decision matrix in
+  [Public Ingress Architecture](public-ingress.md).
 
 ## Cross-references
 
+- Public ingress design: [Public Ingress Architecture](public-ingress.md)
+- Cloudflare Tunnel host-side ops: [Cloudflared Tunnel](../applications/cloudflared-tunnel.md)
 - Ops + troubleshooting: [k3d Cluster](../applications/k3d-cluster.md)
 - Adding services via GitOps: [Factory GitOps](../guides/factory-gitops.md)
 - Module source: `modules/containers/k3d.nix`

--- a/docs/architecture/public-ingress.md
+++ b/docs/architecture/public-ingress.md
@@ -1,0 +1,238 @@
+# Public Ingress Architecture
+
+How services on the homelab become reachable from the public internet
+without a public IP, without port forwards, and without a per-service
+VPN identity that drifts every time a Pod restarts.
+
+> Throughout this page, `<home-domain>` stands in for the public domain
+> hosting our service hostnames, and `<name>.<home-domain>` is a single
+> service hostname (e.g. `argocd.<home-domain>`, `aifactory.<home-domain>`).
+> We don't enumerate the real hostnames in public docs — see
+> [TechDocs hostname policy](#hostname-policy) at the bottom.
+
+## The constraint we had to design around
+
+The host that fronts most home-lab services sits behind **Starlink CGNAT**.
+There is no public IPv4. There is no inbound port. Anything reaching that
+host from "the internet" must come through a service that owns a public IP
+and tunnels traffic to us.
+
+That single constraint disqualifies:
+
+- Port forwarding on the router
+- A records pointing at the home IP
+- Any DNS-only solution
+
+It does NOT disqualify anything that uses an **outbound persistent
+connection** from the host to a relay or edge. Most modern ingress
+solutions are that shape.
+
+## The choice: Cloudflare Tunnel
+
+We use **two `cloudflared` connectors**, both outbound-only, both
+declarative:
+
+1. **Host-level connector** — a NixOS systemd service on the homelab
+   host. Routes a curated list of hostnames to local processes:
+   `<name>.<home-domain>` → `http://localhost:<port>`. Used for
+   services running directly on the host (developer portal, media
+   stack).
+2. **In-cluster connector** — a Kubernetes Deployment in the
+   single-node k3d cluster on the same host. Routes hostnames to
+   in-cluster Services by their FQDN
+   (`<svc>.<ns>.svc.cluster.local:<port>`). Used for everything that
+   lives inside the cluster (Factory suite, ArgoCD, Keycloak).
+
+Each connector dials Cloudflare's edge over outbound QUIC/HTTPS and
+sits there waiting for inbound requests. Cloudflare's edge handles TLS
+termination with a real Let's Encrypt cert for our domain, optionally
+adds a Zero Trust access layer, and forwards the request bytes through
+the established connection.
+
+```text
+                 ┌──── public internet ────────────────────────────┐
+                 │                                                 │
+  user browser →   <name>.<home-domain>                            │
+                                ↓ DNS → Cloudflare anycast IP      │
+                          TLS terminated at Cloudflare edge        │
+                                ↓                                  │
+                      outbound QUIC tunnel                         │
+                 │                                                 │
+                 └─────────────────┬───────────────────────────────┘
+                                   │
+            ┌──────────────────────┴─────────────────────────────┐
+            │ homelab host (behind Starlink CGNAT)                │
+            │                                                     │
+            │  host-cloudflared (systemd)                         │
+            │     <name>.<home-domain> → http://localhost:<port>  │
+            │                                                     │
+            │  ┌────────── k3d cluster ──────────────┐             │
+            │  │  in-cluster cloudflared (Pod)       │             │
+            │  │     <name>.<home-domain>            │             │
+            │  │       → http://<svc>.<ns>.svc:<p>   │             │
+            │  └─────────────────────────────────────┘             │
+            └─────────────────────────────────────────────────────┘
+```
+
+Two tunnels rather than one is deliberate — each connector keeps its own
+config close to the services it routes for. The host-side tunnel changes
+when we add a host-level service (commit, deploy). The cluster-side
+tunnel changes when we add a Pod (commit, ArgoCD syncs). Neither requires
+touching the other.
+
+## Why not the Tailscale Kubernetes Operator (with OAuth)
+
+It is a great fit, in principle. It would auto-provision a tailnet
+identity per Service via an annotation, hand back per-service
+hostnames, and rotate identities cleanly. **We didn't go that direction
+because:**
+
+- The operator requires an OAuth client (a separate object in the
+  Tailscale admin from a normal auth key) with the right scopes and
+  tag ownership configured up front. The friction of generating that
+  delayed the build.
+- All exposed hostnames would live under our tailnet's `*.ts.net` suffix.
+  Browsers wouldn't see our own brand. For an external-facing portal we
+  want our own domain on the URL bar.
+- Tailscale Funnel — the official "expose a tailnet service to the public
+  internet" path — caps at **3 services on the free tier**. Beyond that
+  it requires an upgrade. We needed nearer to twenty hostnames.
+
+## Why not the Tailscale **sidecar** pattern (the path we tried)
+
+The sidecar pattern looks identical to the operator from a YAML
+standpoint: a `tailscale` container in each Pod, environment variable
+`TS_HOSTNAME` set, an auth key in a Secret. It works with a plain
+auth key, no OAuth required. So we built it first.
+
+It bit us **three times**:
+
+1. **Identity suffixes on restart.** Every Pod restart caused tailscaled
+   inside the sidecar to register a fresh tailnet identity (because
+   `TS_STATE_DIR=/tmp/...` was ephemeral). The Tailscale control plane
+   won't return the old hostname when a new node key arrives — it appends
+   a numeric suffix. So `argocd` became `argocd-1`, then `argocd-2`, and
+   DNS for the canonical name kept pointing at the dead original device.
+   We mitigated by adding a PersistentVolumeClaim for the state dir, but
+   it left the cluster recreate path still vulnerable.
+2. **Cached node key after admin deletion.** When we manually deleted the
+   stale device entries from the Tailscale admin to clean up, the live
+   sidecar still had a cached node key for the deleted node and stayed
+   stuck in an infinite `PollNetMap: 404 node not found` retry loop. No
+   auto-recovery. Manual state wipe required.
+3. **Per-Pod boilerplate.** Every Deployment that wanted exposure
+   needed the sidecar container, its env-from-Secret, its volumeMount,
+   plus a separate ConfigMap holding the Tailscale Serve config that
+   bridges the sidecar to the app container. ~20 lines per service,
+   replicated everywhere.
+
+The fragility class for (1) and (2) was the real driver. A Tuesday-night
+"why is ArgoCD down again" became a debugging exercise that touched
+agenix, PVC contents, the tailscale admin console, and `kubectl exec`s
+into the sidecar. Cloudflare Tunnel makes none of that exist.
+
+## Decision matrix
+
+| Concern | Sidecar + auth key (rejected) | Tailscale Operator + OAuth (rejected) | Tailscale Funnel (rejected) | **Cloudflare Tunnel (chosen)** |
+|---|---|---|---|---|
+| Works behind CGNAT | ✅ | ✅ | ✅ | ✅ |
+| No port forward needed | ✅ | ✅ | ✅ | ✅ |
+| Custom domain in URL bar | ❌ | ❌ | ❌ | ✅ |
+| Real Let's Encrypt cert | ❌ (tailnet cert) | ❌ (tailnet cert) | ❌ (tailnet cert) | ✅ |
+| Stable hostname on Pod restart | ❌ unless PVC + lucky | ✅ | ✅ | ✅ |
+| Stable hostname on admin delete | ❌ | ✅ | ✅ | ✅ |
+| Per-service boilerplate | High | Low | Low | Low |
+| Service cap (free tier) | None | None | 3 | None |
+| Public-internet ready by default | No (tailnet only) | No (tailnet only) | Yes | Yes |
+| Optional auth gate | Tailscale ACL | Tailscale ACL | Tailscale ACL | Cloudflare Access (Zero Trust) |
+| Cost | Free | Free | Free up to 3 svc | Free |
+| Setup complexity | Medium | Medium-high (OAuth) | Low | Low-medium (DNS migration) |
+
+## Trade-offs we accept
+
+Cloudflare is now in our public-traffic path. Specifically:
+
+- **TLS terminates at Cloudflare's edge.** Cloudflare can see the
+  plaintext of every request to a service exposed this way. For
+  authenticated SaaS-style services we're comfortable with that;
+  it's no different from any other CDN. Anything genuinely
+  sensitive stays on tailnet-only addressing.
+- **Cloudflare gets to choose to drop us.** A free-tier homelab is
+  not their priority customer. If they ever decide tunnel usage
+  needs to be paid, or our use looks like abuse to their automated
+  systems, we lose ingress until we migrate. Mitigation: every
+  service is also reachable on the tailnet for admins, so the
+  failure mode is "public goes down, admins keep working" rather
+  than total outage.
+- **DNS authority moves to Cloudflare for the public domain.** The
+  registrar stays where it was; only authoritative DNS moves. This
+  is reversible by switching the registrar's NS records back.
+
+## Adding a new public hostname
+
+Two-step regardless of which tunnel you target.
+
+### Host-level service (running directly on the host)
+
+1. Append one line to the host config's cloudflared ingress block:
+
+   ```nix
+   "<name>.<home-domain>" = "http://localhost:<port>";
+   ```
+
+2. Deploy. Run the DNS-route command (one-off, from a place that has
+   the agenix-decrypted cert.pem) to create the Cloudflare CNAME for
+   the new hostname.
+
+### Cluster service
+
+1. Append one entry to the in-cluster cloudflared ConfigMap (managed in
+   the GitOps repo's `infra/cloudflared/`):
+
+   ```yaml
+   - hostname: <name>.<home-domain>
+     service: http://<svc>.<ns>.svc.cluster.local:<port>
+   ```
+
+2. Commit. ArgoCD syncs in ~3 minutes. Run the DNS-route command for
+   the new hostname.
+
+In both cases the new hostname returns service traffic within minutes,
+behind a real TLS cert, with no further wiring.
+
+## Migration state (as of this commit)
+
+| Layer | State |
+|---|---|
+| Host services exposed via host-cloudflared | ✅ active for developer portal and media stack |
+| Cluster services exposed via in-cluster cloudflared | ✅ active for Factory suite + ArgoCD + Keycloak |
+| Old per-Pod Tailscale sidecars | ⚠️ still present on `argocd-server`; decommission queued |
+| Old host-level `tailscale serve` route to developer portal | ⚠️ still wired in NixOS; decommission queued |
+| Cluster route to `Keycloak` for OIDC use | ⏳ Keycloak is reachable; Factory pods are not yet wired to it (no `OIDC_*` env vars) |
+
+## Hostname policy
+
+We deliberately do **not** spell out the full DNS names of services in
+public-facing documentation, including this TechDocs site (which is
+itself public via GitHub Pages and the Backstage portal). The reason
+is asymmetric: an attacker who knows the exact hostname can probe it;
+a legitimate user already has a bookmark or a sidebar link.
+
+The pattern in this doc set:
+
+- `<home-domain>` — the public domain we host services under
+- `<name>.<home-domain>` — a single service hostname
+- `<tunnel-id>` — a Cloudflare Tunnel UUID (never a real value)
+
+Source-controlled files that DO have to contain real hostnames
+(NixOS module values, GitOps manifests) are the source of truth. The
+`hosts/p510/configuration.nix` host config and the `factory-gitops`
+repo are public, so even there we accept the leak; but we don't go
+out of our way to enumerate the list anywhere a search engine will
+crawl.
+
+## Cross-references
+
+- Cloudflared host module operations: [Cloudflared Tunnel](../applications/cloudflared-tunnel.md)
+- k3d cluster architecture (where the in-cluster tunnel lives): [k3d Architecture](k3d-architecture.md)
+- How a new service joins the cluster + becomes publicly reachable: [Factory GitOps](../guides/factory-gitops.md)

--- a/docs/guides/factory-gitops.md
+++ b/docs/guides/factory-gitops.md
@@ -9,6 +9,17 @@ For cluster lifecycle / troubleshooting see
 [applications/k3d-cluster.md](../applications/k3d-cluster.md). For the
 "why" see [architecture/k3d-architecture.md](../architecture/k3d-architecture.md).
 
+> **Public ingress update (2026-06-07):** services are now reached from
+> the public internet via **Cloudflare Tunnel** under our home domain
+> (`<name>.<home-domain>`), via an in-cluster `cloudflared` Deployment.
+> The Tailscale-sidecar pattern this guide originally described is
+> deprecated. The "expose this service" step is now a 2-line entry in
+> `infra/cloudflared/` plus one `cloudflared tunnel route dns` command —
+> not a sidecar container + Secret + ConfigMap per Pod. The Deployment
+> templates further down are kept for reference but should not be
+> copied for new services. Full design: [Public Ingress
+> Architecture](../architecture/public-ingress.md).
+
 ## Repo layout
 
 ```text
@@ -42,7 +53,7 @@ The root Application (`bootstrap/argocd-root-app.yaml`) points at `apps/`
 recursively. **Anything you commit under `apps/` becomes a managed
 service automatically** — no extra registration step.
 
-## The "add a new service" checklist
+## The "add a new service" checklist (current)
 
 1. Write k8s manifests for the service somewhere ArgoCD can reach. The
    conventions:
@@ -52,13 +63,36 @@ service automatically** — no extra registration step.
      CR that points there.
    - Or, for one-off tools without a dedicated repo, commit them straight
      under `factory-gitops/apps/<name>/manifests/`.
+   - The Deployment must declare an in-cluster `Service` on a stable
+     port. **No Tailscale sidecar.** Public reachability is handled by
+     the in-cluster `cloudflared` Deployment.
 2. Add `factory-gitops/apps/<name>/application.yaml` (template below).
-3. In the product repo's Deployment, add a Tailscale sidecar container
-   (template below) — that's how a Pod becomes reachable on the tailnet.
-4. `git push`. ArgoCD picks it up within ~3 minutes (or trigger a sync
-   from the UI).
-5. Verify: `https://<hostname>.tail833f7.ts.net` resolves once the
-   sidecar has registered (~30 s after the Pod starts).
+3. Add one route entry in `factory-gitops/infra/cloudflared/cloudflared.yaml`
+   under `ingress:`:
+
+   ```yaml
+   - hostname: <name>.<home-domain>
+     service: http://<svc>.<ns>.svc.cluster.local:<port>
+   ```
+
+4. `git push`. ArgoCD picks up the new Application and the updated
+   cloudflared ConfigMap within ~3 min (or trigger a sync from the UI).
+5. Create the Cloudflare DNS record for the new hostname (one-off, from
+   any host that has the tunnel's cert.pem — p510 itself works post-deploy):
+
+   ```bash
+   sudo TUNNEL_ORIGIN_CERT=/run/agenix/cloudflared-cert \
+     cloudflared tunnel route dns <in-cluster-tunnel-name> <name>.<home-domain>
+   ```
+
+6. Verify: `curl -sI https://<name>.<home-domain>` returns the service's
+   normal response (`200`, `302`, `401`, etc. — anything that isn't `5xx`).
+
+If the route is reaching but the service responds with a redirect
+loop, the upstream is doing HTTP→HTTPS rewrites at the application
+layer. Either configure the service to trust `X-Forwarded-Proto:
+https`, or point cloudflared at its HTTPS port and set
+`originRequest.noTLSVerify = true`.
 
 ## Templates
 
@@ -90,7 +124,14 @@ spec:
       - CreateNamespace=true
 ```
 
-### Pod exposed on the tailnet via a sidecar
+### Pod exposed on the tailnet via a sidecar (deprecated, kept for reference)
+
+> **Deprecated as of 2026-06-07.** Do not use for new services. Public
+> exposure is now handled by an in-cluster `cloudflared` Deployment
+> with a route entry in `infra/cloudflared/`. The sidecar pattern
+> below is preserved only to make sense of any old YAML you might
+> encounter in the repo history or in still-unmigrated Deployments.
+> Migration to remove the last sidecar (on `argocd-server`) is queued.
 
 Patch your Deployment to add a `tailscale` sidecar in the same Pod. The
 sidecar shares the Pod's network namespace, registers a tailnet node

--- a/mkdocs-full.yml
+++ b/mkdocs-full.yml
@@ -153,6 +153,7 @@ nav:
       - Secrets (agenix): architecture/secrets.md
       - Home Manager: architecture/home-manager.md
       - "k3d Cluster (p510)": architecture/k3d-architecture.md
+      - "Public Ingress": architecture/public-ingress.md
   - Hosts:
       - hosts/index.md
       - "p620 — AMD Workstation": hosts/p620.md
@@ -184,6 +185,7 @@ nav:
       - COSMIC Screen Sharing: applications/screensharing_cosmic.md
       - P620 BIOS / NUMA: applications/P620-BIOS-NUMA-Configuration.md
       - "k3d Cluster (ops)": applications/k3d-cluster.md
+      - "Cloudflared Tunnel (host)": applications/cloudflared-tunnel.md
   - Command System:
       - Overview: Nixos/README.md
       - Commands Index: Nixos/COMMANDS-INDEX.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,6 +158,7 @@ nav:
       - Secrets (agenix): architecture/secrets.md
       - Home Manager: architecture/home-manager.md
       - "k3d Cluster (p510)": architecture/k3d-architecture.md
+      - "Public Ingress": architecture/public-ingress.md
   - Hosts:
       - hosts/index.md
       - "p620 — AMD Workstation": hosts/p620.md
@@ -192,6 +193,7 @@ nav:
       - COSMIC Screen Sharing: applications/screensharing_cosmic.md
       - P620 BIOS / NUMA: applications/P620-BIOS-NUMA-Configuration.md
       - "k3d Cluster (ops)": applications/k3d-cluster.md
+      - "Cloudflared Tunnel (host)": applications/cloudflared-tunnel.md
   - Command System:
       - Overview: Nixos/README.md
       - Commands Index: Nixos/COMMANDS-INDEX.md


### PR DESCRIPTION
New pages:
  - docs/architecture/public-ingress.md — design rationale, two-tunnel
    topology (host-side + in-cluster), decision matrix Cloudflare-vs-
    Tailscale, trade-offs, hostname policy
  - docs/applications/cloudflared-tunnel.md — host-side cloudflared
    ops runbook: bootstrap, adding routes, DNS, rotation, troubleshoot

Updates:
  - docs/architecture/k3d-architecture.md — public-exposure section
    now points at the new architecture doc, sidecar section marked
    deprecated, decision log gets the 2026-06-07 pivot entry
  - docs/applications/k3d-cluster.md — ArgoCD UI URL note moved from
    tailnet hostname to home-domain placeholder
  - docs/guides/factory-gitops.md — "add a new service" checklist
    rewritten to use cloudflared route entries, sidecar template
    section marked deprecated/reference-only
  - mkdocs.yml + mkdocs-full.yml — both new pages added to nav under
    Architecture and Applications sections

Hostname policy: docs never spell out real service hostnames. All
examples use <name>.<home-domain> / <tunnel-id> placeholders. The
single source of truth for live hostnames stays in
hosts/p510/configuration.nix and infra/cloudflared/cloudflared.yaml
in the factory-gitops repo — both are public anyway, but we don't
duplicate them where search engines will pick them up.

Verified by nix build .#docs (exit 0) and explicit existence of
result/architecture/public-ingress/ and
result/applications/cloudflared-tunnel/ in the rendered site.
