### PR TITLE
chore(antigravity): update CLI to 1.0.9 and IDE to 2.0.4

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.0.6-6458082025406464";
+  version = "1.0.9-6003845613092864";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.6-6458082025406464/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-Pq5VJ4HTBUt4IULjz+e+c+O9BoxzakMspvGtqkDxngc=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.9-6003845613092864/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-zYD4X0O1Kzide0mNZ4T4MW1Xqcxi6uI9hAxd42j5xNU=";
   };
 
   # Tarball contains a single file `antigravity` at the root.

--- a/pkgs/antigravity-ide/package.nix
+++ b/pkgs/antigravity-ide/package.nix
@@ -103,11 +103,11 @@ let
 in
 stdenv.mkDerivation {
   pname = "antigravity-ide";
-  version = "2.0.3-6242596486512640";
+  version = "2.0.4-6381998290370560";
 
   src = fetchurl {
-    url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.0.3-6242596486512640/linux-x64/Antigravity%20IDE.tar.gz";
-    hash = "sha256-ALX9cJ/vAsn4GrTt136NW6+LhYQsxlT6AW19BJLN6AM=";
+    url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.0.4-6381998290370560/linux-x64/Antigravity%20IDE.tar.gz";
+    hash = "sha256-ZjN9RfJHLOXonzlOd67HSQmqG+C7M8n3MpmpX0WOZ3A=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -52,7 +52,7 @@
   # Antigravity IDE (2.0.1+) — Google's rebranded Antigravity Desktop.
   # Standalone derivation in pkgs/antigravity-ide/ because upstream
   # jacopone/antigravity-nix is still on 1.x and 2.0.x changed everything
-  # (URL, layout, binary location, product name). Pinned to 2.0.1-4861014…
+  # (URL, layout, binary location, product name). Pinned to 2.0.4-6381998…
   antigravity-ide = pkgs.callPackage ./antigravity-ide/package.nix { };
 
   # Antigravity CLI (agy) — Gemini CLI's successor per Google's


### PR DESCRIPTION
## Summary

Bump Google Antigravity packages to the latest upstream releases.

| Package | Old | New |
|---------|-----|-----|
| Antigravity CLI (`agy`) | `1.0.6-6458082025406464` | `1.0.9-6003845613092864` |
| Antigravity IDE | `2.0.3-6242596486512640` | `2.0.4-6381998290370560` |

Latest versions sourced from Google's live update endpoints (CLI manifest + IDE releases API).

## Testing

- Hashes prefetched independently with `nix store prefetch-file` (IDE hash also cross-checked against upstream `jacopone/antigravity-nix` versions.json).
- Both derivations build cleanly via `nixosConfigurations.razer.pkgs.customPkgs.*`.
- Outputs verified: `bin/agy`, `bin/antigravity-ide`, desktop entry, and icon all present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)