### PR TITLE
fix(packages): install krita+darktable from the active gimp list

### DIFF
--- a/modules/packages/sets.nix
+++ b/modules/packages/sets.nix
@@ -114,8 +114,6 @@
       spotify
       vlc
       gimp
-      krita # Qt-based image editor / GIMP alternative
-      darktable # RAW photo workflow (Lightroom-like)
       inkscape
     ];
 

--- a/modules/services/gnome/gnome-services.nix
+++ b/modules/services/gnome/gnome-services.nix
@@ -45,6 +45,8 @@
     gnomeExtensions.user-themes
     gnomeExtensions.appindicator
     gimp
+    krita # Qt-based image editor / GIMP alternative
+    darktable # RAW photo workflow (Lightroom-like)
     cameractrls-gtk4
   ];
 }


### PR DESCRIPTION
The earlier sets.nix `apps` addition was dead code (that set isn't consumed). gimp is installed via `gnome-services.nix`; krita+darktable now placed there. Verified in razer systemPackages + clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)