### PR TITLE
fix(waveterm): inject libsecret via makeWrapper for Electron safeStorage

### DIFF
--- a/pkgs/waveterm/default.nix
+++ b/pkgs/waveterm/default.nix
@@ -35,6 +35,8 @@
 , vips
 , udev
 , libGL
+, libsecret
+, makeWrapper
 ,
 }:
 
@@ -56,6 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     dpkg
     autoPatchelfHook
+    makeWrapper
   ];
 
   buildInputs = [
@@ -79,6 +82,11 @@ stdenv.mkDerivation (finalAttrs: {
     nss
     nspr
     vips
+    # Electron safeStorage on Linux requires libsecret to back the keyring.
+    # Without this, WaveTerm 0.14+ throws "encryption is not available" when
+    # saving API keys. GNOME Keyring provides the org.freedesktop.secrets
+    # DBus service at runtime; libsecret is the client library Electron links.
+    libsecret
   ];
 
   installPhase = ''
@@ -89,7 +97,8 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r usr/share $out/share
     substituteInPlace $out/share/applications/waveterm.desktop \
       --replace-fail "/opt/Wave/" ""
-    ln -s $out/app/waveterm/waveterm $out/bin/waveterm
+    makeWrapper $out/app/waveterm/waveterm $out/bin/waveterm \
+      --prefix LD_LIBRARY_PATH : ${libsecret}/lib
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Problem

WaveTerm 0.14.0+ uses Electron's `safeStorage` API to encrypt API keys. On Linux, Electron's Chromium OSCrypt layer loads `libsecret-1.so.0` via `dlopen()` to talk to `org.freedesktop.secrets` (GNOME Keyring / KWallet). Because it's `dlopen`-loaded rather than a direct ELF dependency, `autoPatchelfHook` never sets an RPATH for it, so `dlopen` fails silently → `safeStorage.isEncryptionAvailable()` returns `false` → WaveTerm throws:

```
Error: checking secret storage backend: error getting linux storage backend:
failed to get storage backend: encryption is not available
```

This blocks adding any API key (Gemini, OpenAI, etc.) in WaveTerm settings.

## Root cause

- `libsecret` missing from wrapper's `LD_LIBRARY_PATH`
- GNOME Keyring was already running and healthy (`org.freedesktop.secrets` DBus available)

## Fix

Replace the bare `ln -s` with `makeWrapper ... --prefix LD_LIBRARY_PATH : ${libsecret}/lib` so Electron's `dlopen("libsecret-1.so.0")` succeeds at runtime.

## Test plan

- [x] Build clean: `nix build .#nixosConfigurations.p620.pkgs.waveterm`
- [x] Wrapper verified: `head $out/bin/waveterm` shows libsecret in `LD_LIBRARY_PATH`
- [ ] Deploy to p620 + razer
- [ ] Open WaveTerm → Settings → AI → add Gemini API key → no encryption error

🤖 Generated with [Claude Code](https://claude.com/claude-code)