### PR TITLE
feat(desktop): add MangoWM as a third Noctalia compositor session

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -352,6 +352,24 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_3"
+      },
+      "locked": {
         "lastModified": 1767609335,
         "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
         "owner": "hercules-ci",
@@ -365,9 +383,9 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_4": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_3"
+        "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
         "lastModified": 1760948891,
@@ -383,7 +401,7 @@
         "type": "github"
       }
     },
-    "flake-parts_4": {
+    "flake-parts_5": {
       "inputs": {
         "nixpkgs-lib": [
           "nur",
@@ -404,7 +422,7 @@
         "type": "github"
       }
     },
-    "flake-parts_5": {
+    "flake-parts_6": {
       "inputs": {
         "nixpkgs-lib": [
           "stylix",
@@ -781,10 +799,32 @@
         "type": "github"
       }
     },
+    "mango": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "scenefx": "scenefx"
+      },
+      "locked": {
+        "lastModified": 1781502236,
+        "narHash": "sha256-ysZjG8dCiPWBSQU1TY4dzci2Y5Wt9TGtQwCKkQYqE5M=",
+        "owner": "mangowm",
+        "repo": "mango",
+        "rev": "fa24c606a015a327c17943f23c09c30aebfd7209",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mangowm",
+        "repo": "mango",
+        "type": "github"
+      }
+    },
     "mcp-nixos": {
       "inputs": {
         "devshell": "devshell",
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
@@ -901,7 +941,7 @@
     "nix-snapd": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-parts": "flake-parts_3",
+        "flake-parts": "flake-parts_4",
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
@@ -1015,6 +1055,21 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
+        "lastModified": 1748740939,
+        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_3": {
+      "locked": {
         "lastModified": 1765674936,
         "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
@@ -1028,7 +1083,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_3": {
+    "nixpkgs-lib_4": {
       "locked": {
         "lastModified": 1754788789,
         "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
@@ -1043,7 +1098,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_4": {
+    "nixpkgs-lib_5": {
       "locked": {
         "lastModified": 1777168982,
         "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
@@ -1349,7 +1404,7 @@
     },
     "nur": {
       "inputs": {
-        "flake-parts": "flake-parts_4",
+        "flake-parts": "flake-parts_5",
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
@@ -1393,7 +1448,7 @@
     },
     "parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_4"
+        "nixpkgs-lib": "nixpkgs-lib_5"
       },
       "locked": {
         "lastModified": 1778716662,
@@ -1446,6 +1501,7 @@
         "home-manager": "home-manager_2",
         "lan-mouse": "lan-mouse",
         "lanzaboote": "lanzaboote",
+        "mango": "mango",
         "mcp-nixos": "mcp-nixos",
         "microvm": "microvm",
         "niri-flake": "niri-flake",
@@ -1587,6 +1643,27 @@
         "type": "github"
       }
     },
+    "scenefx": {
+      "inputs": {
+        "nixpkgs": [
+          "mango",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750785057,
+        "narHash": "sha256-tGX6j4W91rcb+glXJo43sjPI9zQvPotonknG1BdihR4=",
+        "owner": "wlrfx",
+        "repo": "scenefx",
+        "rev": "3a6cfb12e4ba97b43326357d14f7b3e40897adfc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wlrfx",
+        "repo": "scenefx",
+        "type": "github"
+      }
+    },
     "sops-nix": {
       "inputs": {
         "nixpkgs": [
@@ -1649,7 +1726,7 @@
         "base16-helix": "base16-helix",
         "base16-vim": "base16-vim",
         "firefox-gnome-theme": "firefox-gnome-theme",
-        "flake-parts": "flake-parts_5",
+        "flake-parts": "flake-parts_6",
         "gnome-shell": "gnome-shell",
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,15 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # mango — dwl-based Wayland compositor (wlroots + scenefx). Its flake
+    # provides the NixOS module (programs.mango, wired below) and the
+    # home-manager config option (wayland.windowManager.mango, added to
+    # home-manager.sharedModules). Third Noctalia session alongside niri/labwc.
+    mango = {
+      url = "github:mangowm/mango";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # Development and utilities
     sops-nix = {
       url = "github:mic92/sops-nix";
@@ -292,6 +301,7 @@
               inputs.agenix.nixosModules.default
               inputs.lanzaboote.nixosModules.lanzaboote
               inputs.niri-flake.nixosModules.niri
+              inputs.mango.nixosModules.mango
               inputs.noctalia-greeter.nixosModules.default
               nix-index-database.nixosModules.nix-index
               ./home/shell/zellij/zjstatus.nix
@@ -317,6 +327,9 @@
                     # Noctalia shell (programs.noctalia). Enabled per-user only
                     # where the niri/labwc home profile turns it on.
                     inputs.noctalia.homeModules.default
+                    # mango compositor config (wayland.windowManager.mango),
+                    # enabled per-user in the same niri/labwc home profile.
+                    inputs.mango.hmModules.mango
                   ];
                   extraSpecialArgs = {
                     pkgs-unstable = import nixpkgs-unstable (mkPkgs nixpkgs-unstable system);

--- a/home/desktop/noctalia/default.nix
+++ b/home/desktop/noctalia/default.nix
@@ -402,4 +402,115 @@ in
       </keyboard>
     </labwc_config>
   '';
+
+  # ── mango ──────────────────────────────────────────────────────────────
+  # mango (dwl-based) session config. Gated on the host enabling the compositor
+  # because the mango home-manager module pulls the mango package into
+  # home.packages — without the gate it would compile mango on headless p510,
+  # which also evaluates this shared profile. Same Super-based keybinds,
+  # gruvbox colours and companion daemons as niri/labwc; mango's native
+  # `env=` directive (applied via setenv in the compositor) is its equivalent
+  # of niri's environment block, so Electron apps get NIXOS_OZONE_WL=1.
+  wayland.windowManager.mango = lib.mkIf (osConfig.desktop.mangowm.enable or false) (
+    let
+      inherit (config.lib.stylix) colors;
+      c = n: "0x${colors.${n}}ff"; # mango wants 0xRRGGBBAA
+    in
+    {
+      enable = true;
+
+      extraConfig = ''
+        # Electron apps → Wayland (same fix as niri/labwc).
+        env=NIXOS_OZONE_WL,1
+        env=ELECTRON_OZONE_PLATFORM_HINT,auto
+
+        # UK keyboard
+        xkb_rules_layout=gb
+
+        # Appearance — gruvbox via Stylix (active border = accent base0B).
+        borderpx=2
+        rootcolor=${c "base00"}
+        bordercolor=${c "base01"}
+        focuscolor=${c "base0B"}
+        urgentcolor=${c "base08"}
+        gappih=4
+        gappiv=4
+        gappoh=4
+        gappov=4
+
+        # Apps
+        bind=SUPER,Return,spawn,ghostty
+        bind=SUPER,t,spawn,ghostty
+        bind=SUPER,d,spawn,noctalia msg panel-toggle launcher
+        bind=SUPER,space,spawn,noctalia msg panel-toggle launcher
+        bind=SUPER,c,spawn,noctalia msg panel-toggle control-center
+        bind=SUPER,BackSpace,spawn,noctalia msg session lock
+        bind=SUPER,e,spawn,nautilus
+        bind=SUPER,q,killclient,
+        bind=SUPER+SHIFT,e,quit
+
+        # Focus (arrows + vim hjkl)
+        bind=SUPER,Left,focusdir,left
+        bind=SUPER,Right,focusdir,right
+        bind=SUPER,Up,focusdir,up
+        bind=SUPER,Down,focusdir,down
+        bind=SUPER,h,focusdir,left
+        bind=SUPER,l,focusdir,right
+        bind=SUPER,j,focusdir,down
+        bind=SUPER,k,focusdir,up
+
+        # Move / swap
+        bind=SUPER+SHIFT,Left,exchange_client,left
+        bind=SUPER+SHIFT,Right,exchange_client,right
+        bind=SUPER+SHIFT,Up,exchange_client,up
+        bind=SUPER+SHIFT,Down,exchange_client,down
+        bind=SUPER+SHIFT,h,exchange_client,left
+        bind=SUPER+SHIFT,l,exchange_client,right
+        bind=SUPER+SHIFT,j,exchange_client,down
+        bind=SUPER+SHIFT,k,exchange_client,up
+
+        # Window state
+        bind=SUPER,f,togglemaximizescreen,
+        bind=SUPER+SHIFT,f,togglefullscreen,
+        bind=SUPER,v,togglefloating,
+        bind=SUPER,o,toggleoverview,
+        bind=SUPER,n,switch_layout
+
+        # Tags 1-5: view (switch) / tag (move window to)
+        bind=SUPER,1,view,1,0
+        bind=SUPER,2,view,2,0
+        bind=SUPER,3,view,3,0
+        bind=SUPER,4,view,4,0
+        bind=SUPER,5,view,5,0
+        bind=SUPER+SHIFT,1,tag,1,0
+        bind=SUPER+SHIFT,2,tag,2,0
+        bind=SUPER+SHIFT,3,tag,3,0
+        bind=SUPER+SHIFT,4,tag,4,0
+        bind=SUPER+SHIFT,5,tag,5,0
+
+        # Screenshot (noctalia) + region recording (compositor-agnostic helper)
+        bind=none,Print,spawn,noctalia msg screenshot-region
+        bind=SUPER+SHIFT,r,spawn,niri-screenrecord region
+
+        # Media / brightness
+        bind=none,XF86AudioRaiseVolume,spawn,wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+
+        bind=none,XF86AudioLowerVolume,spawn,wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-
+        bind=none,XF86AudioMute,spawn,wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle
+        bind=none,XF86MonBrightnessUp,spawn,brightnessctl set 5%+
+        bind=none,XF86MonBrightnessDown,spawn,brightnessctl set 5%-
+      '';
+
+      # Companion daemons (same as niri/labwc). mango has no native DPMS action,
+      # so swayidle drives wlopm for screen-off, like labwc. Suspend on laptops.
+      autostart_sh = ''
+        swaybg -m fill -i ${wallpaper} &
+        gammastep -l ${geo} &
+        swayidle -w \
+          timeout 300 '${lockCmd}' \
+          timeout 600 "wlopm --off '*'" resume "wlopm --on '*'" \
+          ${lib.optionalString isLaptop "timeout 1800 'systemctl suspend' \\\n      "}before-sleep '${lockCmd}' &
+        noctalia &
+      '';
+    }
+  );
 }

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -367,9 +367,10 @@ in
     };
   };
 
-  # Phase 1: niri + labwc as selectable login sessions (alongside GNOME).
+  # Phase 1: niri + labwc + mango as selectable login sessions (alongside GNOME).
   desktop.niri.enable = true;
   desktop.labwc.enable = true;
+  desktop.mangowm.enable = true;
 
   # ddcutil: software brightness/contrast control of external monitors (DDC/CI).
   modules.hardware.ddcutil.enable = true;

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -310,9 +310,10 @@ in
     };
   };
 
-  # Phase 1: niri + labwc as selectable login sessions (alongside GNOME).
+  # Phase 1: niri + labwc + mango as selectable login sessions (alongside GNOME).
   desktop.niri.enable = true;
   desktop.labwc.enable = true;
+  desktop.mangowm.enable = true;
 
   # ddcutil: software brightness/contrast control of external monitors (DDC/CI).
   modules.hardware.ddcutil.enable = true;

--- a/modules/desktop/default.nix
+++ b/modules/desktop/default.nix
@@ -5,6 +5,7 @@
     ./cosmic-remote-desktop.nix
     ./niri.nix
     ./labwc.nix
+    ./mangowm.nix
     ./ddcutil.nix
   ];
 

--- a/modules/desktop/mangowm.nix
+++ b/modules/desktop/mangowm.nix
@@ -1,0 +1,20 @@
+{ config, lib, ... }:
+# mango — dwl-based (wlroots + scenefx) Wayland compositor, exposed as a
+# selectable login session. The mango flake's NixOS module (programs.mango) is
+# wired in flake.nix; this feature module just turns it on. programs.mango
+# handles the rest — it installs share/wayland-sessions/mango.desktop (so
+# greetd/GDM list "mango"), enables built-in XWayland, wlr/gtk portals and
+# polkit. Session config (keybinds, env, autostart) lands in the Noctalia home
+# profile, the same place niri/labwc are configured.
+let
+  inherit (lib) mkEnableOption mkIf;
+  cfg = config.desktop.mangowm;
+in
+{
+  options.desktop.mangowm.enable =
+    mkEnableOption "mango dwl-based Wayland compositor (selectable login session)";
+
+  config = mkIf cfg.enable {
+    programs.mango.enable = true;
+  };
+}


### PR DESCRIPTION
## Summary
Adds **MangoWM** (dwl-based Wayland compositor, wlroots + scenefx) as a selectable login session alongside niri and labwc, using the same Noctalia shell — per request, referencing https://mangowm.github.io/docs/installation.

## Changes
- **flake**: `github:mangowm/mango` input (follows nixpkgs); wires `programs.mango` (NixOS) + `wayland.windowManager.mango` (home-manager).
- **modules/desktop/mangowm.nix**: `desktop.mangowm.enable` feature flag → `programs.mango.enable` (registers `mango.desktop` session, built-in XWayland, wlr/gtk portals, polkit). Mirrors `niri.nix`/`labwc.nix`.
- **Noctalia home profile**: mango session config — same Super-based keybinds, gruvbox/Stylix colours, and companion daemons (noctalia, swaybg, gammastep, swayidle+wlopm) as niri/labwc. Uses mango's native `env=NIXOS_OZONE_WL,1` directive so Electron apps (claude-desktop) run on Wayland. **Gated on `osConfig.desktop.mangowm.enable`** so headless p510 doesn't pull in the mango package.
- Enabled on **razer + p620**.

## Testing
- `config.conf` validated at build time via `mango -c … -p`.
- ✅ Built clean on all 3 hosts (razer, p620, p510).
- ✅ p510 closure confirmed free of mango (gate works).
- ✅ razer closure has `mango-nightly` + `mango.desktop` session + validated config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)