### PR TITLE
fix(spice): gate spice-vdagentd behind opt-in guestAgent (stops razer spam)

### DIFF
--- a/modules/virt/spice.nix
+++ b/modules/virt/spice.nix
@@ -13,12 +13,21 @@ in
       default = false;
       description = "Enable the SPICE protocol server.";
     };
+
+    guestAgent = mkEnableOption ''
+      the spice-vdagent guest daemon. Only meaningful when THIS machine is
+      itself a SPICE/VM guest. On a physical host it has no SPICE session
+      and logs "Error getting active session: No data available" on a
+      tight loop, so it stays off even when SPICE (USB redirection / client
+      tools for running VMs locally) is enabled'';
   };
   config = mkIf cfg.enable {
     virtualisation = {
       spiceUSBRedirection.enable = true;
     };
-    services.spice-vdagentd.enable = true;
+    # Guest agent only — pointless and log-spammy on a physical host, so
+    # it tracks guestAgent (default off) rather than cfg.enable.
+    services.spice-vdagentd.enable = cfg.guestAgent;
     environment.systemPackages = with pkgs; [
       spice
       spice-gtk


### PR DESCRIPTION
services.spice.enable hardcoded services.spice-vdagentd.enable = true.
The vdagent is a GUEST daemon — on razer (a physical laptop running VMs
via libvirt) it has no SPICE session and logged
"Error getting active session: No data available" ~7000x per boot.

Add services.spice.guestAgent (default false) and gate the daemon on it.
razer keeps services.spice.enable for spiceUSBRedirection + spice-gtk
(VM USB passthrough / virt-manager console); the guest daemon no longer
starts. Real SPICE guests can opt in with guestAgent = true.

Verified: spice-vdagentd.service absent from razer's built system;
spiceUSBRedirection + spicy tools retained.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
