### PR TITLE
feat(n8n): expose at n8n.freundcloud.org.uk via Cloudflare Tunnel

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -663,7 +663,14 @@ in
   # n8n workflow runtime (localhost:5678) — hosts the "just-finished"
   # media-recommendation workflow that calls Overseerr/Tautulli + local gemma.
   # See docs/plans/2026-05-26-plex-llm-recommendations-design.md.
-  features.n8n.enable = true;
+  features.n8n = {
+    enable = true;
+    # Public UI via Cloudflare Tunnel — n8n's listen address stays loopback;
+    # cloudflared proxies HTTPS edge traffic to 127.0.0.1:5678 from within p510.
+    # Setting publicUrl makes n8n emit correct webhook URLs and Secure cookies
+    # under the public hostname.
+    publicUrl = "https://n8n.freundcloud.org.uk";
+  };
 
   # Cloudflare Tunnel — public ingress under freundcloud.org.uk.
   # Bootstrap (one-time):
@@ -719,6 +726,10 @@ in
       "nzbget.freundcloud.org.uk" = "http://localhost:6789";
       "sabnzbd.freundcloud.org.uk" = "http://localhost:8080";
       "audiobookshelf.freundcloud.org.uk" = "http://localhost:13378";
+      # n8n holds the encryption key for every workflow's credentials — its
+      # own login is the only thing protecting them once this is public.
+      # Use a strong password (or front with Cloudflare Access if doubting).
+      "n8n.freundcloud.org.uk" = "http://localhost:5678";
     };
   };
 }

--- a/modules/services/n8n.nix
+++ b/modules/services/n8n.nix
@@ -28,6 +28,21 @@ in
       default = 5678;
       description = "Loopback HTTP port n8n listens on. Never exposed to the network (no firewall opening).";
     };
+
+    publicUrl = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "https://n8n.example.com";
+      description = ''
+        External base URL when fronting n8n with a reverse proxy (cloudflared,
+        Tailscale Serve, Caddy, …). When set, n8n is told its public hostname
+        and protocol so webhook URLs, OAuth callbacks, and Secure cookies all
+        reference the proxy address instead of localhost. The listen address
+        stays loopback — wire the proxy separately.
+
+        Leave null for loopback-only operation (the original module behavior).
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -52,7 +67,28 @@ in
         N8N_PERSONALIZATION_ENABLED = false;
         # GENERIC_TIMEZONE defaults to config.time.timeZone; diagnostics and
         # version-notifications already default to false upstream.
-      };
+      } // lib.optionalAttrs (cfg.publicUrl != null) (
+        let
+          # Parse "scheme://host[:port][/path]" into the pieces n8n wants.
+          # cfg.publicUrl is the externally-visible base URL.
+          parts = builtins.match "(https?)://([^/:]+)(:[0-9]+)?(/.*)?" cfg.publicUrl;
+          scheme = builtins.elemAt parts 0;
+          host = builtins.elemAt parts 1;
+        in
+        {
+          N8N_HOST = host;
+          N8N_PROTOCOL = scheme;
+          # Trailing slash matters: n8n appends webhook paths to this verbatim.
+          WEBHOOK_URL = "${cfg.publicUrl}/";
+          # One reverse proxy in front (cloudflared / Tailscale Serve / nginx).
+          N8N_PROXY_HOPS = 1;
+        }
+      );
+    };
+
+    assertions = lib.optional (cfg.publicUrl != null) {
+      assertion = builtins.match "https?://[^/:]+(:[0-9]+)?(/.*)?" cfg.publicUrl != null;
+      message = "features.n8n.publicUrl must be of the form http(s)://host[:port][/path]; got: ${cfg.publicUrl}";
     };
   };
 }


### PR DESCRIPTION
## Summary

- Adds `features.n8n.publicUrl` option to `modules/services/n8n.nix`. When set, the module configures `N8N_HOST`, `N8N_PROTOCOL`, `WEBHOOK_URL`, and `N8N_PROXY_HOPS` so n8n emits correct URLs and Secure cookies for the public hostname. Listen address stays loopback (`127.0.0.1:5678`).
- Sets `features.n8n.publicUrl = "https://n8n.freundcloud.org.uk"` on p510.
- Adds `n8n.freundcloud.org.uk → http://localhost:5678` to p510's `features.cloudflared.ingress` map.

## One-time bootstrap (already done)

`cloudflared tunnel route dns p510-home n8n.freundcloud.org.uk` was run on p510 to register the CNAME at Cloudflare. This step isn't declarable in Nix.

## Security note

n8n holds the encryption key for every workflow's credentials. Public exposure puts the n8n UI directly on the internet with only its own login protecting it. Either:
- Use a strong admin password (and turn on n8n's "Owner" 2FA in Settings → My Account once available), **or**
- Front with Cloudflare Access (free Zero Trust click-config — adds Google/GitHub SSO at the edge before the request reaches the tunnel).

The other public hostnames (`sonarr`, `radarr`, `nzbget`, `sabnzbd`, …) already follow the same model; this is documented in the cloudflared block in `hosts/p510/configuration.nix`.

## Test plan

- [x] `nix build .#nixosConfigurations.p510.config.system.build.toplevel` — succeeds
- [x] `just quick-deploy p510` — deploys cleanly, both n8n and cloudflared restart
- [x] n8n systemd unit shows `N8N_HOST=n8n.freundcloud.org.uk`, `N8N_PROTOCOL=https`, `WEBHOOK_URL=https://n8n.freundcloud.org.uk/`, `N8N_PROXY_HOPS=1`, `N8N_LISTEN_ADDRESS=127.0.0.1`
- [x] cloudflared.yml ingress contains `n8n.freundcloud.org.uk → http://localhost:5678`
- [x] Local probe on p510: `curl http://127.0.0.1:5678/` → 200
- [x] Public probe (via Cloudflare edge): `curl https://n8n.freundcloud.org.uk/` → 200 (verified via `--resolve` since local DNS cache hadn't propagated yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)