### PR TITLE
fix(gnome): hide wl-clipboard dummy toplevels from dock

### DIFF
--- a/home/desktop/gnome/default.nix
+++ b/home/desktop/gnome/default.nix
@@ -67,6 +67,7 @@ in
     ./apps.nix
     ./authenticator.nix
     ./keybindings.nix
+    ./wl-clipboard-hide.nix
   ];
 
   config = mkIf cfg.enable {

--- a/home/desktop/gnome/wl-clipboard-hide.nix
+++ b/home/desktop/gnome/wl-clipboard-hide.nix
@@ -1,0 +1,37 @@
+{ config, lib, ... }:
+let
+  inherit (lib) mkIf;
+  cfg = config.desktop.gnome;
+in
+{
+  # GNOME/Mutter deliberately does not implement the wlr-data-control or
+  # ext-data-control Wayland protocols. When wl-copy runs on GNOME it has
+  # to fake a window (an xdg_toplevel with app_id
+  # `io.github.bugaevc.wl-clipboard`) just to be allowed to participate
+  # in the clipboard. GNOME Shell then sees that toplevel as a "running
+  # app" and shows it in the dock — once per wl-copy invocation. This
+  # also tends to steal focus, breaking copy/paste workflows in practice.
+  #
+  # We can't fix the underlying protocol mismatch from NixOS, but we can
+  # provide a NoDisplay .desktop entry mapped to the same app_id via
+  # StartupWMClass. GNOME Shell then associates the dummy toplevel with
+  # this entry and suppresses it from the app grid (and on most GNOME
+  # versions, from the dock's running-apps list too).
+  #
+  # Filename matters: GNOME maps app_id -> <app_id>.desktop, so the entry
+  # key here must be the literal `io.github.bugaevc.wl-clipboard` string.
+  # Exec is a no-op (`true`) — this file exists only to hide the toplevel.
+  config = mkIf cfg.enable {
+    xdg.desktopEntries."io.github.bugaevc.wl-clipboard" = {
+      name = "wl-clipboard";
+      type = "Application";
+      exec = "true";
+      noDisplay = true;
+      startupNotify = false;
+      settings = {
+        StartupWMClass = "io.github.bugaevc.wl-clipboard";
+        NoDisplay = "true";
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary

When `wl-copy` runs on GNOME, it has to create a dummy `xdg_toplevel` window with app_id `io.github.bugaevc.wl-clipboard` (because Mutter doesn't expose wlr-data-control). GNOME Shell shows that toplevel in the dock as a running app — one icon per `wl-copy` invocation — and focus-steals on creation, which breaks paste workflows.

Fix: provide a `NoDisplay` `.desktop` entry whose `StartupWMClass` matches the app_id. GNOME Shell maps the dummy toplevel to the entry and suppresses it from the dock running-apps list (on most GNOME versions).

## Why a `.desktop` file and not removing wl-clipboard

`wl-clipboard` is used in ~15 places across the config: tmux yank, zellij copy-command, screenshot pipelines, clipse manager, productivity automation, etc. Removing the package would break all of those. The .desktop entry suppresses the cosmetic-and-focus-stealing symptom without touching anything that actually copies.

## Files

- `home/desktop/gnome/wl-clipboard-hide.nix` (new) — declares the entry, gated on `desktop.gnome.enable`
- `home/desktop/gnome/default.nix` — imports the new file

## Test plan

- [x] p620 toplevel builds (GNOME on Wayland host)
- [x] razer toplevel builds (also GNOME)
- [x] Verified rendered `.desktop` file has `NoDisplay=true` + `StartupWMClass=io.github.bugaevc.wl-clipboard`
- [ ] Post-deploy: copy something in any app; verify no `wl-clipboard` icon appears in the dock