### PR TITLE
fix(labwc): set UK (gb) keyboard layout via labwc environment file

### DIFF
--- a/home/desktop/noctalia/default.nix
+++ b/home/desktop/noctalia/default.nix
@@ -30,4 +30,11 @@
   xdg.configFile."labwc/autostart".text = ''
     noctalia &
   '';
+
+  # labwc keyboard layout. wlroots compositors don't inherit the system
+  # xkb.layout (gb, set in hosts/common/nixos/i18n.nix); labwc reads XKB_*
+  # from ~/.config/labwc/environment at startup, before keyboard init.
+  xdg.configFile."labwc/environment".text = ''
+    XKB_DEFAULT_LAYOUT=gb
+  '';
 }


### PR DESCRIPTION
wlroots compositors don't inherit the system xkb.layout (gb, from
hosts/common/nixos/i18n.nix). Add ~/.config/labwc/environment with
XKB_DEFAULT_LAYOUT=gb so labwc uses the UK layout at startup.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
