### PR TITLE
fix(tmux/pim-popup): handle timezone offsets in calendar dateTime strings

### DIFF
--- a/home/shell/tmux/default.nix
+++ b/home/shell/tmux/default.nix
@@ -691,7 +691,8 @@ in
               elif test("holiday|holidays") then green
               elif test("birthday|birthdays") then purple
               else orange end;
-            def hhmm: fromdateiso8601 | strftime("%H:%M");
+            def hhmm: .[11:16];
+            def norm_tz: gsub("[+-][0-9]{2}:[0-9]{2}$"; "Z");
             def timespan:
               if .start.dateTime then
                 (.start.dateTime | hhmm) + "–" + (.end.dateTime | hhmm)
@@ -719,13 +720,12 @@ in
               | if length == 0 then gray + "(no upcoming events)" + R
                 else
                   group_by(
-                    if .start.dateTime then
-                      (.start.dateTime | fromdateiso8601 | strftime("%Y-%m-%d"))
+                    if .start.dateTime then .start.dateTime[0:10]
                     else (.start.date // "") end)
                   | .[]
                   | (.[0].start.dateTime // .[0].start.date) as $d
                   | (if ($d | test("T"))
-                     then ($d | fromdateiso8601 | strftime("%a %b %d"))
+                     then ($d | norm_tz | fromdateiso8601 | strftime("%a %b %d"))
                      else $d end) as $label
                   | (yellow + "── " + $label + " ──" + R),
                     (.[] | fmt_event)
@@ -956,7 +956,7 @@ in
                       | .[0]
                       | if . == null then ""
                         else "📅 " + (.summary // "(no title)" | .[0:30]) + " "
-                             + (.start.dateTime | fromdateiso8601 | strftime("%H:%M"))
+                             + (.start.dateTime | .[11:16])
                         end' \
                > "$tmp_event" 2>/dev/null; then
             mv -f "$tmp_event" "$cache/event.txt"


### PR DESCRIPTION
## Summary

`jq`'s `fromdateiso8601` only accepts UTC strings ending in `Z`. Google Calendar returns `dateTime` values with local timezone offsets (e.g. `2026-06-11T10:00:00+01:00`), which caused a parse error in `events-week` and `events-today`.

## Changes

- `hhmm`: replaced `fromdateiso8601 | strftime("%H:%M")` with `.[11:16]` substring — the local time digits are already at position 11–15, no epoch conversion needed
- `norm_tz`: new jq helper `def norm_tz: gsub("[+-][0-9]{2}:[0-9]{2}$"; "Z");` strips trailing tz offset before `fromdateiso8601` for day-of-week labels
- `group_by`: use `[0:10]` date substring for grouping instead of epoch/strftime roundtrip
- Status-bar jq snippet: same `.[11:16]` fix for the tmux status bar event preview

## Test

```
pim-popup events-week   → Thu Jun 11 ── / 10:00–10:30 / colored by calendarId ✓
pim-popup tasks         → red overdue / yellow pending ✓
pim-popup inbox         → aqua CATEGORY_UPDATES / orange STARRED ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)