### PR TITLE
fix(k3d): pin -n factory on factorySecrets kubectl apply

### DIFF
--- a/modules/containers/k3d.nix
+++ b/modules/containers/k3d.nix
@@ -169,7 +169,12 @@ let
       ; do
         f="/run/agenix/$slot"
         if [ -r "$f" ]; then
-          kubectl apply -f "$f" >/dev/null \
+          # -n factory pins the target namespace; the extracted Secret
+          # manifests have metadata.namespace stripped (yq during
+          # extraction), so without this flag kubectl would default to
+          # whichever namespace the kubeconfig has set (`default`),
+          # silently creating duplicates outside factory.
+          kubectl apply -n factory -f "$f" >/dev/null \
             && echo "[k3d-bootstrap] Applied factory/$slot from agenix" \
             || echo "[k3d-bootstrap] WARN: apply of $slot failed (continuing)"
         else


### PR DESCRIPTION
Follow-up to #812. Found while reviewing pre-deploy safety: the agenix Secret manifests have metadata.namespace stripped during extraction (yq), and the bootstrap kubectl apply had no -n flag — so first deploy would have created 8 duplicate Secrets in the `default` ns instead of seeding `factory`.

One-line fix: add `-n factory` to kubectl apply. Caught before any deploy ran.

## Test plan
- [x] p510 toplevel builds  
- [ ] Post-deploy: `kubectl -n default get secrets` shows no factory-secret-* (correctness check)
- [ ] `kubectl -n factory get secrets` shows all 8 originals untouched