### PR TITLE
feat(ollama): add gemma4:12b to p620 + p510 onDemandModels

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -411,7 +411,7 @@ in
     persistentModels = [ ]; # No persistent models to save VRAM
     # gemma4 for n8n; qwen2.5:7b for reliable strict-JSON audiobook metadata
     # extraction + tool-calling (audiobook-import / audiobook-mcp).
-    onDemandModels = [ "gemma4:e4b" "qwen2.5:7b" ];
+    onDemandModels = [ "gemma4:e4b" "qwen2.5:7b" "gemma4:12b" ];
     keepAlive = "5m"; # Evict from VRAM after 5 minutes of idle
   };
 

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -105,7 +105,7 @@ in
     enable = true;
     modelsDir = "/mnt/data/ollama/models";
     persistentModels = [ "qwen3:14b" ];
-    onDemandModels = [ "qwen2.5-coder:14b" "gemma4:e4b" ];
+    onDemandModels = [ "qwen2.5-coder:14b" "gemma4:e4b" "gemma4:12b" ];
   };
 
   # LiteLLM router — Anthropic-compat proxy fronting Ollama (Phase 2).


### PR DESCRIPTION
Re-introduces what #781 attempted (and #782 reverted). Unblocked by #814 (ollama 0.30.5 overlay).

## Verified before commit
- Both hosts running ollama 0.30.5 (post #814 deploy)
- `ollama pull gemma4:12b` succeeded on both
- One-shot inference `ollama run gemma4:12b 'Say only the digit 7'` returned 7 on both

## Test plan
- [x] Manual pull + inference on both hosts
- [ ] Post-deploy: ollama-model-loader.service stays green (no #781-style fail-loop)
- [ ] Eventually: close #784