### PR TITLE
chore(claude-code): bump CLI (claude) to 2.1.187 (#945)

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -31,7 +31,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.186";
+  version = "2.1.187";
 
   # Claude Code reads clipboard images by shelling out to:
   #   xclip -selection clipboard -t TARGETS -o ... || wl-paste -l ...   (detect)
@@ -63,11 +63,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-am1dI0hll8kxOJQcm2jKoPvNLc7b9J4pqcjYPjocsyk=";
+      hash = "sha256-uwL8szYm+MWZ0Q2L7jhYXUz41CJcO0l4ad7nRU5782E=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-gX5f9INWi3jEkXG+MXubkZDK3nckild26RJ4kxKWHLY=";
+      hash = "sha256-tJvopeVlvy1FtQ0t5iAXslRiExrMlCXS/bmLjynJ3OI=";
     };
   };
 


### PR DESCRIPTION
## Summary
Bump `claude-code-native` from **2.1.186 → 2.1.187**.

- Version + both SRI hashes (x86_64, aarch64) refreshed via `scripts/update-claude-code-native.sh latest`.

## Testing
- `nix build .#claude-code-native` → `claude --version` reports `2.1.187`, `ldd` shows no missing libs.
- Host matrix builds clean: **p620 OK**, **razer OK**, **p510 OK**.

Closes #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)