### PR TITLE
feat(home-assistant): enable Starlink + Nest integrations on p510

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -154,6 +154,137 @@ in
         "ffmpeg"
         "stream"
       ];
+      dashboards = {
+        starlink-status = {
+          title = "Starlink";
+          icon = "mdi:satellite-uplink";
+          yaml = ''
+            title: Starlink
+            views:
+              - title: Overview
+                path: overview
+                icon: mdi:satellite-uplink
+                cards:
+                  - type: glance
+                    title: Status
+                    columns: 4
+                    entities:
+                      - entity: binary_sensor.starlink_connectivity
+                        name: Online
+                      - entity: binary_sensor.starlink_obstructed
+                        name: Obstructed
+                      - entity: binary_sensor.starlink_heating
+                        name: Heating
+                      - entity: binary_sensor.starlink_thermal_throttle
+                        name: Throttled
+                  - type: entities
+                    title: Throughput & Latency
+                    entities:
+                      - sensor.starlink_downlink_throughput
+                      - sensor.starlink_uplink_throughput
+                      - sensor.starlink_ping
+                      - sensor.starlink_ping_drop_rate
+                  - type: history-graph
+                    title: Throughput (24h)
+                    hours_to_show: 24
+                    entities:
+                      - sensor.starlink_downlink_throughput
+                      - sensor.starlink_uplink_throughput
+                  - type: history-graph
+                    title: Latency (24h)
+                    hours_to_show: 24
+                    entities:
+                      - sensor.starlink_ping
+                  - type: entities
+                    title: Data & Power
+                    entities:
+                      - sensor.starlink_download
+                      - sensor.starlink_upload
+                      - sensor.starlink_power
+                      - sensor.starlink_energy
+                  - type: entities
+                    title: Dish Status
+                    entities:
+                      - sensor.starlink_last_restart
+                      - binary_sensor.starlink_mast_near_vertical
+                      - binary_sensor.starlink_motors_stuck
+                      - binary_sensor.starlink_ethernet_speeds
+                      - binary_sensor.starlink_update
+                      - binary_sensor.starlink_unexpected_location
+                      - binary_sensor.starlink_roaming_mode
+                      - binary_sensor.starlink_sleep
+                  - type: entities
+                    title: Sleep Schedule
+                    entities:
+                      - switch.starlink_sleep_schedule
+                      - time.starlink_sleep_start
+                      - time.starlink_sleep_end
+                  - type: horizontal-stack
+                    cards:
+                      - type: button
+                        name: Stow
+                        entity: switch.starlink_stowed
+                        icon: mdi:satellite
+                        tap_action:
+                          action: toggle
+                      - type: button
+                        name: Restart
+                        entity: button.starlink_restart
+                        icon: mdi:restart
+                        tap_action:
+                          action: call-service
+                          service: button.press
+                          service_data:
+                            entity_id: button.starlink_restart
+                          confirmation:
+                            text: "Restart Starlink dish? Internet will drop for ~2 minutes."
+          '';
+        };
+
+        nest-cameras = {
+          title = "Cameras";
+          icon = "mdi:cctv";
+          yaml = ''
+            title: Cameras
+            views:
+              - title: Live
+                path: live
+                icon: mdi:cctv
+                cards:
+                  - type: picture-glance
+                    title: Front Door
+                    camera_image: camera.front_door_doorbell
+                    camera_view: auto
+                    entities:
+                      - event.front_door_doorbell_chime
+                      - event.front_door_doorbell_motion
+                  - type: picture-glance
+                    title: Kitchen
+                    camera_image: camera.kitchentop
+                    camera_view: auto
+                    entities:
+                      - event.kitchentop_motion
+                  - type: picture-glance
+                    title: Master Bedroom
+                    camera_image: camera.master_bedroom
+                    camera_view: auto
+                    entities:
+                      - event.master_bedroom_motion
+              - title: Events
+                path: events
+                icon: mdi:bell-alert
+                cards:
+                  - type: logbook
+                    title: Recent Camera Events (24h)
+                    hours_to_show: 24
+                    entities:
+                      - event.front_door_doorbell_chime
+                      - event.front_door_doorbell_motion
+                      - event.kitchentop_motion
+                      - event.master_bedroom_motion
+          '';
+        };
+      };
     };
 
     ai = {

--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -149,7 +149,10 @@ in
       enableCLI = true;
       tailscaleIntegration = true;
       extraComponents = [
-        # Additional integrations
+        "starlink"
+        "nest"
+        "ffmpeg"
+        "stream"
       ];
     };
 

--- a/modules/services/home-assistant.nix
+++ b/modules/services/home-assistant.nix
@@ -52,7 +52,13 @@ in
 
       # Declarative configuration
       config = {
-        # Minimal base configuration
+        # Enable the default_config meta-component which activates the essential
+        # components listed in extraComponents below (my, mobile_app, network,
+        # automation, scene, script, etc). Without this, those components are
+        # installed but never loaded — breaking my.home-assistant.io redirects
+        # and many integrations that depend on application_credentials.
+        default_config = { };
+
         # HTTP configuration
         http = {
           server_host = "0.0.0.0";

--- a/modules/services/home-assistant.nix
+++ b/modules/services/home-assistant.nix
@@ -37,6 +37,42 @@ in
       default = true;
       description = "Configure trusted proxies for Tailscale access";
     };
+
+    dashboards = mkOption {
+      type = types.attrsOf (types.submodule {
+        options = {
+          title = mkOption {
+            type = types.str;
+            description = "Sidebar display title";
+          };
+          icon = mkOption {
+            type = types.str;
+            default = "mdi:view-dashboard";
+            description = "Material Design Icons name for the sidebar entry";
+          };
+          showInSidebar = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Show this dashboard in the HA sidebar";
+          };
+          yaml = mkOption {
+            type = types.lines;
+            description = ''
+              Raw Lovelace dashboard YAML. Must define `title:` and `views:`.
+              Written to /etc/home-assistant/dashboards/<name>.yaml at activation;
+              referenced from configuration.yaml via lovelace.dashboards.
+            '';
+          };
+        };
+      });
+      default = { };
+      description = ''
+        Declarative Lovelace dashboards. Each attr key becomes the URL slug
+        (/<key>) and the corresponding YAML is rendered into a read-only file
+        under /etc/home-assistant/dashboards/. The default Overview dashboard
+        remains in storage mode and is unaffected.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -80,6 +116,18 @@ in
           external_url = "https://p510.home.freundcloud.com:8123"; # Adjust based on Tailscale hostname
         };
       };
+
+      # Declarative Lovelace dashboards (in addition to the default storage-mode one)
+      config.lovelace.dashboards = lib.mapAttrs
+        (name: d: {
+          mode = "yaml";
+          filename = "/etc/home-assistant/dashboards/${name}.yaml";
+          title = d.title;
+          icon = d.icon;
+          show_in_sidebar = d.showInSidebar;
+          require_admin = false;
+        })
+        cfg.dashboards;
 
       # Components required for onboarding + optional cloud
       extraComponents = [
@@ -146,6 +194,16 @@ in
       };
     };
 
+    # Materialize each declared dashboard as a read-only file under /etc.
+    # HA reads /etc as read-only under ProtectSystem=strict, so this works
+    # without weakening the service hardening or touching /var/lib/hass.
+    environment.etc = lib.mapAttrs'
+      (name: d: lib.nameValuePair "home-assistant/dashboards/${name}.yaml" {
+        text = d.yaml;
+        mode = "0444";
+      })
+      cfg.dashboards;
+
     # Home Assistant CLI tool
     environment.systemPackages = mkIf cfg.enableCLI [
       pkgs.home-assistant-cli
@@ -161,6 +219,17 @@ in
       {
         assertion = cfg.enableCloud -> elem "cloud" config.services.home-assistant.extraComponents;
         message = "Home Assistant Cloud requires 'cloud' component in extraComponents";
+      }
+      {
+        assertion = lib.all (n: lib.hasInfix "-" n) (lib.attrNames cfg.dashboards);
+        message = ''
+          Each features.homeAssistant.dashboards attribute name (the URL slug)
+          must contain a hyphen — Home Assistant's lovelace integration rejects
+          single-word slugs at runtime. Offenders: ${
+            lib.concatStringsSep ", "
+              (lib.filter (n: !(lib.hasInfix "-" n)) (lib.attrNames cfg.dashboards))
+          }
+        '';
       }
     ];
   };


### PR DESCRIPTION
## Summary

- Adds `starlink`, `nest`, `ffmpeg`, `stream` to p510's HA `extraComponents` so the dish (local gRPC at 192.168.100.1) and Google Nest cameras can be configured via HA UI.
- Fixes a latent bug in the shared HA module — `extraComponents` listed ~25 essential components ("usually in default_config") but only installed Python deps without enabling them in configuration.yaml. As a result `my` sat dormant, breaking my.home-assistant.io OAuth redirects and silently breaking `application_credentials`, `mobile_app`, `automation`, etc. Adding `default_config = { };` to declarative config activates them all (HA's standard one-liner).

## Manual setup (already done — one-time, can't be declared in Nix)

- GCP project `burnished-block-496010-c9`: OAuth Web client, SDM + Pub/Sub APIs enabled, topic `openclaw` with `sdm-publisher@googlegroups.com` granted `roles/pubsub.publisher`
- Device Access project `f75e0ec3-78e4-456a-b76b-852c329e16d9` (Sandbox tier)
- `olaf.loken@gmail.com` granted `roles/pubsub.editor` on the GCP project + registered as Testing-mode OAuth test user
- Both integrations added in HA UI (Starlink dish autodiscovered, Nest cameras visible: front_door_doorbell, master_bedroom, kitchentop)

## Test plan

- [x] `nix build .#nixosConfigurations.p510.config.system.build.toplevel` — succeeds
- [x] `just quick-deploy p510` — deploys cleanly, HA restarts
- [x] HA log: no errors related to starlink/nest/ffmpeg/stream
- [x] `curl http://p510.lan:8123/_my_redirect/` returns 200 (my component now actually loaded)
- [x] HA config_entries shows both `domain: starlink` and `domain: nest` registered
- [x] Starlink integration produces 28 entities (sensors, binary_sensors, button, switch, time)
- [x] Nest integration produces 3 cameras + event entities; snapshots work; Pub/Sub subscription `openclaw-sub` auto-created

🤖 Generated with [Claude Code](https://claude.com/claude-code)