### PR TITLE
feat(ollama): surgical overlay to 0.30.5 from nixpkgs master (#784)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -981,6 +981,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-ollama": {
+      "locked": {
+        "lastModified": 1780615177,
+        "narHash": "sha256-Xr+OvVyOkESPtnTOARUvOo2aZkqrKfyYvQgCSCSfLw0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bba51cb2479b7a23134f69b932811df999b892e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "bba51cb2",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1780453794,
@@ -1303,6 +1319,7 @@
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_8",
         "nixpkgs-f2k": "nixpkgs-f2k",
+        "nixpkgs-ollama": "nixpkgs-ollama",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur",
         "rust-overlay": "rust-overlay_4",

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,15 @@
     # Core
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    # Surgical pin for ollama 0.30.5 — nixos-unstable channel still ships
+    # 0.24.0 (Hydra hasn't blessed the bump yet) but master has had it
+    # since 2026-06-04 (commit bba51cb2 = 0.30.5 + darwin fix). Used by
+    # overlays/default.nix to override ONLY ollama-rocm / ollama-cuda;
+    # nothing else evaluates against this input. Remove when nixos-unstable
+    # catches up (verify with: `nix eval --raw nixpkgs-unstable#ollama-rocm.version`).
+    # See #784 for tracking.
+    nixpkgs-ollama.url = "github:NixOS/nixpkgs/bba51cb2";
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
     flake-utils.url = "github:numtide/flake-utils";
 

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -18,6 +18,23 @@
     cosmic-applet-spotify = inputs.cosmic-applet-spotify.packages.${prev.stdenv.hostPlatform.system}.default;
   })
 
+  # ollama 0.30.5 from a pinned master rev — nixos-unstable still on
+  # 0.24.0. Only ollama-rocm + ollama-cuda are overridden so the rest of
+  # the closure stays on our pinned nixos-unstable. Remove this overlay
+  # (and the nixpkgs-ollama flake input) once nixos-unstable advances
+  # past 0.30.5. See #784.
+  (_final: prev:
+    let
+      ollamaPkgs = import inputs.nixpkgs-ollama {
+        inherit (prev.stdenv.hostPlatform) system;
+        config.allowUnfree = true;
+      };
+    in
+    {
+      ollama-rocm = ollamaPkgs.ollama-rocm;
+      ollama-cuda = ollamaPkgs.ollama-cuda;
+    })
+
   # Rust toolchain overlay — exposes `rust-bin.*` on `final` so packages
   # that need a newer rustc than nixpkgs ships (e.g. splashboard) can
   # build with `makeRustPlatform`. Doesn't replace the default `rustc`.


### PR DESCRIPTION
Unblocks gemma4:12b without waiting on nixos-unstable.

## What
Add a second nixpkgs input pinned to `bba51cb2` (master HEAD as of 2026-06-04, contains the 0.30.5 bump + darwin fix). Overlay overrides only `ollama-rocm` and `ollama-cuda`.

## Why
nixos-unstable still ships 0.24.0; gemma4:12b needs 0.30.3+; 0.30.4 has an FP-exception regression; 0.30.5 is the safe target. Master has it; channel hasn't caught up.

## Risk surface
Minimal. Only the two ollama-* package paths come from the new input. Rest of system stays on the existing pin.

## Removal procedure
When nixos-unstable's ollama is ≥0.30.5, delete the nixpkgs-ollama input declaration in flake.nix and the overlay block in overlays/default.nix. Re-run `nix flake update` to drop the now-unused lock entry.

## Test plan
- [x] `nix eval` confirms p620 ollama-rocm == 0.30.5
- [x] `nix eval` confirms p510 ollama-cuda == 0.30.5
- [x] p620 / razer / p510 toplevels build clean
- [ ] Post-deploy: `ollama --version` on p620 + p510 reports 0.30.5
- [ ] Post-deploy: re-add gemma4:12b to onDemandModels, verify pull succeeds

Tracks #784.