### PR TITLE
chore(razer): sshd LogLevel=ERROR to quiet Odin probe spam

### DIFF
--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -434,6 +434,8 @@ in
   services = {
     playerctld.enable = true;
     fwupd.enable = true;
+    # Quiet sshd preauth-reset spam from Odin's :22 liveness probes (p510).
+    openssh.settings.LogLevel = "ERROR";
     nfs.server = lib.mkIf vars.services.nfs.enable {
       enable = true;
       inherit (vars.services.nfs) exports;


### PR DESCRIPTION
Odin's host-status check TCP-probes razer:22, spamming sshd logs (~28k preauth resets/1.7d). Set sshd `LogLevel = ERROR` on razer. Root cause tracked in olafkfreund/Odin#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)