### PR TITLE
fix(waveterm): patch brand green accent to Gruvbox bg4

### DIFF
--- a/pkgs/waveterm/default.nix
+++ b/pkgs/waveterm/default.nix
@@ -13,6 +13,7 @@
 , fetchurl
 , dpkg
 , autoPatchelfHook
+, python3
 , atk
 , at-spi2-atk
 , cups
@@ -59,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     dpkg
     autoPatchelfHook
     makeWrapper
+    python3
   ];
 
   buildInputs = [
@@ -104,9 +106,23 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   preFixup = ''
-    patchelf --add-needed libGL.so.1 \
-      --add-rpath ${lib.makeLibraryPath [ libGL udev ]} \
-      $out/app/waveterm/waveterm
+        patchelf --add-needed libGL.so.1 \
+          --add-rpath ${lib.makeLibraryPath [ libGL udev ]} \
+          $out/app/waveterm/waveterm
+
+        # Replace WaveTerm brand green (#58c142) with Gruvbox bg4 (#665c54).
+        # Same-length substitution — asar JSON header offsets stay valid.
+        # autoPatchelfHook already brings python3 into the build env.
+        python3 -c "
+    import sys
+    path = sys.argv[1]
+    data = open(path, 'rb').read()
+    data = data.replace(b'#58c142', b'#665c54')
+    data = data.replace(b'#58C142', b'#665c54')
+    data = data.replace(b'rgb(88, 193, 66)', b'rgb(102, 92, 84)')
+    open(path, 'wb').write(data)
+    print('waveterm: patched accent green -> gruvbox-bg4')
+    " "$out/app/waveterm/resources/app.asar"
   '';
 
   passthru.updateScript = ../../scripts/update-waveterm.sh;


### PR DESCRIPTION
## Summary

WaveTerm 0.14.x has no settings key to change the focused-block border color (upstream issues #1020, #2136). This patches the hardcoded green out of the bundled `app.asar` at derivation build time.

- Replaces `#58c142` / `#58C142` → `#665c54` (Gruvbox bg4, warm gray-brown)
- Replaces `rgb(88, 193, 66)` → `rgb(102, 92, 84)` (same 16-char length)
- Covers: `--accent-color`, `--tab-green` CSS variables, all `border-color`, `background-color`, and alpha-suffixed variants (`#665c5433`, `#665c5480`, etc.)
- Same-length substitution — asar JSON header offsets stay valid, no extract/repack needed

## Test plan

- [x] Build succeeds: `nix build .#nixosConfigurations.p620.pkgs.waveterm`
- [x] Green count in patched asar: 0
- [x] Gruvbox count in patched asar: 104 hex + 2 RGB
- [ ] Deploy to p620 and razer, restart WaveTerm, confirm borders are neutral gray-brown

🤖 Generated with [Claude Code](https://claude.com/claude-code)