### PR TITLE
fix(claude-code): force-own ~/.local/bin/claude + bump to 2.1.185

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -34,7 +34,17 @@
   # `claude /doctor` checks the literal path ~/.local/bin/claude and warns
   # if it's missing — independent of whether `claude` is already on PATH.
   # Point the path at the same nix-managed binary so /doctor stays quiet.
-  home.file.".local/bin/claude".source = "${pkgs.claude-code-native}/bin/claude";
+  #
+  # force = true is REQUIRED: Claude's native installer (~/.local/share/claude)
+  # keeps self-updating and rewriting this symlink to its own build, even with
+  # DISABLE_AUTOUPDATER=1 set — the updater process ignores it. Without force,
+  # HM activation fails ("Existing file ... would be clobbered") and rolls back
+  # the whole deploy. force lets HM reclaim the path unconditionally so a stray
+  # self-update can never break a deploy again.
+  home.file.".local/bin/claude" = {
+    source = "${pkgs.claude-code-native}/bin/claude";
+    force = true;
+  };
 
   # Enable Claude Code "Agent Teams" — experimental feature that lets one
   # Claude session spawn a team of coordinated teammates (separate sessions

--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -31,7 +31,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.183";
+  version = "2.1.185";
 
   # Claude Code reads clipboard images by shelling out to:
   #   xclip -selection clipboard -t TARGETS -o ... || wl-paste -l ...   (detect)
@@ -63,11 +63,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-3ztAnFslKZ31LF7oH2SBHb3LLhjBvu/n9zPDJvCozc4=";
+      hash = "sha256-4SRjOGmfBO4OYn3uP21O16C6tI4FFL3mnG2tQ7wwOVI=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-JgpuQ/6cb9iAAxdYGYL/UOT0QB0C72Jfqk33I7uXELM=";
+      hash = "sha256-24gIEiclBEVd9zFg2S+t+TcO2mhMIZzr+OYrCiYssvg=";
     };
   };
 


### PR DESCRIPTION
## Problem

Yesterday's fix (#931: `DISABLE_AUTOUPDATER=1` globally + remove stray install) **did not hold**. Claude's native installer re-bootstrapped `~/.local/share/claude` and self-updated to **2.1.185** today, clobbering the HM-owned `~/.local/bin/claude` symlink **despite** `DISABLE_AUTOUPDATER=1` being set. HM activation then failed `Existing file ... would be clobbered`, and `update-commit-deploy` rolled back p620 + closed the bump PR.

## Root cause

The env var is not a reliable kill-switch for the native auto-updater — the updating process ignores it (or runs without it). Treating the *source* can't be guaranteed.

## Fix (durable)

- **`home.file.".local/bin/claude".force = true`** — HM reclaims the path unconditionally on every activation. No matter what rewrites the symlink, a deploy **cannot fail** on it again. (HM's own error message recommends exactly this.)
- **Bump `claude-code-native` 2.1.183 → 2.1.185** (latest) so the version nix asserts matches what the updater fetches, minimizing PATH divergence.

`DISABLE_AUTOUPDATER` is kept as best-effort churn reduction, but correctness no longer depends on it.

## Testing

✅ `nix build …claude-code-native` → `2.1.185 (Claude Code)`
✅ `just test-host p620` + `just test-host razer` — both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)