### PR TITLE
chore(claude-code): bump native binary to 2.1.168 (#800)

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.167";
+  version = "2.1.168";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-1tKZW/yj+FOdnpqlE/9Dw9qg1VbW0a8Hxt9oHgUOUiw=";
+      hash = "sha256-4vfLUEQr3uIb8mhu83JaavGHogTkbEr1wS0PbXYyZIU=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-uPOD3x3KVX3I+4F+TnYzVjn5SgqMe4A8ovWu8S03Pwk=";
+      hash = "sha256-QNUOfEV0Kqo3B/o2KNf3ZcVe1QMQi28QBRPjjTJHeqA=";
     };
   };
 


### PR DESCRIPTION
## Summary

- GCS channel bump 2.1.167 → 2.1.168
- Three-line change in `pkgs/claude-code-native/default.nix`: version + x86_64 hash + aarch64 hash
- Closes #800

## Test plan

- [x] `claude --version` reports 2.1.168
- [x] p620 toplevel builds clean
- [x] razer toplevel builds clean
- [x] p510 toplevel builds clean (p510 doesn't ship it but builds it transitively in lib eval)
- [ ] Deploy p620 (post-merge)
- [ ] Deploy razer (post-merge)