### PR TITLE
fix(p620): give Libation webkitgtk so the Audible login WebView works

### DIFF
--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -63,6 +63,15 @@
     # confinement, CEF rendering). Native GNOME alternative to
     # cosmic-utils/web-apps.
     inputs.gnome-quick-web-apps.packages.${pkgs.system}.default
+
+    # Libation — Audible library downloader/DRM-decrypter. Books location is set
+    # to /mnt/media/Media/Audiobooks (P510 ABS library, NFS-mounted here) so
+    # decrypted m4b land straight in Audiobookshelf. nixpkgs wraps it without
+    # webkitgtk, so the Avalonia login/setup WebView crashes with "Unable to
+    # initialize GTK"; add the gtk3-ABI webkit (4.1) back to its runtime libs.
+    (pkgs.libation.overrideAttrs (old: {
+      dotnetRuntimeDeps = (old.dotnetRuntimeDeps or [ ]) ++ [ pkgs.webkitgtk_4_1 ];
+    }))
   ];
 
   # Optional: Add additional packages to the Windsurf environment


### PR DESCRIPTION
nixpkgs wraps libation (buildDotnetModule) with gtk3 + glib but omits
WebKitGTK, so Avalonia's login/setup WebView crashes at startup with
"Unable to initialize GTK" (Source: Avalonia.Controls.WebView; cf.
upstream issue #1598). Append webkitgtk_4_1 (gtk3-ABI WebKit) to the
package's dotnetRuntimeDeps — the env var the dotnet wrapper actually
reads to build LD_LIBRARY_PATH — so libwebkit2gtk-4.1.so is on the path.

Verified: live wrapper carries the webkit store path, the .so resolves,
and Libation launches clean with Books -> /mnt/media/Media/Audiobooks
(the P510 Audiobookshelf library, NFS-mounted).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
