### PR TITLE
fix(razer): bump lanzaboote past removed boot.bootspec.enable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1765145449,
-        "narHash": "sha256-aBVHGWWRzSpfL++LubA0CwOOQ64WNLegrYHwsVuVN7A=",
+        "lastModified": 1780532242,
+        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "69f538cdce5955fcd47abfed4395dc6d5194c1c5",
+        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
         "type": "github"
       },
       "original": {
@@ -302,15 +302,15 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1761588595,
-        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
-        "owner": "edolstra",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -727,11 +727,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781667738,
-        "narHash": "sha256-OxrwHpsWf+QGbos1LMDGAcv7sjBGshcw/43th6waeYI=",
+        "lastModified": 1781706760,
+        "narHash": "sha256-jkSzXcasiZZ72q5f92FLHdIGAlGhX+124xQrbbczbF0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7664e05e2413d5e2b8c54a884eb8ea0f8a504fc2",
+        "rev": "a2e23ee8f8699f8971b4fde86efc1b7ec1e19681",
         "type": "github"
       },
       "original": {
@@ -785,17 +785,17 @@
         "rust-overlay": "rust-overlay_3"
       },
       "locked": {
-        "lastModified": 1765382359,
-        "narHash": "sha256-RJmgVDzjRI18BWVogG6wpsl1UCuV6ui8qr4DJ1LfWZ8=",
+        "lastModified": 1781649287,
+        "narHash": "sha256-ycG9a7svaV/zF9G03waY7BqUcNQn2HODMN/lXy3C7Zc=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "e8c096ade12ec9130ff931b0f0e25d2f1bc63607",
+        "rev": "001e560fffc8f0235e9db20ebeb4ccde0ade1caf",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "v1.0.0",
         "repo": "lanzaboote",
+        "rev": "001e560fffc8f0235e9db20ebeb4ccde0ade1caf",
         "type": "github"
       }
     },
@@ -1408,11 +1408,11 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1781705835,
-        "narHash": "sha256-Oy0rpO/U3cf2AAACJGjKwQshtu12iKEZrdmUXzWaJZY=",
+        "lastModified": 1781706985,
+        "narHash": "sha256-YebJdNT90vQ5b7WdqvaowUAK3+NrLx2hXB7HOGmVs7A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "96ba1008a18a2c8ab6b31e9cf9422fced152d271",
+        "rev": "50cda583cb6bb973f8d58153e198ced2f091f14a",
         "type": "github"
       },
       "original": {
@@ -1474,11 +1474,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765016596,
-        "narHash": "sha256-rhSqPNxDVow7OQKi4qS5H8Au0P4S3AYbawBSmJNUtBQ=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "548fc44fca28a5e81c5d6b846e555e6b9c2a5a3c",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -1589,11 +1589,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765075567,
-        "narHash": "sha256-KFDCdQcHJ0hE3Nt5Gm5enRIhmtEifAjpxgUQ3mzSJpA=",
+        "lastModified": 1781407245,
+        "narHash": "sha256-VzJq4MmD0uyNDAceudSe1hHqcQMe9Tau0U4S+5iRGh0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "769156779b41e8787a46ca3d7d76443aaf68be6f",
+        "rev": "d5f483210eb016d66102eef22baa128b3b3233fc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -99,10 +99,11 @@
     nix-snapd.url = "github:io12/nix-snapd";
     microvm.url = "github:astro/microvm.nix";
 
-    # Secure Boot — v0.4.1 broke against current nixpkgs (rust-1.78 toolchain
-    # fetch failure). v1.0.0 (released 2025-12-10) is the latest stable.
+    # Secure Boot — v1.0.0 (latest tag) still sets the removed
+    # boot.bootspec.enable option, which throws against current nixpkgs
+    # (bootspec is now always-on). Pinned to master past that fix.
     lanzaboote = {
-      url = "github:nix-community/lanzaboote/v1.0.0";
+      url = "github:nix-community/lanzaboote/001e560fffc8f0235e9db20ebeb4ccde0ade1caf";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/hosts/razer/nixos/secure-boot.nix
+++ b/hosts/razer/nixos/secure-boot.nix
@@ -3,9 +3,6 @@
 { lib, ... }: {
   # Boot configuration for Secure Boot
   boot = {
-    # Enable bootspec for lanzaboote (required for Secure Boot)
-    bootspec.enable = true;
-
     # Enable Lanzaboote for Secure Boot.
     # pkiBundle path changed from /etc/secureboot to /var/lib/sbctl in
     # sbctl 0.14+ (lanzaboote v1.0.0 ships sbctl 0.18). Keys live at


### PR DESCRIPTION
nixpkgs `567a49d191` removed `boot.bootspec.enable` (bootspec is now always generated). lanzaboote v1.0.0 and `hosts/razer/nixos/secure-boot.nix` both still set it, throwing a failed-assertion at eval and blocking every razer deploy.

- Pin lanzaboote to master (`001e560fffc`), which drops the removed option
- Remove the redundant local `bootspec.enable` definition

Verified: `nix eval .#nixosConfigurations.razer.config.system.build.toplevel.outPath` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)