### PR TITLE
chore(claude-code): update native CLI to 2.1.175 (#878)

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -31,7 +31,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.173";
+  version = "2.1.175";
 
   # Claude Code reads clipboard images by shelling out to:
   #   xclip -selection clipboard -t TARGETS -o ... || wl-paste -l ...   (detect)
@@ -63,11 +63,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-z36hlOF0iTL6MPGA6qn1b5pwOdzjcDApiMKSZimyohk=";
+      hash = "sha256-T8cvpgkMmgPxhQ4bHMs9aAa/gCtn48udxfLO1LftXKE=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-zFk9/CY/cH7SIuM0/1wSqa3cJKvCBnaJYvnQY7L9esk=";
+      hash = "sha256-Ng8fb0PsJtm7biDkh79Et1PZuEB+iedL/ut5cHOZ9DU=";
     };
   };
 


### PR DESCRIPTION
## Summary
Bumps `claude-code-native` **2.1.173 → 2.1.175** (Anthropic latest channel). Version + both SRI hashes only.

## Testing
- `nix build .#claude-code-native` → `claude --version` = **2.1.175**, no missing libs
- All three host toplevels build (p620, razer, p510)

Closes #878 · Supersedes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)