### PR TITLE
fix(claude-code): stop notification spam — defer to tmux-ccm

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -158,11 +158,11 @@ in
   modules.programs.claude-code-managed = {
     enable = true;
     parrProtocol.enable = true;
-    # Surface Notification (popup+toast), Stop and SubagentStop (status
-    # flash, rate-limited) via the claude-notify helper. See module for
-    # tunables (events.{notification,stop,subagentStop}, desktopToasts,
-    # tmuxPopups, rateLimitSeconds).
-    notifications.enable = true;
+    # Notifications are handled by the tmux-ccm plugin (status-bar
+    # attention flag + rate-limited completion ping). Our claude-notify
+    # hooks stay OFF to avoid a duplicate, un-throttled toaster firing
+    # "Claude needs your permission" on the same Notification events.
+    notifications.enable = false;
   };
 
   # /use-ollama, /use-claude, /use-default slash commands + apiKeyHelper

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -352,10 +352,11 @@ in
   modules.programs.claude-code-managed = {
     enable = true;
     parrProtocol.enable = true;
-    # Top-right desktop toasts (with Claude icon) + tmux popups on
-    # Notification, status-line flashes on Stop/SubagentStop. Same
-    # defaults as p620; tunables in modules/programs/claude-code-managed.nix.
-    notifications.enable = true;
+    # Notifications are handled by the tmux-ccm plugin (status-bar
+    # attention flag + rate-limited completion ping). Our claude-notify
+    # hooks stay OFF to avoid a duplicate, un-throttled toaster on the
+    # same Notification events. Same rationale as p620.
+    notifications.enable = false;
   };
 
   # /use-ollama, /use-claude, /use-default slash commands + apiKeyHelper


### PR DESCRIPTION
Our claude-code-managed notify hooks (Notification/Stop/SubagentStop →
claude-notify) duplicated the tmux-ccm plugin, which already monitors
Claude Code for the status bar. Worse, the `notification` branch was
un-throttled, so every Notification event — including the per-session
"Claude needs your permission" prompts that fire whenever bypass isn't
persistent — produced an un-cooldowned desktop toast + tmux popup + bell.

Disable our notify hooks on the desktop hosts (p620, razer) and let
tmux-ccm be the single source of Claude notifications (status-bar
attention flag + its own rate-limited completion ping). The PARR
UserPromptSubmit hook is unaffected; p510 (headless) never enabled
notifications.

Verified: rendered managed-settings.json hooks now contain only
UserPromptSubmit.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
