### PR TITLE
feat(home): install tesseract OCR (eng/pol/nor)

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -49,5 +49,12 @@
   home.packages = [
     inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.opencode
     (pkgs.callPackage ../pkgs/weather-popup/default.nix { })
+
+    # tesseract OCR with explicit language packs only — passing
+    # enableLanguages = null bundles all ~130 languages (~500MB).
+    # Bokmål covers most Norwegian use; tesseract has no separate Nynorsk.
+    (pkgs.tesseract.override {
+      enableLanguages = [ "eng" "pol" "nor" ];
+    })
   ];
 }


### PR DESCRIPTION
Add tesseract 5.5.2 to user home.packages with English, Polish, Norwegian language packs. Explicit selection keeps closure small (~MBs not ~500MB).

## Test plan
- [x] p620 toplevel builds
- [x] razer toplevel builds  
- [ ] Post-deploy: `tesseract --list-langs` shows eng/nor/pol