### PR TITLE
chore(claude-code): update native CLI to 2.1.173 (#854)

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -31,7 +31,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.170";
+  version = "2.1.173";
 
   # Claude Code reads clipboard images by shelling out to:
   #   xclip -selection clipboard -t TARGETS -o ... || wl-paste -l ...   (detect)
@@ -63,11 +63,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-hJ4AcnegRCqydXDT49bUN4dQeUZZDo3RlH5aObcIH54=";
+      hash = "sha256-z36hlOF0iTL6MPGA6qn1b5pwOdzjcDApiMKSZimyohk=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-G7nQMkQKdVMvfdTK+8aH8iCq8Wxj66F+GS377C8EvSU=";
+      hash = "sha256-zFk9/CY/cH7SIuM0/1wSqa3cJKvCBnaJYvnQY7L9esk=";
     };
   };
 


### PR DESCRIPTION
## Summary

Bumps `claude-code-native` from **2.1.170 → 2.1.173** (Anthropic latest channel).

Only three lines changed in `pkgs/claude-code-native/default.nix`: version + both SRI hashes (linux-x64, linux-arm64).

## Testing

- `nix build .#claude-code-native` → `claude --version` = **2.1.173**, `ldd` shows no missing libs
- All three host toplevels build clean: **p620, razer, p510**

## Issues

Closes #854
Supersedes #853 (2.1.172 — superseded by this newer bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)