### PR TITLE
feat(desktop): add niri + labwc as selectable login sessions (Phase 1)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -244,7 +244,7 @@
     "emacs": {
       "inputs": {
         "nixpkgs": "nixpkgs_10",
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
         "lastModified": 1781324653,
@@ -820,6 +820,64 @@
         "type": "github"
       }
     },
+    "niri-flake": {
+      "inputs": {
+        "niri-stable": "niri-stable",
+        "niri-unstable": "niri-unstable",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable",
+        "xwayland-satellite-stable": "xwayland-satellite-stable",
+        "xwayland-satellite-unstable": "xwayland-satellite-unstable"
+      },
+      "locked": {
+        "lastModified": 1781234038,
+        "narHash": "sha256-jo4a47qDgsx1F1i0MtHZl12FfzqKJOES25vbm0ZUxeI=",
+        "owner": "sodiboo",
+        "repo": "niri-flake",
+        "rev": "eb5789cba8d37802d330df5a13c691622c83121f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sodiboo",
+        "repo": "niri-flake",
+        "type": "github"
+      }
+    },
+    "niri-stable": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1756556321,
+        "narHash": "sha256-RLD89dfjN0RVO86C/Mot0T7aduCygPGaYbog566F0Qo=",
+        "owner": "YaLTeR",
+        "repo": "niri",
+        "rev": "01be0e65f4eb91a9cd624ac0b76aaeab765c7294",
+        "type": "github"
+      },
+      "original": {
+        "owner": "YaLTeR",
+        "ref": "v25.08",
+        "repo": "niri",
+        "type": "github"
+      }
+    },
+    "niri-unstable": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780938415,
+        "narHash": "sha256-QHyIMGSbCQW8d5qbOrMsm6gem10bO3Au2YLa3alJfHo=",
+        "owner": "YaLTeR",
+        "repo": "niri",
+        "rev": "6f1a2c5f0e8274223d4204b1f8d6f7f91538967e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "YaLTeR",
+        "repo": "niri",
+        "type": "github"
+      }
+    },
     "nix-index-database": {
       "inputs": {
         "nixpkgs": [
@@ -1001,6 +1059,22 @@
       }
     },
     "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1780952837,
+        "narHash": "sha256-Fwd1+spDtQ0hDyBwme6ufG3n4mY0UrjjFdYHv+G/Hds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e820eb4a444b46a19b2e03e8dfd2359439ff30fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
       "locked": {
         "lastModified": 1780902259,
         "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
@@ -1334,6 +1408,7 @@
         "lanzaboote": "lanzaboote",
         "mcp-nixos": "mcp-nixos",
         "microvm": "microvm",
+        "niri-flake": "niri-flake",
         "nix-index-database": "nix-index-database",
         "nix-snapd": "nix-snapd",
         "nixos-hardware": "nixos-hardware",
@@ -1769,6 +1844,39 @@
       "original": {
         "owner": "tinted-theming",
         "repo": "base16-zed",
+        "type": "github"
+      }
+    },
+    "xwayland-satellite-stable": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755491097,
+        "narHash": "sha256-m+9tUfsmBeF2Gn4HWa6vSITZ4Gz1eA1F5Kh62B0N4oE=",
+        "owner": "Supreeeme",
+        "repo": "xwayland-satellite",
+        "rev": "388d291e82ffbc73be18169d39470f340707edaa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Supreeeme",
+        "ref": "v0.7",
+        "repo": "xwayland-satellite",
+        "type": "github"
+      }
+    },
+    "xwayland-satellite-unstable": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781226823,
+        "narHash": "sha256-28696iIw8uE0ZUyFTtzhEM8xMh85clCYypMxkvUi+sc=",
+        "owner": "Supreeeme",
+        "repo": "xwayland-satellite",
+        "rev": "8575d0ef55d70f9b4c46b6bffb3accf912217e1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Supreeeme",
+        "repo": "xwayland-satellite",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,15 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # niri — scrollable-tiling Wayland compositor. niri-flake provides the
+    # NixOS module (programs.niri) + the home-manager config option
+    # (programs.niri.settings). We pin the package to pkgs.niri (nixpkgs) and
+    # disable niri-flake's binary cache, so no extra substituter/rebuild dance.
+    niri-flake = {
+      url = "github:sodiboo/niri-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # Development and utilities
     sops-nix = {
       url = "github:mic92/sops-nix";
@@ -260,6 +269,7 @@
               inputs.nix-snapd.nixosModules.default
               inputs.agenix.nixosModules.default
               inputs.lanzaboote.nixosModules.lanzaboote
+              inputs.niri-flake.nixosModules.niri
               nix-index-database.nixosModules.nix-index
               ./home/shell/zellij/zjstatus.nix
             ]

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -353,6 +353,11 @@ in
   # the option path is `desktop.displayManager`, not `features.desktop.displayManager`.
   desktop.displayManager.backend = "gdm";
 
+  # Phase 1: niri + labwc as selectable login sessions (alongside GNOME).
+  # Login manager stays GDM for now; greetd/Noctalia greeter is a later phase.
+  desktop.niri.enable = true;
+  desktop.labwc.enable = true;
+
   # Citrix Workspace for client project remote access
   # Disabled — no longer needed. Module + overlay + package retained so this
   # can be flipped back to true without re-installing anything.

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -294,6 +294,11 @@ in
   # works there; not here.
   desktop.displayManager.backend = "gdm";
 
+  # Phase 1: niri + labwc as selectable login sessions (alongside GNOME).
+  # Login manager stays GDM for now; greetd/Noctalia greeter is a later phase.
+  desktop.niri.enable = true;
+  desktop.labwc.enable = true;
+
   # GDM greeter visual baseline — dark colour scheme + 24h clock so it
   # doesn't render as a near-blank Adwaita-light surface over RDP.
   programs.dconf.profiles.gdm.databases = [{

--- a/modules/desktop/default.nix
+++ b/modules/desktop/default.nix
@@ -3,6 +3,8 @@
     ./display-manager.nix
     ./gnome-remote-desktop.nix
     ./cosmic-remote-desktop.nix
+    ./niri.nix
+    ./labwc.nix
   ];
 
   # Make sure the adwaita-qt packages are installed

--- a/modules/desktop/labwc.nix
+++ b/modules/desktop/labwc.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+# labwc — stacking (Openbox-like) Wayland compositor, exposed as a selectable
+# login session. nixpkgs' labwc ships no wayland-sessions/*.desktop, so we
+# generate one and register it via services.displayManager.sessionPackages
+# (same mechanism the COSMIC greeter wiring on razer relies on). A usable
+# default config + the Noctalia shell land in a later phase.
+let
+  inherit (lib) mkEnableOption mkIf;
+  cfg = config.desktop.labwc;
+
+  # services.displayManager.sessionPackages requires the package to declare
+  # passthru.providedSessions matching the .desktop basename ("labwc").
+  labwcSession = (pkgs.writeTextFile {
+    name = "labwc-wayland-session";
+    destination = "/share/wayland-sessions/labwc.desktop";
+    text = ''
+      [Desktop Entry]
+      Name=labwc
+      Comment=Openbox-like stacking Wayland compositor
+      Exec=labwc
+      Type=Application
+    '';
+  }).overrideAttrs (_: { passthru.providedSessions = [ "labwc" ]; });
+in
+{
+  options.desktop.labwc.enable =
+    mkEnableOption "labwc stacking Wayland compositor (selectable login session)";
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.labwc ];
+
+    # Make greetd/GDM list "labwc" as a session.
+    services.displayManager.sessionPackages = [ labwcSession ];
+  };
+}

--- a/modules/desktop/niri.nix
+++ b/modules/desktop/niri.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+# niri — scrollable-tiling Wayland compositor, exposed as a selectable login
+# session. The niri-flake NixOS module (programs.niri) is wired in flake.nix;
+# this feature module just turns it on with the nixpkgs package and registers
+# the session. Shell/keybind refinement (Noctalia) lands in a later phase.
+let
+  inherit (lib) mkEnableOption mkIf;
+  cfg = config.desktop.niri;
+in
+{
+  options.desktop.niri.enable =
+    mkEnableOption "niri scrollable-tiling Wayland compositor (selectable login session)";
+
+  config = mkIf cfg.enable {
+    # Use the nixpkgs niri package and skip niri-flake's binary cache, so we
+    # don't add an extra trusted substituter or need the cache-then-enable
+    # rebuild dance documented upstream.
+    niri-flake.cache.enable = false;
+
+    programs.niri = {
+      enable = true;
+      package = pkgs.niri;
+    };
+
+    # programs.niri installs share/wayland-sessions/niri.desktop automatically,
+    # so greetd/GDM list "niri" at login. Minimal runtime deps for a usable
+    # bare session before the Noctalia shell phase.
+    environment.systemPackages = with pkgs; [
+      xwayland-satellite # rootless Xwayland for niri
+    ];
+  };
+}


### PR DESCRIPTION
First phase of the Noctalia rollout: make niri (scrollable-tiling) and
labwc (Openbox-like stacking) available as Wayland sessions alongside
GNOME, without touching the login manager (GDM stays).

- flake: add niri-flake input (programs.niri module); pin to pkgs.niri and
  disable niri-flake's binary cache (no extra substituter/rebuild dance)
- modules/desktop/niri.nix: feature flag desktop.niri.enable → programs.niri
  + xwayland-satellite; registers niri.desktop automatically
- modules/desktop/labwc.nix: feature flag desktop.labwc.enable → labwc pkg +
  a generated wayland-sessions/labwc.desktop (nixpkgs ships none) registered
  via sessionPackages with passthru.providedSessions
- enable both on p620 + razer

Verified: wayland-sessions/ lists niri.desktop + labwc.desktop; all three
hosts build. Shell (Noctalia) and greetd/greeter are later phases.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
