### PR TITLE
fix(gnome): keep gruvbox gtk/shell/icons + bibata cursor (stop Stylix clobbering)

### DIFF
--- a/home/desktop/gnome/theme.nix
+++ b/home/desktop/gnome/theme.nix
@@ -26,6 +26,17 @@ in
     # document-font-name, monospace-font-name, color-scheme). Only keep
     # dconf entries here for things Stylix does not manage.
     dconf.settings = {
+      # Keep the user's named gruvbox themes — Stylix's GNOME target otherwise
+      # resets gtk-theme → adw-gtk3 and the shell user-theme → "Stylix" on every
+      # rebuild. mkForce wins over Stylix's dconf entries. (Icons + cursor are
+      # driven through Stylix itself in modules/desktop/stylix-theme.nix.)
+      "org/gnome/desktop/interface" = {
+        gtk-theme = lib.mkForce "Gruvbox-Dark";
+      };
+      "org/gnome/shell/extensions/user-theme" = {
+        name = lib.mkForce "Gruvbox-Dark";
+      };
+
       "org/gnome/desktop/wm/preferences" = {
         # Stylix doesn't theme the WM titlebar font; follow the Stylix sans
         # so the titlebar matches the rest of the GNOME UI.

--- a/modules/desktop/stylix-theme.nix
+++ b/modules/desktop/stylix-theme.nix
@@ -44,18 +44,18 @@ in
         size = vars.baseTheme.cursor.size;
       };
 
-      # YAMIS — monochrome icon theme with FollowsColorScheme=true, so the
-      # same theme name works for both light and dark polarity (Stylix flips
-      # the polarity via dconf; the theme adapts automatically).
-      # Falls back to Papirus-Dark / breeze-dark / Cosmic / Adwaita for any
-      # icon YAMIS doesn't ship — see pkgs/yet-another-monochrome-icons.
+      # Gruvbox-Material icons — shipped in gruvbox-material-gtk-theme as
+      # share/icons/Gruvbox-Material-Dark. Driving the icon theme THROUGH
+      # Stylix (rather than fighting it) is what stops Stylix clobbering the
+      # icon choice on every rebuild. Only a Dark variant ships; polarity is
+      # dark so `light` reuses it harmlessly.
       # Note: use the modern `stylix.icons` namespace; the old
       # `stylix.iconTheme` is deprecated and emits a warning.
       icons = {
         enable = true;
-        package = pkgs.yet-another-monochrome-icons;
-        dark = "yet-another-monochrome-icon-set";
-        light = "yet-another-monochrome-icon-set";
+        package = pkgs.gruvbox-material-gtk-theme;
+        dark = "Gruvbox-Material-Dark";
+        light = "Gruvbox-Material-Dark";
       };
 
       targets = {


### PR DESCRIPTION
## Summary

Stylix's GNOME target was resetting your theme on **every rebuild** — gtk-theme → `adw-gtk3`, gnome-shell user-theme → `Stylix`, and icons to the YAMIS→Papirus fallback. This makes your gruvbox config declarative and Stylix-proof.

- **icons**: route Stylix's *own* icon theme at `gruvbox-material-gtk-theme` (ships `share/icons/Gruvbox-Material-Dark`) instead of YAMIS. Stylix now *sets* the icons you want → can't clobber them.
- **gtk-theme + gnome-shell user-theme**: `mkForce` the dconf entries to `Gruvbox-Dark` (from `gruvbox-gtk-theme`) so they win over Stylix's GNOME target.
- **cursor** (`Bibata-Modern-Classic`) already came from Stylix — unchanged.

## Testing
Verified on p620 across a full `nixos-rebuild switch` (the exact thing that used to break it):
- `interface/gtk-theme` = `Gruvbox-Dark`
- `interface/icon-theme` = `Gruvbox-Material-Dark`
- `interface/cursor-theme` = `Bibata-Modern-Classic`
- `shell/extensions/user-theme/name` = `Gruvbox-Dark`

All survive the rebuild. p620 + razer + p510 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)