### PR TITLE
chore(claude-code): bump native binary to 2.1.170

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -27,7 +27,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.169";
+  version = "2.1.170";
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -37,11 +37,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-zwZr82DL97UavrjLIwAS/A8v7UJTss4wXeSMzW1Jo5w=";
+      hash = "sha256-hJ4AcnegRCqydXDT49bUN4dQeUZZDo3RlH5aObcIH54=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-NBByOVhEsrbShG2NYdVRdSsSpEQzySDQzH/m57VpKps=";
+      hash = "sha256-G7nQMkQKdVMvfdTK+8aH8iCq8Wxj66F+GS377C8EvSU=";
     };
   };
 


### PR DESCRIPTION
## Summary

Bump pinned \`claude-code\` from **2.1.169 → 2.1.170** (latest channel from Anthropic's GCS distribution).

Patch bump. No claude-code-update watcher issue was open — picked up directly.

## What changed

\`pkgs/claude-code-native/default.nix\`: version + 2 platform hashes.

## Verification

- \`nix build .#claude-code-native\` clean
- \`result/bin/claude --version\` → \`2.1.170 (Claude Code)\`
- \`ldd\` shows no missing libs
- All 3 host configs build clean:
  - p620: \`l3fhyb0z2rzvwqg711msf2zn7nscza7h-nixos-system-p620-...\`
  - razer: \`5myh4xpchi2g767ia0q844h5mqar4dx3-nixos-system-razer-...\`
  - p510: \`lbiqk2s6ksj3q1zdg01i01s4flhh8n3d-nixos-system-p510-...\` ← unchanged hash; confirms p510 genuinely doesn't ship claude-code (matches \`/update-claude-code\` skill's host matrix)

## Deploy plan

- p620: local \`sudo nixos-rebuild switch --flake .#p620\` after merge
- razer: offload pattern (build local + \`nix copy --to ssh://razer\` + remote \`switch-to-configuration switch\`) per repo memory
- p510: no deploy needed (no behavior change)