### PR TITLE
feat(k3d): add daily skillai-db backup timer (#960)

### DIFF
--- a/docs/applications/k3d-cluster.md
+++ b/docs/applications/k3d-cluster.md
@@ -422,21 +422,49 @@ kubectl get secret <name> -n factory -o json \
 
 ### Backups
 
-- **Daily** via `keycloak-realm-backup.timer` →
+- **Keycloak realm — daily** via `keycloak-realm-backup.timer` →
   `/mnt/img_pool/k3d/backups/keycloak/keycloakdb-{TIMESTAMP,latest}.mv.db`
   (14 timestamped copies kept).
+- **skillai database — daily** via `skillai-db-backup.timer` →
+  `/mnt/img_pool/k3d/backups/skillai/skillai-{TIMESTAMP,latest}.dump`
+  (logical `pg_dump -Fc`, 14 timestamped copies kept).
 - **On demand:** `sudo systemctl start keycloak-realm-backup.service`
+  / `sudo systemctl start skillai-db-backup.service`
 - ⚠️ Backups live on the **same disk** as the cluster — fine for
   recreate/corruption recovery, **not** full disk loss. Add an off-host copy
   (rsync/restic to p620 or object storage) for true DR.
 
+#### Restore the skillai database from a dump
+
+The `pg_dump -Fc` archive restores into a live (possibly empty) `skillai-db`:
+
+```bash
+KC=/tmp/kc; sudo k3d kubeconfig get factory > "$KC"; export KUBECONFIG=$KC
+# pipe the latest dump into pg_restore inside the running DB pod
+kubectl exec -i -n factory skillai-db-0 -- \
+  pg_restore -U skillai -d skillai --clean --if-exists --no-owner \
+  < /mnt/img_pool/k3d/backups/skillai/skillai-latest.dump
+# verify
+kubectl exec -n factory skillai-db-0 -- psql -U skillai -d skillai \
+  -tAc 'SELECT count(*) FROM candidates;'
+```
+
+> For recovery from an **orphaned pre-crash PVC dir** (no dump available — the
+> 2026-06-25 case), the data lives under
+> `/mnt/img_pool/k3d/storage/pvc-*_factory_data-skillai-db-0/pgdata`. Identify
+> the pre-crash dir by newest internal file mtime, scale `skillai-db`/`skillai-app`
+> to 0 (disable ArgoCD auto-sync first), `cp -a` its `pgdata` over the live PVC's
+> `pgdata`, then scale back up — PostgreSQL crash-recovers on start.
+
 ### Known residual gaps
 
-- **App databases** (postgres/minio PVCs) have **no restore automation** — a
-  full cluster *recreate* rebuilds them empty. The hardened bootstrap now
-  *avoids* recreate (it self-heals in place), so this is a rare-catastrophe
-  gap, not an everyday one. Adding per-DB dump timers + restore-on-bootstrap
-  would close it.
+- **App databases** — `skillai-db` now has a daily logical-dump timer
+  (`skillai-db-backup.timer`). The remaining app DBs (`postgres`, `minio`,
+  `rolehunter-db`) still have **no restore automation** — a full cluster
+  *recreate* rebuilds them empty. The hardened bootstrap now *avoids* recreate
+  (it self-heals in place), so this is a rare-catastrophe gap. Extending the
+  same per-DB dump-timer pattern (+ restore-on-bootstrap) would close it
+  fully.
 - The reboot self-heal logic is deployed but was **not yet validated with a
   live reboot** (deferred). Run the verification checklist after the next
   natural reboot.

--- a/modules/containers/k3d.nix
+++ b/modules/containers/k3d.nix
@@ -532,6 +532,56 @@ in
       };
     };
 
+    # skillai application database backup. skillai-db is a PostgreSQL
+    # StatefulSet on a dynamic local-path PVC; a full cluster recreate
+    # re-points it at a fresh empty PVC and the data is lost (incident
+    # 2026-06-25, recovered only because the previous PVC dir lingered
+    # orphaned on disk). Unlike Keycloak's raw H2 copy, a logical pg_dump
+    # (-Fc custom format) is consistent and version-independent — restore
+    # with `pg_restore -U skillai -d skillai --clean --if-exists`.
+    systemd.services.skillai-db-backup = mkIf cfg.argocd.enable {
+      description = "Backup skillai PostgreSQL database (pg_dump) to durable storage";
+      after = [ "k3d-cluster-bootstrap.service" ];
+      path = with pkgs; [ kubectl coreutils ];
+      environment.KUBECONFIG = cfg.kubeconfigPath;
+      serviceConfig = {
+        Type = "oneshot";
+        User = "root";
+        ExecStart = pkgs.writeShellScript "skillai-db-backup" ''
+          set -uo pipefail
+          BACKUP_DIR="${builtins.dirOf (toString cfg.storageDir)}/backups/skillai"
+          mkdir -p "$BACKUP_DIR"
+          # Only dump when the DB pod is actually Running; skip cleanly
+          # otherwise (mid-start, scaled down, cluster not up yet).
+          phase=$(kubectl get pod skillai-db-0 -n factory -o jsonpath='{.status.phase}' 2>/dev/null) || exit 0
+          [ "$phase" = "Running" ] || { echo "[skillai-backup] skillai-db-0 not Running ($phase); skipping" >&2; exit 0; }
+          ts=$(date +%Y%m%d-%H%M%S)
+          out="$BACKUP_DIR/skillai-$ts.dump"
+          # -Fc emits binary; no TTY (-t) so the stream stays clean.
+          if kubectl exec -n factory skillai-db-0 -- pg_dump -U skillai -d skillai -Fc > "$out" 2>/dev/null && [ -s "$out" ]; then
+            cp -f "$out" "$BACKUP_DIR/skillai-latest.dump"
+            # keep the 14 most recent timestamped dumps
+            ls -1t "$BACKUP_DIR"/skillai-2*.dump 2>/dev/null | tail -n +15 | xargs -r rm -f
+            echo "[skillai-backup] saved -> $out ($(wc -c < "$out") bytes)"
+          else
+            rm -f "$out"
+            echo "[skillai-backup] pg_dump failed (db mid-start?); skipping" >&2
+            exit 0
+          fi
+        '';
+      };
+    };
+
+    systemd.timers.skillai-db-backup = mkIf cfg.argocd.enable {
+      description = "Periodic skillai database backup";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "daily";
+        Persistent = true;
+        RandomizedDelaySec = "30m";
+      };
+    };
+
     # Make `kubectl` Just Work for wheel users without manual KUBECONFIG
     # exports. This is a host-wide env var; harmless when the file doesn't
     # exist yet (kubectl errors clearly), and Just Right once the bootstrap


### PR DESCRIPTION
## Summary

Adds a daily `skillai-db-backup` systemd service + timer to `modules/containers/k3d.nix`, closing the documented app-DB backup gap for skillai. Mirrors the existing `keycloak-realm-backup` unit but uses a logical `pg_dump -Fc` via `kubectl exec` (consistent, version-independent, restorable with `pg_restore`).

Motivated by the **2026-06-25 incident**: a cluster recreate re-pointed `skillai-db` at a fresh empty PVC; the data (131 candidates, as of 2026-06-15) was recovered only because the prior PVC dir lingered orphaned on disk.

## Changes
- `modules/containers/k3d.nix`: `skillai-db-backup` service + daily timer (gated on `cfg.argocd.enable`), writes `/mnt/img_pool/k3d/backups/skillai/skillai-{TIMESTAMP,latest}.dump`, 14-copy retention, skips cleanly if the pod isn't Running.
- `docs/applications/k3d-cluster.md`: backups section, `pg_restore` procedure, orphaned-PVC recovery note, residual-gap update.

## Testing
- `nix-instantiate --parse` → OK
- `just test-host p510` → builds clean (new derivations: `skillai-db-backup` service/timer/script only)

## Deploy
Activate with `just quick-deploy p510` after merge.

Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)