### PR TITLE
feat(tmux/which-key): full menu — built-ins + plugin/custom binds

### DIFF
--- a/home/shell/tmux/default.nix
+++ b/home/shell/tmux/default.nix
@@ -458,6 +458,51 @@ in
     #   fg       = base05 (default foreground)
     #   muted    = base03 (comments / dim)
     #   accent   = base0B (green — gruvbox's classic positive accent)
+    # tmux-which-key menu (prefix+Space). The upstream default menu covers
+    # built-in tmux commands (./which-key-base.yaml); we append a +Tools
+    # submenu (key P) exposing our plugin/custom bindings so they're
+    # discoverable from one place. Generated rather than shipped static
+    # because the +Tools commands embed nix-store paths that change on every
+    # rebuild. NOTE: which-key is a *curated* menu — it is NOT auto-synced
+    # with `list-keys`. For the complete live list use tmux-fzf
+    # (prefix C-f → keybinding) or the built-in `?` entry (list-keys -N).
+    xdg.configFile."tmux/plugins/tmux-which-key/config.yaml".text =
+      let
+        palette = "${pkgs.customPkgs.tmux-palette}/bin/tmux-palette";
+        expose = "${pkgs.customPkgs.tmux-expose}/bin/tmux-expose";
+        floax = "${pkgs.tmuxPlugins.tmux-floax}/share/tmux-plugins/tmux-floax/scripts/floax.sh";
+        tsm = "${pkgs.tmuxPlugins.t-smart-tmux-session-manager}/share/tmux-plugins/t-smart-tmux-session-manager/bin/t";
+        toolsMenu = lib.concatStringsSep "\n" [
+          "  - separator: true"
+          "  - name: +Tools"
+          "    key: P"
+          "    menu:"
+          "      - name: AI tools (palette)"
+          "        key: a"
+          "        command: run-shell \"${palette} ai-tools\""
+          "      - name: Command palette"
+          "        key: p"
+          "        command: run-shell ${palette}"
+          "      - name: Mail / Calendar / Tasks"
+          "        key: m"
+          "        command: run-shell \"${palette} pim\""
+          "      - separator: true"
+          "      - name: Session expose"
+          "        key: e"
+          "        command: display-popup -E -w \"100%\" -h \"100%\" ${expose}"
+          "      - name: Floating pane"
+          "        key: f"
+          "        command: run-shell ${floax}"
+          "      - name: Smart session switch"
+          "        key: s"
+          "        command: run-shell ${tsm}"
+          "      - name: ccm dashboard"
+          "        key: C"
+          "        command: display-popup -E -w \"80%\" -h \"60%\" -T \"  ccm  \" \"ccm dashboard\""
+        ] + "\n";
+      in
+      builtins.readFile ./which-key-base.yaml + toolsMenu;
+
     xdg.configFile."tmux-palette/theme.json".text = builtins.toJSON {
       bg = "#${colors.base00}";
       panel = "#${colors.base01}";

--- a/home/shell/tmux/which-key-base.yaml
+++ b/home/shell/tmux/which-key-base.yaml
@@ -1,0 +1,280 @@
+# yaml-language-server: $schema=config.schema.yaml
+command_alias_start_index: 200
+keybindings:
+  # root_table: C-Space
+  prefix_table: Space
+title:
+  style: align=centre,bold
+  prefix: tmux
+  prefix_style: fg=green,align=centre,bold
+position:
+  x: R
+  y: P
+custom_variables:
+  - name: log_info
+    value: "#[fg=green,italics] [info]#[default]#[italics]"
+macros:
+  - name: reload-config
+    commands:
+      - display "#{log_info} Loading config... "
+      - source-file $HOME/.tmux.conf
+      - display -p "\n\n... Press ENTER to continue"
+  - name: restart-pane
+    commands:
+      - display "#{log_info} Restarting pane"
+      - "respawnp -k -c #{pane_current_path}"
+items:
+  - name: Run
+    key: space
+    command: command-prompt
+  - name: Last window
+    key: tab
+    command: last-window
+  - name: Last pane
+    key: "`"
+    command: last-pane
+  - name: Copy
+    key: c
+    menu:
+      - name: Copy
+        key: c
+        command: copy-mode
+      - name: List buffers
+        key: "#"
+        command: list-buffers
+  - separator: true
+  - name: +Windows
+    key: w
+    menu:
+      - name: Last
+        key: tab
+        command: last-window
+      - name: Choose
+        key: w
+        command: choose-tree -Zw
+      - name: Previous
+        key: p
+        command: previous-window
+      - name: Next
+        key: n
+        command: next-window
+      - name: New
+        key: c
+        command: "neww -c #{pane_current_path}"
+      - separator: true
+      - name: +Layout
+        key: l
+        menu:
+          - name: Next
+            key: l
+            command: nextl
+            transient: true
+          - name: Tiled
+            key: t
+            command: selectnl tiled
+          - name: Horizontal
+            key: h
+            command: selectl even-horizontal
+          - name: Vertical
+            key: v
+            command: selectl even-vertical
+          - name: Horizontal main
+            key: H
+            command: selectl main-horizontal
+          - name: Vertical main
+            key: V
+            command: selectl main-vertical
+      - name: Split horizontal
+        key: /
+        command: "splitw -h -c #{pane_current_path}"
+      - name: Split vertical
+        key: "-"
+        command: "splitw -v -c #{pane_current_path}"
+      - name: Rotate
+        key: o
+        command: rotatew
+        transient: true
+      - name: Rotate reverse
+        key: O
+        command: rotatew -D
+        transient: true
+      - separator: true
+      - name: Rename
+        key: R
+        command: command-prompt -I "#W" "renamew -- \"%%\""
+      - name: Kill
+        key: X
+        command: 'confirm -p "Kill window #W? (y/n)" killw'
+  - name: +Panes
+    key: p
+    menu:
+      - name: Last
+        key: tab
+        command: lastp
+      - name: Choose
+        key: p
+        command: displayp -d 0
+      - separator: true
+      - name: Left
+        key: h
+        command: selectp -L
+      - name: Down
+        key: j
+        command: selectp -D
+      - name: Up
+        key: k
+        command: selectp -U
+      - name: Right
+        key: l
+        command: selectp -R
+      - separator: true
+      - name: Zoom
+        key: z
+        command: resizep -Z
+      - name: +Resize
+        key: r
+        menu:
+          - name: Left
+            key: h
+            command: resizep -L
+            transient: true
+          - name: Down
+            key: j
+            command: resizep -D
+            transient: true
+          - name: Up
+            key: k
+            command: resizep -U
+            transient: true
+          - name: Right
+            key: l
+            command: resizep -R
+            transient: true
+          - name: Left more
+            key: H
+            command: resizep -L 10
+            transient: true
+          - name: Down more
+            key: J
+            command: resizep -D 10
+            transient: true
+          - name: Up more
+            key: K
+            command: resizep -U 10
+            transient: true
+          - name: Right more
+            key: L
+            command: resizep -R 10
+            transient: true
+      - name: Swap left
+        key: H
+        command: swapp -t "{left-of}"
+      - name: Swap down
+        key: J
+        command: swapp -t "{down-of}"
+      - name: Swap up
+        key: K
+        command: swapp -t "{up-of}"
+      - name: Swap right
+        key: L
+        command: swapp -t "{right-of}"
+      - name: Break
+        key: "!"
+        command: break-pane
+      - separator: true
+      - name: Mark
+        key: m
+        command: selectp -m
+      - name: Unmark
+        key: M
+        command: selectp -M
+      - name: Capture
+        key: C
+        command: capture-pane
+      - name: Respawn pane
+        key: R
+        macro: restart-pane
+      - name: Kill
+        key: X
+        command: 'confirm -p "Kill pane #P? (y/n)" killp'
+  - name: +Buffers
+    key: b
+    menu:
+      - name: Choose
+        key: b
+        command: choose-buffer -Z
+      - name: List
+        key: l
+        command: lsb
+      - name: Paste
+        key: p
+        command: pasteb
+  - name: +Sessions
+    key: s
+    menu:
+      - name: Choose
+        key: s
+        command: choose-tree -Zs
+      - name: New
+        key: N
+        command: new
+      - name: Rename
+        key: r
+        command: rename
+  - name: +Client
+    key: C
+    menu:
+      - name: Choose
+        key: c
+        command: choose-client -Z
+      - name: Last
+        key: l
+        command: switchc -l
+      - name: Previous
+        key: p
+        command: switchc -p
+      - name: Next
+        key: n
+        command: switchc -n
+      - separator: true
+      - name: Refresh
+        key: R
+        command: refresh
+      - name: +Plugins
+        key: P
+        menu:
+          - name: Install
+            key: i
+            command:
+              run-shell $TMUX_PLUGIN_MANAGER_PATH/tpm/bindings/install_plugins
+          - name: Update
+            key: u
+            command:
+              run-shell $TMUX_PLUGIN_MANAGER_PATH/tpm/bindings/update_plugins
+          - name: Clean
+            key: c
+            command:
+              run-shell $TMUX_PLUGIN_MANAGER_PATH/tpm/bindings/clean_plugins
+      - name: Detach
+        key: D
+        command: detach
+      - name: Suspend
+        key: Z
+        command: suspendc
+      - separator: true
+      - name: Reload config
+        key: r
+        macro: reload-config
+      - name: Customize
+        key: ","
+        command: customize-mode -Z
+  - separator: true
+  - name: Time
+    key: T
+    command: clock-mode
+  - name: Show messages
+    key: "~"
+    command: show-messages
+  - name: +Keys
+    key: "?"
+    command: list-keys -N


### PR DESCRIPTION
## Summary
Make `tmux-which-key` (prefix+Space) a complete, discoverable launcher: the upstream default menu (built-in tmux commands) **plus** a `+Tools` submenu exposing our plugin/custom bindings (AI/command/PIM palettes, session expose, floating pane, smart session switch, ccm dashboard).

- Vendored default menu: `home/shell/tmux/which-key-base.yaml`
- `config.yaml` generated = base + interpolated `+Tools` (nix-store paths stay valid across rebuilds), managed via `xdg.configFile`.

## Note
which-key is a **curated** menu — not auto-synced with `list-keys`. For the complete live list: tmux-fzf (`prefix C-f` → keybinding) or the built-in `?` entry.

## Testing
- `nix build` p620 ✓; rendered `config.yaml` parses (yq-go), `+Tools` = 8 entries, store paths interpolated
- Deployed + verified live on **p620** (managed symlink in place, `+Tools` present)
- razer: built ✓, switch pending (interactive sudo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)