### PR TITLE
chore(ollama): drop stale nixpkgs-ollama surgical pin (#784)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -963,22 +963,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-ollama": {
-      "locked": {
-        "lastModified": 1780615177,
-        "narHash": "sha256-Xr+OvVyOkESPtnTOARUvOo2aZkqrKfyYvQgCSCSfLw0=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "bba51cb2479b7a23134f69b932811df999b892e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "bba51cb2",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1780902259,
@@ -1301,7 +1285,6 @@
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_8",
         "nixpkgs-f2k": "nixpkgs-f2k",
-        "nixpkgs-ollama": "nixpkgs-ollama",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur",
         "rust-overlay": "rust-overlay_4",

--- a/flake.nix
+++ b/flake.nix
@@ -32,14 +32,6 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
 
-    # Surgical pin for ollama 0.30.5 — nixos-unstable channel still ships
-    # 0.24.0 (Hydra hasn't blessed the bump yet) but master has had it
-    # since 2026-06-04 (commit bba51cb2 = 0.30.5 + darwin fix). Used by
-    # overlays/default.nix to override ONLY ollama-rocm / ollama-cuda;
-    # nothing else evaluates against this input. Remove when nixos-unstable
-    # catches up (verify with: `nix eval --raw nixpkgs-unstable#ollama-rocm.version`).
-    # See #784 for tracking.
-    nixpkgs-ollama.url = "github:NixOS/nixpkgs/bba51cb2";
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
     flake-utils.url = "github:numtide/flake-utils";
 

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -18,23 +18,6 @@
     cosmic-applet-spotify = inputs.cosmic-applet-spotify.packages.${prev.stdenv.hostPlatform.system}.default;
   })
 
-  # ollama 0.30.5 from a pinned master rev — nixos-unstable still on
-  # 0.24.0. Only ollama-rocm + ollama-cuda are overridden so the rest of
-  # the closure stays on our pinned nixos-unstable. Remove this overlay
-  # (and the nixpkgs-ollama flake input) once nixos-unstable advances
-  # past 0.30.5. See #784.
-  (_final: prev:
-    let
-      ollamaPkgs = import inputs.nixpkgs-ollama {
-        inherit (prev.stdenv.hostPlatform) system;
-        config.allowUnfree = true;
-      };
-    in
-    {
-      ollama-rocm = ollamaPkgs.ollama-rocm;
-      ollama-cuda = ollamaPkgs.ollama-cuda;
-    })
-
   # Rust toolchain overlay — exposes `rust-bin.*` on `final` so packages
   # that need a newer rustc than nixpkgs ships (e.g. splashboard) can
   # build with `makeRustPlatform`. Doesn't replace the default `rustc`.


### PR DESCRIPTION
## Summary

The `nixpkgs-ollama` surgical pin (rev `bba51cb2` → ollama-rocm 0.30.5) is no longer needed. nixos-unstable has caught up and **surpassed** it — the channel now ships **ollama-rocm 0.30.6**.

This removes:
- the `nixpkgs-ollama` flake input (+ its explanatory comment) in `flake.nix`
- the overlay in `overlays/default.nix` that overrode `ollama-rocm`/`ollama-cuda` against the pinned input
- the now-orphaned `nixpkgs-ollama` node in `flake.lock` (auto-reconciled)

The ollama service consumes `pkgs.ollama-rocm`, which now transparently resolves to the channel package — no consumer change required.

## Testing

- ✅ `just check-syntax` — all Nix files valid
- ✅ `just test-host p620` — full system derivation built
- ✅ `nix eval .#nixosConfigurations.p620.pkgs.ollama-rocm.version` → **0.30.6** (up from pinned 0.30.5)
- ✅ Other overlays unaffected (clblast cmake4 patch still applied)

Net: **42 deletions, 0 additions** — pure removal. One fewer flake input.

Relates to #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)