### PR TITLE
chore(claude-code): update native binary 2.1.193 → 2.1.195 (#969)

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -31,7 +31,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.193";
+  version = "2.1.195";
 
   # Claude Code reads clipboard images by shelling out to:
   #   xclip -selection clipboard -t TARGETS -o ... || wl-paste -l ...   (detect)
@@ -63,11 +63,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-yfBNkp8YvZoQHziX8n3k4eDxXr6EANSq8CmD1z3Wax0=";
+      hash = "sha256-gyPnASUGMUekR4uVd0XYNah+XnL/0luDjqmoQcA+ajc=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-OUVM5i55XutIcagfZFPNqW6Sbi25pN1B0OwbYLAVNEg=";
+      hash = "sha256-sCJ5mZBY3ICg4cXTlGPRVFoXhhVJL4QTmqyNYSFKfpo=";
     };
   };
 


### PR DESCRIPTION
## Summary

Updates the `claude-code` native binary from **2.1.193 → 2.1.195** (Anthropic GCS `latest` channel).

- `version = "2.1.195"`
- Updated x86_64-linux + aarch64-linux source hashes

## Testing

- ✅ `nix build .#claude-code-native` → `claude --version` reports `2.1.195`
- ✅ `ldd` shows no missing libs
- ✅ All 3 host configs build: p620, razer, p510

Closes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)