### PR TITLE
feat(tmux): package yohasebe/tmux-ccm v0.4.0

### DIFF
--- a/home/shell/tmux/default.nix
+++ b/home/shell/tmux/default.nix
@@ -23,6 +23,18 @@ let
           sha256 = "sha256-wBhOKM85aOcV4jD7wdyB/zXKDdhODE5k1iud+cm6Wk0=";
         };
       };
+
+  # tmux-ccm plugin wrapper — home-manager enforces pname starts with
+  # "tmuxplugins", so we wrap the CLI package's src via mkTmuxPlugin for
+  # the plugin role while pkgs.customPkgs.tmux-ccm stays the CLI bin. Both
+  # share the same fetched source via Nix dedup.
+  tmux-ccm-plugin =
+    pkgs.tmuxPlugins.mkTmuxPlugin
+      {
+        pluginName = "tmux-ccm";
+        version = pkgs.customPkgs.tmux-ccm.version;
+        src = pkgs.customPkgs.tmux-ccm.src;
+      };
 in
 {
   options.multiplexer.tmux = {
@@ -137,6 +149,21 @@ in
         # Development productivity plugins
         tmuxPlugins.tmux-thumbs # Quick text copying
         tmuxPlugins.extrakto # Enhanced text extraction
+
+        # tmux-ccm — attention manager for parallel Claude Code sessions.
+        # One tmux window = one project = one claude pane (state-tagged).
+        # `prefix + Tab` opens the popup dashboard. Menu/Tree bindings stay
+        # opt-in (set @ccm-key-menu / @ccm-key-tree) to avoid colliding with
+        # other plugins above.
+        {
+          plugin = tmux-ccm-plugin;
+          extraConfig = ''
+            # Default binding is prefix+Tab (set by plugin). To opt into
+            # menu/tree, uncomment:
+            # set -g @ccm-key-menu C
+            # set -g @ccm-key-tree t
+          '';
+        }
       ];
 
       # Enhanced configuration for modern terminal workflows
@@ -334,6 +361,11 @@ in
         set -g popup-border-lines rounded
       '';
     };
+
+    # Expose `ccm` (tmux-ccm's CLI) on user PATH so commands like
+    # `ccm add`, `ccm status`, `ccm send <project> <msg>` work from any
+    # shell, not just from inside the tmux popup that the plugin opens.
+    home.packages = [ pkgs.customPkgs.tmux-ccm ];
 
     # tmux-palette active theme — full color override sourced from our
     # active stylix base16 scheme, so the palette popup is BYTE-IDENTICAL

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -20,6 +20,7 @@
   media-bot = pkgs.callPackage ./media-bot { };
   mpris-album-art = pkgs.callPackage ./mpris-album-art { };
   weather-popup = pkgs.callPackage ./weather-popup { };
+  tmux-ccm = pkgs.callPackage ./tmux-ccm { };
   # gemini-cli removed in #560 (replaced by pkgs.customPkgs.antigravity-cli)
   # Claude Desktop - native Linux build from k3d3/claude-desktop-linux-flake (see flake.nix overlay)
   claude-desktop = pkgs.claude-desktop-linux;

--- a/pkgs/tmux-ccm/default.nix
+++ b/pkgs/tmux-ccm/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, makeWrapper
+, python3
+, jq
+, fzf
+, tmux
+,
+}:
+# tmux-ccm — attention manager for parallel Claude Code sessions.
+# bash + Python tmux plugin: one tmux window per project, live PERMIT/BUSY/
+# IDLE state detection per claude pane, popup dashboard, cross-project send.
+#
+# ccm.tmux (loaded by tmux as the plugin entry) and the ccm launcher resolve
+# their support files relative to $BASH_SOURCE, so the whole tree must live
+# at a single nix-store path with the original layout preserved. We copy it
+# under share/tmux-plugins/tmux-ccm/ (the layout home-manager's tmux module
+# expects) and wrap ccm into bin/ for CLI use outside the tmux popup.
+#
+# Wrapping is load-bearing for the popup case: `display-popup -E "ccm ..."`
+# spawns a fresh shell that does NOT inherit the user's PATH, so python3/jq/
+# fzf must be reachable via the wrapper itself. Same pattern as
+# pkgs/tmux-palette/default.nix.
+#
+# Upstream: https://github.com/yohasebe/tmux-ccm
+stdenvNoCC.mkDerivation rec {
+  pname = "tmux-ccm";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "yohasebe";
+    repo = "tmux-ccm";
+    rev = "v${version}";
+    hash = "sha256-sQO4NhlSChW34zw5AyhodSFxeWbXA1pC6ETNG5eQtc4=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/tmux-plugins/tmux-ccm $out/bin
+    cp -r ./. $out/share/tmux-plugins/tmux-ccm/
+
+    makeWrapper $out/share/tmux-plugins/tmux-ccm/ccm $out/bin/ccm \
+      --prefix PATH : ${lib.makeBinPath [ python3 jq fzf tmux ]}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Attention manager for parallel Claude Code sessions — tmux plugin with live state detection, dashboard, and cross-project messaging";
+    homepage = "https://github.com/yohasebe/tmux-ccm";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    mainProgram = "ccm";
+  };
+}


### PR DESCRIPTION
## Summary

Package [`yohasebe/tmux-ccm`](https://github.com/yohasebe/tmux-ccm) v0.4.0 — attention manager for parallel Claude Code sessions.

- One tmux window = one project = one claude pane
- Live state detection (PERMIT / BUSY / IDLE)
- Popup dashboard at `prefix + Tab`
- CLI: `ccm add`, `ccm status`, `ccm send <project> <msg>`

### Implementation

- New `pkgs/tmux-ccm/default.nix` — `stdenvNoCC.mkDerivation` preserving upstream layout, wraps `bin/ccm` with python3/jq/fzf/tmux on PATH
- `home/shell/tmux/default.nix` — register via `mkTmuxPlugin` (home-manager enforces "tmuxplugins" pname prefix), and add `ccm` to `home.packages` for CLI use outside popups
- Same `src` shared between CLI package and plugin via Nix dedup

### Scope

p620 + razer only. p510 doesn't import `home/default.nix` and has no `claude-code-native` — tmux-ccm has no value there.

## Test plan

- [x] `nix build .#nixosConfigurations.p620.pkgs.customPkgs.tmux-ccm` produces expected layout (`bin/ccm` wrapped, `share/tmux-plugins/tmux-ccm/` full tree)
- [x] p620 toplevel builds
- [x] razer toplevel builds
- [ ] Post-deploy: `prefix + Tab` opens the dashboard
- [ ] Post-deploy: `ccm --version` reports `0.4.0`