### PR TITLE
fix(razer): use nvidia latest (610.43.02) for kernel 7.1 compat

### DIFF
--- a/hosts/razer/nixos/nvidia.nix
+++ b/hosts/razer/nixos/nvidia.nix
@@ -11,7 +11,9 @@
       nvidiaPersistenced = false;
       open = true; # NVIDIA 590+ requires open kernel modules for Turing GPUs (RTX 2070 Super)
       nvidiaSettings = true;
-      package = config.boot.kernelPackages.nvidiaPackages.beta;
+      # beta (595.45.04) fails to build against kernel 7.1 — it includes
+      # linux/of_gpio.h, removed in 7.x. latest (610.43.02) handles the removal.
+      package = config.boot.kernelPackages.nvidiaPackages.latest;
 
       prime = {
         sync.enable = true;


### PR DESCRIPTION
`nvidiaPackages.beta` (595.45.04) fails to build against kernel 7.1 — `common/inc/nv-linux.h` includes `linux/of_gpio.h`, removed in kernel 7.x. `nvidiaPackages.latest` (610.43.02) handles the removal.

Verified: full razer closure builds (`nix build .#nixosConfigurations.razer.config.system.build.toplevel` → exit 0); `nvidia-open-610.43.02-7.1` available in cache.nixos.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)