### PR TITLE
feat(nvim): local-Ollama coding stack + lang extras; drop codeium

### DIFF
--- a/docs/NVIM-IMPROVEMENT-PLAN.md
+++ b/docs/NVIM-IMPROVEMENT-PLAN.md
@@ -1,0 +1,92 @@
+<!-- markdownlint-disable MD013 -->
+
+# Neovim Improvement Plan — Claude Code + Antigravity + local Ollama
+
+> Created: 2026-06-11
+> Scope: review + plan only (nothing changed yet). Goal: the ideal LazyVim coding
+> setup for *your* AI stack — Claude Code, Antigravity, local Ollama — and nothing else.
+
+## Status snapshot
+
+Your nvim is **LazyVim**, config at `home/shell/lazyvim/` (delivered via `home.file`,
+lazy.nvim manages plugins). It's already in good shape on the Claude side; the
+**local-Ollama layer is the big missing piece**.
+
+| Area | Current | Verdict |
+|---|---|---|
+| **Claude Code ↔ nvim** | `coder/claudecode.nvim` + official `extras.ai.claudecode`; snacks terminal, right 35% split, `<leader>a*` keymaps | 🟢 **best-in-class, already done** |
+| Completion engine | blink.cmp, **Nix-built** (prebuilt Rust fuzzy matcher) | 🟢 ideal |
+| Nix LSP | `nixd` via lspconfig (Nix-provided, no Mason) | 🟢 correct |
+| **Local Ollama (inline completion)** | none | 🔴 **missing** — your "Copilot but local" |
+| **Local Ollama (chat / agentic edits)** | none | 🔴 **missing** |
+| Other-language LSP/format | no LazyVim `lang.*` extras enabled (rust/python/go/ts) | 🟡 relies on defaults |
+| File explorer for @-mentions | (not confirmed oil) | 🟡 `oil.nvim` helps claudecode @-mentions |
+| **Antigravity ↔ nvim** | `agy` only via tmux palette | ⚪ no real nvim plugin (honest, below) |
+
+**Ollama models you already have** (localhost:11434): `qwen2.5-coder:14b` ✅ (chat-ready), plus qwen3/gemma. **Missing for fast inline FIM:** `qwen2.5-coder:7b`.
+
+**Headline:** Claude Code is already wired the right way. The whole opportunity is **adding the local-Ollama coding layer** (inline FIM completion + a local chat/agentic editor), plus tightening language tooling. No avante, no Copilot — exactly your "only Claude/Antigravity/Ollama" constraint.
+
+---
+
+## The recommended stack (opinionated)
+
+| Layer | Pick | Role |
+|---|---|---|
+| Claude Code | `coder/claudecode.nvim` *(have it)* | Big agentic jobs, diffs, selection/diagnostics → Claude |
+| **Inline completion** | `milanglacier/minuet-ai.nvim` → Ollama FIM | As-you-type ghost text from a local model (blink source) |
+| **Chat / agentic (local)** | `olimorris/codecompanion.nvim` → Ollama adapter | `@buffers`/`@lsp` chat, inline rewrites — private/offline. Also an **ACP Claude-Code front-end** |
+| Antigravity | terminal/tmux `agy` *(have it)* | No load-bearing nvim plugin yet — see below |
+| Fundamentals | LazyVim `lang.*` extras + Nix LSPs | Solid IDE base under the AI |
+
+**Deliberately excluded:** `avante.nvim` (overlaps Claude Code's diff-apply *and* has a Rust build that's the #1 NixOS pain), Copilot/Supermaven (cloud, not your stack), `gen.nvim`/`ollama.nvim` (superseded by codecompanion).
+
+---
+
+## Plan
+
+### Phase 1 — Local Ollama coding layer (the gap) `M`
+
+**Goal: a private, offline "Copilot + Cursor-lite" running on your own GPU.**
+
+1. **Inline completion — `minuet-ai.nvim`** as a blink.cmp source, `openai_fim_compatible` provider → `http://localhost:11434/v1/completions`, model `qwen2.5-coder:7b`, `max_tokens≈256`, streaming on. Ghost-text completion as you type, fully local.
+   - Add `"minuet"` to `blink.lua` `sources.default`.
+2. **Chat / agentic — `codecompanion.nvim`** with the Ollama adapter (`qwen2.5-coder:14b`, which you already have). Gives `:CodeCompanion` inline rewrites, a chat buffer with `@buffers`/`@lsp` context, and slash-commands. Keymaps under a non-conflicting prefix (e.g. `<leader>o` for "ollama", keeping `<leader>a` = Claude).
+   - **Bonus:** codecompanion also has an **ACP `claude_code` adapter** — optional, lets you drive Claude Code from inside a chat buffer too (one UI for both). Optional; you already have claudecode.nvim for that.
+3. **Pull the FIM model on p620:** `ollama pull qwen2.5-coder:7b` (fast FIM). Keep `:14b` for chat; optionally try `:32b` for heavier chat if ROCm VRAM allows.
+
+**Routing rule (the mental model):** small/private/offline edits + autocomplete → **Ollama**; big multi-file agentic refactors → **Claude Code** (a local 7–14B won't match it). Two keymap families: `<leader>a` Claude, `<leader>o` Ollama.
+
+**Verify:** ghost-text appears from Ollama; `:CodeCompanion` rewrites a selection; Claude `<leader>a` flow unchanged; nvim startup not regressed.
+
+### Phase 2 — Coding fundamentals (tighten, stay lean) `S`
+
+1. **Enable LazyVim `lang.*` extras** for your stack: `lang.rust`, `lang.python`, `lang.go`, `lang.typescript` (you already have nix). These wire LSP + formatter + treesitter per language.
+2. **Keep LSP/formatters Nix-provided** (the Mason-on-NixOS trap): ensure `rust-analyzer`, `pyright`/`ruff`, `gopls`, `typescript-language-server`, `lua-language-server`, plus `stylua`/`alejandra`/`prettierd` come from Nix, and Mason auto-install stays off. (nixd already does this for Nix.)
+3. **`oil.nvim`** as the editable file explorer — it's the surface `claudecode.nvim` (and antigravity-cli.nvim) hook for `@`-mentioning files/dirs into the AI.
+
+### Phase 3 — Antigravity in nvim (honest, low priority) `XS`
+
+There is **no official Google nvim plugin** (Antigravity is a standalone VS Code/Windsurf fork). Options, least-risk first:
+
+1. **Keep `agy` in a terminal/tmux split** (you already launch it from the M-a palette) — robust, no surprises. **Recommended.**
+2. *Optionally* trial the community **`McEazy2700/antigravity-cli.nvim`** (MCP-over-HTTP, native vimdiff) — real but single-maintainer/experimental; don't make it load-bearing.
+3. The **shared `AGENTS.md`** you already shipped means Antigravity, Claude, and Ollama agents share project context regardless.
+
+---
+
+## NixOS strategy (keep it painless)
+
+- **Let lazy.nvim keep managing the plugins** (mutable, fast iteration). `minuet-ai`, `codecompanion`, `claudecode` are **pure Lua, no build step** → just add lazy specs. Provide the *binaries* via Nix (you already have `ollama`/`ollama-rocm`, `claude`, `agy`, `nixd`, blink's prebuilt matcher).
+- **Avoid avante** precisely because its Rust build is the one thing that fights Nix.
+- No new flake inputs needed for Phase 1.
+
+## Open questions for you
+
+1. **Inline completion model:** pull `qwen2.5-coder:7b` (fast, recommended) or reuse `:14b` (slower ghost-text, one fewer model)?
+2. **codecompanion keymaps:** OK to claim `<leader>o` (ollama) so `<leader>a` stays 100% Claude?
+3. Want the **ACP claude_code adapter** in codecompanion too (one chat UI for Claude + Ollama), or keep them separate (claudecode.nvim for Claude, codecompanion for Ollama)?
+
+## Sources
+
+`coder/claudecode.nvim` (+ LazyVim ai.claudecode extra), `milanglacier/minuet-ai.nvim` (Ollama FIM recipe), `olimorris/codecompanion.nvim` (Ollama + ACP adapters), avante-vs-codecompanion 2026 writeup, qwen2.5-coder/codestral/deepseek-coder model rankings, `McEazy2700/antigravity-cli.nvim` (experimental). Full list in the research thread.

--- a/home/shell/lazyvim/lazyvim/lazyvim.json
+++ b/home/shell/lazyvim/lazyvim/lazyvim.json
@@ -1,0 +1,22 @@
+{
+  "extras": [
+    "lazyvim.plugins.extras.ai.claudecode",
+    "lazyvim.plugins.extras.formatting.prettier",
+    "lazyvim.plugins.extras.lang.go",
+    "lazyvim.plugins.extras.lang.json",
+    "lazyvim.plugins.extras.lang.markdown",
+    "lazyvim.plugins.extras.lang.nix",
+    "lazyvim.plugins.extras.lang.python",
+    "lazyvim.plugins.extras.lang.rust",
+    "lazyvim.plugins.extras.lang.typescript",
+    "lazyvim.plugins.extras.ui.dashboard-nvim",
+    "lazyvim.plugins.extras.util.gh",
+    "lazyvim.plugins.extras.util.gitui",
+    "lazyvim.plugins.extras.util.mini-hipatterns"
+  ],
+  "install_version": 7,
+  "news": {
+    "NEWS.md": "11866"
+  },
+  "version": 8
+}

--- a/home/shell/lazyvim/lazyvim/lua/plugins/antigravity.lua
+++ b/home/shell/lazyvim/lazyvim/lua/plugins/antigravity.lua
@@ -1,0 +1,21 @@
+-- Antigravity (agy) in Neovim.
+-- There is no mature nvim plugin for Antigravity (it's a standalone VS Code
+-- fork). The robust path mirrors the Claude Code workflow: launch the `agy`
+-- CLI in a snacks terminal split on <leader>ag. The shared repo-root AGENTS.md
+-- already gives agy the same project context Claude and Ollama get.
+return {
+  {
+    "folke/snacks.nvim",
+    keys = {
+      {
+        "<leader>ag",
+        function()
+          require("snacks").terminal("agy", {
+            win = { position = "right", width = 0.4 },
+          })
+        end,
+        desc = "Antigravity (agy) terminal",
+      },
+    },
+  },
+}

--- a/home/shell/lazyvim/lazyvim/lua/plugins/blink.lua
+++ b/home/shell/lazyvim/lazyvim/lua/plugins/blink.lua
@@ -29,7 +29,17 @@ return {
         nerd_font_variant = "mono",
       },
       sources = {
-        default = { "lsp", "path", "snippets", "buffer" },
+        default = { "lsp", "path", "snippets", "buffer", "minuet" },
+        providers = {
+          -- Local Ollama FIM completion (minuet-ai.nvim → qwen2.5-coder:7b)
+          minuet = {
+            name = "minuet",
+            module = "minuet.blink",
+            async = true,
+            timeout_ms = 4000,
+            score_offset = 50, -- rank AI suggestions above buffer/snippets
+          },
+        },
       },
       completion = {
         accept = { auto_brackets = { enabled = true } },

--- a/home/shell/lazyvim/lazyvim/lua/plugins/codecompanion.lua
+++ b/home/shell/lazyvim/lazyvim/lua/plugins/codecompanion.lua
@@ -1,0 +1,49 @@
+-- Local Ollama chat / inline / agentic edits via CodeCompanion.
+-- Keymaps live under <leader>o ("ollama") so <leader>a stays 100% Claude Code.
+-- Model: qwen2.5-coder:14b (already pulled). OLLAMA_ENDPOINT env overrides host.
+-- Mental model: <leader>o = small/private/offline edits + completion on your own
+-- GPU; <leader>a (Claude Code) = big multi-file agentic refactors.
+return {
+  {
+    "olimorris/codecompanion.nvim",
+    dependencies = {
+      "nvim-lua/plenary.nvim",
+      "nvim-treesitter/nvim-treesitter",
+    },
+    cmd = {
+      "CodeCompanion",
+      "CodeCompanionChat",
+      "CodeCompanionActions",
+      "CodeCompanionCmd",
+    },
+    keys = {
+      { "<leader>o", "", desc = "+ollama (codecompanion)", mode = { "n", "v" } },
+      { "<leader>oo", "<cmd>CodeCompanionActions<cr>", mode = { "n", "v" }, desc = "CodeCompanion actions" },
+      { "<leader>oc", "<cmd>CodeCompanionChat Toggle<cr>", mode = { "n", "v" }, desc = "Toggle Ollama chat" },
+      { "<leader>oi", ":CodeCompanion ", mode = { "n", "v" }, desc = "Inline Ollama prompt" },
+      { "<leader>oa", "<cmd>CodeCompanionChat Add<cr>", mode = "v", desc = "Add selection to chat" },
+    },
+    opts = {
+      adapters = {
+        http = {
+          ollama = function()
+            return require("codecompanion.adapters").extend("ollama", {
+              env = {
+                url = vim.env.OLLAMA_ENDPOINT or "http://localhost:11434",
+              },
+              schema = {
+                model = { default = "qwen2.5-coder:14b" },
+                num_ctx = { default = 16384 },
+              },
+            })
+          end,
+        },
+      },
+      strategies = {
+        chat = { adapter = "ollama" },
+        inline = { adapter = "ollama" },
+        cmd = { adapter = "ollama" },
+      },
+    },
+  },
+}

--- a/home/shell/lazyvim/lazyvim/lua/plugins/mason.lua
+++ b/home/shell/lazyvim/lazyvim/lua/plugins/mason.lua
@@ -1,0 +1,10 @@
+-- NixOS: disable Mason. Mason downloads prebuilt binaries that don't run under
+-- NixOS (no FHS). Every LSP/formatter we use (rust-analyzer, pyright, ruff,
+-- gopls, typescript-language-server, lua-language-server, nixd, stylua,
+-- alejandra, gofmt, prettierd) is provided on PATH via home-manager, and
+-- nvim-lspconfig/conform find them there. This is what lets the lang.* extras
+-- below work without Mason trying (and failing) to install anything.
+return {
+  { "mason-org/mason.nvim", enabled = false },
+  { "mason-org/mason-lspconfig.nvim", enabled = false },
+}

--- a/home/shell/lazyvim/lazyvim/lua/plugins/minuet.lua
+++ b/home/shell/lazyvim/lazyvim/lua/plugins/minuet.lua
@@ -1,0 +1,36 @@
+-- Local Ollama inline completion (Copilot-but-local) via minuet-ai.
+-- FIM model: qwen2.5-coder:7b on the local Ollama (OLLAMA_ENDPOINT env overrides
+-- the host, e.g. http://p620:11434 from a machine without a local daemon).
+-- Surfaces as a blink.cmp source (see blink.lua) so AI suggestions sit in the
+-- normal completion menu alongside LSP — no duplicate ghost-text. Throttled to
+-- keep the local GPU sane.
+return {
+  {
+    "milanglacier/minuet-ai.nvim",
+    dependencies = { "nvim-lua/plenary.nvim" },
+    event = "InsertEnter",
+    config = function()
+      require("minuet").setup({
+        provider = "openai_fim_compatible",
+        n_completions = 1, -- one suggestion → lighter on a local model
+        context_window = 1024,
+        request_timeout = 4,
+        throttle = 1500, -- ms between requests
+        debounce = 600,
+        provider_options = {
+          openai_fim_compatible = {
+            api_key = "TERM", -- dummy; Ollama needs no key
+            name = "Ollama",
+            end_point = (vim.env.OLLAMA_ENDPOINT or "http://localhost:11434") .. "/v1/completions",
+            model = "qwen2.5-coder:7b",
+            stream = true,
+            optional = {
+              max_tokens = 256,
+              top_p = 0.9,
+            },
+          },
+        },
+      })
+    end,
+  },
+}

--- a/home/shell/lazyvim/lazyvim/lua/plugins/oil.lua
+++ b/home/shell/lazyvim/lazyvim/lua/plugins/oil.lua
@@ -1,0 +1,18 @@
+-- oil.nvim — edit the filesystem like a buffer. Kept as a secondary explorer
+-- (not the default) because it's the surface claudecode.nvim hooks for
+-- @-mentioning files/dirs into Claude. `-` opens the parent dir.
+return {
+  {
+    "stevearc/oil.nvim",
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    lazy = false,
+    opts = {
+      default_file_explorer = false, -- leave snacks/neo-tree as the primary tree
+      view_options = { show_hidden = true },
+      skip_confirm_for_simple_edits = false,
+    },
+    keys = {
+      { "-", "<cmd>Oil<cr>", desc = "Open parent dir (oil)" },
+    },
+  },
+}


### PR DESCRIPTION
## Summary

Makes nvim the ideal editor for your Claude/Antigravity/Ollama-only stack. Claude Code (`coder/claudecode.nvim`) was already wired well — this adds the missing **local-Ollama layer** + tightens fundamentals, and removes a stray Codeium plugin.

### Phase 1 — local Ollama
- **minuet-ai.nvim** — inline FIM completion via Ollama **`qwen2.5-coder:7b`**, as a blink.cmp source (throttled). "Copilot but local." `OLLAMA_ENDPOINT` env overrides host.
- **codecompanion.nvim** — chat/inline/agentic via Ollama **`qwen2.5-coder:14b`**, keymaps under **`<leader>o`** (Claude stays on `<leader>a`).

### Phase 2 — fundamentals
- lang extras **python/rust/typescript** added (go/nix/json/markdown/prettier already on); LSPs/formatters from **Nix on PATH**.
- **Mason disabled** (`mason.lua`) — its binaries don't run on NixOS; verified rust-analyzer/pyright/ruff still attach.
- **oil.nvim** as the editable explorer claudecode hooks for `@`-mentions.

### Phase 3 — Antigravity
`<leader>ag` launches `agy` in a snacks terminal split (no mature nvim plugin; shared `AGENTS.md` gives it context).

### Cleanup
Removed the **orphaned `ai.codeium`** extra (you only want Claude/Antigravity/Ollama). `lazyvim.json` is now **declarative in-repo** — manage `:LazyExtras` from the flake, not the UI.

## Testing (p620)
Plugins install + load; FIM endpoint returns completions (`a + b`); rust/python LSPs attach with Mason off; no codeium/config warnings. p620 + razer build.

## Keymaps
`<leader>a*` Claude · `<leader>o*` Ollama chat · `<leader>ag` Antigravity · `-` oil · AI completion appears in the blink menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)