### PR TITLE
chore(claude-code): update native binary to 2.1.193

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -31,7 +31,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.191";
+  version = "2.1.193";
 
   # Claude Code reads clipboard images by shelling out to:
   #   xclip -selection clipboard -t TARGETS -o ... || wl-paste -l ...   (detect)
@@ -63,11 +63,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-EDjbqIvfG4CUHcPjg+k7CIMlsASXMprFDaRgyHhtW+4=";
+      hash = "sha256-yfBNkp8YvZoQHziX8n3k4eDxXr6EANSq8CmD1z3Wax0=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-GjGny8/XhPjAc7/IoKFYP7bpPmDvcLdtf89mP/7YlJs=";
+      hash = "sha256-OUVM5i55XutIcagfZFPNqW6Sbi25pN1B0OwbYLAVNEg=";
     };
   };
 


### PR DESCRIPTION
## Summary

Bump `claude-code-native` 2.1.191 → **2.1.193** (Anthropic GCS channel).

## Changes
- `version` 2.1.191 → 2.1.193
- x86_64-linux + aarch64-linux hashes (from `scripts/update-claude-code-native.sh`)

## Testing
- ✅ `nix build .#claude-code-native` → `claude --version` = 2.1.193
- ✅ `ldd` clean (no missing libs)
- ✅ All three host toplevels build: p620, razer, p510

Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)