### PR TITLE
chore(claude-desktop): bump to v2.0.22+claude1.15200.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -116,17 +116,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1781050920,
-        "narHash": "sha256-ud0qBit9mUAIVvhfXEgatq4PNASe6nhicwHMmW5Jlpo=",
+        "lastModified": 1782362306,
+        "narHash": "sha256-s5cSeHUQIuvWJGaCt+vXwzDAfF6LvW9KcOPao6bpdDo=",
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "f56421294d46f5db61fba0f833215d18d8c7fa2f",
+        "rev": "cdf934a06185f7f6564606071044139760cae090",
         "type": "github"
       },
       "original": {
         "owner": "aaddrick",
         "repo": "claude-desktop-debian",
-        "rev": "f56421294d46f5db61fba0f833215d18d8c7fa2f",
+        "rev": "cdf934a06185f7f6564606071044139760cae090",
         "type": "github"
       }
     },
@@ -1240,11 +1240,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1780747962,
-        "narHash": "sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1+j+MRChI3TL4tAA=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -122,14 +122,17 @@
     # Workaround: close claude-desktop entirely to release inhibitor,
     # or set CLAUDE_KEEP_AWAKE=0 (#645).
     # Bump via /update-claude-code.
-    # = tag v2.0.19+claude1.11847.5 (commit f56421294d, 2026-06-12)
-    # Delta from previous pin: AppArmor profiles for Ubuntu 24.04+ user
-    # namespaces, GPU-crash auto-recovery, software-center AppStream metainfo,
-    # no more app.asar open prompt; tracks Claude Desktop 1.11847.5.
-    # NOTE: main HEAD (d2ce0466, Claude 1.12603.1) does NOT build — upstream
-    # build.sh aborts on the #649 .asar --add-dir patch (upstream issue #718).
-    # Stay on the latest *release* until that's fixed. Bump via /update-claude-code.
-    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/f56421294d46f5db61fba0f833215d18d8c7fa2f";
+    # = tag v2.0.22+claude1.15200.0 (commit cdf934a061, 2026-06-25)
+    # Delta from previous pin (v2.0.19+claude1.11847.5): cowork renderer
+    # support-gate fix (#743) and upstream tracking up to Claude Desktop
+    # 1.15200.0.
+    # NOTE: pin to the latest *release* tag, NOT main HEAD — historically main
+    # can fail to build (e.g. upstream issue #718). Bump via /update-claude-code.
+    # Known open upstream runtime bugs at this pin (UI-only, not build blockers):
+    # menu-bar icon glitch on 1.15200.0 (#746), launcher.log O(n²) hang on large
+    # logs (#726/#747). We consume upstream's claude-desktop-fhs as-is (no local
+    # patch); node-pty/asar handling lives in upstream build.sh.
+    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/cdf934a06185f7f6564606071044139760cae090";
 
     # GogMail — keyboard-driven Google Workspace TUI (Gmail/Calendar/Tasks/
     # Drive/Contacts/Chat) built on the gog CLI. Consumed via overlays as


### PR DESCRIPTION
## Summary

Bump the `claude-desktop-linux` flake input from **v2.0.19+claude1.11847.5** (`f56421294d`, 2026-06-10) to **v2.0.22+claude1.15200.0** (`cdf934a061`, 2026-06-25).

Delta: cowork renderer support-gate fix (upstream #743) + tracking up to Claude Desktop 1.15200.0. We consume upstream's `claude-desktop-fhs` directly — no local patch.

## Testing
- ✅ `claude-desktop-fhs` builds; inner = `claude-desktop-1.15200.0`
- ✅ `pty.node` is ELF in `app.asar.unpacked/` (node-pty native binary intact)
- ✅ All three host toplevels build: p620, razer, p510
- Diff scope: only `flake.nix` + `flake.lock` (input rev + its own transitive nixpkgs; main nixpkgs untouched)

## Known open upstream runtime bugs at this pin (UI-only, not build blockers)
- Menu-bar icon glitch on 1.15200.0 (aaddrick#746)
- launcher.log O(n²) hang on large logs (aaddrick#726/#747)

## Deploy note
claude-desktop runs on **razer + p620** only. The running Electron app keeps the OLD store path until `pkill -f claude-desktop` + relaunch — will lose in-flight state, so deploy/restart is left to the user.

Closes #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)