### PR TITLE
feat(waveterm): custom-tracked derivation, bump to v0.14.5

### DIFF
--- a/.claude/commands/update-waveterm.md
+++ b/.claude/commands/update-waveterm.md
@@ -1,0 +1,136 @@
+# Update WaveTerm
+
+One-shot bump of `pkgs/waveterm/versions.json` to the latest stable
+release, followed by a verification **build** (no `switch`, no deploy).
+Stops short of activating the new generation so you can review and deploy
+on your own schedule with `nhs <host>` (or `just quick-deploy <host>`).
+
+## When to use
+
+- You want the latest WaveTerm stable but haven't deployed in a while.
+- You launched WaveTerm and noticed it's behind upstream's release notes.
+- You're starting a session and want a clean baseline before working.
+
+## Prerequisites
+
+- [ ] Working tree clean enough to commit (`git status` — at minimum, no
+      uncommitted edits to `pkgs/waveterm/versions.json`).
+- [ ] On a host that can build x86_64-linux closures (any of p620, razer,
+      p510 — the script and overlay are host-agnostic).
+
+## Steps
+
+1. **Check first — early-exit if already current.**
+
+   ```bash
+   ./scripts/update-waveterm.sh --check
+   ```
+
+   Exit 0 → already on latest stable. Stop, tell the user, do nothing
+   else. Exit 1 → newer release exists; continue.
+
+2. **Bump `versions.json`.**
+
+   ```bash
+   ./scripts/update-waveterm.sh
+   ```
+
+   The script resolves the latest version via the GitHub Releases API,
+   prefetches per-arch SRI hashes via `nix store prefetch-file`, and
+   rewrites `pkgs/waveterm/versions.json` in place. Idempotent — safe
+   to re-run.
+
+3. **Show the diff.**
+
+   ```bash
+   git --no-pager diff -- pkgs/waveterm/versions.json
+   ```
+
+   Sanity check: only `version` and `hash` for `linux_x86_64` and
+   `linux_aarch64` should change. If anything else moved, stop and
+   investigate.
+
+4. **Build (no link, no switch).**
+
+   Pick the current host (use `hostname` if unsure).
+
+   ```bash
+   HOST=$(hostname)
+   nix build --no-link --print-out-paths \
+     .#nixosConfigurations.${HOST}.pkgs.waveterm
+   ```
+
+   For a deeper check that the toplevel closure still composes cleanly:
+
+   ```bash
+   nix build --no-link --print-out-paths \
+     .#nixosConfigurations.${HOST}.config.system.build.toplevel
+   ```
+
+   Both must succeed.
+
+5. **Sanity-check the built binary.**
+
+   ```bash
+   OUT=$(nix build --no-link --print-out-paths \
+     .#nixosConfigurations.${HOST}.pkgs.waveterm)
+   file "$OUT/app/waveterm/waveterm" | grep -q ELF \
+     && echo "OK: binary is ELF" \
+     || echo "FAIL: not ELF"
+
+   nix eval --raw .#nixosConfigurations.${HOST}.pkgs.waveterm.version
+   ```
+
+   ELF + version match → green light. Either failing → roll back
+   `versions.json` (`git checkout -- pkgs/waveterm/versions.json`)
+   and stop.
+
+6. **Commit (local, on main).**
+
+   ```bash
+   NEW_VERSION=$(jq -r '.linux_x86_64.version' pkgs/waveterm/versions.json)
+   git add pkgs/waveterm/versions.json
+   git commit --no-verify -m "chore(waveterm): bump to v${NEW_VERSION}"
+   ```
+
+7. **Tell the user how to deploy.** Do NOT run `nhs` or
+   `nixos-rebuild switch` from this command — that's an explicit
+   user decision.
+
+   ```text
+   Bumped waveterm to v<NEW_VERSION>. To deploy:
+       nhs <host>          # current host or a remote host
+   ```
+
+## Failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `--check` exits 0 | Already on latest. | Tell user, stop. Not an error. |
+| GitHub API returns no version | Rate limit or network issue. | Wait and retry; or check `curl -s https://api.github.com/repos/wavetermdev/waveterm/releases/latest \| jq .tag_name` manually. |
+| `nix build` fails with `hash mismatch` | Race: upstream rebuilt same version. | Re-run `./scripts/update-waveterm.sh` — second pass picks up new hash. |
+| `nix build` fails on `autoPatchelfHook` | New Warp release added a runtime dep. | Read missing-library error, add package to `pkgs/waveterm/default.nix` `buildInputs`. |
+| Binary not ELF | Something wrong with `.deb` extraction. | Inspect `$OUT` manually; check `installPhase` paths match current `.deb` layout. |
+
+## Anti-patterns to avoid
+
+- ❌ Do NOT chain a `switch` into this command.
+- ❌ Do NOT skip the `--check` early-exit.
+- ❌ Do NOT bump `pkgs/waveterm/default.nix` or `flake.nix` from this command.
+  This command's blast radius is **only** `pkgs/waveterm/versions.json`.
+
+## Related files
+
+- `pkgs/waveterm/default.nix` — the derivation (Linux-only, mirrors nixpkgs).
+- `pkgs/waveterm/versions.json` — the data file this command bumps.
+- `scripts/update-waveterm.sh` — the bash worker. Wired into the derivation
+  as `passthru.updateScript`.
+- `overlays/custom-packages.nix` — overlay that points `pkgs.waveterm` at
+  our fork so `home/desktop/terminals/wave/default.nix` picks it up.
+- `home/desktop/terminals/wave/default.nix` — home-manager consumer.
+
+## Why this exists
+
+`pkgs.waveterm` from nixpkgs lags upstream by weeks. This command + the
+overlay let us bump on our own cadence without waiting for nixpkgs, matching
+the same pattern as `/update-warp` for Warp Terminal.

--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -5,6 +5,7 @@ final: _prev: {
   zsh-ai-cmd = final.callPackage ../pkgs/zsh-ai-cmd { };
   claude-code-native = final.callPackage ../pkgs/claude-code-native { };
   warp-terminal = final.callPackage ../pkgs/warp-terminal { };
+  waveterm = final.callPackage ../pkgs/waveterm { };
   # splashboard — Rust TUI splash screen for shell startup. Needs rustc
   # 1.95+ (sysinfo 0.39 transitive), which nixpkgs doesn't ship yet, so
   # we build with the latest stable from rust-overlay via a custom

--- a/pkgs/waveterm/default.nix
+++ b/pkgs/waveterm/default.nix
@@ -1,0 +1,113 @@
+# waveterm — custom-tracked latest stable.
+#
+# Mirrors upstream nixpkgs pkgs/by-name/wa/waveterm/package.nix (Linux only —
+# we have no macOS hosts). versions.json is bumped by
+# ../../scripts/update-waveterm.sh, which is also wired in as
+# passthru.updateScript. Run it before `nhs <host>` whenever you want the
+# latest WaveTerm release.
+#
+# Registered as an overlay in flake.nix so pkgs.waveterm everywhere in
+# the repo (notably home/desktop/terminals/wave/default.nix) resolves here.
+{ lib
+, stdenv
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, atk
+, at-spi2-atk
+, cups
+, libdrm
+, gtk3
+, pango
+, cairo
+, libx11
+, libxcomposite
+, libxdamage
+, libxext
+, libxfixes
+, libxrandr
+, libgbm
+, expat
+, libxcb
+, alsa-lib
+, nss
+, nspr
+, vips
+, udev
+, libGL
+,
+}:
+
+let
+  pname = "waveterm";
+  versions = lib.importJSON ./versions.json;
+  arch = if stdenv.hostPlatform.system == "x86_64-linux" then "amd64" else "arm64";
+  key = if stdenv.hostPlatform.system == "x86_64-linux" then "linux_x86_64" else "linux_aarch64";
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname;
+  inherit (versions.${key}) version;
+
+  src = fetchurl {
+    inherit (versions.${key}) hash;
+    url = "https://github.com/wavetermdev/waveterm/releases/download/v${finalAttrs.version}/waveterm-linux-${arch}-${finalAttrs.version}.deb";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    atk
+    at-spi2-atk
+    cups
+    libdrm
+    gtk3
+    pango
+    cairo
+    libx11
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxrandr
+    libgbm
+    expat
+    libxcb
+    alsa-lib
+    nss
+    nspr
+    vips
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/app
+    cp -r opt/Wave $out/app/waveterm
+    cp -r usr/share $out/share
+    substituteInPlace $out/share/applications/waveterm.desktop \
+      --replace-fail "/opt/Wave/" ""
+    ln -s $out/app/waveterm/waveterm $out/bin/waveterm
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    patchelf --add-needed libGL.so.1 \
+      --add-rpath ${lib.makeLibraryPath [ libGL udev ]} \
+      $out/app/waveterm/waveterm
+  '';
+
+  passthru.updateScript = ../../scripts/update-waveterm.sh;
+
+  meta = {
+    description = "Open-source, cross-platform terminal for seamless workflows (custom-tracked latest stable)";
+    homepage = "https://www.waveterm.dev";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    mainProgram = "waveterm";
+  };
+})

--- a/pkgs/waveterm/versions.json
+++ b/pkgs/waveterm/versions.json
@@ -1,0 +1,10 @@
+{
+  "linux_x86_64": {
+    "hash": "sha256-aRrOVi5mog2XJ7i+6vmP5kpEXfZVI7sf0R7TD1b9E3s=",
+    "version": "0.14.5"
+  },
+  "linux_aarch64": {
+    "hash": "sha256-139jgwHkiQ3X/WTObXUyJwciiXg64PhAY/LRUeGGqlU=",
+    "version": "0.14.5"
+  }
+}

--- a/scripts/update-waveterm.sh
+++ b/scripts/update-waveterm.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Bump pkgs/waveterm/versions.json to the latest stable WaveTerm release.
+#
+# Modes:
+#   ./scripts/update-waveterm.sh           # resolve latest, edit versions.json in place (idempotent)
+#   ./scripts/update-waveterm.sh --check   # exit 0 if up-to-date, 1 if a bump is available; never edits
+#
+# Source-of-truth for versions: GitHub Releases API latest endpoint, which
+# always points to the most recent non-prerelease tag.
+#
+# Hashes: nix store prefetch-file --json | jq -r '.hash' (SRI-format).
+#
+# Wired into the derivation as passthru.updateScript. Typical workflow:
+#   ./scripts/update-waveterm.sh && nhs p620   # bump + deploy
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VERSIONS_JSON="${ROOT_DIR}/pkgs/waveterm/versions.json"
+
+CHECK_ONLY=0
+case "${1:-}" in
+  --check) CHECK_ONLY=1 ;;
+  "") ;;
+  *)
+    echo "usage: $0 [--check]" >&2
+    exit 2
+    ;;
+esac
+
+[ -f "${VERSIONS_JSON}" ] || {
+  echo "error: ${VERSIONS_JSON} not found" >&2
+  exit 1
+}
+
+for cmd in curl jq nix; do
+  command -v "$cmd" >/dev/null || {
+    echo "error: '$cmd' is required" >&2
+    exit 1
+  }
+done
+
+# Resolve latest stable release version from GitHub API.
+latest_version=$(curl -fsSL "https://api.github.com/repos/wavetermdev/waveterm/releases/latest" \
+  | jq -r '.tag_name | ltrimstr("v")')
+
+[ -z "${latest_version}" ] && {
+  echo "error: could not resolve latest version from GitHub API" >&2
+  exit 1
+}
+
+# Compute SRI hash for a URL (no side effects on the working tree).
+prefetch_sri() {
+  nix store prefetch-file --json --hash-type sha256 "$1" 2>/dev/null | jq -r '.hash'
+}
+
+declare -A ARCH_FOR_KEY=(
+  [linux_x86_64]=amd64
+  [linux_aarch64]=arm64
+)
+
+any_changes=0
+tmp_json=$(mktemp)
+cp "${VERSIONS_JSON}" "${tmp_json}"
+
+for key in linux_x86_64 linux_aarch64; do
+  arch="${ARCH_FOR_KEY[$key]}"
+  url="https://github.com/wavetermdev/waveterm/releases/download/v${latest_version}/waveterm-linux-${arch}-${latest_version}.deb"
+  current_version=$(jq -r ".${key}.version" "${tmp_json}")
+
+  printf '  %-15s current=%s latest=%s\n' "${key}" "${current_version}" "${latest_version}"
+
+  if [ "${current_version}" = "${latest_version}" ]; then
+    continue
+  fi
+
+  any_changes=1
+  if [ "${CHECK_ONLY}" -eq 1 ]; then
+    continue
+  fi
+
+  echo "    prefetching ${url} ..."
+  hash=$(prefetch_sri "${url}")
+  [ -z "${hash}" ] && {
+    echo "error: prefetch failed for ${url}" >&2
+    exit 1
+  }
+
+  jq --arg v "${latest_version}" --arg h "${hash}" \
+    ".${key}.version = \$v | .${key}.hash = \$h" \
+    "${tmp_json}" >"${tmp_json}.new" && mv "${tmp_json}.new" "${tmp_json}"
+done
+
+if [ "${CHECK_ONLY}" -eq 1 ]; then
+  if [ "${any_changes}" -eq 0 ]; then
+    echo "up-to-date"
+    exit 0
+  fi
+  echo "outdated: a newer WaveTerm release is available"
+  exit 1
+fi
+
+if [ "${any_changes}" -eq 0 ]; then
+  echo "up-to-date; no changes written"
+  rm -f "${tmp_json}"
+  exit 0
+fi
+
+mv "${tmp_json}" "${VERSIONS_JSON}"
+echo "wrote ${VERSIONS_JSON}"


### PR DESCRIPTION
## Summary

- Adds `pkgs/waveterm/` — Linux-only derivation mirroring nixpkgs but tracked on our own cadence
- Adds `scripts/update-waveterm.sh` — same pattern as `update-warp-terminal.sh`, uses GitHub Releases API
- Registers `waveterm` in `overlays/custom-packages.nix` so `pkgs.waveterm` everywhere resolves to our fork
- Adds `.claude/commands/update-waveterm.md` skill for `/update-waveterm` slash command
- Bumps from nixpkgs `0.13.1` → upstream `0.14.5` (2026-04-16, skips ~4 months of lag)

## Why

`pkgs.waveterm` in nixpkgs unstable is stuck at 0.13.1 while upstream is 0.14.5. Same motivation as the warp-terminal custom derivation (#401).

## Test plan

- [x] `nix build .#nixosConfigurations.p620.pkgs.waveterm` — clean, binary is ELF
- [x] `nix build .#nixosConfigurations.p620.config.system.build.toplevel` — clean
- [x] `./scripts/update-waveterm.sh --check` returns `up-to-date` after bump
- [ ] Deploy to p620 + razer and verify WaveTerm launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)