### PR TITLE
chore(secrets): wire aws-synechron-terraform into age.secrets (all hosts)

### DIFF
--- a/modules/secrets/api-keys.nix
+++ b/modules/secrets/api-keys.nix
@@ -116,6 +116,17 @@ in
         group = "users";
       };
 
+      # AWS long-lived IAM key for synechron-terraform-cli (migration/Terraform
+      # provisioning). Decrypts to /run/agenix/aws-synechron-terraform on every
+      # host; the file is an AWS credentials-file block under [synechron-tf],
+      # consumed via AWS_SHARED_CREDENTIALS_FILE. Rotate/delete after migration.
+      aws-synechron-terraform = {
+        file = ../../secrets/aws-synechron-terraform.age;
+        mode = "0600";
+        owner = username;
+        group = "users";
+      };
+
       tailscale-auth-key = {
         file = ../../secrets/tailscale-auth-key.age;
         mode = "0600";


### PR DESCRIPTION
Wires the `aws-synechron-terraform` secret (added in #911 but unconsumed) into `age.secrets` via the common `modules/secrets/api-keys.nix`, so it decrypts to `/run/agenix/aws-synechron-terraform` on **all hosts** (p620/razer/p510).

- mode 0600, owner = primary user (mirrors `synechron-github-api`).
- Verified: `config.age.secrets.aws-synechron-terraform.path` resolves on all 3 hosts.
- Consume via `AWS_SHARED_CREDENTIALS_FILE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)