### PR TITLE
feat(gnome): declare remaining user-installed extensions

### DIFF
--- a/home/desktop/gnome/extensions.nix
+++ b/home/desktop/gnome/extensions.nix
@@ -43,8 +43,17 @@ in
           "dim-background-windows@stephane-13.github.com"
           "yetanotherradio@io.github.buddysirjava"
           "allowlockedremotedesktop@kamens.us"
-          "claude-code-usage@haletran.com"
+          # Claude Code Usage Monitor — dvdstelt's variant (the one actually
+          # installed). Replaces the older claude-code-usage@haletran.com.
+          "claude-usage@dvdstelt.github.io"
           "otp-keys@osmank3.net"
+          # Added 2026-06 from the user's installed set:
+          "docker-manager@omerfarukgungor"
+          "dynamic-calendar-and-clocks-icons-reborn@thecalamityjoe87.github.com"
+          "notification-configurator@exposedcat"
+          "screencast.extra.feature@wissle.me"
+          "shotzy@SamkitJain660.github.io"
+          "slider-percentages@imdarktom"
           "rudra@narkagni"
           "spotify-controller@narkagni"
           "accent-directories@taiwbi.com"
@@ -125,11 +134,17 @@ in
         gnomeExtensions.dim-background-windows
         gnomeExtensions.yet-another-radio
         gnomeExtensions.clipboard-indicator
+        gnomeExtensions.notification-configurator
+        gnomeExtensions.shotzy
+        gnomeExtensions.screencast-extra-feature
 
         # Manually-packaged extensions (extensions.gnome.org pinned ZIPs,
         # see pkgs/gnome-ext-*). Not in nixpkgs.
         gnome-ext-allow-locked-remote-desktop
-        gnome-ext-claude-code-usage
+        gnome-ext-claude-usage-dvdstelt
+        gnome-ext-docker-manager
+        gnome-ext-slider-percentages
+        gnome-ext-dynamic-calendar-reborn
         gnome-ext-otp-keys
         gnome-ext-rudra
         gnome-ext-spotify-controller

--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -36,6 +36,10 @@ final: _prev: {
   gnome-ext-spotify-controller = final.callPackage ../pkgs/gnome-ext-spotify-controller { };
   gnome-ext-accent-directories = final.callPackage ../pkgs/gnome-ext-accent-directories { };
   gnome-ext-allow-locked-remote-desktop = final.callPackage ../pkgs/gnome-ext-allow-locked-remote-desktop { };
+  gnome-ext-docker-manager = final.callPackage ../pkgs/gnome-ext-docker-manager { };
+  gnome-ext-slider-percentages = final.callPackage ../pkgs/gnome-ext-slider-percentages { };
+  gnome-ext-dynamic-calendar-reborn = final.callPackage ../pkgs/gnome-ext-dynamic-calendar-reborn { };
+  gnome-ext-claude-usage-dvdstelt = final.callPackage ../pkgs/gnome-ext-claude-usage-dvdstelt { };
   # gnome-ext-forge — pinned to master commit (see pkgs/gnome-ext-forge
   # for rationale). Source-of-truth for UUID + version is the metadata.json
   # baked into the upstream commit we pin.

--- a/pkgs/gnome-ext-claude-usage-dvdstelt/default.nix
+++ b/pkgs/gnome-ext-claude-usage-dvdstelt/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, unzip
+, glib
+}:
+# Claude Code Usage Monitor (dvdstelt's variant — claude-usage@dvdstelt.github.io).
+# This is the one actually installed; it replaces the older
+# claude-code-usage@haletran.com (gnome-ext-claude-code-usage).
+stdenvNoCC.mkDerivation rec {
+  pname = "gnome-ext-claude-usage-dvdstelt";
+  version = "5";
+  uuid = "claude-usage@dvdstelt.github.io";
+
+  src = fetchurl {
+    url = "https://extensions.gnome.org/extension-data/claude-usagedvdstelt.github.io.v${version}.shell-extension.zip";
+    sha256 = "15138qmh8j814nj6n853f65f8vla1v5qkh95yy60ybhnlnh5jd2h";
+  };
+
+  nativeBuildInputs = [ unzip glib ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -d "$out/share/gnome-shell/extensions/${uuid}"
+    unzip -q "$src" -d "$out/share/gnome-shell/extensions/${uuid}"
+    if [ -d "$out/share/gnome-shell/extensions/${uuid}/schemas" ]; then
+      glib-compile-schemas "$out/share/gnome-shell/extensions/${uuid}/schemas"
+    fi
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Show Claude Code token/usage stats in the GNOME top panel";
+    homepage = "https://github.com/dvdstelt/claude-usage";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/gnome-ext-docker-manager/default.nix
+++ b/pkgs/gnome-ext-docker-manager/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, unzip
+, glib
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "gnome-ext-docker-manager";
+  version = "1";
+  uuid = "docker-manager@omerfarukgungor";
+
+  src = fetchurl {
+    url = "https://extensions.gnome.org/extension-data/docker-manageromerfarukgungor.v${version}.shell-extension.zip";
+    sha256 = "1gfxxh4qvkf7cgljb0vfj6n10hbk45srlrlmbpic4ymbnkkj7prk";
+  };
+
+  nativeBuildInputs = [ unzip glib ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -d "$out/share/gnome-shell/extensions/${uuid}"
+    unzip -q "$src" -d "$out/share/gnome-shell/extensions/${uuid}"
+    if [ -d "$out/share/gnome-shell/extensions/${uuid}/schemas" ]; then
+      glib-compile-schemas "$out/share/gnome-shell/extensions/${uuid}/schemas"
+    fi
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Manage Docker containers from the GNOME top panel";
+    homepage = "https://github.com/omerfarukgungor/docker-manager";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/gnome-ext-dynamic-calendar-reborn/default.nix
+++ b/pkgs/gnome-ext-dynamic-calendar-reborn/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, unzip
+, glib
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "gnome-ext-dynamic-calendar-reborn";
+  version = "6";
+  uuid = "dynamic-calendar-and-clocks-icons-reborn@thecalamityjoe87.github.com";
+
+  src = fetchurl {
+    url = "https://extensions.gnome.org/extension-data/dynamic-calendar-and-clocks-icons-rebornthecalamityjoe87.github.com.v${version}.shell-extension.zip";
+    sha256 = "05ba4h6ysp9zca567dss3qfphrn69x1qbcsi25fkhr78gyfhwazj";
+  };
+
+  nativeBuildInputs = [ unzip glib ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -d "$out/share/gnome-shell/extensions/${uuid}"
+    unzip -q "$src" -d "$out/share/gnome-shell/extensions/${uuid}"
+    if [ -d "$out/share/gnome-shell/extensions/${uuid}/schemas" ]; then
+      glib-compile-schemas "$out/share/gnome-shell/extensions/${uuid}/schemas"
+    fi
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Dynamic date/clock/weather panel icons that update live (Reborn fork)";
+    homepage = "https://github.com/thecalamityjoe87/dynamic-calendar-and-clocks-icons-reborn";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/gnome-ext-slider-percentages/default.nix
+++ b/pkgs/gnome-ext-slider-percentages/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, unzip
+, glib
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "gnome-ext-slider-percentages";
+  version = "1";
+  uuid = "slider-percentages@imdarktom";
+
+  src = fetchurl {
+    url = "https://extensions.gnome.org/extension-data/slider-percentagesimdarktom.v${version}.shell-extension.zip";
+    sha256 = "15n2y7cqpq73zdgrlnac37nbhmh5vc05pxhvlmmanawbzlcnn8kr";
+  };
+
+  nativeBuildInputs = [ unzip glib ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -d "$out/share/gnome-shell/extensions/${uuid}"
+    unzip -q "$src" -d "$out/share/gnome-shell/extensions/${uuid}"
+    if [ -d "$out/share/gnome-shell/extensions/${uuid}/schemas" ]; then
+      glib-compile-schemas "$out/share/gnome-shell/extensions/${uuid}/schemas"
+    fi
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Show percentage labels on GNOME quick-settings sliders";
+    homepage = "https://github.com/imdarktom/slider-percentages";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
Brings the hand-installed GNOME extensions under declarative management (installed + enabled). 3 from nixpkgs (notification-configurator, shotzy, screencast-extra-feature), 3 custom-packaged from EGO zips (docker-manager, slider-percentages, dynamic-calendar-reborn), and swaps the Claude usage monitor to the installed dvdstelt variant. Verified on p620: all 11 installed + enabled in dconf; all hosts build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)