### PR TITLE
fix(mesa): pin mesa to 26.1.1 to stop amdgpu GBM gnome-shell crash

### DIFF
--- a/overlays/upstream-fixes.nix
+++ b/overlays/upstream-fixes.nix
@@ -13,6 +13,24 @@ _final: prev: {
       (oldAttrs.patches or [ ]);
   });
 
+  # mesa 26.1.2 regressed the GBM back-buffer path: gnome-shell/mutter on
+  # amdgpu segfaults in gbm_bo_destroy (reached via get_back_bo during
+  # eglMakeCurrent / frame presentation). mesa 26.1.1 + libgbm 26.0.3 ran
+  # crash-free for weeks; the 26.1.1 -> 26.1.2 bump (nixpkgs 14dbea35565,
+  # 2026-06-03) is the regression. Revert mesa to 26.1.1 against current
+  # build deps; libgbm stays 26.0.3 (unchanged, matching the known-good combo).
+  # Remove once a fixed mesa (>= 26.1.3) lands upstream.
+  mesa = prev.mesa.overrideAttrs (_old: {
+    version = "26.1.1";
+    src = prev.fetchFromGitLab {
+      domain = "gitlab.freedesktop.org";
+      owner = "mesa";
+      repo = "mesa";
+      rev = "mesa-26.1.1";
+      hash = "sha256-OmhBmBGR12Tl+5msiyL8lYQ3XYcDYCqUUjQObEqjytI=";
+    };
+  });
+
   # nixpkgs-unstable ships nix-prefetch-git as `nix-prefetch-git-VERSION`,
   # breaking fetchCargoVendor which calls the binary by its short name.
   # Symlink the short name to the versioned binary.


### PR DESCRIPTION
## Problem

gnome-shell/mutter on p620 (amdgpu) repeatedly segfaults — 3 crashes in 4 days, accelerating to twice in ~1.5h. Each crash restarts the GNOME session.

Symbolized coredump backtrace:
```
#0  gbm_bo_destroy             (libgbm 26.0.3)
#1  get_back_bo                (mesa 26.1.2 / libEGL_mesa)
#2  dri2_drm_image_get_buffers
#4  dri2_allocate_textures     (libgallium 26.1.2)
#11 eglMakeCurrent
#13 _cogl_winsys_egl_make_current (mutter 50.1)
#15 maybe_post_next_frame
```

## Root cause

Generation history: `mesa 26.1.1` + `libgbm 26.0.3` ran crash-free for weeks. Crashes began only after the running system picked up **mesa 26.1.2** (nixpkgs bump `14dbea35565`, 2026-06-03). `libgbm` has been 26.0.3 throughout — so **mesa 26.1.2 is the regression**, not a version skew. Both nixos-unstable and master still ship 26.1.2, so a plain flake bump won't fix it.

## Fix

Revert `mesa` to 26.1.1 via `overrideAttrs` against current build deps (libgbm stays 26.0.3 = the known-good combo). Most GUI apps link libglvnd and load the driver at runtime, so only mesa's direct dependents rebuild.

## Testing

- ✅ `just check-syntax`
- ✅ `just test-host p620` — builds clean (exit 0)
- ✅ `pkgs.mesa.version` → 26.1.1, `pkgs.libgbm.version` → 26.0.3
- Profiles/generations untouched (overlay rebuild, not a rollback)

Remove this overlay once a fixed mesa (>= 26.1.3) lands upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)