### PR TITLE
chore(antigravity): bump CLI (agy) to 1.0.10

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.0.9-6003845613092864";
+  version = "1.0.10-6349723456634880";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.9-6003845613092864/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-zYD4X0O1Kzide0mNZ4T4MW1Xqcxi6uI9hAxd42j5xNU=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.10-6349723456634880/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-ZUfPmjcifyYAT6S4BUGLHflvVMV7lyPKfRCGTSYQuw8=";
   };
 
   # Tarball contains a single file `antigravity` at the root.


### PR DESCRIPTION
## Summary

Bump `antigravity-cli` (`agy`) **1.0.9 → 1.0.10** (full pin `1.0.10-6349723456634880`) per upstream's auto-updater manifest.

- New SRI hash: `sha256-ZUfPmjcifyYAT6S4BUGLHflvVMV7lyPKfRCGTSYQuw8=`
- **antigravity-ide** left at `2.0.4` — confirmed already latest via the upstream IDE release manifest (`antigravity-ide-auto-updater-.../releases`).

## Testing

- ✅ Builds via `customPkgs` overlay (fetch hash matches, autoPatchelf clean)
- ✅ `agy --version` → `1.0.10`
- ✅ Deployed to **p620** (`just quick-deploy p620`) — new generation activated, no failed units; live `agy --version` = `1.0.10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)