### PR TITLE
feat(ai-tooling): secure Antigravity GitHub PAT via agenix + declarative agent curation

### DIFF
--- a/home/development/antigravity-config.nix
+++ b/home/development/antigravity-config.nix
@@ -36,8 +36,10 @@ let
     then (osConfig.age.secrets."api-github-token" or null)
     else null;
 
+  # github-mcp-server only reads GITHUB_PERSONAL_ACCESS_TOKEN (not
+  # GITHUB_TOKEN_FILE) and requires the `stdio` subcommand to start.
   githubWrapper = pkgs.writeShellScript "antigravity-github-mcp" ''
-    export GITHUB_TOKEN_FILE=${if ghToken != null then ghToken.path else "/dev/null"}
+    export GITHUB_PERSONAL_ACCESS_TOKEN="$(cat ${if ghToken != null then ghToken.path else "/dev/null"})"
     exec ${pkgs.github-mcp-server}/bin/github-mcp-server stdio
   '';
 

--- a/home/development/antigravity-config.nix
+++ b/home/development/antigravity-config.nix
@@ -20,12 +20,40 @@
 { config
 , lib
 , pkgs
+, osConfig ? null
 , ...
 }:
 let
   cfg = config.programs.antigravityConfig;
 
   geminiDir = "${config.home.homeDirectory}/.gemini";
+
+  # GitHub PAT — sourced from agenix at runtime instead of sitting in plaintext
+  # in mcp_config.json. Mirrors the Claude Code github-mcp wrapper. Only applied
+  # if the host actually decrypts api-github-token.
+  ghToken =
+    if osConfig != null
+    then (osConfig.age.secrets."api-github-token" or null)
+    else null;
+
+  githubWrapper = pkgs.writeShellScript "antigravity-github-mcp" ''
+    export GITHUB_TOKEN_FILE=${if ghToken != null then ghToken.path else "/dev/null"}
+    exec ${pkgs.github-mcp-server}/bin/github-mcp-server stdio
+  '';
+
+  # Override layer (mine wins): replaces any plaintext-token github-mcp-server
+  # entry with the agenix-backed wrapper. Empty if the secret isn't available
+  # or the feature is off — the existing entry is then left untouched.
+  overrideMcpServers = lib.optionalAttrs (cfg.secureGithubMcp && ghToken != null) {
+    github-mcp-server = {
+      command = toString githubWrapper;
+      args = [ ];
+    };
+  };
+
+  overrideMcpFile = (pkgs.formats.json { }).generate "antigravity-override-mcp.json" {
+    mcpServers = overrideMcpServers;
+  };
 
   # Clean, secret-free stdio MCP servers to share into Antigravity. These map
   # 1:1 onto Antigravity's command/args/env schema. SSE/secret-bound servers
@@ -99,6 +127,17 @@ in
         this only fills gaps and never removes anything.
       '';
     };
+
+    secureGithubMcp = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Replace any github-mcp-server entry in mcp_config.json (which Antigravity
+        stores with the PAT in plaintext) with an agenix-backed wrapper that
+        sources the token from api-github-token at runtime. No-op if the secret
+        isn't decrypted on this host.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -110,17 +149,26 @@ in
       lib.hm.dag.entryAfter [ "writeBoundary" ] ''
         cfgfile="${geminiDir}/config/mcp_config.json"
         shared="${sharedMcpFile}"
+        override="${overrideMcpFile}"
         mkdir -p "$(dirname "$cfgfile")"
 
         if [ ! -f "$cfgfile" ]; then
-          $DRY_RUN_CMD install -m 0644 "$shared" "$cfgfile"
-          $DRY_RUN_CMD echo "Antigravity: seeded mcp_config.json from shared MCP set"
+          # Seed = shared servers, with the secure github override applied.
+          if seeded=$(${pkgs.jq}/bin/jq -s \
+              '.[0] + {mcpServers: ((.[0].mcpServers // {}) + (.[1].mcpServers // {}))}' \
+              "$shared" "$override" 2>/dev/null); then
+            $DRY_RUN_CMD printf '%s\n' "$seeded" > "$cfgfile"
+            $DRY_RUN_CMD chmod 0644 "$cfgfile"
+            $DRY_RUN_CMD echo "Antigravity: seeded mcp_config.json (shared + secure github)"
+          fi
         elif merged=$(${pkgs.jq}/bin/jq -s \
-            '.[1] + {mcpServers: ((.[0].mcpServers // {}) + (.[1].mcpServers // {}))}' \
-            "$shared" "$cfgfile" 2>/dev/null); then
-          # Existing user servers (.[1]) win over shared (.[0]); only gaps filled.
+            '.[1] + {mcpServers: ((.[0].mcpServers // {}) + (.[1].mcpServers // {}) + (.[2].mcpServers // {}))}' \
+            "$shared" "$cfgfile" "$override" 2>/dev/null); then
+          # Precedence: override (.[2]) > existing (.[1]) > shared (.[0]).
+          # Existing servers preserved; gaps filled by shared; github-mcp-server
+          # replaced by the agenix-backed wrapper (drops the plaintext token).
           $DRY_RUN_CMD printf '%s\n' "$merged" > "$cfgfile"
-          $DRY_RUN_CMD echo "Antigravity: synced shared MCP servers (existing preserved)"
+          $DRY_RUN_CMD echo "Antigravity: synced MCP (existing preserved, github secured)"
         else
           $DRY_RUN_CMD echo "Antigravity: mcp_config.json not valid JSON — left untouched"
         fi

--- a/home/development/claude-code-agents.nix
+++ b/home/development/claude-code-agents.nix
@@ -1,0 +1,84 @@
+# Claude Code agent curation
+#
+# The ~/.claude/agents/ pack (hand-installed, syncthing-synced across hosts) is
+# NOT Home-Manager-managed — making it nix-store symlinks would break syncthing
+# (peers would get dangling links into this host's store). So instead of owning
+# the files, we keep a declarative *disable list* and, on every activation, move
+# any listed agent out of agents/ into agents-disabled/.
+#
+# This makes the curation reproducible (the list lives in Nix) and self-healing
+# (if a peer re-syncs a disabled agent back, the next switch hides it again),
+# while staying fully compatible with the syncthing-managed, mutable agents dir.
+# Reversible: drop a name from the list and move its file back.
+{ config
+, lib
+, ...
+}:
+let
+  cfg = config.programs.claudeCode.agentCuration;
+  disabledStr = lib.concatStringsSep " " cfg.disabledAgents;
+in
+{
+  options.programs.claudeCode.agentCuration = {
+    enable = lib.mkEnableOption "Claude Code agent curation (hide irrelevant agents)" // {
+      default = true;
+    };
+
+    disabledAgents = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        # business / finance / marketing / legal
+        "business-analyst"
+        "content-marketer"
+        "customer-support"
+        "legal-advisor"
+        "payment-integration"
+        "quant-analyst"
+        "risk-manager"
+        "sales-automator"
+        # languages not in this stack (keep python/rust/go/ts/js)
+        "c-pro"
+        "cpp-pro"
+        "csharp-pro"
+        "elixir-pro"
+        "java-pro"
+        "php-pro"
+        "scala-pro"
+        # mobile / games
+        "ios-developer"
+        "mobile-developer"
+        "unity-developer"
+        "minecraft-bukkit-pro"
+        # data / ML / web / misc not core to this infra
+        "api-documenter"
+        "data-engineer"
+        "data-scientist"
+        "ml-engineer"
+        "mlops-engineer"
+        "graphql-architect"
+        "legacy-modernizer"
+        "frontend-developer"
+        "ui-ux-designer"
+      ];
+      description = ''
+        Agent names (without .md) to keep out of ~/.claude/agents/. On each
+        activation they are moved to ~/.claude/agents-disabled/ if present.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.activation.claudeAgentCuration = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      A="$HOME/.claude/agents"
+      D="$HOME/.claude/agents-disabled"
+      if [ -d "$A" ]; then
+        mkdir -p "$D"
+        for a in ${disabledStr}; do
+          if [ -f "$A/$a.md" ]; then
+            $DRY_RUN_CMD mv "$A/$a.md" "$D/"
+          fi
+        done
+      fi
+    '';
+  };
+}

--- a/home/development/claude-code-mcp.nix
+++ b/home/development/claude-code-mcp.nix
@@ -145,8 +145,10 @@ let
         // (lib.optionalAttrs (osConfig.age.secrets."api-github-token" or null != null) {
           github = {
             command = "${mkWrapper "github-mcp-wrapper" ''
-              export GITHUB_TOKEN_FILE=${osConfig.age.secrets."api-github-token".path}
-              exec ${pkgs.github-mcp-server}/bin/github-mcp-server "$@"
+              # github-mcp-server only reads GITHUB_PERSONAL_ACCESS_TOKEN (not
+              # GITHUB_TOKEN_FILE) and needs the `stdio` subcommand to start.
+              export GITHUB_PERSONAL_ACCESS_TOKEN="$(cat ${osConfig.age.secrets."api-github-token".path})"
+              exec ${pkgs.github-mcp-server}/bin/github-mcp-server stdio "$@"
             ''}";
             args = [ ];
             description = "GitHub repository integration - PR automation, issue management, repository queries";

--- a/home/development/default.nix
+++ b/home/development/default.nix
@@ -31,6 +31,7 @@ _: {
     ./claude-code-mcp.nix # Claude Code MCP server configuration
     ./antigravity-config.nix # Declarative Antigravity rules + MCP sync
     ./claude-code-output-styles.nix # Declarative Claude Code output styles
+    ./claude-code-agents.nix # Declarative agent curation (hide irrelevant agents)
 
     # Development workflow enhancements (conflicts resolved)
     ./workflow.nix


### PR DESCRIPTION
## Summary

Two follow-ups from the AI-tooling plan.

### Security — `antigravity-config.nix`
Antigravity stored a **GitHub PAT in plaintext** in `~/.gemini/config/mcp_config.json` (synced across hosts). New **`secureGithubMcp`** option (default on) replaces that entry with an **agenix-backed wrapper** (`GITHUB_TOKEN_FILE` → `github-mcp-server stdio`, sourcing `api-github-token`), mirroring the Claude Code github-mcp wrapper. The MCP merge gains an **override layer** (precedence: override > existing > shared) so the plaintext entry is replaced while every other user server is preserved. No-op if the secret isn't decrypted on the host.

### Agent curation — `claude-code-agents.nix`
`~/.claude/agents/` is **syncthing-synced** (not HM-managed) — nix-store symlinks would break sync. Instead, a declarative **`disabledAgents`** list + activation moves any listed agent into `~/.claude/agents-disabled/` each switch. Reproducible (list in Nix), self-healing (re-hides if a peer re-syncs one), syncthing-safe, reversible. Hides 28 irrelevant agents, keeps 32 infra/dev-relevant ones.

## Testing
- All three hosts build.
- **Deployed to p620 + razer** (p510 deferred per request).
- Verified both: `github-mcp-server` → wrapper, **0 plaintext `ghp_` tokens**, other servers + `context7` preserved, valid JSON; **32 active agents**.

## ⚠️ Follow-up for you
**Rotate the previously-exposed PAT** — it sat in a synced plaintext file, so treat it as compromised. After rotating on GitHub, update the `api-github-token` agenix secret (`./scripts/manage-secrets.sh edit api-github-token`).

> Note: Claude's own github-mcp wrapper (`home/development/claude-code-mcp.nix`) calls `github-mcp-server` with `args=[]` and **no `stdio` subcommand** — that binary needs `stdio` to start the MCP server, so that wrapper may be silently non-functional. Worth a look (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)