### PR TITLE
fix(gnome): drain wl-copy with wl-paste --watch + declare Clipboard Indicator

### DIFF
--- a/home/desktop/gnome/default.nix
+++ b/home/desktop/gnome/default.nix
@@ -68,6 +68,7 @@ in
     ./authenticator.nix
     ./keybindings.nix
     ./wl-clipboard-hide.nix
+    ./wl-paste-watch.nix
   ];
 
   config = mkIf cfg.enable {

--- a/home/desktop/gnome/extensions.nix
+++ b/home/desktop/gnome/extensions.nix
@@ -49,6 +49,13 @@ in
           "spotify-controller@narkagni"
           "accent-directories@taiwbi.com"
           "forge@jmmaranan.com"
+          # Clipboard Indicator — panel-bar clipboard history. Paired with
+          # the wl-paste --watch user service (home/desktop/gnome/wl-paste-watch.nix)
+          # which actually drains wl_data_source ownership so wl-copy
+          # zombies stop piling up in the dock. The extension itself
+          # only provides the UI; without the watcher daemon the
+          # dock-icon problem persists.
+          "clipboard-indicator@tudmotu.com"
           # User-managed drift — see policy comment above.
           "aurora-shell@luminusos.github.io"
         ];
@@ -117,6 +124,7 @@ in
         gnomeExtensions.bluetooth-battery-meter
         gnomeExtensions.dim-background-windows
         gnomeExtensions.yet-another-radio
+        gnomeExtensions.clipboard-indicator
 
         # Manually-packaged extensions (extensions.gnome.org pinned ZIPs,
         # see pkgs/gnome-ext-*). Not in nixpkgs.

--- a/home/desktop/gnome/wl-clipboard-hide.nix
+++ b/home/desktop/gnome/wl-clipboard-hide.nix
@@ -12,11 +12,20 @@ in
   # app" and shows it in the dock — once per wl-copy invocation. This
   # also tends to steal focus, breaking copy/paste workflows in practice.
   #
-  # We can't fix the underlying protocol mismatch from NixOS, but we can
-  # provide a NoDisplay .desktop entry mapped to the same app_id via
-  # StartupWMClass. GNOME Shell then associates the dummy toplevel with
-  # this entry and suppresses it from the app grid (and on most GNOME
-  # versions, from the dock's running-apps list too).
+  # Two complementary defences are wired in this repo:
+  #
+  #   1. This file — a NoDisplay .desktop entry mapped to the wl-clipboard
+  #      app_id, which keeps the entry out of the app grid / Activities
+  #      overview / launcher.
+  #
+  #   2. wl-paste-watch.nix — a user systemd service that runs
+  #      `wl-paste --watch` so each wl-copy's data is consumed
+  #      immediately, the supersession event fires deterministically,
+  #      and the dummy toplevel exits. This is what actually keeps the
+  #      dock clean. On GNOME 50+ at least, NoDisplay does NOT hide
+  #      running windows from the dock's running-apps section —
+  #      contrary to what the original commit message of this file
+  #      (#808) hoped for.
   #
   # Filename matters: GNOME maps app_id -> <app_id>.desktop, so the entry
   # key here must be the literal `io.github.bugaevc.wl-clipboard` string.

--- a/home/desktop/gnome/wl-paste-watch.nix
+++ b/home/desktop/gnome/wl-paste-watch.nix
@@ -1,0 +1,57 @@
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib) mkIf;
+  cfg = config.desktop.gnome;
+in
+{
+  # Drain the Wayland CLIPBOARD selection so wl-copy zombies don't pile up
+  # in the GNOME dock.
+  #
+  # Background: GNOME/Mutter doesn't implement wlr-data-control or
+  # ext-data-control. wl-copy therefore creates a dummy xdg_toplevel
+  # (app_id io.github.bugaevc.wl-clipboard) to participate in the
+  # clipboard, and that toplevel renders as a dock icon. wl-copy is
+  # supposed to exit when superseded by the next clipboard owner, but on
+  # Mutter the `cancelled` event delivery is unreliable — so tmux's
+  # `copy-pipe-and-cancel wl-copy` accumulates a process (and a dock
+  # icon) per yank. We've seen this go past 25.
+  #
+  # Running `wl-paste --watch` forces an immediate read of every new
+  # selection, which makes the supersession/cleanup deterministic on
+  # Mutter: each new wl-copy sees its data delivered and the prior one
+  # gets cancelled and exits cleanly.
+  #
+  # We pipe to `cat` and discard — Clipboard Indicator
+  # (extensions.nix) already provides the history UI by polling
+  # St.Clipboard from inside gnome-shell, so storing the data twice
+  # would be pointless. The watcher exists only for its consumption
+  # side-effect.
+  #
+  # PRIMARY selection isn't watched: tmux's copy-pipe targets CLIPBOARD,
+  # not PRIMARY. Add a second service if some other tool starts using
+  # PRIMARY heavily.
+  config = mkIf cfg.enable {
+    systemd.user.services.wl-paste-watch = {
+      Unit = {
+        Description = "Drain Wayland CLIPBOARD to make wl-copy exit cleanly on GNOME";
+        # Wait for the graphical session so $WAYLAND_DISPLAY is set.
+        PartOf = [ "graphical-session.target" ];
+        After = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        # `wl-paste --watch` long-runs and invokes the command on every new
+        # selection. `cat` reads stdin to EOF (wl-paste closes it after each
+        # selection) and discards.
+        ExecStart = "${pkgs.wl-clipboard}/bin/wl-paste --watch ${pkgs.coreutils}/bin/cat";
+        StandardOutput = "null";
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+
+      Install = {
+        WantedBy = [ "graphical-session.target" ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary

#808's NoDisplay .desktop fix was the wrong tool — it hides apps from the launcher, not running windows from the dock. On GNOME 50+ wl-copy processes still pile up in the dock, one per tmux yank, climbing past 25 in a normal session. This PR provides the actual fix.

## The problem chain

```
tmux y (copy-mode-vi yank)
  └→ copy-pipe-and-cancel wl-copy
     └→ wl-copy creates dummy xdg_toplevel (Mutter has no wlr-data-control)
        └→ GNOME Shell tracks it as a "running window" → dock icon
           └→ wl-copy keeps the toplevel alive waiting for the next clipboard owner
              └→ on Mutter, the supersession `cancelled` event is unreliable
                 └→ old wl-copy never exits
                    └→ icons accumulate
```

## What this PR does

**1. `home/desktop/gnome/wl-paste-watch.nix` (new):** User systemd service running `wl-paste --watch cat` for the CLIPBOARD selection. Reading every new selection forces deterministic supersession on Mutter — each new wl-copy delivers its data, the prior one receives `cancelled` and exits cleanly. This is the actual dock-icon fix.

**2. `home/desktop/gnome/extensions.nix`:** Declared `clipboard-indicator@tudmotu.com` + added `gnomeExtensions.clipboard-indicator` to `home.packages`. The extension was manually installed by the user; without this declaration it'd be disabled at next `home-manager switch` per the snapshot policy in that file. Clipboard Indicator provides the *UI* (history popup); it's complementary to the watcher, not a replacement.

**3. `home/desktop/gnome/wl-clipboard-hide.nix`:** Updated comment to reflect the new architecture and correct the misleading hope from #808's commit message ("on most GNOME versions, from the dock's running-apps list too" — it didn't).

## Upstream tracking

- wl-clipboard issues [#95](https://github.com/bugaevc/wl-clipboard/issues/95), [#149](https://github.com/bugaevc/wl-clipboard/issues/149), [#208](https://github.com/bugaevc/wl-clipboard/issues/208) — wl-copy doesn't exit on GNOME
- Mutter [#2257](https://gitlab.gnome.org/GNOME/mutter/-/issues/2257) — wlr-data-control declined on security-model grounds

## Test plan

- [x] Killed 25 wl-copy zombies in the current session
- [x] `just test-host p620` builds clean
- [ ] Deploy to p620; verify `systemctl --user status wl-paste-watch.service` shows `active (running)`
- [ ] Yank in tmux 5–10 times in copy-mode-vi (`y` after selection); verify `pgrep -c '^/nix/store/.*wl-copy$'` returns ≤ 1 and stays there

## Out of scope / follow-up

The user has ~17 other GNOME extensions enabled at runtime that aren't in the Nix snapshot (`blur-my-shell`, `shotzy`, `docker-manager`, `quake-terminal`, etc.). The current snapshot is from 2026-05; updating it is a separate concern (snapshot-refresh task, not a bug fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)