### PR TITLE
feat(gnome): install YetAnotherRadio extension

### DIFF
--- a/home/desktop/gnome/extensions.nix
+++ b/home/desktop/gnome/extensions.nix
@@ -41,6 +41,7 @@ in
           "tailscale-status@maxgallup.github.com"
           "Bluetooth-Battery-Meter@maniacx.github.com"
           "dim-background-windows@stephane-13.github.com"
+          "yetanotherradio@io.github.buddysirjava"
           "allowlockedremotedesktop@kamens.us"
           "claude-code-usage@haletran.com"
           "otp-keys@osmank3.net"
@@ -115,6 +116,7 @@ in
         gnomeExtensions.tailscale-status
         gnomeExtensions.bluetooth-battery-meter
         gnomeExtensions.dim-background-windows
+        gnomeExtensions.yet-another-radio
 
         # Manually-packaged extensions (extensions.gnome.org pinned ZIPs,
         # see pkgs/gnome-ext-*). Not in nixpkgs.


### PR DESCRIPTION
GNOME Shell panel applet for internet radio (Radio Browser API + gstreamer). Our closure already has full gstreamer (base/good/bad/ugly/rs + libav), so prior "missing plugin" issues should be resolved.

## Test plan
- [x] p620 toplevel builds
- [x] razer toplevel builds
- [ ] Post-deploy: extension appears in Extensions app, enables, plays a station