### PR TITLE
chore(claude-desktop): update to v2.0.19+claude1.11847.5 (#850)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,17 +116,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1780710221,
-        "narHash": "sha256-UWuDKE1O1PeKnlNzAGmRREwOOZR6F+cOYOiFT7o2KoM=",
+        "lastModified": 1781050920,
+        "narHash": "sha256-ud0qBit9mUAIVvhfXEgatq4PNASe6nhicwHMmW5Jlpo=",
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "d99cdbd0e054fc04eb2ccfaf31777f11e89416c3",
+        "rev": "f56421294d46f5db61fba0f833215d18d8c7fa2f",
         "type": "github"
       },
       "original": {
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "d99cdbd0e054fc04eb2ccfaf31777f11e89416c3",
+        "rev": "f56421294d46f5db61fba0f833215d18d8c7fa2f",
         "type": "github"
       }
     },
@@ -1058,11 +1058,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1780030872,
-        "narHash": "sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL+WNQD0rJfJZQ=",
+        "lastModified": 1780747962,
+        "narHash": "sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1+j+MRChI3TL4tAA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e9a7635a57597d9754eccebdfc7045e6c8600e6b",
+        "rev": "cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -84,10 +84,11 @@
     # Workaround: close claude-desktop entirely to release inhibitor,
     # or set CLAUDE_KEEP_AWAKE=0 (#645).
     # Bump via /update-claude-code.
-    # = tag v2.0.18+claude1.11187.4 (commit d99cdbd0e0, 2026-06-06)
-    # Delta from previous pin: bubblewrap added to FHS targetPkgs for cowork
-    # sandbox + Claude binary URLs bumped to 1.11187.4.
-    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/d99cdbd0e054fc04eb2ccfaf31777f11e89416c3";
+    # = tag v2.0.19+claude1.11847.5 (commit f56421294d, 2026-06-12)
+    # Delta from previous pin: AppArmor profiles for Ubuntu 24.04+ user
+    # namespaces, GPU-crash auto-recovery, software-center AppStream metainfo,
+    # no more app.asar open prompt; tracks Claude Desktop 1.11847.5.
+    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/f56421294d46f5db61fba0f833215d18d8c7fa2f";
 
     # Claude Code skill catalogue (borghei). flake = false because it's a
     # plain markdown/assets catalogue, not a Nix flake. We symlink one


### PR DESCRIPTION
Bump claude-desktop-linux input d99cdbd0e0 -> f56421294d
(tag v2.0.19+claude1.11847.5, tracks Claude Desktop 1.11847.5).

Notable upstream changes: AppArmor profiles for Ubuntu 24.04+ user
namespaces, GPU-crash auto-recovery, software-center AppStream metainfo,
no more app.asar open prompt, cleaner quit/helper teardown.

Our overlay is a plain passthrough of claude-desktop-fhs (no node-pty sed
to revalidate). Verified: p620 + razer toplevels build.

Closes #850

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
