### PR TITLE
fix(tmux): stop async gruvbox.tmux from clobbering window-status-format

### DIFF
--- a/home/shell/tmux/default.nix
+++ b/home/shell/tmux/default.nix
@@ -357,11 +357,17 @@ in
         # Clear screen and history
         bind C-l send-keys 'clear' Enter \; clear-history
 
-        # ========== Apply Theme ==========
-        run-shell "${tmux-gruvbox}/share/tmux-plugins/tmux-gruvbox/gruvbox.tmux"
-
-        # ========== Override Theme Settings for Alignment ==========
-        # Apply our alignment fixes after theme loads
+        # ========== Status-bar theme (explicit, no gruvbox.tmux) ==========
+        # Used to call gruvbox.tmux here as a workaround for the home-manager
+        # mkTmuxPlugin auto-loader pointing at the wrong filename
+        # (tmux_gruvbox.tmux vs upstream's gruvbox.tmux). Removed because the
+        # workaround re-ran gruvbox AFTER the explicit overrides below, and
+        # gruvbox's $window_format computation produced an empty
+        # window-status-format that overrode the intended " #I #W " string
+        # async, leaving every window's name as an empty box in the status
+        # bar (visible briefly after reload, then gone once gruvbox
+        # finished). The explicit settings below define the entire theme
+        # we actually want; gruvbox.tmux adds nothing.
         set -g status-left-length 40      # Override theme left length
         set -g status-right-length 120    # Override theme right length
         set -g window-status-separator " " # Clean separator between windows


### PR DESCRIPTION
## Summary

Window names in the tmux status bar render as empty boxes after every config reload. Cause: an extraConfig `run-shell .../gruvbox.tmux` was workaround-loading gruvbox to compensate for the home-manager mkTmuxPlugin auto-loader pointing at the wrong filename (same `tmux_gruvbox.tmux` vs `gruvbox.tmux` packaging bug as #830 for tmux-ccm).

The workaround had a subtle race: gruvbox.tmux does part of its setup via async `run-shell -b`, which fires AFTER the synchronous extraConfig completes, clobbering the explicit `window-status-format " #I #W "` setting with an empty value. The user described it perfectly: "visible for a short while and then they are gone."

## Fix

Delete the workaround `run-shell .../gruvbox.tmux` line. The extraConfig already explicitly sets:
- `status-left`, `status-right`, `status-style`
- `window-status-format`, `window-status-current-format`, `window-status-separator`
- `status-left-length`, `status-right-length`
- `popup-style`, `popup-border-style`, `popup-border-lines`

gruvbox.tmux had nothing left to contribute, only race conditions.

The home-manager auto-loader at the top of the rendered conf still tries to run `tmux_gruvbox.tmux` and fails with exit 127 (just like before this change) — but with the workaround gone, no gruvbox code runs, and the explicit theme settings stick.

## Test plan

- [x] `just test-host p620` builds clean
- [ ] Deploy to p620
- [ ] `tmux source-file ~/.config/tmux/tmux.conf`
- [ ] `tmux show-options -g window-status-format` returns `" #I #W "` (not empty)
- [ ] Window names render in the status bar and stay there

## Follow-up (not in this PR)

- The `@gruvbox_*` option declarations earlier in the file are now dead config (nothing reads them). Worth cleaning up but separate.
- The home-manager auto-loader 127 errors for both gruvbox and tmux-gruvbox can be silenced by either adding `rtpFilePath = "gruvbox.tmux"` to the gruvbox `mkTmuxPlugin` definition, or by dropping gruvbox from `programs.tmux.plugins` entirely (since we don't use it). Either way is cosmetic — current state works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)