### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1204,11 +1204,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1780739035,
-        "narHash": "sha256-fuiFfcyOuUyQ3U68UlVNwlCb50Uz37zv82CSCwQ+t8g=",
+        "lastModified": 1780795956,
+        "narHash": "sha256-gFRV5zPnWiscNzRW5iWMCIMoVoMvUoX6k3ihaeSWVzo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2595669cd5b6efdad8adef74d088d8f2ee3d8c70",
+        "rev": "807b5e8f5839e3f4362a705667e6df21ea27786e",
         "type": "github"
       },
       "original": {
@@ -1767,11 +1767,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780436770,
-        "narHash": "sha256-R4xHWcXW0KKBo8aojABFw0DZEN84tMAcCSFrNHvW44A=",
+        "lastModified": 1780778382,
+        "narHash": "sha256-gEG5c6bY9bvw3mLZLKXzprsV+lbQ/3YG/y9ZY4mAdlo=",
         "owner": "Benexl",
         "repo": "yt-x",
-        "rev": "5590eccb1b7cb9c6cf9083a0d42ab6e2e3166810",
+        "rev": "76a20d9f9939f91d7e1a2ac93ca7e43f7c7895d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=p620, scope=all).

Built and verified locally against nixosConfigurations.p620 before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)