### PR TITLE
chore(claude-code): bump CLI (claude) to 2.1.186

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -31,7 +31,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.185";
+  version = "2.1.186";
 
   # Claude Code reads clipboard images by shelling out to:
   #   xclip -selection clipboard -t TARGETS -o ... || wl-paste -l ...   (detect)
@@ -63,11 +63,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-4SRjOGmfBO4OYn3uP21O16C6tI4FFL3mnG2tQ7wwOVI=";
+      hash = "sha256-am1dI0hll8kxOJQcm2jKoPvNLc7b9J4pqcjYPjocsyk=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-24gIEiclBEVd9zFg2S+t+TcO2mhMIZzr+OYrCiYssvg=";
+      hash = "sha256-gX5f9INWi3jEkXG+MXubkZDK3nckild26RJ4kxKWHLY=";
     };
   };
 


### PR DESCRIPTION
## Summary

Bumps `claude-code-native` (the CLI) from **2.1.185 → 2.1.186** (latest channel).

- Updated `version` in `pkgs/claude-code-native/default.nix`
- Refreshed both SRI hashes (`x86_64-linux`, `aarch64-linux`) from Anthropic's GCS distribution via `scripts/update-claude-code-native.sh`

## Testing

- `claude --version` → `2.1.186 (Claude Code)` ✓
- `ldd` on the wrapped binary → no missing libs ✓
- Host matrix toplevel builds all green:
  - p620 ✓
  - razer ✓
  - p510 ✓

Tracks `claude-code` only — `claude-desktop` untouched (separate cadence/risk).

Closes #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)