### PR TITLE
feat(desktop): idle daemon, wallpaper, night-light for niri/labwc (#908)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -247,11 +247,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1781324653,
-        "narHash": "sha256-JbSHKB0kACPIzVJJcbDsH/03QOxoEd0iyR91gYFKxnU=",
+        "lastModified": 1781412351,
+        "narHash": "sha256-kl6eSjcNTjv4zkSpy+uvSMnlEq4hM7MZIu+R7iBDhqM=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "51ecc521a0cc49abed6094a9b16448124394e23e",
+        "rev": "178580864930491ee6382ac79d6d8035fbe75c87",
         "type": "github"
       },
       "original": {
@@ -709,11 +709,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781365335,
-        "narHash": "sha256-zqDBhXMzfbdlO7F2bGHe7MOtB3xngd/+4ieMHDC+ZXo=",
+        "lastModified": 1781477932,
+        "narHash": "sha256-7EZqIpytCiWoVsUQIRytWr2H0esy2xuntQHjG4Hb/48=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5b6f5733726a1b2ccafb5dec6ac4ca7299fad66c",
+        "rev": "ed8263e7d7813ec8f447e78e5dcd7f94f333f1d5",
         "type": "github"
       },
       "original": {
@@ -744,11 +744,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1781269631,
-        "narHash": "sha256-6EqA9WfiukOymUT4FkNdMvzmFKByW0LLoI/9sv4TzBU=",
+        "lastModified": 1781478098,
+        "narHash": "sha256-VyMJQIguEVeFuXhG3Yqi2cshcpbpolU3omkYzA4WuqU=",
         "owner": "feschber",
         "repo": "lan-mouse",
-        "rev": "0d2190e787db9e482e17d4c16fb7c00ef4841bcb",
+        "rev": "497a1a081aed1dd9ad54b5c90be5bad9f077aeb6",
         "type": "github"
       },
       "original": {
@@ -885,11 +885,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780816331,
-        "narHash": "sha256-0BYqs8yKWkOz2Q7+SP18N5E5gmDKSo6LSxIVIa0wWes=",
+        "lastModified": 1781422160,
+        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "1a2ea89c917781e88508d9fd2b507f2d2a0e173c",
+        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
         "type": "github"
       },
       "original": {
@@ -939,16 +939,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
-        "owner": "nixos",
+        "lastModified": 1754028485,
+        "narHash": "sha256-IiiXB3BDTi6UqzAZcf2S797hWEPCRZOwyNThJIYhUfk=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "59e69648d345d6e8fef86158c555730fa12af9de",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -962,11 +962,11 @@
         "parts": "parts"
       },
       "locked": {
-        "lastModified": 1781331691,
-        "narHash": "sha256-5zuV10CN/Wy8Xca7AmczfNI8r75EWdfb1m4Ziya6jwI=",
+        "lastModified": 1781419577,
+        "narHash": "sha256-vO2NrjYn8tJGzV7RduGN5l5P3+z39Cf4KXryFFhjGFA=",
         "owner": "moni-dz",
         "repo": "nixpkgs-f2k",
-        "rev": "df4f01615f3c9c350abd532d03241f2b649cb934",
+        "rev": "a63d19081a9b061f0e0691aa9b05c444e6fabc31",
         "type": "github"
       },
       "original": {
@@ -1076,11 +1076,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1780902259,
-        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
+        "lastModified": 1781216227,
+        "narHash": "sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
         "type": "github"
       },
       "original": {
@@ -1124,11 +1124,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1781328464,
-        "narHash": "sha256-j9uBlHI0eJ9zWU9IlF6SlBBPdeJu30hcvar31IRKHpw=",
+        "lastModified": 1781418921,
+        "narHash": "sha256-oAqOQ2DVbhrfgkkAhdPR0Zqt7oDUAMJcsit1v31+CAo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a722a7155bfc9fbe657f28d26b71860d95324bc",
+        "rev": "03599837aee3a3114e77d17811cc9431958a9a54",
         "type": "github"
       },
       "original": {
@@ -1156,11 +1156,11 @@
     },
     "nixpkgs_13": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-G5B1h4sOH4DN/RZ85xYi6zPm2MHdOrNMeUmMslZ28Qs=",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "lastModified": 1781074563,
+        "narHash": "sha256-d34lhgOet4IqYMnCxbIvwFBMOyTV6PT4TyNEOP0/ZhU=",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1011622.a799d3e3886d/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1014179.9ae611a455b9/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
@@ -1314,11 +1314,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781400232,
-        "narHash": "sha256-get3TXhQqCDVNIX6gGS/U2LVcoY37nfJuG00a2cwLrs=",
+        "lastModified": 1781477603,
+        "narHash": "sha256-dVK5iUyk6EEwYuitkri8/nULajXj+nCwtIAp279YyBU=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "f0b49926114219600df9583d84594de55f8c83d0",
+        "rev": "c6a7df952a269c5a219ef3d8fba95c9d0d6899a0",
         "type": "github"
       },
       "original": {
@@ -1334,11 +1334,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781432335,
-        "narHash": "sha256-+CW0yjC1Wr1vnDSwuvVIawBiYqLH/IpqXM/KKVgOVG4=",
+        "lastModified": 1781469970,
+        "narHash": "sha256-b1BFKXdcfsylt8aOF9mBEib791kPPY/OiF7wgpcqcs0=",
         "owner": "noctalia-dev",
         "repo": "noctalia-greeter",
-        "rev": "4787940eb8f768fba824dd6327acd47d54eae4b1",
+        "rev": "f19b5fe2e20f1a80de178c8dedfbd838ce8eb2ca",
         "type": "github"
       },
       "original": {
@@ -1353,11 +1353,11 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1781400420,
-        "narHash": "sha256-HDTf2EhvFB5TRl+DP4hEMbvVvcQ6ZNMgM9XzBK1PVyA=",
+        "lastModified": 1781474283,
+        "narHash": "sha256-pz9fqYrp8qaoyinv42xsqMGp8U2kROe7KkIEuqnBXEU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1a49876ef73f9aa1c7b88cc6fdbfc81e582ae72a",
+        "rev": "43ba01f6a5b64dc58a0bd8997095d7f7ba12d363",
         "type": "github"
       },
       "original": {
@@ -1553,11 +1553,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781320681,
-        "narHash": "sha256-mjJ/VxJaIkgcUvKANgKOaaN5M1X1X+6NjCP0C5hw0WI=",
+        "lastModified": 1781407245,
+        "narHash": "sha256-VzJq4MmD0uyNDAceudSe1hHqcQMe9Tau0U4S+5iRGh0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5b929d8c854149d926d05ea0cd6469bf4e54db27",
+        "rev": "d5f483210eb016d66102eef22baa128b3b3233fc",
         "type": "github"
       },
       "original": {
@@ -1629,11 +1629,11 @@
         "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1781101834,
-        "narHash": "sha256-gNVY6SYglFe37FpD+NnOjTipsqvVMM2vh/uc22KDEsA=",
+        "lastModified": 1781425310,
+        "narHash": "sha256-GTBka4Df/ZOacmisI/DI2LICyNChEqn/giah83LucdM=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "0243dd6707c969fc8440216c811b3f2e4a4cceb7",
+        "rev": "aeaf7c81a45d3761da61cb05bfc370ac6d1b0441",
         "type": "github"
       },
       "original": {
@@ -1930,11 +1930,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781281122,
-        "narHash": "sha256-V04aT0a/1l6+dl60G70CIJIVZLtIOe2HJ2rNW6FT8q8=",
+        "lastModified": 1781363265,
+        "narHash": "sha256-GL6jPjOZjvSZEwDf4AJVAoGBedjB+WljkDlvwf3xSaQ=",
         "owner": "Benexl",
         "repo": "yt-x",
-        "rev": "8b79ee2ab19259becd2469a41bab31cb0da1457c",
+        "rev": "fbd2669c10f3d8a559b95c8a647da083e6178254",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -116,6 +116,9 @@
     # Delta from previous pin: AppArmor profiles for Ubuntu 24.04+ user
     # namespaces, GPU-crash auto-recovery, software-center AppStream metainfo,
     # no more app.asar open prompt; tracks Claude Desktop 1.11847.5.
+    # NOTE: main HEAD (d2ce0466, Claude 1.12603.1) does NOT build — upstream
+    # build.sh aborts on the #649 .asar --add-dir patch (upstream issue #718).
+    # Stay on the latest *release* until that's fixed. Bump via /update-claude-code.
     claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/f56421294d46f5db61fba0f833215d18d8c7fa2f";
 
     # GogMail — keyboard-driven Google Workspace TUI (Gmail/Calendar/Tasks/

--- a/home/desktop/noctalia/default.nix
+++ b/home/desktop/noctalia/default.nix
@@ -144,6 +144,17 @@ in
     };
 
   # ── niri ───────────────────────────────────────────────────────────────
+  # Session environment for everything niri spawns. NIXOS_OZONE_WL=1 makes
+  # Electron apps (claude-desktop, VS Code, …) use the Wayland backend instead
+  # of falling back to XWayland. The system sets this in environment.session-
+  # Variables, but greetd launches `exec niri` without a login shell, so those
+  # never reach the session — niri's own environment block is what propagates
+  # it to child processes here.
+  programs.niri.settings.environment = {
+    NIXOS_OZONE_WL = "1";
+    ELECTRON_OZONE_PLATFORM_HINT = "auto";
+  };
+
   # UK keyboard for the niri session (wlroots compositors don't inherit the
   # system xkb.layout).
   programs.niri.settings.input.keyboard.xkb.layout = "gb";
@@ -307,9 +318,14 @@ in
     noctalia &
   '';
 
-  # UK keyboard (read at labwc startup, before keyboard init).
+  # Session environment, read at labwc startup. XKB layout for the keyboard,
+  # plus NIXOS_OZONE_WL=1 so Electron apps (claude-desktop, VS Code, …) use the
+  # Wayland backend rather than XWayland — greetd's `exec labwc` doesn't source
+  # the system environment.sessionVariables, so labwc exports them from here.
   xdg.configFile."labwc/environment".text = ''
     XKB_DEFAULT_LAYOUT=gb
+    NIXOS_OZONE_WL=1
+    ELECTRON_OZONE_PLATFORM_HINT=auto
   '';
 
   # Gruvbox-dark theming for labwc's OSD (window-switcher / workspace overlays

--- a/home/desktop/noctalia/default.nix
+++ b/home/desktop/noctalia/default.nix
@@ -173,6 +173,12 @@ in
       focus-ring.enable = false;
     };
 
+  # Ask clients to drop their own (white) client-side decorations so niri draws
+  # the themed server-side border instead. Without this, CSD apps like kitty
+  # render a white titlebar *inside* niri's green border. labwc is unaffected
+  # (its SSD titlebars are themed via themerc-override above).
+  programs.niri.settings.prefer-no-csd = true;
+
   # Launch the shell + companion daemons at session start (inherit the niri
   # session env). swayidle works on niri (ext-idle-notify-v1): lock at 5 min,
   # monitors off at 10 min, and — laptops only — suspend at 30 min.

--- a/home/desktop/noctalia/default.nix
+++ b/home/desktop/noctalia/default.nix
@@ -1,12 +1,31 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, osConfig, ... }:
 # Noctalia desktop shell + niri/labwc session config (keybinds, layout, UK
 # keyboard) for the niri and labwc sessions. Noctalia is launched only from the
 # niri/labwc startup hooks (NOT via its systemd service, which binds to the
 # graphical-session target that GNOME also reaches → would spawn a second shell
 # over gnome-shell).
 #
+# Session companion tools (wallpaper, idle, night-light) follow the SAME rule:
+# they are spawned from the niri/labwc startup hooks, never as systemd user
+# services, so they don't also start under GNOME and fight its equivalents.
+#
 # Theming: builtin Catppuccin for now. TODO (fast-follow): bridge Stylix's
 # base16 palette into programs.noctalia.customPalettes + theme.source="custom".
+let
+  # Wallpaper shared with Stylix (the system sets stylix.image to this same
+  # path); swaybg paints it on the niri/labwc sessions, which Stylix does not.
+  wallpaper = (import ../../../hosts/common/shared-variables.nix).baseTheme.wallpaper;
+
+  # Only laptops auto-suspend on idle; the workstation stays up (RDP / AI host).
+  isLaptop = (osConfig.host.class or "") == "laptop";
+
+  # Reused for the idle lock action and the manual Mod+Backspace bind.
+  lockCmd = "noctalia msg session lock";
+
+  # Fixed UK coordinates (London) so gammastep adjusts colour temperature by
+  # sun position without pulling in geoclue2.
+  geo = "51.5:-0.13";
+in
 {
   # wl-mirror: mirror an output to a window (niri has no native mirroring).
   # jq: parse `niri msg --json`. wl-screenrec/slurp: HW-encoded screen recording.
@@ -15,6 +34,12 @@
     jq
     wl-screenrec
     slurp
+    swaybg # static wallpaper for niri/labwc (Stylix only themes GNOME's bg)
+    swayidle # idle → lock / screen-off / (laptop) suspend
+    gammastep # night-light / colour temperature by sun position
+    wlopm # labwc DPMS off/on (niri has a native power-off-monitors action)
+    kanshi # output-profile daemon; per-host profiles are a TODO (niri does
+    #         output config natively in config.kdl, so this is mainly for labwc)
     # Screen-recording toggle bound to Mod+Shift+R / Mod+Alt+R. Records the
     # focused output (or a slurp-selected region) to ~/Videos; re-run to stop.
     (writeShellScriptBin "niri-screenrecord" ''
@@ -148,9 +173,29 @@
       focus-ring.enable = false;
     };
 
-  # Launch the shell at session start (inherits the niri session env).
+  # Launch the shell + companion daemons at session start (inherit the niri
+  # session env). swayidle works on niri (ext-idle-notify-v1): lock at 5 min,
+  # monitors off at 10 min, and — laptops only — suspend at 30 min.
   programs.niri.settings.spawn-at-startup = lib.mkAfter [
     { command = [ "noctalia" ]; }
+    { command = [ "swaybg" "-m" "fill" "-i" "${wallpaper}" ]; }
+    { command = [ "gammastep" "-l" geo ]; }
+    {
+      command = [
+        "swayidle"
+        "-w"
+        "timeout"
+        "300"
+        lockCmd
+        "timeout"
+        "600"
+        "niri msg action power-off-monitors"
+        "resume"
+        "niri msg action power-on-monitors"
+      ]
+      ++ lib.optionals isLaptop [ "timeout" "1800" "systemctl suspend" ]
+      ++ [ "before-sleep" lockCmd ];
+    }
   ];
 
   # Keybinds. Mod = Super/logo. Press Mod+Shift+/ for niri's hotkey overlay.
@@ -243,8 +288,16 @@
   };
 
   # ── labwc ──────────────────────────────────────────────────────────────
-  # Launch the shell from labwc's autostart hook.
+  # Launch the shell + companion daemons from labwc's autostart hook. labwc has
+  # no native DPMS action, so swayidle drives wlopm for screen-off. Same idle
+  # timings as niri; suspend only on laptops.
   xdg.configFile."labwc/autostart".text = ''
+    swaybg -m fill -i ${wallpaper} &
+    gammastep -l ${geo} &
+    swayidle -w \
+      timeout 300 '${lockCmd}' \
+      timeout 600 "wlopm --off '*'" resume "wlopm --on '*'" \
+      ${lib.optionalString isLaptop "timeout 1800 'systemctl suspend' \\\n      "}before-sleep '${lockCmd}' &
     noctalia &
   '';
 
@@ -296,6 +349,9 @@
         <keybind key="W-c"><action name="Execute" command="noctalia msg panel-toggle control-center"/></keybind>
         <keybind key="W-BackSpace"><action name="Execute" command="noctalia msg session lock"/></keybind>
         <keybind key="Print"><action name="Execute" command="noctalia msg screenshot-region"/></keybind>
+        <!-- Region screen recording (re-press to stop). niri-screenrecord's
+             region branch is compositor-agnostic (slurp + wl-screenrec). -->
+        <keybind key="W-S-r"><action name="Execute" command="niri-screenrecord region"/></keybind>
         <keybind key="W-e"><action name="Execute" command="nautilus"/></keybind>
         <keybind key="W-q"><action name="Close"/></keybind>
         <keybind key="A-Tab"><action name="NextWindow"/></keybind>

--- a/home/desktop/terminals/default.nix
+++ b/home/desktop/terminals/default.nix
@@ -198,6 +198,11 @@ in
           # `true` which left Kitty borderless and hard to manage in GNOME.
           window_margin_width = 8;
           hide_window_decorations = false;
+          # Theme the CSD titlebar to the terminal background (Stylix gruvbox)
+          # instead of the default white "system" colour. Applies wherever Kitty
+          # draws its own decorations (GNOME, and niri/labwc for clients that
+          # ignore prefer-no-csd).
+          wayland_titlebar_color = "background";
           placement_strategy = "center";
           background_opacity = mkDefault (
             if cfg.features.transparency


### PR DESCRIPTION
Audit of our niri/labwc sessions against community best practice (niri wiki,
labwc docs, user dotfiles) found a few missing companion tools. Noctalia already
covers bar/launcher/notifications/lock/OSD; this adds the rest, spawned from the
niri spawn-at-startup / labwc autostart hooks (NOT systemd user services, which
would also fire under GNOME):

- swayidle: idle -> lock (5m) -> monitors off (10m) -> suspend (30m, laptop only)
- swaybg:   wallpaper from the Stylix image (Stylix only paints GNOME's bg)
- gammastep: night-light by sun position (fixed UK coords, no geoclue)
- wlopm:    labwc DPMS off/on (niri uses its native power-off-monitors action)
- labwc W-S-r: region screen-record keybind (parity with niri)
- kanshi:   installed as a tool; per-host output profiles deferred

Auto-suspend gated to host.class == "laptop" so the p620 workstation (RDP/AI
host) never suspends. Verified: both p620 and razer toplevels build clean.

Closes #908

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
