### PR TITLE
fix(tmux): point mkTmuxPlugin at ccm.tmux (the upstream entrypoint)

### DIFF
--- a/home/shell/tmux/default.nix
+++ b/home/shell/tmux/default.nix
@@ -34,6 +34,11 @@ let
         pluginName = "tmux-ccm";
         version = pkgs.customPkgs.tmux-ccm.version;
         src = pkgs.customPkgs.tmux-ccm.src;
+        # Upstream (yohasebe/tmux-ccm) names the entrypoint `ccm.tmux`, not
+        # the mkTmuxPlugin default of `tmux_ccm.tmux` (derived from
+        # pluginName). Without this override the plugin loader silently fails
+        # with exit 127 and no ccm keybindings ever land.
+        rtpFilePath = "ccm.tmux";
       };
 in
 {


### PR DESCRIPTION
## Summary

One-line fix: `rtpFilePath = "ccm.tmux";` in the `tmux-ccm-plugin` definition.

## Background

home-manager's `mkTmuxPlugin` defaults `rtpFilePath` to `${pluginName}.tmux` with name-normalisation, which becomes `tmux_ccm.tmux` for `pluginName = "tmux-ccm"`. Upstream `yohasebe/tmux-ccm` ships `ccm.tmux` instead. As a result the loader returns exit 127 on every tmux start — silently, since `run-shell` doesn't surface plugin errors — and **no ccm keybindings have ever landed**:

- `prefix Tab` (default dashboard) — never bound
- `prefix C-Space` (override from #828) — never bound
- mouse-on-status-icon dashboard — never wired
- `inject-status` periodic call — never wired

This explains why the documented `prefix Tab` chord has done nothing in this repo's tmux servers.

Stacks neatly on top of #828 — they touch different lines in the same file, no conflict.

## Verification

- [x] `nixpkgs.tmuxPlugins.mkTmuxPlugin` confirmed to accept `rtpFilePath` (used by `tmux-thumbs`, `tmux-fingers`, `tmux-which-key` in the same nixpkgs revision)
- [x] `just test-host p620` builds clean
- [ ] Post-deploy: `tmux source-file ~/.config/tmux/tmux.conf` then `tmux list-keys -T prefix | grep C-Space` shows the binding (assumes #828 also merged)

## Test plan

- [ ] Merge #827, #828, #829 first (any order)
- [ ] Merge this PR
- [ ] Deploy to p620 + razer (claude-code part) → tmux reload → press `prefix C-Space` → ccm dashboard popup appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)