### PR TITLE
feat(desktop): niri borders/screenshots/recording, Noctalia greeter+gruvbox, ddcutil

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -709,11 +709,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781305496,
-        "narHash": "sha256-g8Vv4Qfc7n+lgov97REu3X6BeJtvYY0hlSUZR1GrGQQ=",
+        "lastModified": 1781365335,
+        "narHash": "sha256-zqDBhXMzfbdlO7F2bGHe7MOtB3xngd/+4ieMHDC+ZXo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c87a39aa979acc4848016d2220c6238390d84779",
+        "rev": "5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c",
         "type": "github"
       },
       "original": {
@@ -807,11 +807,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1780588968,
-        "narHash": "sha256-zQk+GqLO+T9taIl1UUt3swvaOksWJxL7PL8K0+Fc/Hs=",
+        "lastModified": 1781389237,
+        "narHash": "sha256-Ne1/E5XNUq0gleaQz0vW5R4xf/0h/uEZ+bOW1aNjeQk=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "4d3fb17437944ea57eef2b9e6108ca777b1209ca",
+        "rev": "6ad601df0a07d9855c5e8f9b81135ecaf7c287eb",
         "type": "github"
       },
       "original": {
@@ -1314,16 +1314,36 @@
         ]
       },
       "locked": {
-        "lastModified": 1781385467,
-        "narHash": "sha256-qAYdp4q4NXBUSma0WE4Qx3tQD/NTaz3Z2ZSop3U5RGE=",
+        "lastModified": 1781400232,
+        "narHash": "sha256-get3TXhQqCDVNIX6gGS/U2LVcoY37nfJuG00a2cwLrs=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "90c91f2f19ad5c16eb5f7042d9cdd88875a279dc",
+        "rev": "f0b49926114219600df9583d84594de55f8c83d0",
         "type": "github"
       },
       "original": {
         "owner": "noctalia-dev",
         "repo": "noctalia",
+        "type": "github"
+      }
+    },
+    "noctalia-greeter": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781432335,
+        "narHash": "sha256-+CW0yjC1Wr1vnDSwuvVIawBiYqLH/IpqXM/KKVgOVG4=",
+        "owner": "noctalia-dev",
+        "repo": "noctalia-greeter",
+        "rev": "4787940eb8f768fba824dd6327acd47d54eae4b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noctalia-dev",
+        "repo": "noctalia-greeter",
         "type": "github"
       }
     },
@@ -1333,11 +1353,11 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1781346642,
-        "narHash": "sha256-o92OOSMAB08HQgG7pW2BZVIO53Pkv4oAjLk4Iol3Iko=",
+        "lastModified": 1781400420,
+        "narHash": "sha256-HDTf2EhvFB5TRl+DP4hEMbvVvcQ6ZNMgM9XzBK1PVyA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6e4e8d731fbb3831296607d5f88de727cf7bf6de",
+        "rev": "1a49876ef73f9aa1c7b88cc6fdbfc81e582ae72a",
         "type": "github"
       },
       "original": {
@@ -1436,6 +1456,7 @@
         "nixpkgs-f2k": "nixpkgs-f2k",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "noctalia": "noctalia",
+        "noctalia-greeter": "noctalia-greeter",
         "nur": "nur",
         "rust-overlay": "rust-overlay_4",
         "sops-nix": "sops-nix",

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,15 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # Noctalia greeter — greetd login screen matching the Noctalia shell. Ships
+    # nixosModules.default (programs.noctalia-greeter) which auto-wires
+    # services.greetd + the bundled wlroots compositor. Enabled per-host where
+    # we replace GDM with greetd.
+    noctalia-greeter = {
+      url = "github:noctalia-dev/noctalia-greeter";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # niri — scrollable-tiling Wayland compositor. niri-flake provides the
     # NixOS module (programs.niri) + the home-manager config option
     # (programs.niri.settings). We pin the package to pkgs.niri (nixpkgs) and
@@ -280,6 +289,7 @@
               inputs.agenix.nixosModules.default
               inputs.lanzaboote.nixosModules.lanzaboote
               inputs.niri-flake.nixosModules.niri
+              inputs.noctalia-greeter.nixosModules.default
               nix-index-database.nixosModules.nix-index
               ./home/shell/zellij/zjstatus.nix
             ]

--- a/home/desktop/noctalia/default.nix
+++ b/home/desktop/noctalia/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 # Noctalia desktop shell + niri/labwc session config (keybinds, layout, UK
 # keyboard) for the niri and labwc sessions. Noctalia is launched only from the
 # niri/labwc startup hooks (NOT via its systemd service, which binds to the
@@ -8,23 +8,145 @@
 # Theming: builtin Catppuccin for now. TODO (fast-follow): bridge Stylix's
 # base16 palette into programs.noctalia.customPalettes + theme.source="custom".
 {
+  # wl-mirror: mirror an output to a window (niri has no native mirroring).
+  # jq: parse `niri msg --json`. wl-screenrec/slurp: HW-encoded screen recording.
+  home.packages = with pkgs; [
+    wl-mirror
+    jq
+    wl-screenrec
+    slurp
+    # Screen-recording toggle bound to Mod+Shift+R / Mod+Alt+R. Records the
+    # focused output (or a slurp-selected region) to ~/Videos; re-run to stop.
+    (writeShellScriptBin "niri-screenrecord" ''
+      set -euo pipefail
+      out="$HOME/Videos"; mkdir -p "$out"
+      if ${procps}/bin/pgrep -x wl-screenrec >/dev/null 2>&1; then
+        ${procps}/bin/pkill -INT -x wl-screenrec
+        ${libnotify}/bin/notify-send "Screen recording" "Saved to $out"
+      else
+        f="$out/rec-$(date +%Y%m%d-%H%M%S).mp4"
+        if [ "''${1:-}" = "region" ]; then
+          geom="$(${slurp}/bin/slurp)" || exit 0
+          ${wl-screenrec}/bin/wl-screenrec -g "$geom" -f "$f" &
+        else
+          name="$(${niri}/bin/niri msg --json focused-output | ${jq}/bin/jq -r .name)"
+          ${wl-screenrec}/bin/wl-screenrec -o "$name" -f "$f" &
+        fi
+        ${libnotify}/bin/notify-send "Screen recording" "Recording… Mod+Shift+R to stop"
+      fi
+    '')
+  ];
+
   programs.noctalia = {
     enable = true;
     systemd.enable = false;
     settings = {
       shell.font = "JetBrainsMono Nerd Font";
+      # Enable the calendar service. The Google account + OAuth tokens are added
+      # once via the GUI (Settings → Services → Calendar → Google) and stored in
+      # the runtime state.toml — not here.
+      calendar = {
+        enabled = true;
+        refresh_minutes = 15;
+      };
+      # Use the custom Gruvbox palette generated below (palettes/Gruvbox.json)
+      # so the Noctalia shell matches Stylix/GNOME/tmux instead of Catppuccin.
       theme = {
         mode = "dark";
-        source = "builtin";
-        builtin = "Catppuccin";
+        source = "custom";
+        custom_palette = "Gruvbox";
       };
     };
   };
+
+  # Gruvbox palette for the Noctalia shell, derived from the Stylix base16
+  # scheme so the bar/launcher/control-center match the rest of the system.
+  # Selected via theme.source="custom" + custom_palette="Gruvbox" above.
+  xdg.configFile."noctalia/palettes/Gruvbox.json".source =
+    let
+      inherit (config.lib.stylix) colors;
+      c = n: "#${colors.${n}}";
+      palette = {
+        mPrimary = c "base0B"; # green accent (same as window borders)
+        mOnPrimary = c "base00";
+        mSecondary = c "base0D"; # blue
+        mOnSecondary = c "base00";
+        mTertiary = c "base0E"; # purple
+        mOnTertiary = c "base00";
+        mError = c "base08"; # red
+        mOnError = c "base00";
+        mSurface = c "base00"; # background
+        mOnSurface = c "base05"; # foreground
+        mSurfaceVariant = c "base01";
+        mOnSurfaceVariant = c "base04";
+        mOutline = c "base03";
+        mShadow = c "base00";
+        mHover = c "base02";
+        mOnHover = c "base05";
+        terminal = {
+          background = c "base00";
+          foreground = c "base05";
+          cursor = c "base05";
+          cursorText = c "base00";
+          selectionBg = c "base02";
+          selectionFg = c "base05";
+          normal = {
+            black = c "base01";
+            red = c "base08";
+            green = c "base0B";
+            yellow = c "base0A";
+            blue = c "base0D";
+            magenta = c "base0E";
+            cyan = c "base0C";
+            white = c "base05";
+          };
+          bright = {
+            black = c "base03";
+            red = c "base08";
+            green = c "base0B";
+            yellow = c "base0A";
+            blue = c "base0D";
+            magenta = c "base0E";
+            cyan = c "base0C";
+            white = c "base07";
+          };
+        };
+      };
+    in
+    (pkgs.formats.json { }).generate "Gruvbox.json" {
+      dark = palette;
+      light = palette;
+    };
 
   # ── niri ───────────────────────────────────────────────────────────────
   # UK keyboard for the niri session (wlroots compositors don't inherit the
   # system xkb.layout).
   programs.niri.settings.input.keyboard.xkb.layout = "gb";
+
+  # Layout: open windows full-width (niri's default is half) and draw a themed
+  # border around EVERY window. Colours come from the Stylix base16 scheme
+  # (gruvbox-dark) so niri matches labwc/GNOME/tmux — active border = accent
+  # (base0B, same as labwc's window.active.border), inactive = dim (base01).
+  programs.niri.settings.layout =
+    let inherit (config.lib.stylix) colors; in {
+      gaps = 4;
+      default-column-width.proportion = 1.0;
+      preset-column-widths = [
+        { proportion = 0.5; }
+        { proportion = 0.666667; }
+        { proportion = 1.0; }
+      ];
+
+      border = {
+        enable = true;
+        width = 2;
+        active.color = "#${colors.base0B}";
+        inactive.color = "#${colors.base01}";
+      };
+
+      # One outline only: the per-window border replaces niri's focus-ring.
+      focus-ring.enable = false;
+    };
 
   # Launch the shell at session start (inherits the niri session env).
   programs.niri.settings.spawn-at-startup = lib.mkAfter [
@@ -77,16 +199,40 @@
     # Window/column sizing & state
     "Mod+F".action = maximize-column;
     "Mod+Shift+F".action = fullscreen-window;
+    # Windowed/"fake" fullscreen: tells the app it's fullscreen while keeping it
+    # a normal resizable window. Great for Google Slides / browser presentations.
+    "Mod+Ctrl+Shift+F".action = toggle-windowed-fullscreen;
     "Mod+R".action = switch-preset-column-width;
     "Mod+V".action = toggle-window-floating;
     "Mod+Comma".action = consume-window-into-column;
     "Mod+Period".action = expel-window-from-column;
+    # Overview (zoomed-out workspace/column view) — great for many editors open.
+    "Mod+O".action = toggle-overview;
+    # Fine column-width nudge.
+    "Mod+Minus".action = set-column-width "-10%";
+    "Mod+Equal".action = set-column-width "+10%";
+    # Mouse: Mod+scroll switches workspaces (cooldown avoids over-scrolling).
+    "Mod+WheelScrollDown" = { cooldown-ms = 150; action = focus-workspace-down; };
+    "Mod+WheelScrollUp" = { cooldown-ms = 150; action = focus-workspace-up; };
 
-    # Screenshots (via Noctalia) + overlay (Mod+Shift+/ lists all binds)
-    "Print".action = spawn "noctalia" "msg" "screenshot-region";
-    "Mod+Shift+S".action = spawn "noctalia" "msg" "screenshot-region";
-    "Mod+Print".action = spawn "noctalia" "msg" "screenshot-fullscreen";
+    # Screenshots — this keyboard has NO Print key, so everything is Mod-based.
+    # Saved to ~/Pictures/Screenshots/ AND the clipboard.
+    "Mod+S".action = spawn "niri" "msg" "action" "screenshot"; # interactive picker (region/window/output)
+    "Mod+Shift+S".action = spawn "niri" "msg" "action" "screenshot-window"; # focused window
+    "Mod+Ctrl+S".action = spawn "niri" "msg" "action" "screenshot-screen"; # whole focused output
     "Mod+Shift+Slash".action = show-hotkey-overlay;
+
+    # Screen recording (wl-screenrec, hardware-encoded) → ~/Videos. Re-press to
+    # stop. Mod+Shift+R = focused output; Mod+Alt+R = slurp-selected region.
+    "Mod+Shift+R".action = spawn "niri-screenrecord";
+    "Mod+Alt+R".action = spawn "niri-screenrecord" "region";
+
+    # Screen mirroring (wl-mirror): mirror the focused output into a window.
+    # Move that window to the target output and Mod+Shift+F it to fullscreen.
+    "Mod+P" = {
+      repeat = false;
+      action = spawn-sh "wl-mirror \"$(niri msg --json focused-output | jq -r .name)\"";
+    };
 
     # Media / brightness keys
     "XF86AudioRaiseVolume".action = spawn "wpctl" "set-volume" "@DEFAULT_AUDIO_SINK@" "5%+";

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -351,12 +351,28 @@ in
   # cosmic module; the unified DM module defaults to "none" without it).
   # NOTE: must live at top-level, NOT inside the features = {...} block above —
   # the option path is `desktop.displayManager`, not `features.desktop.displayManager`.
-  desktop.displayManager.backend = "gdm";
+  # Login manager: Noctalia greeter (greetd). backend="none" turns GDM off; the
+  # noctalia-greeter module below auto-enables greetd + its bundled wlroots
+  # compositor. GNOME/niri/labwc remain selectable SESSIONS in the greeter.
+  desktop.displayManager.backend = "none";
+
+  programs.noctalia-greeter = {
+    enable = true;
+    package = inputs.noctalia-greeter.packages.${pkgs.system}.default;
+    # Match the login cursor to the Stylix (bibata) theme used everywhere else.
+    settings.cursor = {
+      theme = config.stylix.cursor.name;
+      size = config.stylix.cursor.size;
+      package = config.stylix.cursor.package;
+    };
+  };
 
   # Phase 1: niri + labwc as selectable login sessions (alongside GNOME).
-  # Login manager stays GDM for now; greetd/Noctalia greeter is a later phase.
   desktop.niri.enable = true;
   desktop.labwc.enable = true;
+
+  # ddcutil: software brightness/contrast control of external monitors (DDC/CI).
+  modules.hardware.ddcutil.enable = true;
 
   # Citrix Workspace for client project remote access
   # Disabled — no longer needed. Module + overlay + package retained so this

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -299,6 +299,9 @@ in
   desktop.niri.enable = true;
   desktop.labwc.enable = true;
 
+  # ddcutil: software brightness/contrast control of external monitors (DDC/CI).
+  modules.hardware.ddcutil.enable = true;
+
   # GDM greeter visual baseline — dark colour scheme + 24h clock so it
   # doesn't render as a near-blank Adwaita-light surface over RDP.
   programs.dconf.profiles.gdm.databases = [{

--- a/modules/desktop/ddcutil.nix
+++ b/modules/desktop/ddcutil.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+# ddcutil — control external monitors over DDC/CI (brightness, contrast, input
+# source) from software, no on-screen-display buttons needed. Enables the I2C
+# subsystem and grants normal users access to /dev/i2c-* via the `i2c` group.
+let
+  inherit (lib) mkEnableOption mkIf filterAttrs;
+  cfg = config.modules.hardware.ddcutil;
+in
+{
+  options.modules.hardware.ddcutil.enable =
+    mkEnableOption "ddcutil DDC/CI control of external monitors (brightness/contrast/input over I2C)";
+
+  config = mkIf cfg.enable {
+    # Loads the i2c-dev kernel module and installs udev rules giving the `i2c`
+    # group read/write on /dev/i2c-*.
+    hardware.i2c.enable = true;
+
+    environment.systemPackages = [ pkgs.ddcutil ];
+
+    # Put every normal user in the i2c group so `ddcutil` works without sudo.
+    users.groups.i2c.members =
+      builtins.attrNames (filterAttrs (_: u: u.isNormalUser) config.users.users);
+  };
+}

--- a/modules/desktop/default.nix
+++ b/modules/desktop/default.nix
@@ -5,6 +5,7 @@
     ./cosmic-remote-desktop.nix
     ./niri.nix
     ./labwc.nix
+    ./ddcutil.nix
   ];
 
   # Make sure the adwaita-qt packages are installed


### PR DESCRIPTION
## Summary

Desktop overhaul for the niri/labwc Wayland sessions, moving the fleet off GDM and aligning everything to the Gruvbox (Stylix base16) theme.

### niri (`home/desktop/noctalia/default.nix`)
- Full-width windows + themed **2px gruvbox borders** (focus-ring off)
- **Windowed/fake fullscreen** (`Mod+Ctrl+Shift+F`) for browser presentations
- **Screen mirroring** (`Mod+P`, wl-mirror+jq)
- **Print-free screenshots**: `Mod+S` interactive / `Mod+Shift+S` window / `Mod+Ctrl+S` output
- **HW-encoded recording** (`Mod+Shift+R` output, `Mod+Alt+R` region, wl-screenrec)
- Overview (`Mod+O`), column-width nudge (`Mod+-/=`), `Mod+scroll` workspace switch
- **Noctalia shell → custom Gruvbox palette** (was Catppuccin), generated from Stylix base16
- Calendar service enabled (Google OAuth connected via GUI)

### Login (`hosts/p620`)
- **Replace GDM with the Noctalia greeter** (greetd) via the `noctalia-greeter` flake input. `backend="none"` disables GDM; GNOME/niri/labwc stay selectable. Cursor matched to Stylix bibata.

### Hardware (`modules/desktop/ddcutil.nix`)
- New module: **ddcutil** DDC/CI external-monitor brightness/contrast over I2C (i2c-dev + `i2c` group), enabled on p620 + razer.

## Testing
- `just test-host p620` ✅ and `just test-host razer` ✅ (incl. `noctalia config validate`)
- razer deployed live; p620 staged via `nixos-rebuild boot`

## Notes
- Electron/Wayland issues from the niri wiki were already covered by `NIXOS_OZONE_WL=1`.
- M1–M5 macro-key bindings are a follow-up (need keysym discovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)