### PR TITLE
feat(tmux): flash window indicator when Claude/agy need attention

### DIFF
--- a/home/shell/tmux/default.nix
+++ b/home/shell/tmux/default.nix
@@ -387,12 +387,39 @@ in
         # workflow without having to read window names. #{m:pattern,str}
         # is tmux's glob-match; pane_current_command is the immediate
         # foreground process in the active pane of that window.
-        set -g window-status-format         " #{?#{m:claude*,#{pane_current_command}},✻ ,#{?#{m:agy*,#{pane_current_command}},🛸 ,#{?#{m:gemini*,#{pane_current_command}},♊ ,}}}#I #W "
+        # Trailing alert glyphs are flag-driven and only render on
+        # *background* windows (the current window never carries bell/
+        # silence flags): 🔔 = bell (Claude wants attention — see the
+        # terminal-bell emitted by claude-notify), 💤 = monitor-silence
+        # fired (agy idle, via agy-window-launcher). Deterministic markers
+        # that don't depend on tmux's per-build alert-styling internals;
+        # the window-status-{bell,activity}-style below add a colour flash
+        # on top. Only the non-current format needs them.
+        set -g window-status-format         " #{?#{m:claude*,#{pane_current_command}},✻ ,#{?#{m:agy*,#{pane_current_command}},🛸 ,#{?#{m:gemini*,#{pane_current_command}},♊ ,}}}#I #W#{?window_bell_flag, 🔔,}#{?window_silence_flag, 💤,} "
         set -g window-status-current-format " #{?#{m:claude*,#{pane_current_command}},✻ ,#{?#{m:agy*,#{pane_current_command}},🛸 ,#{?#{m:gemini*,#{pane_current_command}},♊ ,}}}#I #W "
 
         # Ensure no powerline characters are used
         set -g window-status-separator " │ "
         set -g status-style "bg=#${colors.base00},fg=#${colors.base04}"
+
+        # ========== Attention alerts (Claude / agy) ==========
+        # Flash a *background* window's status cell when its pane signals
+        # it wants attention. Two signal sources feed this:
+        #   • Claude Code → claude-notify emits a terminal BEL into the
+        #     pane (modules/programs/claude-code-managed.nix, terminalBell)
+        #     which trips the bell flag → red flash + 🔔.
+        #   • agy → agy-window-launcher sets `monitor-silence 20`; a window
+        #     idle that long trips the silence flag → yellow flash + 💤.
+        # Kept audibly silent on purpose: `bell-action none` suppresses the
+        # client terminal beep, and `visual-bell off` suppresses the
+        # takeover "Bell in window" message — yet `monitor-bell on` still
+        # sets window_bell_flag, so the cell still flashes (verified on
+        # tmux 3.6a). The result is a quiet, visual-only indicator.
+        set -g monitor-bell on
+        set -g bell-action none
+        set -g visual-bell off
+        set -g window-status-bell-style     "bg=#${colors.base08},fg=#${colors.base00},bold"
+        set -g window-status-activity-style "bg=#${colors.base0A},fg=#${colors.base00},bold"
 
         # Popup chrome — match the Stylix base16 scheme so display-popup
         # (tmux-palette, tmux-expose, choose-tree -Z, etc.) blends into the

--- a/modules/programs/claude-code-managed.nix
+++ b/modules/programs/claude-code-managed.nix
@@ -109,6 +109,17 @@ let
       rate_limit_seconds=${toString cfg.notifications.rateLimitSeconds}
       use_desktop=${if cfg.notifications.desktopToasts then "1" else "0"}
       use_tmux=${if cfg.notifications.tmuxPopups then "1" else "0"}
+      use_bell=${if cfg.notifications.terminalBell then "1" else "0"}
+
+      # Ring the terminal bell in Claude's own pane so tmux (monitor-bell)
+      # flashes that window's status-bar cell. Writes straight to the
+      # controlling terminal (/dev/tty), bypassing Claude's captured hook
+      # stdout, so the BEL reaches the pty tmux watches. No-ops cleanly
+      # outside a tty (headless / CI). Paired with `monitor-bell on` +
+      # `bell-action none` in home/shell/tmux — visual flash, no audible beep.
+      ring_bell() {
+        [ "$use_bell" = "1" ] && printf '\a' > /dev/tty 2>/dev/null || true
+      }
 
       msg=$(printf '%s' "$payload" | jq -r '.message // ""' 2>/dev/null || echo "")
       cwd_path=$(printf '%s' "$payload" | jq -r '.cwd // ""' 2>/dev/null || echo "")
@@ -117,6 +128,7 @@ let
       case "$cmd" in
         notification)
           text="''${msg:-Claude needs your attention}"
+          ring_bell
           if [ "$use_desktop" = "1" ] && command -v notify-send >/dev/null 2>&1; then
             notify-send -u normal -i "$icon_path" -a "Claude Code" "✻ Claude · $cwd" "$text" &
           fi
@@ -142,6 +154,7 @@ let
             fi
           fi
           echo "$now" > "$rate_file"
+          ring_bell
 
           label="✻ Claude"
           [ "$cmd" = "subagent-stop" ] && label="✻ subagent"
@@ -283,6 +296,20 @@ in
           Fire a tmux display-popup for Notification events and
           display-message status flash for Stop/SubagentStop. No-ops
           gracefully if $TMUX isn't set.
+        '';
+      };
+
+      terminalBell = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Emit a terminal BEL into Claude's own pane on Notification and
+          (rate-limited) Stop/SubagentStop events, written to /dev/tty.
+          With `monitor-bell on` + `bell-action none` in the tmux config
+          (home/shell/tmux), tmux flashes that window's status-bar cell
+          (red + 🔔) when Claude is in a background window — a quiet,
+          visual-only "needs attention" indicator with no audible beep.
+          No-ops outside a tty (headless / CI).
         '';
       };
 


### PR DESCRIPTION
## Summary
tmux now flashes a background window's status-bar cell — quietly, visually, no audible beep — when Claude Code or `agy` wants attention.

- **Claude Code**: `claude-notify` rings a BEL into Claude's pane (`/dev/tty`) on Notification + rate-limited Stop/SubagentStop → bell flag → **red flash + 🔔**. New `notifications.terminalBell` toggle (default on), routed through the existing managed hooks (applies regardless of mutable `~/.claude/settings.json`).
- **agy**: existing `agy-window-launcher` `monitor-silence 20` → silence flag → **yellow flash + 💤**.
- tmux: `monitor-bell on` + `bell-action none` + `visual-bell off` (visual-only, no beep — verified `bell-action none` still raises `window_bell_flag` on 3.6a); vivid bell/activity styles + deterministic 🔔/💤 glyphs.

## Testing
- `nix build` p620 toplevel — OK
- Rendered `tmux.conf` + `claude-notify` contain the changes; managed JSON valid
- Live tmux render: bell flag → ` 2 claude 🔔`, silence flag → ` 1 work 💤`

## Limitation
`agy` has no hook system → only the launcher path flashes (unchanged). Claude is covered in any pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)