### PR TITLE
feat(vscode): add factory.cfactoryUrl and make settings.json mutable

### DIFF
--- a/home/development/claude-code-lsp.nix
+++ b/home/development/claude-code-lsp.nix
@@ -186,35 +186,37 @@ in
           #
           # Runs after claudeUserSettingsInit so the settings file exists
           # before `claude plugin install` tries to write to it.
+          # NOTE: never `exit` from an activation entry — entries are concatenated
+          # into one activate script, so `exit` aborts ALL later entries. Guard
+          # with if/else instead so only this block is skipped.
           claudeCodeLspSetup = lib.hm.dag.entryAfter [ "claudeUserSettingsInit" ] ''
             if ! command -v claude >/dev/null 2>&1; then
               $DRY_RUN_CMD echo "Claude Code not found, skipping LSP setup"
-              exit 0
+            else
+              $DRY_RUN_CMD echo "Setting up Claude Code LSP plugins..."
+
+              marketplace_exists() {
+                claude plugin marketplace list | grep -q "nixos-lsp-marketplace"
+              }
+
+              plugin_installed() {
+                claude plugin marketplace list | grep -q "nix-lsp@nixos-lsp-marketplace" \
+                  || ( [ -f "$HOME/.claude/plugins/installed_plugins.json" ] \
+                       && grep -q "nix-lsp@nixos-lsp-marketplace" "$HOME/.claude/plugins/installed_plugins.json" )
+              }
+
+              if ! marketplace_exists; then
+                $DRY_RUN_CMD echo "Adding nixos-lsp-marketplace..."
+                $DRY_RUN_CMD claude plugin marketplace add "${cfg.customMarketplacePath}"
+              fi
+
+              if ! plugin_installed; then
+                $DRY_RUN_CMD echo "Installing nix-lsp plugin..."
+                $DRY_RUN_CMD claude plugin install nix-lsp@nixos-lsp-marketplace
+              fi
+
+              $DRY_RUN_CMD echo "Claude Code LSP setup complete!"
             fi
-
-            $DRY_RUN_CMD echo "Setting up Claude Code LSP plugins..."
-
-            marketplace_exists() {
-              claude plugin marketplace list | grep -q "nixos-lsp-marketplace"
-            }
-
-            plugin_installed() {
-              claude plugin marketplace list | grep -q "nix-lsp@nixos-lsp-marketplace" \
-                || ( [ -f "$HOME/.claude/plugins/installed_plugins.json" ] \
-                     && grep -q "nix-lsp@nixos-lsp-marketplace" "$HOME/.claude/plugins/installed_plugins.json" )
-            }
-
-            if ! marketplace_exists; then
-              $DRY_RUN_CMD echo "Adding nixos-lsp-marketplace..."
-              $DRY_RUN_CMD claude plugin marketplace add "${cfg.customMarketplacePath}"
-            fi
-
-            if ! plugin_installed; then
-              $DRY_RUN_CMD echo "Installing nix-lsp plugin..."
-              $DRY_RUN_CMD claude plugin install nix-lsp@nixos-lsp-marketplace
-            fi
-
-            $DRY_RUN_CMD echo "Claude Code LSP setup complete!"
           '';
 
           # MCP server configuration is now handled by claude-code-mcp.nix module

--- a/home/development/vscode.nix
+++ b/home/development/vscode.nix
@@ -7,8 +7,14 @@
 let
   inherit (lib) mkIf mkEnableOption;
   cfg = config.editor.vscode;
-  # Custom extensions not available in nixpkgs
-  # Note: Uncomment and add proper sha256 hashes when needed
+
+  # Stylix's theming and our own keys both land in programs.vscode userSettings.
+  # Rendered to a store file so the activation script can merge them into a
+  # MUTABLE settings.json (Stylix/we *add*, but never own the file — the Factory
+  # extension and the user can still write to it).
+  declarativeSettingsFile =
+    (pkgs.formats.json { }).generate "vscode-settings.json"
+      config.programs.vscode.profiles.default.userSettings;
 in
 {
   options.editor.vscode = {
@@ -16,6 +22,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    # Stop Home Manager (and therefore Stylix) from owning settings.json as a
+    # read-only store symlink. The activation script below renders the same
+    # declarative settings into a mutable, hand-editable file instead.
+    home.file."${config.xdg.configHome}/Code/User/settings.json".enable = lib.mkForce false;
+
     home = {
       packages = with pkgs; [
         alejandra
@@ -48,57 +59,39 @@ in
         rm -f "$HOME/.claude/settings.json.hm-backup"
       '';
 
-      # Initialize VS Code settings and MCP files as mutable
-      # This runs AFTER home-manager creates symlinks (writeBoundary)
-      # We remove any symlinks created by programs.vscode.profiles to keep files mutable
+      # Keep settings.json MUTABLE (Factory extension + user can write it) while
+      # merging in our declarative keys (Stylix theming + factory.cfactoryUrl) on
+      # every switch. Existing keys the extension wrote (e.g. cfactoryToken) are
+      # preserved; declarative keys win on conflict.
       activation.vscodeSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
         SETTINGS_DIR="$HOME/.config/Code/User"
         SETTINGS_FILE="$SETTINGS_DIR/settings.json"
         MCP_FILE="$SETTINGS_DIR/mcp.json"
-        SETTINGS_TEMPLATE_FILE="${./vscode-settings-template.json}"
+        DECLARATIVE_SETTINGS="${declarativeSettingsFile}"
         MCP_TEMPLATE_FILE="${./vscode-mcp-template.json}"
 
-        # Create VS Code config directory if it doesn't exist
         mkdir -p "$SETTINGS_DIR"
 
-        # Remove any existing backup files that cause conflicts
-        if [ -f "$SETTINGS_DIR/settings.json.backup" ]; then
-          echo "Removing conflicting settings.json.backup file..."
-          rm "$SETTINGS_DIR/settings.json.backup"
-        fi
-        if [ -f "$SETTINGS_DIR/settings.json.hm-backup" ]; then
-          echo "Removing conflicting settings.json.hm-backup file..."
-          rm "$SETTINGS_DIR/settings.json.hm-backup"
-        fi
-
-        # Handle settings.json - convert symlink to mutable file
-        if [ -L "$SETTINGS_FILE" ]; then
-          echo "Removing Home Manager symlink for VS Code settings..."
-          rm "$SETTINGS_FILE"
-        fi
+        # Drop any leftover Home Manager symlink / backups so the file is writable.
+        rm -f "$SETTINGS_DIR/settings.json.backup" "$SETTINGS_DIR/settings.json.hm-backup"
+        [ -L "$SETTINGS_FILE" ] && rm "$SETTINGS_FILE"
 
         if [ ! -f "$SETTINGS_FILE" ]; then
-          echo "Creating initial mutable VS Code settings file..."
-          cp "$SETTINGS_TEMPLATE_FILE" "$SETTINGS_FILE"
+          install -m 644 "$DECLARATIVE_SETTINGS" "$SETTINGS_FILE"
+          echo "✅ VS Code settings.json initialized (mutable)."
+        elif MERGED=$(${pkgs.jq}/bin/jq -s '.[0] * .[1]' "$SETTINGS_FILE" "$DECLARATIVE_SETTINGS" 2>/dev/null); then
+          printf '%s\n' "$MERGED" > "$SETTINGS_FILE"
           chmod 644 "$SETTINGS_FILE"
-          echo "✅ VS Code settings.json initialized as mutable file."
+          echo "✅ VS Code settings.json updated (declarative keys merged, edits preserved)."
         else
-          echo "VS Code settings.json file exists and is already mutable - leaving it alone."
+          echo "⚠️  settings.json is not valid JSON; left untouched."
         fi
 
-        # Handle mcp.json - convert symlink to mutable file
-        if [ -L "$MCP_FILE" ]; then
-          echo "Removing Home Manager symlink for MCP configuration..."
-          rm "$MCP_FILE"
-        fi
-
+        [ -L "$MCP_FILE" ] && rm "$MCP_FILE"
         if [ ! -f "$MCP_FILE" ]; then
-          echo "Creating initial mutable MCP configuration file..."
           cp "$MCP_TEMPLATE_FILE" "$MCP_FILE"
           chmod 644 "$MCP_FILE"
-          echo "✅ VS Code mcp.json initialized as mutable file."
-        else
-          echo "VS Code mcp.json file exists and is already mutable - leaving it alone."
+          echo "✅ VS Code mcp.json initialized (mutable)."
         fi
       '';
     };
@@ -132,8 +125,12 @@ in
           golang.go
         ];
 
-        # IMPORTANT: No settings defined here - activation script handles settings.json
-        # This allows settings to remain mutable (editable by VS Code itself)
+        # settings.json is a Stylix-owned store symlink (theming/fonts), so it
+        # cannot be edited by hand. Persistent keys go here and merge with
+        # Stylix's userSettings.
+        userSettings = {
+          "factory.cfactoryUrl" = "https://cfactory.freundcloud.org.uk";
+        };
       };
     };
 


### PR DESCRIPTION
## Summary

Adds the requested VS Code setting and fixes the underlying reason it couldn't be edited:

```jsonc
"factory.cfactoryUrl": "https://cfactory.freundcloud.org.uk"
```

### Why settings.json had to change
`settings.json` was a **read-only, Stylix-owned store symlink** (`programs.vscode … userSettings` → `home.file`). That meant the Factory extension could not persist its runtime keys (e.g. `cfactoryToken`) and the file could not be hand-edited.

**Now:** Stylix *adds* settings but no longer *owns* the file —
- Home Manager's `settings.json` symlink is disabled.
- `userSettings` (Stylix theme + our keys) is rendered to a store file and **merged into a mutable `settings.json`** on activation, preserving extension/user-written keys.

### Bonus fix
`claude-code-lsp.nix` used `exit 0` in an activation entry when `claude` wasn't on the activation `PATH`. Because HM concatenates activation entries into one script, that `exit` **aborted the whole activation**, silently skipping every later step (`installPackages`, `dconfSettings`, `vscodeSettings`, …). Replaced with `if/else`.

## Testing
- p620 switched & verified: `settings.json` is a mutable regular file, `colorTheme: Stylix`, `factory.cfactoryUrl` clean, `factory.cfactoryToken` preserved.
- Activation now runs to completion (confirmed `installPackages` + `vscodeSettings` fire).
- All three hosts build: **p620, razer, p510**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)