### PR TITLE
chore(antigravity): bump agy 1.0.3 → 1.0.6

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.0.3-6260531212976128";
+  version = "1.0.6-6458082025406464";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.3-6260531212976128/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-BH02Ndl7Su7MDcM79SfYQRF50VRDAwA+ifw8uDsNBGI=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.6-6458082025406464/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-Pq5VJ4HTBUt4IULjz+e+c+O9BoxzakMspvGtqkDxngc=";
   };
 
   # Tarball contains a single file `antigravity` at the root.


### PR DESCRIPTION
## Summary
Routine bump of `pkgs.customPkgs.antigravity-cli` from 1.0.3 → 1.0.6 per upstream's auto-updater manifest.

## Test plan
- [x] `agy --version` reports 1.0.6
- [x] p620/razer/p510 toplevels build clean
- [ ] Deploy