### PR TITLE
feat(waveterm): add Gruvbox Dark terminal theme

### DIFF
--- a/home/desktop/terminals/wave/default.nix
+++ b/home/desktop/terminals/wave/default.nix
@@ -5,6 +5,33 @@
 let
   inherit (lib) mkIf mkEnableOption;
   cfg = config.wave;
+
+  gruvboxDark = {
+    "display:name" = "Gruvbox Dark";
+    "display:order" = 8;
+    black = "#282828";
+    red = "#cc241d";
+    green = "#98971a";
+    yellow = "#d79921";
+    blue = "#458588";
+    magenta = "#b16286";
+    cyan = "#689d6a";
+    white = "#a89984";
+    brightBlack = "#928374";
+    brightRed = "#fb4934";
+    brightGreen = "#b8bb26";
+    brightYellow = "#fabd2f";
+    brightBlue = "#83a598";
+    brightMagenta = "#d3869b";
+    brightCyan = "#8ec07c";
+    brightWhite = "#ebdbb2";
+    gray = "#7c6f64";
+    cmdtext = "#ebdbb2";
+    foreground = "#ebdbb2";
+    background = "#282828";
+    cursor = "#ebdbb2";
+    selectionBackground = "#504945";
+  };
 in
 {
   options.wave = {
@@ -12,10 +39,12 @@ in
   };
 
   config = mkIf cfg.enable {
-    # Wave Terminal — Electron + Go hybrid, in nixpkgs as pkgs.waveterm.
-    # We use the home-manager module so future declarative `programs.waveterm.settings`
-    # / `programs.waveterm.themes` wiring is a one-line addition. The AppImage
-    # upstream ships does NOT render on NixOS, so nixpkgs is the only viable path.
     programs.waveterm.enable = true;
+
+    xdg.configFile."waveterm/termthemes.json".text =
+      builtins.toJSON { "gruvbox-dark" = gruvboxDark; };
+
+    xdg.configFile."waveterm/settings.json".text =
+      builtins.toJSON { "term:theme" = "gruvbox-dark"; };
   };
 }


### PR DESCRIPTION
## Summary

- Declare the Gruvbox Dark color palette in `~/.config/waveterm/termthemes.json` via `xdg.configFile`
- Set `term:theme = gruvbox-dark` in `~/.config/waveterm/settings.json` so WaveTerm uses it on launch
- Both files are fully reproducible and managed by Home Manager

## Test plan

- [ ] Build p620 toplevel: `nix build --no-link .#nixosConfigurations.p620.config.system.build.toplevel` ✅ (already verified)
- [ ] Theme files present in HM generation closure ✅ (verified via store path inspection)
- [ ] Deploy to p620 and razer, restart WaveTerm, confirm Gruvbox Dark is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)