### PR TITLE
chore(pkgs): bump antigravity-cli 1.0.12 and antigravity-ide 2.1.1

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.0.9-6003845613092864";
+  version = "1.0.12-6156052174077952";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.9-6003845613092864/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-zYD4X0O1Kzide0mNZ4T4MW1Xqcxi6uI9hAxd42j5xNU=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.12-6156052174077952/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-fjB132jrrViqHPQiMenYuDvyiVtbBYqxc2sLY4PHUAg=";
   };
 
   # Tarball contains a single file `antigravity` at the root.

--- a/pkgs/antigravity-ide/package.nix
+++ b/pkgs/antigravity-ide/package.nix
@@ -103,11 +103,11 @@ let
 in
 stdenv.mkDerivation {
   pname = "antigravity-ide";
-  version = "2.0.4-6381998290370560";
+  version = "2.1.1-6123990880747520";
 
   src = fetchurl {
-    url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.0.4-6381998290370560/linux-x64/Antigravity%20IDE.tar.gz";
-    hash = "sha256-ZjN9RfJHLOXonzlOd67HSQmqG+C7M8n3MpmpX0WOZ3A=";
+    url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.1.1-6123990880747520/linux-x64/Antigravity%20IDE.tar.gz";
+    hash = "sha256-Wyzr99M6aNAD/Y8fqYjRYAkFrOIlBKCF5ThCFCkIeL0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Summary

Bump both Antigravity packages to latest upstream.

| Package | Old → New | Source |
|---|---|---|
| `antigravity-cli` (`agy`) | 1.0.9 → **1.0.12-6156052174077952** | official cloud-run manifest |
| `antigravity-ide` (desktop) | 2.0.4 → **2.1.1-6123990880747520** | Google edgedl CDN |

## Testing

- ✅ `antigravity-cli` builds (`nixosConfigurations.p620.pkgs.customPkgs.antigravity-cli`)
- ✅ `antigravity-ide` builds; output paths intact (wrapper bin, real binary, `.desktop`, icon)
- ✅ IDE hash cross-checked against `Hy4ri/antigravity-flake` tracker and verified directly against Google's CDN

🤖 Generated with [Claude Code](https://claude.com/claude-code)