### PR TITLE
fix(ops): drop stale nix-serve check from p620 health check

### DIFF
--- a/scripts/health-checks/p620.sh
+++ b/scripts/health-checks/p620.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # p620 post-deploy health check.
 #
-# Workstation: AMD Ryzen + Radeon, GDM + Hyprland desktop. Runs as the local
-# binary cache server too. Run by scripts/update-commit-deploy.sh after the
-# new generation has been activated; exit 0 = healthy, non-zero = roll back.
+# Workstation: AMD Ryzen + Radeon, GDM + Hyprland desktop. Run by
+# scripts/update-commit-deploy.sh after the new generation has been
+# activated; exit 0 = healthy, non-zero = roll back.
 set -uo pipefail
 
 if ! systemctl is-active --quiet display-manager.service; then
@@ -21,18 +21,12 @@ if journalctl -u display-manager.service --since "2 minutes ago" --no-pager 2>/d
   exit 1
 fi
 
-# Binary cache server — other hosts depend on it for fast deploys.
-if ! systemctl is-active --quiet nix-serve.service 2>/dev/null; then
-  echo "FAIL: nix-serve.service not active (other hosts can't use p620 as a cache)"
-  exit 1
-fi
-
 # Positive signal: a session on seat0 (greeter or logged-in user). Useful but
 # not load-bearing — on a freshly-activated config it may not exist yet.
 if loginctl list-sessions --no-legend 2>/dev/null \
   | awk '$4 == "seat0" {found=1} END {exit !found}'; then
-  echo "OK: display-manager live, nix-serve active, seat0 has a session"
+  echo "OK: display-manager live, seat0 has a session"
 else
-  echo "OK: display-manager live, nix-serve active (no seat0 session yet but no GDM exhaustion)"
+  echo "OK: display-manager live (no seat0 session yet but no GDM exhaustion)"
 fi
 exit 0


### PR DESCRIPTION
nix-serve was deliberately removed in 27895b133 ("No dependency on P620
availability for other hosts"), but the per-host health check added later
in 052f20519 still required nix-serve.service to be active. That made
every p620 deploy fail its post-activation health check and auto-roll
back. Remove the check (and the now-inaccurate comments/OK messages);
the load-bearing display-manager + GDM-exhaustion checks are unchanged.

Verified: script exits 0 on the live system.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
