### PR TITLE
feat(p510): add ntfy-sh self-hosted push notification server

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -46,6 +46,7 @@ in
       ../../modules/services/kometa # Plex Meta Manager — collections, posters, metadata
       ../../modules/services/plex-auto-languages # Per-show audio/sub track memorization
       ../../modules/services/n8n.nix # Workflow automation (media-recommendation engine)
+      ../../modules/services/ntfy.nix # Push notification server (ntfy-sh)
       ../../modules/services/cloudflared.nix # Cloudflare Tunnel — public ingress (CGNAT-safe)
       # Desktop-specific imports (needed for GNOME):
       # ./nixos/greetd.nix      # Display manager - using GDM instead
@@ -676,6 +677,22 @@ in
     publicUrl = "https://n8n.freundcloud.org.uk";
   };
 
+  features.ntfy = {
+    enable = true;
+    baseUrl = "https://ntfy.freundcloud.org.uk";
+    # port defaults to 2586; attachmentSizeLimit to 15M; attachmentTotalLimit to 2G
+    #
+    # After first deploy, create an admin account:
+    #   ssh p510 -- sudo ntfy user add --role=admin olafkfreund
+    #   ssh p510 -- sudo ntfy user change-pass olafkfreund
+    #
+    # Then subscribe at https://ntfy.freundcloud.org.uk (web app) or the
+    # ntfy mobile app (iOS / Android) using the same credentials.
+    #
+    # The Cloudflare DNS CNAME must be created once:
+    #   cloudflared tunnel route dns p510-home ntfy.freundcloud.org.uk
+  };
+
   # Cloudflare Tunnel — public ingress under freundcloud.org.uk.
   # Bootstrap (one-time):
   #   1. On a workstation with browser: `cloudflared login` (need
@@ -734,6 +751,10 @@ in
       # own login is the only thing protecting them once this is public.
       # Use a strong password (or front with Cloudflare Access if doubting).
       "n8n.freundcloud.org.uk" = "http://localhost:5678";
+      # ntfy-sh — self-hosted push notifications. Runs on loopback; auth enforced
+      # via deny-all default (agenix ntfy-env). Create the DNS CNAME once:
+      #   cloudflared tunnel route dns p510-home ntfy.freundcloud.org.uk
+      "ntfy.freundcloud.org.uk" = "http://localhost:2586";
     };
 
     # Warm-ping each origin every 2 minutes so idle apps (Backstage Node

--- a/modules/services/ntfy.nix
+++ b/modules/services/ntfy.nix
@@ -1,0 +1,84 @@
+# ntfy-sh — self-hosted push notification server.
+#
+# Wraps the upstream nixpkgs services.ntfy-sh module with a feature flag and
+# injects the agenix-decrypted environment file for auth configuration.
+#
+# Quick-start after first deploy:
+#   ssh p510 -- sudo ntfy user add --role=admin <your-username>
+#   ssh p510 -- sudo ntfy user change-pass <your-username>
+#   # Then subscribe on mobile/desktop via https://ntfy.freundcloud.org.uk
+#
+# Sending a notification (example):
+#   curl -u user:pass https://ntfy.freundcloud.org.uk/alerts -d "Hello!"
+#
+# Secrets required (edit before deploy):
+#   agenix -e secrets/ntfy-env.age
+#   Content:
+#     NTFY_AUTH_DEFAULT_ACCESS=deny-all
+#
+# Reference: https://ntfy.sh/docs/config/
+{ config
+, lib
+, ...
+}:
+let
+  cfg = config.features.ntfy;
+in
+{
+  options.features.ntfy = {
+    enable = lib.mkEnableOption "ntfy-sh push notification server";
+
+    baseUrl = lib.mkOption {
+      type = lib.types.str;
+      example = "https://ntfy.freundcloud.org.uk";
+      description = "Public-facing base URL (required for attachments and iOS push).";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 2586;
+      description = "Local port ntfy-sh listens on (loopback only).";
+    };
+
+    attachmentSizeLimit = lib.mkOption {
+      type = lib.types.str;
+      default = "15M";
+      description = "Maximum size of a single attachment.";
+    };
+
+    attachmentTotalLimit = lib.mkOption {
+      type = lib.types.str;
+      default = "2G";
+      description = "Total attachment cache size on disk.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    age.secrets."ntfy-env" = {
+      file = ../../secrets/ntfy-env.age;
+      mode = "0400";
+    };
+
+    services.ntfy-sh = {
+      enable = true;
+      environmentFile = config.age.secrets."ntfy-env".path;
+      settings = {
+        base-url = cfg.baseUrl;
+        listen-http = "127.0.0.1:${toString cfg.port}";
+        behind-proxy = true;
+
+        attachment-file-size-limit = cfg.attachmentSizeLimit;
+        attachment-total-size-limit = cfg.attachmentTotalLimit;
+        visitor-attachment-total-size-limit = "100M";
+
+        # Persist messages across restarts (sqlite)
+        cache-duration = "12h";
+
+        # Rate limits — sensible defaults for a personal instance
+        visitor-request-limit-burst = 60;
+        visitor-request-limit-replenish = "5s";
+        visitor-message-daily-limit = 250;
+      };
+    };
+  };
+}

--- a/secrets.nix
+++ b/secrets.nix
@@ -118,6 +118,13 @@ in
   #   agenix -e secrets/audiobook-mcp-env.age
   "secrets/audiobook-mcp-env.age".publicKeys = allUsers ++ [ p510 ];
 
+  # ntfy-sh environment file (EnvironmentFile) on p510 — push notification
+  # server. Contains: NTFY_AUTH_DEFAULT_ACCESS (deny-all for public instance).
+  # Add admin user post-deploy with: ssh p510 -- sudo ntfy user add --role=admin <user>
+  # Edit with:
+  #   agenix -e secrets/ntfy-env.age
+  "secrets/ntfy-env.age".publicKeys = allUsers ++ [ p510 ];
+
   # media-bot environment file (EnvironmentFile) on p510 — household
   # Telegram bot. Contains: TELEGRAM_BOT_TOKEN, OLLAMA_BASE_URL,
   # OLLAMA_MODEL, plus *arr API keys and PLEX_TOKEN (duplicated from

--- a/secrets/ntfy-env.age
+++ b/secrets/ntfy-env.age
@@ -1,0 +1,7 @@
+age-encryption.org/v1
+-> ssh-ed25519 wgedHw IC+LzPNlmdHV6JYK/NzOAu4VKmnJNr/NTqNw91JSyl8
+tZklR1ftDpP3PhLQ+MkipMP7OCfBnRZRE98JAM+SmIc
+-> ssh-ed25519 tbxj3w 42n2D4gFi99Kl9PQlvIT/2S3W5UJGimpih93NLOXVlQ
+Cz1USfUmA5+wp8ln8mq1UtLT8cTacHzs/DpD++Tn8WE
+--- Aq+16OYmQKi6xNaUyVy6dAzRcD/yHul3A4gfW0XYI2Y
+lYГ╖╩z╤qЪmЦpiЫIr║,═jTя╡''╩фаВ6'╙Ўjїв┴yца*╟Не╙═Сp─с∙lt7к╕


### PR DESCRIPTION
## Summary

- Adds `modules/services/ntfy.nix` — thin wrapper around nixpkgs `services.ntfy-sh` with a `features.ntfy` option set
- Enabled on p510; public access at `https://ntfy.freundcloud.org.uk` via existing Cloudflare tunnel
- Auth locked to `deny-all` via agenix-decrypted `ntfy-env.age` (only olafkfreund + p510 keys)
- Full systemd hardening inherited from upstream nixpkgs module (DynamicUser, ProtectSystem, MemoryDenyWriteExecute…)

## Configuration

| Setting | Value |
|---------|-------|
| Listen | `127.0.0.1:2586` |
| Public URL | `https://ntfy.freundcloud.org.uk` |
| Auth default | `deny-all` (env file) |
| Message cache | 12h (SQLite) |
| Attachment limit | 15M per file / 2G total |
| Visitor rate | 250 msg/day, 60 burst |

## Test plan

- [x] `nix build .#nixosConfigurations.p510.config.system.build.toplevel` — clean
- [x] `nix build .#nixosConfigurations.{p620,razer}` — no regressions
- [ ] Deploy to p510 and verify `systemctl status ntfy-sh`
- [ ] Run `cloudflared tunnel route dns p510-home ntfy.freundcloud.org.uk`
- [ ] Create admin user: `sudo ntfy user add --role=admin olafkfreund`
- [ ] Confirm `https://ntfy.freundcloud.org.uk` loads web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)