### PR TITLE
feat(time): sync clocks over Tailscale with HTTPS fallback

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -80,6 +80,22 @@ in
     openFirewall = true;
   };
 
+  # NTP server for the tailnet. Roaming hosts (razer) frequently land on
+  # networks that block public NTP (UDP 123); they sync from here instead,
+  # tunnelled inside Tailscale (WireGuard/DERP on 443) so the block never
+  # applies. p620 itself disciplines from the public pool over its home LAN.
+  # Firewall is disabled on this host, so UDP 123 is already reachable on
+  # tailscale0. chronyd replaces systemd-timesyncd automatically.
+  services.chrony = {
+    enable = true;
+    extraConfig = ''
+      # Serve time to tailnet clients (Tailscale CGNAT range).
+      allow 100.64.0.0/10
+      # Serve from the local clock if upstream is briefly unreachable.
+      local stratum 10
+    '';
+  };
+
   # Use AI provider defaults with workstation profile
   aiDefaults = {
     enable = true;

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -99,6 +99,26 @@ in
     openFirewall = true;
   };
 
+  # Time sync. razer roams onto networks (e.g. corporate/guest WiFi) that
+  # block public NTP on UDP 123, which left the clock free-running and
+  # drifting. Sync from p620 over Tailscale instead — tunnelled inside
+  # WireGuard/DERP (443), so the UDP-123 block never applies. Public pool
+  # kept as fallback for networks that do allow NTP when the tailnet is down.
+  services.timesyncd = {
+    enable = true;
+    servers = [ "100.69.100.115" ]; # p620 (stable tailnet IP, chrony server)
+    fallbackServers = [
+      "0.pool.ntp.org"
+      "1.pool.ntp.org"
+      "2.pool.ntp.org"
+    ];
+  };
+
+  # Last-resort fallback: if NTP is unreachable (UDP 123 blocked AND Tailscale
+  # down), step the clock from HTTPS Date headers over 443. Only acts when
+  # timesyncd has not synchronised, so it never fights normal NTP discipline.
+  services.httpTimeFallback.enable = true;
+
   # COSMIC Notifications NG - Disabled: removed from active config
   # services.cosmic-ext-notifications = {
   #   enable = true;

--- a/modules/services/default.nix
+++ b/modules/services/default.nix
@@ -24,6 +24,9 @@ _: {
     # Network stability modules (service merged into main module)
     ./network-stability.nix
 
+    # HTTPS time-sync fallback for networks that block NTP (UDP 123)
+    ./http-time-fallback.nix
+
     # AI/MCP services
     ./whatsapp-bridge.nix
 

--- a/modules/services/http-time-fallback.nix
+++ b/modules/services/http-time-fallback.nix
@@ -1,0 +1,96 @@
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib) mkEnableOption mkOption mkIf types concatStringsSep escapeShellArgs;
+  cfg = config.services.httpTimeFallback;
+
+  syncScript = pkgs.writeShellScript "http-time-fallback" ''
+    set -euo pipefail
+
+    # Only act as a fallback: if the primary NTP path (timesyncd over
+    # Tailscale, or the public pool) has already synchronised, do nothing.
+    if [ "$(${pkgs.systemd}/bin/timedatectl show -p NTPSynchronized --value)" = "yes" ]; then
+      echo "NTP already synchronised; HTTPS time fallback not needed."
+      exit 0
+    fi
+
+    echo "NTP not synchronised — setting clock from HTTPS Date headers."
+    for url in ${escapeShellArgs cfg.urls}; do
+      date_hdr=$(${pkgs.curl}/bin/curl -sf --max-time 10 -I "$url" \
+        | ${pkgs.gnugrep}/bin/grep -i '^date:' \
+        | ${pkgs.gnused}/bin/sed 's/^[Dd]ate: //I' \
+        | ${pkgs.coreutils}/bin/tr -d '\r') || continue
+      if [ -n "$date_hdr" ]; then
+        ${pkgs.coreutils}/bin/date -s "$date_hdr"
+        # --noadjfile avoids writing /etc/adjtime (ProtectSystem=strict makes
+        # /etc read-only); RTC is kept in UTC on this fleet.
+        ${pkgs.util-linux}/bin/hwclock --systohc --noadjfile --utc || true
+        echo "Clock set from $url ($date_hdr)."
+        exit 0
+      fi
+    done
+
+    echo "http-time-fallback: no HTTPS time source reachable." >&2
+    exit 1
+  '';
+in
+{
+  options.services.httpTimeFallback = {
+    enable = mkEnableOption "HTTPS-based time sync fallback for networks that block NTP (UDP 123)";
+
+    urls = mkOption {
+      type = types.listOf types.str;
+      default = [
+        "https://www.cloudflare.com"
+        "https://www.google.com"
+        "https://www.kernel.org"
+      ];
+      description = "HTTPS endpoints whose Date response headers set the clock, tried in order.";
+    };
+
+    interval = mkOption {
+      type = types.str;
+      default = "*:0/15";
+      description = "systemd OnCalendar expression controlling how often the fallback check runs.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.http-time-fallback = {
+      description = "HTTPS time sync fallback (when NTP/UDP 123 is blocked)";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = syncScript;
+
+        # Setting the system clock and RTC requires CAP_SYS_TIME and access
+        # to /dev/rtc; ProtectClock must stay false for both to work.
+        AmbientCapabilities = [ "CAP_SYS_TIME" ];
+        CapabilityBoundingSet = [ "CAP_SYS_TIME" ];
+        ProtectClock = false;
+
+        # Hardening otherwise.
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+        RestrictNamespaces = true;
+        MemoryDenyWriteExecute = true;
+      };
+    };
+
+    systemd.timers.http-time-fallback = {
+      description = "Periodic HTTPS time sync fallback check";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "2min";
+        OnCalendar = cfg.interval;
+        Persistent = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary

razer roams onto networks (corporate/guest WiFi) that block public NTP on UDP 123, leaving its clock free-running and drifting. This makes the fleet's time sync survive restrictive networks.

## Changes

- **p620**: run `chrony` as a tailnet NTP server (`allow 100.64.0.0/10`, `local stratum 10`). Tunnelled inside Tailscale (WireGuard/DERP on 443) so the UDP-123 block never applies. p620 disciplines from the public pool over its LAN.
- **razer**: point `timesyncd` at p620's tailnet IP (`100.69.100.115`), keep the public pool as `fallbackServers`.
- **New `services.httpTimeFallback` module**: last-resort timer that steps the clock from HTTPS `Date` headers (port 443) **only when NTP has not synchronised**, so it never fights normal NTP discipline. Enabled on razer.

## Testing

- `nix build` of both `razer` and `p620` system closures: ✅
- razer deployed; `http-time-fallback` confirmed setting the clock from Cloudflare's HTTPS Date header on a UDP-123-blocked network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)