### PR TITLE
fix(claude-code): shim wl-paste to stop GNOME dock popup from clipboard polling

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -21,6 +21,8 @@
 , openssl
 , zlib
 , glibc
+, wl-clipboard
+, writeScriptBin
 ,
 }:
 
@@ -28,6 +30,20 @@ let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
   version = "2.1.170";
+
+  # Shim that intercepts wl-paste's `-l`/`--list-types` call used by Claude
+  # Code's background clipboard-image polling.  Returning an empty type list
+  # tells Claude no images are in the clipboard so it never spawns persistent
+  # wl-paste processes — those create xdg_toplevel windows visible in GNOME's
+  # dock.  All other wl-paste calls (e.g. text paste) forward to the real binary.
+  wlPasteShim = writeScriptBin "wl-paste" ''
+    for arg in "$@"; do
+      case "$arg" in
+        -l|--list-types) exit 0 ;;
+      esac
+    done
+    exec ${wl-clipboard}/bin/wl-paste "$@"
+  '';
 
   # Anthropic's official distribution bucket
   gcs_bucket = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
@@ -90,10 +106,13 @@ stdenv.mkDerivation {
     cp $src $out/lib/claude-code/claude
     chmod +x $out/lib/claude-code/claude
 
-    # Create wrapper with environment variables to disable auto-update
+    # Create wrapper: disable auto-update and prepend wl-paste shim so the
+    # clipboard-image polling returns an empty type list instead of spawning
+    # real wl-paste processes (which create GNOME dock windows on Wayland).
     makeWrapper $out/lib/claude-code/claude $out/bin/claude \
       --set DISABLE_AUTOUPDATER "1" \
-      --set CLAUDE_CODE_SKIP_UPDATE_CHECK "1"
+      --set CLAUDE_CODE_SKIP_UPDATE_CHECK "1" \
+      --prefix PATH : ${wlPasteShim}/bin
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Summary

- Claude Code background-polls the clipboard for images via `wl-paste -l | grep image/...`; on GNOME-Wayland every `wl-paste` invocation creates an `xdg_toplevel` window (GNOME/Mutter rejects `wlr-data-control`), visible as a persistent "wl-clipboard" entry in the GNOME 50 dock
- Add a `wl-paste` shim to the wrapper PATH that intercepts `-l`/`--list-types` calls with empty output (exit 0), so Claude thinks the clipboard never has images and never spawns real `wl-paste` processes
- All non-type-listing calls are forwarded to the real `wl-clipboard` binary so text-paste paths remain intact

## Test plan

- [x] `nix build .#claude-code-native` — builds cleanly, shim present in wrapper PATH
- [x] All three host toplevel builds pass (p620, razer, p510)
- [ ] Start `claude` on p620/razer and confirm no `wl-paste` processes appear in `pgrep -a wl-paste`
- [ ] Confirm GNOME dock no longer shows `io.github.bugaevc.wl-clipboard` while Claude is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)