### PR TITLE
chore(razer): disable /extdisk NFS export

### DIFF
--- a/hosts/razer/variables.nix
+++ b/hosts/razer/variables.nix
@@ -28,7 +28,8 @@ let
 
     # NFS server configuration for external disk sharing
     nfsConfig = {
-      enable = true;
+      # Disabled: /extdisk now holds ~/Source (private code), not LAN-shared.
+      enable = false;
       exports = "/extdisk         192.168.1.*(rw,fsid=0,no_subtree_check)";
     };
 


### PR DESCRIPTION
`/extdisk` now holds `~/Source` (relocated off `/` to free ~122G). It was NFS-exported rw to `192.168.1.*`, so disable the export to avoid LAN-exposing private source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)