### PR TITLE
fix(zsh): default command/result boxes OFF

### DIFF
--- a/home/shell/zsh.nix
+++ b/home/shell/zsh.nix
@@ -326,7 +326,10 @@ in
         # Global variables for command tracking
         typeset -g COMMAND_START_TIME
         typeset -g CURRENT_COMMAND
-        typeset -g BOX_ENABLED=1
+        # Command/result boxes OFF by default — they ate vertical space and the
+        # "✔ Command completed" confirmation wasn't wanted. Run `toggle_boxes`
+        # to turn them on for a session.
+        typeset -g BOX_ENABLED=0
 
         # Function to calculate terminal width dynamically
         get_term_width() {


### PR DESCRIPTION
The visual command-boxes ate vertical space and added unwanted "✔ Command completed" confirmation noise. They surfaced after the OMZ removal un-broke the precmd hooks. Default `BOX_ENABLED=0`; `toggle_boxes` re-enables per session. Verified on p620: `BOX_ENABLED=0`, no boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)