### PR TITLE
feat(desktop): Noctalia shell on niri + labwc sessions (Phase 2)

### DIFF
--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -5,6 +5,7 @@
 }: {
   imports = [
     ./profile.nix
+    ../../home/desktop/noctalia # Noctalia shell for niri/labwc sessions
   ];
 
   desktop.gnome.profile = "workstation";

--- a/Users/olafkfreund/razer_home.nix
+++ b/Users/olafkfreund/razer_home.nix
@@ -7,7 +7,10 @@ let
   vars = import ../../hosts/razer/variables.nix { };
 in
 {
-  imports = [ ./profile.nix ];
+  imports = [
+    ./profile.nix
+    ../../home/desktop/noctalia # Noctalia shell for niri/labwc sessions
+  ];
 
   desktop.gnome.profile = "laptop";
 

--- a/flake.lock
+++ b/flake.lock
@@ -1307,6 +1307,26 @@
         "type": "github"
       }
     },
+    "noctalia": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781385467,
+        "narHash": "sha256-qAYdp4q4NXBUSma0WE4Qx3tQD/NTaz3Z2ZSop3U5RGE=",
+        "owner": "noctalia-dev",
+        "repo": "noctalia",
+        "rev": "90c91f2f19ad5c16eb5f7042d9cdd88875a279dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noctalia-dev",
+        "repo": "noctalia",
+        "type": "github"
+      }
+    },
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_4",
@@ -1415,6 +1435,7 @@
         "nixpkgs": "nixpkgs_9",
         "nixpkgs-f2k": "nixpkgs-f2k",
         "nixpkgs-unstable": "nixpkgs-unstable",
+        "noctalia": "noctalia",
         "nur": "nur",
         "rust-overlay": "rust-overlay_4",
         "sops-nix": "sops-nix",

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,16 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # Noctalia — Quickshell-based Wayland desktop shell (bar, launcher,
+    # notifications, lock). Used on niri + labwc (not GNOME). homeModules.default
+    # provides programs.noctalia. Follows nixpkgs: the package is a light QML
+    # wrapper over pkgs.quickshell (already cached in nixpkgs), so this avoids
+    # duplicating the Qt closure and needs no extra cachix.
+    noctalia = {
+      url = "github:noctalia-dev/noctalia";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # niri — scrollable-tiling Wayland compositor. niri-flake provides the
     # NixOS module (programs.niri) + the home-manager config option
     # (programs.niri.settings). We pin the package to pkgs.niri (nixpkgs) and
@@ -291,6 +301,9 @@
                     {
                       stylix.targets.firefox.enable = false;
                     }
+                    # Noctalia shell (programs.noctalia). Enabled per-user only
+                    # where the niri/labwc home profile turns it on.
+                    inputs.noctalia.homeModules.default
                   ];
                   extraSpecialArgs = {
                     pkgs-unstable = import nixpkgs-unstable (mkPkgs nixpkgs-unstable system);

--- a/home/desktop/noctalia/default.nix
+++ b/home/desktop/noctalia/default.nix
@@ -1,0 +1,33 @@
+{ lib, ... }:
+# Noctalia desktop shell (bar, launcher, notifications, lock) for the niri and
+# labwc sessions. Deliberately NOT using programs.noctalia.systemd.enable: that
+# service binds to the graphical-session target, which GNOME also reaches, so it
+# would spawn a second shell on top of gnome-shell. Instead we launch noctalia
+# only from the niri/labwc startup hooks, so it runs solely under those sessions.
+#
+# Theming: builtin Catppuccin for now. TODO (fast-follow): bridge Stylix's
+# base16 palette into programs.noctalia.customPalettes + theme.source="custom".
+{
+  programs.noctalia = {
+    enable = true;
+    systemd.enable = false;
+    settings = {
+      shell.font = "JetBrainsMono Nerd Font";
+      theme = {
+        mode = "dark";
+        source = "builtin";
+        builtin = "Catppuccin";
+      };
+    };
+  };
+
+  # niri: launch the shell at session start (inherits the niri session env).
+  programs.niri.settings.spawn-at-startup = lib.mkAfter [
+    { command = [ "noctalia" ]; }
+  ];
+
+  # labwc: launch the shell from its autostart hook.
+  xdg.configFile."labwc/autostart".text = ''
+    noctalia &
+  '';
+}


### PR DESCRIPTION
Add Noctalia (Quickshell desktop shell: bar, launcher, notifications,
lock) for the niri and labwc sessions on p620 + razer.

- flake: add noctalia input (follows nixpkgs — package is a light QML
  wrapper over pkgs.quickshell, already cached; no extra cachix needed) +
  wire noctalia.homeModules.default into home-manager sharedModules
- home/desktop/noctalia: programs.noctalia enabled with builtin Catppuccin
  theme; systemd service DISABLED on purpose (it binds to graphical-session,
  which GNOME also reaches → would spawn a second shell over gnome-shell).
  Instead launch noctalia only from niri spawn-at-startup and labwc autostart,
  so it runs solely under those sessions.
- import the module in p620 + razer homes

noctalia's own 'config validate' runs at build and passed. All three hosts
build. TODO fast-follow: bridge Stylix base16 -> noctalia custom palette
(currently builtin Catppuccin).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
