### PR TITLE
feat(ai-tooling): output styles + auto nixpkgs-fmt hook (Phase 3)

### DIFF
--- a/home/development/claude-code-output-styles.nix
+++ b/home/development/claude-code-output-styles.nix
@@ -1,0 +1,90 @@
+# Claude Code output styles
+#
+# Output styles replace Claude Code's system prompt to put it in a focused
+# "role" for a session (`/output-style <name>`). Declaratively managed as
+# read-only files under ~/.claude/output-styles/ — they are static prompts,
+# never mutated at runtime, so a nix-store symlink is safe.
+{ config
+, lib
+, pkgs
+, ...
+}:
+let
+  cfg = config.programs.claudeCode.outputStyles;
+
+  nixArchitect = pkgs.writeText "nix-architect.md" ''
+    ---
+    name: Nix Architect
+    description: NixOS module/architecture focus — types, anti-patterns, security, performance
+    ---
+
+    # Nix Architect mode
+
+    You are reviewing and designing NixOS/Home-Manager configuration for a
+    declarative, multi-host flake. Hold every change to these standards:
+
+    - **Architecture first.** New functionality belongs in a feature module
+      behind a flag (`features.* `/ `options.* `), never inline in a host's
+      `configuration.nix`. Prefer composition and shared templates over
+      duplication.
+    - **Module system correctness.** Right `types.*`, `mkOption` with
+      descriptions, `mkDefault`/`mkForce`/priorities used deliberately,
+      assertions for invariants. No `mkIf cond true` — assign `cond`.
+    - **Anti-patterns are blockers.** No bare URLs, minimal `with`/`rec`, no
+      Import-From-Derivation, explicit imports only. Cite
+      `docs/NIXOS-ANTI-PATTERNS.md` when you flag one.
+    - **Security by default.** New services: `DynamicUser`,
+      `ProtectSystem=strict`, `NoNewPrivileges`, `ProtectHome`, minimal
+      capabilities, least-privilege firewall.
+    - **Secrets at runtime only** (agenix path / `*File`), never read during
+      evaluation.
+    - **Performance & reproducibility.** Avoid eval blow-ups and IFD; keep
+      builds cache-friendly.
+
+    For every proposal: name the module/file it belongs in, the option surface,
+    the failure modes, and how to test it (`just test-host <host>` /
+    `just validate`). Be concrete; show the smallest correct diff.
+  '';
+
+  securityAuditor = pkgs.writeText "security-auditor.md" ''
+    ---
+    name: Security Auditor
+    description: Threat-model services, secrets, systemd hardening, firewall, network exposure
+    ---
+
+    # Security Auditor mode
+
+    You are auditing this infrastructure for security weaknesses. Think like an
+    attacker, recommend like a defender. For anything you review, work through:
+
+    - **Secrets.** Are any secrets read at evaluation time or committed in
+      plaintext (config files, MCP env, scripts)? Everything must be agenix
+      runtime references (`*File` / `config.age.secrets.*.path`). Flag plaintext
+      tokens/keys explicitly.
+    - **Service isolation.** Does each systemd service run unprivileged
+      (`DynamicUser`/dedicated user) with `ProtectSystem=strict`,
+      `NoNewPrivileges`, `ProtectHome`, `PrivateTmp`, capability bounding, and a
+      tight `SystemCallFilter`? Call out anything running as root.
+    - **Network exposure.** Minimal open firewall ports, interface-scoped where
+      possible, no `0.0.0.0` bind unless required. Prefer Tailscale/LAN-only.
+    - **Supply chain & updates.** Pinned inputs, verified hashes, no unpinned
+      `fetchurl`. GC + update hygiene.
+    - **Auth & access.** SSH key-only, sudo scope, agenix recipient hygiene.
+
+    Output findings ranked **critical / high / medium / low** with the exact
+    file:line, the concrete risk, and the minimal remediation diff. Do not
+    soften severity. Prefer defensive, least-privilege fixes.
+  '';
+in
+{
+  options.programs.claudeCode.outputStyles.enable =
+    lib.mkEnableOption "Declarative Claude Code output styles (nix-architect, security-auditor)"
+    // { default = true; };
+
+  config = lib.mkIf cfg.enable {
+    home.file = {
+      ".claude/output-styles/nix-architect.md".source = nixArchitect;
+      ".claude/output-styles/security-auditor.md".source = securityAuditor;
+    };
+  };
+}

--- a/home/development/default.nix
+++ b/home/development/default.nix
@@ -30,6 +30,7 @@ _: {
     ./claude-code-lsp.nix
     ./claude-code-mcp.nix # Claude Code MCP server configuration
     ./antigravity-config.nix # Declarative Antigravity rules + MCP sync
+    ./claude-code-output-styles.nix # Declarative Claude Code output styles
 
     # Development workflow enhancements (conflicts resolved)
     ./workflow.nix

--- a/modules/programs/claude-code-managed.nix
+++ b/modules/programs/claude-code-managed.nix
@@ -240,9 +240,32 @@ let
     "Bash(git branch:*)"
   ];
 
+  # Auto-format edited .nix files with nixpkgs-fmt (the repo's pre-commit
+  # formatter), so files Claude touches stay commit-clean. PostToolUse fires
+  # after Write/Edit/MultiEdit; the script no-ops on non-.nix paths and never
+  # fails the tool.
+  formatScript = pkgs.writeShellScript "claude-nix-format.sh" ''
+    payload="$(cat)"
+    fp="$(${pkgs.jq}/bin/jq -r '.tool_input.file_path // empty' <<<"$payload" 2>/dev/null)"
+    case "$fp" in
+      *.nix) [ -f "$fp" ] && ${pkgs.nixpkgs-fmt}/bin/nixpkgs-fmt "$fp" >/dev/null 2>&1 || true ;;
+    esac
+    exit 0
+  '';
+
+  formatHooks = lib.optionalAttrs cfg.formatOnEdit.enable {
+    PostToolUse = [{
+      matcher = "Write|Edit|MultiEdit";
+      hooks = [{
+        type = "command";
+        command = toString formatScript;
+      }];
+    }];
+  };
+
   mergedSettings =
     (cfg.settings // {
-      hooks = (cfg.settings.hooks or { }) // parrHooks // notifyHooks;
+      hooks = (cfg.settings.hooks or { }) // parrHooks // notifyHooks // formatHooks;
     })
     // lib.optionalAttrs (baselineAllow != [ ]) {
       permissions = (cfg.settings.permissions or { }) // {
@@ -294,6 +317,17 @@ in
         routine repo operations never trigger a permission prompt. System-
         mutating commands (deploys, nixos-rebuild, git commit/push, sudo, rm)
         are deliberately excluded and still require explicit approval.
+      '';
+    };
+
+    formatOnEdit.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Run nixpkgs-fmt (the repo's pre-commit formatter) on any .nix file
+        Claude Code edits, via a managed-scope PostToolUse hook. Keeps touched
+        files commit-clean automatically. No-ops on non-.nix paths and never
+        fails the tool.
       '';
     };
 


### PR DESCRIPTION
## Summary

Phase 3 of `docs/AI-TOOLING-CUSTOMIZATION-PLAN.md` (statusline + permission allowlist were already done in earlier phases, so this covers the remaining items).

- **Output styles** (`home/development/claude-code-output-styles.nix`) — declarative `~/.claude/output-styles/{nix-architect,security-auditor}.md` role prompts, switchable with `/output-style`. Static files → read-only store symlinks.
- **`claude-code-managed`: new `formatOnEdit.enable` (default on)** — a managed-scope `PostToolUse` hook runs **nixpkgs-fmt** (the repo's pre-commit formatter) on any `.nix` file Claude edits, keeping touched files commit-clean. No-ops on non-`.nix` paths, never fails the tool. Merges alongside the PARR hook, notification hooks, and the permission allowlist.

## Testing
- All three hosts build (p620, razer, p510).
- p620 switched: `~/.claude/output-styles/` has both styles; `/etc/claude-code/managed-settings.json` carries the **PARR hook + the PostToolUse format hook (`Write|Edit|MultiEdit`) + the 27-entry allowlist** together.

## Plan status
Phase 1 ✅ merged · Phase 2 ✅ merged · Phase 3 ✅ (this PR). Remaining: **Phase 4** (trim the 62-agent / ~30-skill sprawl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)