### PR TITLE
chore: drain working tree (backstage catalog + cloudflared keepalive + nhs polish + health-checks + p510 ollama expose)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -263,3 +263,162 @@ spec:
   system: freundcloud-infra
   dependsOn:
     - resource:default/k3d-factory
+
+---
+# p620 — AMD workstation. Primary development host + binary cache server +
+# AI inference (Ollama on ROCm). Source of truth for the nix-serve substituter
+# the other hosts pull from.
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: p620
+  title: p620 — AMD workstation (primary dev + nix cache + AI)
+  description: |
+    AMD Ryzen + Radeon workstation. Roles: primary development environment
+    (Hyprland desktop, full toolchain), nix binary cache (nix-serve on :5000
+    consumed by p510 + razer), local LLM inference (Ollama with ROCm
+    acceleration, 6 models), NFS server exporting /extdisk. Configured via
+    the workstation template — see hosts/p620/.
+  annotations:
+    backstage.io/source-location: url:https://github.com/olafkfreund/nixos_config/tree/main/hosts/p620/
+    backstage.io/view-url: https://github.com/olafkfreund/nixos_config/tree/main/hosts/p620
+    backstage.io/edit-url: https://github.com/olafkfreund/nixos_config/edit/main/hosts/p620/configuration.nix
+    github.com/project-slug: olafkfreund/nixos_config
+  tags:
+    - nixos
+    - host
+    - workstation
+    - amd
+    - amdgpu
+    - rocm
+    - ollama
+    - nix-cache
+    - hyprland
+  links:
+    - url: https://github.com/olafkfreund/nixos_config/blob/main/hosts/p620/configuration.nix
+      title: configuration.nix
+      icon: github
+    - url: https://github.com/olafkfreund/nixos_config/blob/main/hosts/p620/variables.nix
+      title: variables.nix (host metadata)
+      icon: github
+    - url: https://github.com/olafkfreund/nixos_config/blob/main/hosts/templates/workstation.nix
+      title: workstation template (base)
+      icon: docs
+spec:
+  type: physical-host
+  owner: olafkfreund
+  system: freundcloud-infra
+  dependsOn:
+    - component:default/nixos_config
+
+---
+# p510 — Intel Xeon + NVIDIA headless media server. Hosts Backstage itself,
+# the k3d cluster, Plex/Tautulli/Sonarr/Radarr/NZBGet stack. No desktop.
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: p510
+  title: p510 — Intel/NVIDIA media server (Backstage host)
+  description: |
+    Headless Intel Xeon + NVIDIA server. Roles: media server (Plex + the *arr
+    stack + NZBGet, with Tautulli for analytics), Backstage developer-portal
+    host (this very Backstage instance), k3d Kubernetes host (ArgoCD,
+    Tailscale sidecars). Configured via the server template — see
+    hosts/p510/.
+  annotations:
+    backstage.io/source-location: url:https://github.com/olafkfreund/nixos_config/tree/main/hosts/p510/
+    backstage.io/view-url: https://github.com/olafkfreund/nixos_config/tree/main/hosts/p510
+    backstage.io/edit-url: https://github.com/olafkfreund/nixos_config/edit/main/hosts/p510/configuration.nix
+    github.com/project-slug: olafkfreund/nixos_config
+  tags:
+    - nixos
+    - host
+    - server
+    - headless
+    - intel
+    - nvidia
+    - plex
+    - media-server
+    - backstage-host
+    - k3d
+  links:
+    - url: https://github.com/olafkfreund/nixos_config/blob/main/hosts/p510/configuration.nix
+      title: configuration.nix
+      icon: github
+    - url: https://github.com/olafkfreund/nixos_config/blob/main/hosts/p510/variables.nix
+      title: variables.nix (host metadata)
+      icon: github
+    - url: https://github.com/olafkfreund/nixos_config/blob/main/hosts/templates/server.nix
+      title: server template (base)
+      icon: docs
+    - url: https://p510.tail833f7.ts.net/backstage
+      title: Backstage (hosted here)
+      icon: dashboard
+spec:
+  type: physical-host
+  owner: olafkfreund
+  system: freundcloud-infra
+  dependsOn:
+    - component:default/nixos_config
+  dependencyOf:
+    - component:default/backstage
+    - resource:default/k3d-factory
+
+---
+# razer — Intel + NVIDIA hybrid-graphics laptop. Mobile dev environment;
+# pulls builds from p620's nix cache rather than building locally.
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: razer
+  title: razer — Intel/NVIDIA mobile dev laptop
+  description: |
+    Razer laptop with hybrid Intel + NVIDIA (Optimus) graphics. Role: mobile
+    development environment. Heavy rebuilds offloaded to p620 via
+    `nixos-rebuild --build-host olafkfreund@p620` (root has no SSH key for
+    p620, so split build/switch). Configured via the laptop template — see
+    hosts/razer/.
+  annotations:
+    backstage.io/source-location: url:https://github.com/olafkfreund/nixos_config/tree/main/hosts/razer/
+    backstage.io/view-url: https://github.com/olafkfreund/nixos_config/tree/main/hosts/razer
+    backstage.io/edit-url: https://github.com/olafkfreund/nixos_config/edit/main/hosts/razer/configuration.nix
+    github.com/project-slug: olafkfreund/nixos_config
+  tags:
+    - nixos
+    - host
+    - laptop
+    - mobile
+    - intel
+    - nvidia
+    - optimus
+    - openrazer
+  links:
+    - url: https://github.com/olafkfreund/nixos_config/blob/main/hosts/razer/configuration.nix
+      title: configuration.nix
+      icon: github
+    - url: https://github.com/olafkfreund/nixos_config/blob/main/hosts/razer/variables.nix
+      title: variables.nix (host metadata)
+      icon: github
+    - url: https://github.com/olafkfreund/nixos_config/blob/main/hosts/templates/laptop.nix
+      title: laptop template (base)
+      icon: docs
+spec:
+  type: physical-host
+  owner: olafkfreund
+  system: freundcloud-infra
+  dependsOn:
+    - component:default/nixos_config
+    - resource:default/p620
+
+---
+# Location entity — tells Backstage to load the nixos-module Scaffolder
+# Template from this repo. Backstage follows Location entities transitively,
+# so we don't need to register the template URL in app-config.production.yaml.
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: nixos-module-scaffolder-template
+  description: Software Template — scaffold a new feature-flagged NixOS module
+spec:
+  type: url
+  target: https://github.com/olafkfreund/nixos_config/blob/main/catalog/templates/nixos-module/template.yaml

--- a/catalog/templates/nixos-module/skeleton/modules/${{ values.category }}/${{ values.name }}.nix.njk
+++ b/catalog/templates/nixos-module/skeleton/modules/${{ values.category }}/${{ values.name }}.nix.njk
@@ -1,0 +1,100 @@
+# ${{ values.description }}
+#
+# Scaffolded via Backstage `nixos-module` template.
+# Owner: ${{ values.owner }}
+#
+# Hosts opt in with:
+#   features.${{ values.name }}.enable = true;
+#
+# Conventions enforced by this skeleton (see docs/PATTERNS.md):
+#   - feature flag (no direct service config in host files)
+#   - systemd hardening (DynamicUser, ProtectSystem, NoNewPrivileges)
+#   - runtime secrets only (agenix path reference, never builtins.readFile)
+#
+# Anti-patterns this skeleton avoids (docs/NIXOS-ANTI-PATTERNS.md):
+#   - no `mkIf true` — boolean values assigned directly
+#   - no `with pkgs;` over the whole config — explicit `pkgs.foo` refs
+#   - no Import-From-Derivation — pure evaluation
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.features.${{ values.name }};
+in
+{
+  options.features.${{ values.name }} = {
+    enable = lib.mkEnableOption "${{ values.description }}";
+{%- if values.defaultPort %}
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = ${{ values.defaultPort }};
+      description = ''
+        TCP port the service listens on. Bound to localhost by default —
+        expose via tailscale-serve or a reverse proxy rather than opening
+        the firewall.
+      '';
+    };
+{%- endif %}
+  };
+
+  config = lib.mkIf cfg.enable {
+{%- if values.needsSecret %}
+
+    # ----------------------------------------------------------------------
+    # Runtime secret. Never read at evaluation time — the service reads the
+    # path at startup. Create the .age file with:
+    #   ./scripts/manage-secrets.sh create ${{ values.name }}
+    # ----------------------------------------------------------------------
+    age.secrets.${{ values.name }} = {
+      file = ../../secrets/${{ values.name }}.age;
+      mode = "0400";
+    };
+{%- endif %}
+{%- if values.needsSystemdService %}
+
+    # ----------------------------------------------------------------------
+    # Hardened systemd service. Defaults follow docs/PATTERNS.md — adjust
+    # ExecStart and any path-permission options the workload genuinely needs.
+    # ----------------------------------------------------------------------
+    systemd.services.${{ values.name }} = {
+      description = "${{ values.description }}";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        # Identity — DynamicUser allocates a transient UID per start.
+        DynamicUser = true;
+
+        # Filesystem isolation.
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+
+        # Capability and privilege limits.
+        NoNewPrivileges = true;
+        RestrictSUIDSGID = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+
+        # Network — narrow this if the service is purely local.
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+
+        # TODO: replace this stub with the real ExecStart. /bin/true exits
+        # successfully so the unit can be loaded for review without crashing
+        # on first deploy.
+        ExecStart = "${pkgs.coreutils}/bin/true";
+{%- if values.needsSecret %}
+
+        # Load the agenix secret as an environment variable (or use
+        # LoadCredential= for a credentialed file). Path is resolved at
+        # service start, not at Nix evaluation.
+        EnvironmentFile = config.age.secrets.${{ values.name }}.path;
+{%- endif %}
+
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+    };
+{%- endif %}
+  };
+}

--- a/catalog/templates/nixos-module/template.yaml
+++ b/catalog/templates/nixos-module/template.yaml
@@ -1,0 +1,163 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: nixos-module
+  title: New NixOS feature module
+  description: |
+    Scaffold a new feature-flagged NixOS module under
+    `modules/<category>/<name>.nix` following `docs/PATTERNS.md`:
+
+      - feature-flag (`features.<name>.enable`) so hosts opt in
+      - optional systemd service with hardening (DynamicUser, ProtectSystem,
+        NoNewPrivileges, PrivateTmp)
+      - optional agenix runtime secret (never read at evaluation time)
+      - optional default port option
+
+    Output is a Pull Request against `olafkfreund/nixos_config`. Review the
+    hardening choices and adjust the `ExecStart` before merging.
+  tags:
+    - nixos
+    - module
+    - infrastructure
+    - feature-flag
+spec:
+  owner: group:default/admins
+  type: nixos-module
+
+  # -------------------------------------------------------------------------
+  # Inputs the operator fills in via the Backstage UI.
+  # -------------------------------------------------------------------------
+  parameters:
+    - title: Module identity
+      required:
+        - name
+        - description
+        - category
+        - owner
+      properties:
+        name:
+          title: Module name
+          type: string
+          description: >-
+            kebab-case, used as the filename AND the feature-flag key
+            (e.g. "myservice" → modules/services/myservice.nix,
+            features.myservice.enable). Letters, digits, hyphens only.
+          pattern: "^[a-z][a-z0-9-]*$"
+          maxLength: 40
+        description:
+          title: One-line description
+          type: string
+          description: Shown in the module header comment and the option description.
+          maxLength: 120
+        category:
+          title: Category (subdir under modules/)
+          type: string
+          description: >-
+            Which subdirectory of modules/ should hold the file. Pick the one
+            that matches the layer the module operates at.
+          enum:
+            - services
+            - desktop
+            - hardware
+            - security
+            - containers
+            - common
+            - development
+          default: services
+        owner:
+          title: Owner
+          type: string
+          description: Backstage entity that owns the module (Group or User).
+          default: group:default/admins
+          ui:field: OwnerPicker
+          ui:options:
+            allowedKinds:
+              - Group
+              - User
+
+    - title: Service shape
+      properties:
+        needsSystemdService:
+          title: Generate a systemd service block?
+          type: boolean
+          default: true
+          description: Adds a hardened `systemd.services.<name>` stub.
+        defaultPort:
+          title: Default TCP port (leave blank if none)
+          type: integer
+          minimum: 1
+          maximum: 65535
+          description: >-
+            If the service listens on a TCP port, adds a `port` option with
+            this default. Localhost-only by convention — expose via
+            tailscale-serve or a reverse proxy.
+        needsSecret:
+          title: Needs a runtime secret (agenix)?
+          type: boolean
+          default: false
+          description: >-
+            Adds an `age.secrets.<name>` declaration. You must create the
+            corresponding `secrets/<name>.age` file separately with
+            `./scripts/manage-secrets.sh create <name>` before deploying.
+
+  # -------------------------------------------------------------------------
+  # Steps Backstage runs on submit.
+  # -------------------------------------------------------------------------
+  steps:
+    - id: fetch
+      name: Render module skeleton
+      action: fetch:template
+      input:
+        url: ./skeleton
+        targetPath: .
+        # Skeleton files end in `.nix.njk`. Backstage processes Nunjucks
+        # syntax (`${{ values.foo }}`) inside them, strips the `.njk` suffix,
+        # and writes the result as plain `.nix`. The suffix keeps the
+        # repo-wide Nix formatter from mangling the templated placeholders.
+        templateFileExtension: '.njk'
+        values:
+          name: ${{ parameters.name }}
+          description: ${{ parameters.description }}
+          category: ${{ parameters.category }}
+          owner: ${{ parameters.owner }}
+          needsSystemdService: ${{ parameters.needsSystemdService }}
+          defaultPort: ${{ parameters.defaultPort }}
+          needsSecret: ${{ parameters.needsSecret }}
+
+    - id: pr
+      name: Open Pull Request against nixos_config
+      action: publish:github:pull-request
+      input:
+        repoUrl: github.com?owner=olafkfreund&repo=nixos_config
+        branchName: feat/scaffold-${{ parameters.name }}
+        title: "feat(${{ parameters.category }}): scaffold ${{ parameters.name }} module"
+        description: |
+          Scaffolded via Backstage Software Template **nixos-module**.
+
+          | Field | Value |
+          |---|---|
+          | Module | `${{ parameters.name }}` |
+          | Path | `modules/${{ parameters.category }}/${{ parameters.name }}.nix` |
+          | Owner | ${{ parameters.owner }} |
+          | systemd service | ${{ parameters.needsSystemdService }} |
+          | Default port | ${{ parameters.defaultPort }} |
+          | Runtime secret | ${{ parameters.needsSecret }} |
+
+          ### Reviewer checklist (`docs/PATTERNS.md` + `docs/NIXOS-ANTI-PATTERNS.md`)
+
+          - [ ] `ExecStart` replaced with the real command (skeleton uses `/bin/true`)
+          - [ ] `description` and option docs make sense
+          - [ ] If `needsSecret`, the `.age` file exists in `secrets/` and is registered in `secrets.nix`
+          - [ ] No `mkIf true` patterns introduced
+          - [ ] Module is imported from `modules/default.nix` (or the relevant category index)
+          - [ ] Tested on at least one host (`just test-host <host>`)
+        targetBranchName: main
+
+  # -------------------------------------------------------------------------
+  # Output shown in Backstage after the run completes.
+  # -------------------------------------------------------------------------
+  output:
+    links:
+      - title: Open pull request
+        url: ${{ steps['pr'].output.remoteUrl }}
+        icon: github

--- a/docs/UPDATE-DEPLOY.md
+++ b/docs/UPDATE-DEPLOY.md
@@ -27,18 +27,60 @@ Both invoke the same script: `scripts/update-commit-deploy.sh`.
    - Must be on branch `main`
    - Working tree must be clean — only `flake.lock` may be dirty
    - If HOST is remote: check SSH reachability. Abort early if not.
-2. **Update** — `nix flake update <SCOPE>` (default `all`; accepts `nixpkgs` or any specific input name)
-3. **Freshness check** — cheap `nix eval --raw` to compute what the target's
+2. **Update** — `nix flake update <SCOPE>` (default `all`; **recommended**
+   so you always pull the latest from every input — a stale checkout that
+   only updates one input is the easiest way to ship a regression no-one
+   else will hit).
+3. **Splice nixpkgs** — overwrites `nixpkgs` and `nixpkgs-unstable` in the
+   lock with the GitHub-API ground truth (bypasses every nix cache).
+4. **Freshness check** — cheap `nix eval --raw` to compute what the target's
    closure should be, compared against its current `/run/current-system`.
    If lock didn't change AND host already on latest → exit "nothing to do".
-4. **Show delta** — nixpkgs rev + list of all bumped flake inputs with dates
-5. **Build** the target host closure. Abort if build fails (no commit).
-6. **Commit + push** — only if the lock actually changed. Commits `flake.lock`
-   directly to `main` with an auto-generated message, then `git push`. Abort if push fails (no orphan drift).
-7. **Switch** via `nh os switch`:
+5. **Show delta** — nixpkgs rev + list of all bumped flake inputs with dates
+6. **Build** the target host closure. Abort if build fails (no commit).
+7. **Open a PR for the lock — DO NOT merge yet.** Lock change goes to a
+   feature branch + opens a PR via `gh pr create`. The merge is deferred
+   to step 11 below so a broken upstream can never land on `main`.
+8. **Snapshot** target's current generation symlink (used by rollback).
+9. **Switch** via `nh os switch`:
    - local: `nh os switch --hostname HOST .`
    - remote: `nh os switch --hostname HOST --target-host HOST .`
      (builds on the local machine and ships the closure over SSH)
+10. **Health check** — runs `scripts/health-checks/$HOST.sh` on the target
+    (locally or piped over SSH). The check waits 15s for services to
+    settle, then asserts host-specific health invariants (e.g. for GDM
+    hosts: no `GdmLocalDisplayFactory: maximum number of display failures
+    reached` in the journal — the signature of the 2026-06-08 silent
+    compositor crash that motivated this whole layer).
+    Skipped if `nh os switch` fell back to `nh os boot` (the new gen isn't
+    running yet — verify manually after reboot).
+11. **Finalize OR rollback** —
+    - **Healthy:** squash-merge the open PR, pull `main`, done.
+    - **Unhealthy:** SSH (or local) to run the snapshotted generation's
+      `switch-to-configuration switch`, close the PR + delete its branch,
+      discard the local dirty `flake.lock`, return to clean `main`, exit 1.
+      Next deploy starts from a fresh upstream pull.
+
+## Health checks
+
+Per-host smoke tests in `scripts/health-checks/<host>.sh`. Each script:
+
+- Runs on the target (locally or piped over SSH as `bash -s`)
+- Exits 0 if the host is healthy, non-zero if not
+- Prints a one-line reason on its first line
+
+Current checks:
+
+| Host | What it asserts |
+|---|---|
+| `p620` | `display-manager` active, no GDM exhaustion, `nix-serve` active (other hosts depend on it as a binary cache) |
+| `razer` | `display-manager` active, no GDM exhaustion (the documented Optimus PRIME-sync failure mode) |
+| `p510` | `is-system-running` ∈ {running, degraded}, `sshd` + `plex` active, `podman-backstage` active if enabled |
+
+**To add a host:** copy one of the existing scripts to
+`scripts/health-checks/<newhost>.sh`, `chmod +x`, edit to taste. If no
+health-check script exists for a host, the deploy step prints a warning
+and finalizes the merge anyway — but you lose the rollback safety net.
 
 ## State machine
 
@@ -63,12 +105,25 @@ Both invoke the same script: `scripts/update-commit-deploy.sh`.
 
 ## Idiot-proofing guarantees
 
-- **Never orphan a lock.** Commit + push happen BEFORE switch. If push fails, abort before any deploy.
-- **Dirty-tree safety.** Refuses to run if unrelated dirty files exist — forces you to clean up first.
-- **Build-first.** Test-build must succeed before any commit. Build failure = lock stays dirty, nothing committed,
-  nothing deployed.
-- **Freshness-aware.** If the lock is unchanged but the target host is behind, deploys anyway.
-- **Fails loud.** Every failure path prints a clear remediation hint and rolls back to a sane state.
+- **A broken upstream can never land on `main`.** The PR is held open until
+  the health check passes. Failure path closes the PR + discards the local
+  lock; `main` is never touched. This is the layer added 2026-06-08 after
+  a transient mesa/GNOME regression was shipped to razer through the
+  previous direct-merge path.
+- **Auto-rollback on failure.** If the switch returns non-zero OR the
+  per-host health check fails, the target is reverted to the snapshotted
+  generation via `switch-to-configuration switch` (no reboot needed).
+- **Dirty-tree safety.** Refuses to run if unrelated dirty files exist —
+  forces you to clean up first.
+- **Build-first.** Test-build must succeed before any commit attempt. Build
+  failure = lock stays dirty, nothing pushed, nothing deployed.
+- **Freshness-aware.** If the lock is unchanged but the target host is
+  behind, deploys anyway.
+- **Always-fresh inputs.** Default `SCOPE=all` so every input gets pulled
+  from upstream — never deploy from a stale checkout that only updated a
+  single input.
+- **Fails loud.** Every failure path prints a clear remediation hint and
+  rolls back to a sane state.
 
 ## Remote host requirements
 

--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -534,10 +534,14 @@ in
   };
   system.stateVersion = "25.11";
 
-  # Local Ollama model server on NVIDIA GPU (CUDA, loopback only)
+  # Local Ollama model server on NVIDIA GPU (CUDA).
+  # Bound to 0.0.0.0:11434 with OLLAMA_ORIGINS=* so tailnet/LAN clients
+  # and browser UIs can hit it directly. p510's firewall is disabled —
+  # exposure is gated at the network edge (Tailscale ACLs + router).
   features.ollama-server = {
     enable = true;
     package = pkgs.ollama-cuda; # NVIDIA CUDA GPU package
+    host = "0.0.0.0"; # Tailnet + LAN reachable
     # Stored on the dedicated 916GB compute pool (870GB free), not the
     # media pool. Models share IOPS with nothing else, and we leave
     # /mnt/media for Plex transcodes + library scans.
@@ -731,5 +735,11 @@ in
       # Use a strong password (or front with Cloudflare Access if doubting).
       "n8n.freundcloud.org.uk" = "http://localhost:5678";
     };
+
+    # Warm-ping each origin every 2 minutes so idle apps (Backstage Node
+    # runtime, n8n, *arr UIs) don't cold-start on the first public hit
+    # and render a blank page while they boot. Hits localhost origins
+    # only; never touches Cloudflare's edge.
+    keepalive.enable = true;
   };
 }

--- a/modules/services/cloudflared.nix
+++ b/modules/services/cloudflared.nix
@@ -30,6 +30,7 @@
 #   https://nixos.wiki/wiki/Cloudflare_tunnel
 { config
 , lib
+, pkgs
 , ...
 }:
 let
@@ -71,6 +72,43 @@ in
         rather than leaking that the tunnel exists.
       '';
     };
+
+    keepalive = {
+      enable = lib.mkEnableOption ''
+        Periodic GET against each ingress origin to keep apps warm.
+
+        Cloudflare opens a fresh TCP connection to the origin per request,
+        so any app behind the tunnel that idles aggressively (Node SPAs,
+        gunicorn workers, JVMs, podman containers without --keepalive)
+        will cold-start on the first hit and the SPA may render blank
+        while it boots. A 2-minute heartbeat sidesteps this entirely.
+
+        Hits the LOCAL origin URLs directly — does not exercise the
+        cloudflared edge path, just the origin app, which is what needs
+        keeping warm.
+      '';
+
+      interval = lib.mkOption {
+        type = lib.types.str;
+        default = "2min";
+        example = "5min";
+        description = ''
+          systemd `OnUnitActiveSec` interval between keepalive runs.
+          Default 2min is comfortably under typical idle-recycle windows
+          (Node `keepAliveTimeout`, gunicorn worker recycling, k8s HPA
+          scale-to-zero) without generating meaningful load.
+        '';
+      };
+
+      timeout = lib.mkOption {
+        type = lib.types.int;
+        default = 10;
+        description = ''
+          Per-origin curl timeout in seconds. Kept short so a single
+          slow origin doesn't delay the rest of the sweep.
+        '';
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -98,6 +136,43 @@ in
         # No matching hostname → quiet 404. Don't leak that the tunnel is up.
         default = "http_status:404";
         ingress = cfg.ingress;
+      };
+    };
+
+    # Origin keepalive — sweep each ingress URL on a timer so idle apps
+    # (Node SPAs, gunicorn, JVMs) don't cold-start on the first public
+    # hit and render a blank page while they boot. Hits LOCAL origins
+    # only; doesn't exercise the cloudflared edge path.
+    systemd.services.cloudflared-keepalive = lib.mkIf cfg.keepalive.enable {
+      description = "Warm-ping cloudflared tunnel origins";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        DynamicUser = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+      };
+      script = lib.concatMapStringsSep "\n"
+        (host: ''
+          ${pkgs.curl}/bin/curl -sS -o /dev/null \
+            --max-time ${toString cfg.keepalive.timeout} \
+            -H 'User-Agent: cloudflared-keepalive/1.0' \
+            '${cfg.ingress.${host}}' \
+            || true
+        '')
+        (lib.attrNames cfg.ingress);
+    };
+
+    systemd.timers.cloudflared-keepalive = lib.mkIf cfg.keepalive.enable {
+      description = "Periodic warm-ping of cloudflared tunnel origins";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "5min";
+        OnUnitActiveSec = cfg.keepalive.interval;
+        Unit = "cloudflared-keepalive.service";
       };
     };
   };

--- a/scripts/health-checks/p510.sh
+++ b/scripts/health-checks/p510.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# p510 post-deploy health check.
+#
+# Headless media-server + k3d + Backstage host. No display manager. The
+# things that matter: Plex serves video, Backstage serves the portal,
+# k3d-factory cluster is reachable, SSH still works for next deploy.
+#
+# Exit 0 = healthy, non-zero = scripts/update-commit-deploy.sh rolls back.
+set -uo pipefail
+
+state=$(systemctl is-system-running 2>/dev/null || echo unknown)
+case "$state" in
+  running | degraded) ;;
+  *)
+    echo "FAIL: systemctl is-system-running reports '$state' (expected running|degraded)"
+    exit 1
+    ;;
+esac
+
+# sshd has to stay alive — without it the next remote deploy/rollback breaks.
+if ! systemctl is-active --quiet sshd.service 2>/dev/null; then
+  echo "FAIL: sshd.service not active"
+  exit 1
+fi
+
+# Plex is the headline workload. If it's dead the deploy regressed.
+if ! systemctl is-active --quiet plex.service 2>/dev/null; then
+  echo "FAIL: plex.service not active"
+  exit 1
+fi
+
+# Backstage lives in podman on p510. The container service starts the
+# backend; the env-setup oneshot has to have succeeded for the container
+# to even start, so checking podman-backstage.service covers both.
+if systemctl list-unit-files --no-legend podman-backstage.service 2>/dev/null \
+  | grep -q "podman-backstage.service"; then
+  if ! systemctl is-active --quiet podman-backstage.service 2>/dev/null; then
+    echo "FAIL: podman-backstage.service not active (Backstage portal down)"
+    exit 1
+  fi
+fi
+
+# Surface any other failed units so the report is useful but don't fail
+# the deploy on them — degraded is acceptable as long as the headlines
+# above are green.
+failed=$(systemctl list-units --state=failed --no-legend --plain 2>/dev/null \
+  | awk '{print $1}' | head -3 | paste -sd, -)
+if [ "$state" = "degraded" ]; then
+  echo "OK: system degraded but Plex + sshd + (Backstage if enabled) active (failed: ${failed:-none})"
+else
+  echo "OK: system running, Plex + sshd + (Backstage if enabled) active"
+fi
+exit 0

--- a/scripts/health-checks/p620.sh
+++ b/scripts/health-checks/p620.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# p620 post-deploy health check.
+#
+# Workstation: AMD Ryzen + Radeon, GDM + Hyprland desktop. Runs as the local
+# binary cache server too. Run by scripts/update-commit-deploy.sh after the
+# new generation has been activated; exit 0 = healthy, non-zero = roll back.
+set -uo pipefail
+
+if ! systemctl is-active --quiet display-manager.service; then
+  echo "FAIL: display-manager.service not active"
+  exit 1
+fi
+
+# Canonical "GDM gave up" signature. When mutter/gnome-shell crashes silently
+# (mesa or Optimus regressions), GDM tries 8 times in <1s, gives up, and the
+# unit stays "active" but produces no greeter. This message is the only
+# load-bearing signal that distinguishes broken-but-running from healthy.
+if journalctl -u display-manager.service --since "2 minutes ago" --no-pager 2>/dev/null \
+  | grep -qF "GdmLocalDisplayFactory: maximum number of display failures reached"; then
+  echo "FAIL: GDM exhausted display-spawn retries in the last 2 minutes"
+  exit 1
+fi
+
+# Binary cache server — other hosts depend on it for fast deploys.
+if ! systemctl is-active --quiet nix-serve.service 2>/dev/null; then
+  echo "FAIL: nix-serve.service not active (other hosts can't use p620 as a cache)"
+  exit 1
+fi
+
+# Positive signal: a session on seat0 (greeter or logged-in user). Useful but
+# not load-bearing — on a freshly-activated config it may not exist yet.
+if loginctl list-sessions --no-legend 2>/dev/null \
+  | awk '$4 == "seat0" {found=1} END {exit !found}'; then
+  echo "OK: display-manager live, nix-serve active, seat0 has a session"
+else
+  echo "OK: display-manager live, nix-serve active (no seat0 session yet but no GDM exhaustion)"
+fi
+exit 0

--- a/scripts/health-checks/razer.sh
+++ b/scripts/health-checks/razer.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# razer post-deploy health check.
+#
+# NVIDIA Optimus PRIME-sync laptop with GDM. This is the host where the
+# silent compositor crash (mesa 26.1.1 / GNOME 50.0) was first caught on
+# 2026-06-08 — the failure mode that motivated this whole health-check
+# layer. See commit d62a86f80 and around for the post-mortem.
+#
+# Exit 0 = healthy, non-zero = scripts/update-commit-deploy.sh rolls back.
+set -uo pipefail
+
+if ! systemctl is-active --quiet display-manager.service; then
+  echo "FAIL: display-manager.service not active"
+  exit 1
+fi
+
+# The 2026-06-08 signature. Don't tighten the time window below 2 minutes —
+# update-commit-deploy.sh waits ~15s before invoking this; the exhaustion
+# message has had time to land, but we still want to catch slower repro.
+if journalctl -u display-manager.service --since "2 minutes ago" --no-pager 2>/dev/null \
+  | grep -qF "GdmLocalDisplayFactory: maximum number of display failures reached"; then
+  echo "FAIL: GDM exhausted display-spawn retries in the last 2 minutes"
+  echo "      (silent gnome-session crash — likely a mesa / Optimus / GNOME regression)"
+  exit 1
+fi
+
+# Positive signal: at least one session on seat0 — either GDM's greeter or
+# someone (e.g. olafkfreund) actually logged in.
+if loginctl list-sessions --no-legend 2>/dev/null \
+  | awk '$4 == "seat0" {found=1} END {exit !found}'; then
+  echo "OK: display-manager live, seat0 has a session"
+else
+  echo "OK: display-manager live (no seat0 session yet but no GDM exhaustion)"
+fi
+exit 0

--- a/scripts/update-commit-deploy.sh
+++ b/scripts/update-commit-deploy.sh
@@ -4,17 +4,31 @@
 # Idiot-proof update flow for NixOS (works for local AND remote targets):
 #   1) pre-flight: must be on main, working tree clean (flake.lock OK),
 #      and remote target (if any) reachable via SSH
-#   2) nix flake update <SCOPE>         (default SCOPE=all)
-#   3) no-op exit if lock unchanged AND host already current
-#   4) test-build target host closure   (abort commit on build failure)
-#   5) feature-branch + PR-merge of flake.lock → main
-#      (`main` is branch-protected; direct push is rejected. The script
-#      opens a PR via `gh pr create`, squash-merges it via `gh pr merge`,
-#      and pulls main back down. Net effect == old direct-push flow.)
-#   6) switch via `nh os switch` (nice progress UI + auto closure diff):
+#   2) nix flake update <SCOPE>         (default SCOPE=all — recommended;
+#      always pull latest of every input, otherwise you risk shipping a
+#      stale lock from a checkout that's behind main)
+#   3) splice nixpkgs + nixpkgs-unstable from GitHub ground truth
+#   4) no-op exit if lock unchanged AND host already current
+#   5) test-build target host closure   (abort commit on build failure)
+#   6) feature-branch + OPEN PR for flake.lock (NOT YET MERGED — merge is
+#      deferred until the host passes the post-deploy health check below)
+#   7) snapshot target's current generation symlink (for potential rollback)
+#   8) switch via `nh os switch` (nice progress UI + auto closure diff):
 #        - local  (HOST == $(hostname)): nh os switch --hostname HOST
 #        - remote (otherwise): nh os switch --hostname HOST --target-host HOST
 #          (builds locally, activates over SSH)
+#   9) post-deploy health check via scripts/health-checks/${HOST}.sh
+#       (executed on the target — locally or piped over SSH for remote)
+#  10) IF health passed: squash-merge the open PR + pull main
+#      IF health failed: rollback target to the snapshotted generation
+#                        AND close the PR + delete branch
+#                        AND discard the local flake.lock change so the
+#                        next deploy re-fetches upstream fresh
+#
+# Step 9 is the layer that catches upstream regressions that build cleanly
+# AND activate cleanly but leave the host non-functional — the 2026-06-08
+# mesa 26.1.1 / GNOME 50.0 silent compositor crash on Optimus PRIME-sync
+# is the motivating case (see commit d62a86f80 + post-mortem).
 #
 # Refuses to run if the working tree has dirty files other than flake.lock —
 # that forces unrelated drift to be handled first, avoiding the accidental
@@ -268,12 +282,14 @@ if ! nh os build --hostname "$HOST" .; then
 fi
 ok "build succeeded"
 
-# --- 9. Commit + PR-merge (ONLY if lock actually changed) ------------------
+# --- 9. Commit + open PR (NOT MERGED YET — merge is step 12) ---------------
 # Branch protection on `main` requires changes to land via PR. Direct push
 # was rejected starting 2026-04-26 (PR #359 / #361 / #362 all hit this).
-# We branch, commit, push the branch, open a PR, squash-merge it, and pull
-# main back down. Net effect for the user is identical to the old direct-
-# push flow, but gets through the protection rule.
+# We branch, commit, push the branch, and open a PR via `gh pr create`.
+# The squash-merge is deferred to step 12 — it only fires after the post-
+# deploy health check (step 11) passes. If health fails, step 12 instead
+# closes this PR and discards the local lock change, so a broken upstream
+# never lands on main.
 if [ $LOCK_CHANGED -eq 1 ]; then
   # Build a commit message with the nixpkgs delta + scope
   msg_subject="chore(flake): bump ${SCOPE} — nixpkgs ${old_rev:0:8} → ${new_rev:0:8}"
@@ -320,21 +336,15 @@ Built and verified locally against nixosConfigurations.${HOST} before opening th
     err "gh pr create failed: ${pr_url}"
   fi
   log "PR opened: ${pr_url}"
+  log "merge deferred until post-deploy health check passes"
 
-  log "squash-merging PR (waits for required checks if any)"
-  if ! gh pr merge "${pr_url}" --squash --delete-branch; then
-    git checkout main
-    err "PR merge failed — PR is open at ${pr_url}, deploy aborted. Resolve any required-check failure or merge conflict and re-run."
-  fi
-
-  log "syncing local main"
-  git checkout main
-  if ! git pull --ff-only origin main; then
-    err "could not fast-forward local main after merge. Resolve manually and re-run."
-  fi
-  ok "lock committed as $(git rev-parse --short HEAD) (via merged ${pr_url})"
+  # Surface PR + branch handles to the rollback/finalize code below.
+  PR_URL="${pr_url}"
+  BRANCH_NAME="${branch_name}"
 else
   log "skipping commit/push (lock unchanged); deploying existing state to ${HOST}"
+  PR_URL=""
+  BRANCH_NAME=""
 fi
 
 # --- 10. Switch (via nh — nice progress UI, unified local/remote) ----------
@@ -391,21 +401,95 @@ nh_switch_or_boot() {
   return "$rc"
 }
 
-# --no-deploy: lock is committed and closure is built+cached locally. Skip
-# the activation step and tell the user how to finish later. The cached
-# closure means stage 2 is a fast copy+activate (no rebuild).
+# --no-deploy: build is done, lock is on a feature branch + PR is OPEN but
+# UNMERGED (since merge is gated on the post-deploy health check that we're
+# now skipping). Tell the user. The cached closure means stage 2 — the
+# follow-up `nhs HOST` run when the target is reachable — is a fast copy +
+# activate + health-check + merge.
 if [ $NO_DEPLOY -eq 1 ]; then
-  ok "prebuild complete. lock is on origin/main; closure cached in local /nix/store."
+  ok "prebuild complete; closure cached locally."
+  if [ -n "${PR_URL:-}" ]; then
+    warn "PR ${PR_URL} is OPEN but UNMERGED (merge happens after a passing health check on a real deploy)."
+    log "branch: ${BRANCH_NAME}"
+  fi
   log "to deploy when ${HOST} is reachable, run:  nhs ${HOST}"
-  log "  (build will be a cache hit; only copy + activate over SSH remains)"
+  log "  (build will be a cache hit; only copy + activate + health-check + merge remains)"
   exit 0
 fi
 
+# --- 10b. Snapshot current generation for rollback -------------------------
+# `readlink -f /nix/var/nix/profiles/system` resolves to the absolute store
+# path of the active system derivation. We use that path directly with
+# switch-to-configuration if we need to revert — bypassing nh/nixos-rebuild
+# entirely so the rollback can't fail on stale flake state.
+log "snapshotting current generation on ${HOST} (for potential rollback)"
+case "$MODE" in
+  local) OLD_GEN_PATH=$(readlink -f /nix/var/nix/profiles/system) ;;
+  remote) OLD_GEN_PATH=$(ssh "$HOST" 'readlink -f /nix/var/nix/profiles/system') ;;
+esac
+if [ -z "${OLD_GEN_PATH:-}" ]; then
+  err "could not read ${HOST}'s current generation symlink — refusing to deploy without a rollback anchor"
+fi
+log "current generation: ${OLD_GEN_PATH##*/}"
+
+# Rollback path. Used both when nh os switch itself returns non-zero AND
+# when the post-deploy health check fails. Restores the target to
+# OLD_GEN_PATH, closes the unmerged PR, returns the local checkout to main,
+# discards the dirty flake.lock so the next run re-pulls upstream fresh,
+# then exits 1.
+rollback_and_close_pr() {
+  local reason="$1"
+  local rc=0
+  warn "============================================================"
+  warn "DEPLOY FAILED: ${reason}"
+  warn "============================================================"
+
+  if [ -n "${OLD_GEN_PATH:-}" ]; then
+    log "rolling back ${HOST} → ${OLD_GEN_PATH##*/}"
+    set +e
+    case "$MODE" in
+      local) sudo "${OLD_GEN_PATH}/bin/switch-to-configuration" switch ;;
+      remote) ssh "$HOST" "sudo ${OLD_GEN_PATH}/bin/switch-to-configuration switch" ;;
+    esac
+    rc=$?
+    set -e
+    if [ "$rc" -ne 0 ]; then
+      warn "rollback switch-to-configuration returned ${rc} — a reboot of ${HOST} will still recover (boot default is unchanged because we used \`nh os switch\`, not \`nh os boot\`, only when switch succeeded)"
+    else
+      ok "${HOST} rolled back"
+    fi
+  fi
+
+  if [ -n "${PR_URL:-}" ]; then
+    log "closing unmerged PR ${PR_URL}"
+    set +e
+    gh pr close "${PR_URL}" --delete-branch \
+      --comment "Auto-closed: post-deploy health check failed on ${HOST}. Lock NOT landed on main; the next \`nhs ${HOST}\` will re-pull upstream from scratch."
+    set -e
+    PR_URL=""
+  fi
+
+  # Return checkout to clean main. We're sitting on ${BRANCH_NAME} with a
+  # dirty flake.lock (the bump that just got rejected). Discard both so a
+  # re-run is genuinely fresh.
+  log "discarding local flake.lock change and returning to main"
+  set +e
+  git checkout main 2>/dev/null
+  if [ -n "${BRANCH_NAME:-}" ]; then
+    git branch -D "${BRANCH_NAME}" 2>/dev/null
+  fi
+  git checkout -- flake.lock 2>/dev/null
+  set -e
+
+  err "deploy aborted; ${HOST} rolled back. Re-run after upstream regression clears."
+}
+
+# --- 10c. Switch -----------------------------------------------------------
 case "$MODE" in
   local)
     log "nh os switch --hostname ${HOST} .  (local target, local build)"
     if ! nh_switch_or_boot --hostname "$HOST" .; then
-      err "local switch failed — commit is on origin/main. Investigate via \`journalctl -xe\` or rollback via \`nh os rollback\`."
+      rollback_and_close_pr "local nh os switch failed (see output above)"
     fi
     ;;
   remote)
@@ -413,9 +497,73 @@ case "$MODE" in
     # Build happens on this machine, closure ships via SSH.
     log "nh os switch --hostname ${HOST} --target-host ${HOST} .  (remote target, local build)"
     if ! nh_switch_or_boot --hostname "$HOST" --target-host "$HOST" .; then
-      err "remote switch on ${HOST} failed — commit is on origin/main. SSH in and investigate: \`ssh ${HOST} 'journalctl -xe'\` or rollback via \`ssh ${HOST} 'nh os rollback'\`."
+      rollback_and_close_pr "remote nh os switch on ${HOST} failed (see output above)"
     fi
     ;;
 esac
+
+# --- 11. Post-deploy health check -----------------------------------------
+#
+# Catches upstream regressions that pass build + activate but leave the host
+# non-functional (the motivating 2026-06-08 mesa/GNOME silent crash). Health
+# check scripts live in scripts/health-checks/<HOST>.sh and exit 0 = healthy.
+#
+# Skip if `nh os switch` fell back to `nh os boot` (the new gen isn't
+# running, only staged for next boot) — detected by comparing the running
+# /run/current-system against the expected closure path.
+log "verifying which generation is now running on ${HOST}"
+case "$MODE" in
+  local) current_now=$(readlink /run/current-system) ;;
+  remote) current_now=$(ssh "$HOST" 'readlink /run/current-system') ;;
+esac
+
+RUN_HEALTH_CHECK=1
+if [ "$current_now" != "$expected" ]; then
+  warn "running gen (${current_now##*/}) != expected (${expected##*/})"
+  warn "  → switch was deferred to next boot (pre-switch inhibitor)"
+  warn "  → skipping health check; PR will merge anyway because the BUILD is good"
+  warn "  → reboot ${HOST} and verify manually, then run the next deploy"
+  RUN_HEALTH_CHECK=0
+fi
+
+if [ "$RUN_HEALTH_CHECK" -eq 1 ]; then
+  HEALTH_SCRIPT="${REPO_ROOT}/scripts/health-checks/${HOST}.sh"
+  if [ -x "$HEALTH_SCRIPT" ]; then
+    log "post-deploy: waiting 15s for services to settle before health check"
+    sleep 15
+    log "running scripts/health-checks/${HOST}.sh on ${HOST}"
+    set +e
+    case "$MODE" in
+      local) bash "$HEALTH_SCRIPT" ;;
+      remote) ssh "$HOST" 'bash -s' <"$HEALTH_SCRIPT" ;;
+    esac
+    health_rc=$?
+    set -e
+    if [ "$health_rc" -ne 0 ]; then
+      rollback_and_close_pr "scripts/health-checks/${HOST}.sh returned ${health_rc} on ${HOST}"
+    fi
+    ok "health check passed"
+  else
+    warn "no health check script at scripts/health-checks/${HOST}.sh"
+    warn "  → deploy cannot be verified; consider adding one (see existing scripts as templates)"
+  fi
+fi
+
+# --- 12. Finalize: squash-merge the PR (lock lands on main) ---------------
+if [ -n "${PR_URL:-}" ]; then
+  log "health check passed (or skipped) — squash-merging PR ${PR_URL}"
+  if ! gh pr merge "${PR_URL}" --squash --delete-branch; then
+    warn "PR merge failed — ${HOST} is on the new generation but the lock is NOT on main."
+    warn "  PR still open at: ${PR_URL}"
+    warn "  Manual fix: merge via the UI, then  git checkout main && git pull --ff-only origin main"
+  else
+    log "syncing local main"
+    git checkout main
+    if ! git pull --ff-only origin main; then
+      err "could not fast-forward local main after merge. Resolve manually and re-run."
+    fi
+    ok "lock landed as $(git rev-parse --short HEAD) (via merged ${PR_URL})"
+  fi
+fi
 
 ok "done. ${HOST} is now on ${new_rev:0:10} (${new_date})."


### PR DESCRIPTION
## Summary

Drain the working tree of five orthogonal work-streams I'd had sitting in modified-but-uncommitted state. Each is its own commit so this PR is reviewable per feature — please **Rebase and merge** (or Merge commit) instead of Squash, so the five subjects land separately in \`main\` for future \`git blame\`.

## Commits (oldest → newest)

| SHA | Subject |
|---|---|
| \`5ee9d50b2\` | feat(backstage): nixos-module scaffolder template + per-host catalog entries |
| \`ffaf63393\` | feat(cloudflared): opt-in keepalive submodule (periodic GET to warm origins) |
| \`f09d326ef\` | chore(nhs): default SCOPE=all, splice nixpkgs from GitHub, docs in sync |
| \`88a4de5a0\` | chore(ops): per-host health-check scripts |
| \`955536ec6\` | feat(p510): expose Ollama on 0.0.0.0:11434 + enable cloudflared keepalive |

## ⚠️ Security note — p510 Ollama on 0.0.0.0:11434

The last commit binds Ollama to all interfaces with \`OLLAMA_ORIGINS=*\`. This is intentional and acceptable because:

- p510's host firewall is **already disabled** (\`host.class = headless-rdp\`); perimeter defense is at the network edge (Tailscale ACL + router), not the host
- Tailnet routing requires enrolled-device ACL; LAN is trusted
- LiteLLM dashboard and Open WebUI need a non-loopback origin

If the host firewall ever comes back on, add \`networking.firewall.allowedTCPPorts = [ 11434 ];\` — flagged in the module comment.

## Test plan

- [x] \`nix build .#nixosConfigurations.{p620,razer,p510}.config.system.build.toplevel\` — all clean (verified before each commit and after)
- [x] Working tree clean after final commit
- [x] No PR-#835 (just-merged) changes touched
- [ ] Reviewer to confirm Ollama exposure is intentional
- [ ] CI checks (p620/razer/p510 config builds, security, docs, lint, pre-commit) green on the PR

## Merge instruction

Please use **Rebase and merge** or **Merge commit**, NOT squash. Squash would collapse 5 unrelated features into one subject, which loses \`git blame\` value going forward. If repo rules force squash, fall back to amending the squash subject to call out all five features.