### PR TITLE
fix(gnome-ext): patch shell-version to include 50

### DIFF
--- a/pkgs/gnome-ext-claude-code-usage/default.nix
+++ b/pkgs/gnome-ext-claude-code-usage/default.nix
@@ -23,6 +23,19 @@ stdenvNoCC.mkDerivation rec {
     runHook preInstall
     install -d "$out/share/gnome-shell/extensions/${uuid}"
     unzip -q "$src" -d "$out/share/gnome-shell/extensions/${uuid}"
+
+    # Upstream v4 declares shell-version ["46","47","48","49"]; GNOME 50
+    # then marks the extension incompatible (red icon). The extension is
+    # a small panel indicator polling Anthropic's REST API for usage —
+    # no GNOME 50-ABI-breaking surfaces — so widen the declared support
+    # to include 50. Remove when upstream publishes a 50-native release.
+    META="$out/share/gnome-shell/extensions/${uuid}/metadata.json"
+    if ! grep -q '"50"' "$META"; then
+      # sed -z reads the whole file as one record, letting the regex span
+      # newlines (metadata.json formats shell-version as a multi-line array).
+      sed -i -z 's/\("shell-version":[[:space:]]*\[[^]]*\)\]/\1,\n    "50"\n  ]/' "$META"
+    fi
+
     if [ -d "$out/share/gnome-shell/extensions/${uuid}/schemas" ]; then
       glib-compile-schemas "$out/share/gnome-shell/extensions/${uuid}/schemas"
     fi

--- a/pkgs/gnome-ext-spotify-controller/default.nix
+++ b/pkgs/gnome-ext-spotify-controller/default.nix
@@ -23,6 +23,20 @@ stdenvNoCC.mkDerivation rec {
     runHook preInstall
     install -d "$out/share/gnome-shell/extensions/${uuid}"
     unzip -q "$src" -d "$out/share/gnome-shell/extensions/${uuid}"
+
+    # Upstream v4 declares shell-version ["45"…"49"]; GNOME 50 then marks
+    # the extension incompatible (red icon). The extension is a panel
+    # indicator + MPRIS DBus subscriber for Spotify — no GNOME 50-ABI-
+    # breaking surfaces in the usual sense — so widen the declared
+    # support to include 50. Remove when upstream publishes a 50-native
+    # release.
+    META="$out/share/gnome-shell/extensions/${uuid}/metadata.json"
+    if ! grep -q '"50"' "$META"; then
+      # sed -z reads the whole file as one record, letting the regex span
+      # newlines (metadata.json formats shell-version as a multi-line array).
+      sed -i -z 's/\("shell-version":[[:space:]]*\[[^]]*\)\]/\1,\n    "50"\n  ]/' "$META"
+    fi
+
     if [ -d "$out/share/gnome-shell/extensions/${uuid}/schemas" ]; then
       glib-compile-schemas "$out/share/gnome-shell/extensions/${uuid}/schemas"
     fi


### PR DESCRIPTION
Both claude-code-usage and spotify-controller upstream v4 declare shell-version 45/46–49; GNOME 50 marks them incompatible (red icon). No v5 upstream yet, so we patch the metadata.json in our installPhase to add 50.

Verified the patched JSON parses correctly and contains 50.

## Test plan
- [x] both packages build
- [x] both metadata.json parse as valid JSON post-patch
- [ ] Post-deploy + Shell restart (logout/login on Wayland): red "incompatible" indicator gone in Extensions app
- [ ] Both extensions actually function (Claude usage shows in panel; Spotify Controller shows track info when Spotify running)

If runtime breaks, GNOME Shell silently disables the extension — no system damage. Remove the sed block when upstream publishes v5.