### PR TITLE
fix(claude-code): pin native 2.1.183 + disable self-updater globally

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -46,6 +46,15 @@
   # https://code.claude.com/docs/en/agent-teams
   home.sessionVariables.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
 
+  # Version is controlled declaratively via pkgs.claude-code-native; the
+  # built-in self-updater must stay off. The nix wrapper already sets these,
+  # but a stray native install (~/.local/share/claude) self-updates and
+  # reclaims ~/.local/bin/claude, breaking the next HM activation. Setting
+  # them in the session environment disables the updater for ANY claude
+  # binary, not just the wrapper. Bump with ./scripts/update-claude-code-native.sh.
+  home.sessionVariables.DISABLE_AUTOUPDATER = "1";
+  home.sessionVariables.CLAUDE_CODE_SKIP_UPDATE_CHECK = "1";
+
   home.packages = [
     inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.opencode
     (pkgs.callPackage ../pkgs/weather-popup/default.nix { })

--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -31,7 +31,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.181";
+  version = "2.1.183";
 
   # Claude Code reads clipboard images by shelling out to:
   #   xclip -selection clipboard -t TARGETS -o ... || wl-paste -l ...   (detect)
@@ -63,11 +63,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-Nf/U6dmoY5XQuk4F+LI78Ji/6rlel96s1lN5CdEyTpw=";
+      hash = "sha256-3ztAnFslKZ31LF7oH2SBHb3LLhjBvu/n9zPDJvCozc4=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-E5P5k1M+CNXJYkVQR1Cn/P43SQpfRO7DWwvqw9cJ2rk=";
+      hash = "sha256-JgpuQ/6cb9iAAxdYGYL/UOT0QB0C72Jfqk33I7uXELM=";
     };
   };
 


### PR DESCRIPTION
## Problem

Claude Code's native installer (`~/.local/share/claude/`) self-updates in the background and rewrites `~/.local/bin/claude`, which home-manager owns (`home/default.nix` → `pkgs.claude-code-native`). After a self-update, the next deploy fails HM activation with `Existing file ... would be clobbered` (exit 4). The nix wrapper's `DISABLE_AUTOUPDATER` only applied to the nix binary, not the stray native install.

## Fix

- **Pin the version declaratively:** `claude-code-native` `2.1.181` → **`2.1.183`** (Anthropic `latest` channel). nix is now the single source of truth.
- **Disable the updater globally:** `DISABLE_AUTOUPDATER=1` + `CLAUDE_CODE_SKIP_UPDATE_CHECK=1` as `home.sessionVariables`, so *any* claude binary in the session has self-update off — not just the wrapper.

Future version bumps: `./scripts/update-claude-code-native.sh <version>`.

## Testing

✅ `nix build .#…claude-code-native` → binary reports `2.1.183 (Claude Code)`
✅ `just test-host p620` — builds clean
✅ `just test-host razer` — builds clean

Post-merge: deploy both hosts, remove the stray `~/.local/share/claude` self-install so nix is the only claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)