### PR TITLE
fix(home): symlink ~/.local/bin/claude to silence /doctor

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -31,6 +31,11 @@
     package = pkgs.claude-code-native;
   };
 
+  # `claude /doctor` checks the literal path ~/.local/bin/claude and warns
+  # if it's missing — independent of whether `claude` is already on PATH.
+  # Point the path at the same nix-managed binary so /doctor stays quiet.
+  home.file.".local/bin/claude".source = "${pkgs.claude-code-native}/bin/claude";
+
   # Enable Claude Code "Agent Teams" — experimental feature that lets one
   # Claude session spawn a team of coordinated teammates (separate sessions
   # with their own context windows that can talk to each other).


### PR DESCRIPTION
## Summary

- `claude /doctor` checks the literal path `~/.local/bin/claude` and warns when missing, even if `claude` is already on PATH via `/etc/profiles/per-user/...`
- Add `home.file.".local/bin/claude".source = "${pkgs.claude-code-native}/bin/claude"` so home-manager creates the symlink declaratively
- Applies to p620 + razer only (p510 doesn't import `home/default.nix`)

## Test plan

- [x] p620 toplevel builds
- [x] razer toplevel builds
- [ ] Post-deploy: confirm `claude doctor` no longer warns