### PR TITLE
chore(antigravity): bump CLI 1.0.13 and SDK 0.1.5

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.0.12-6156052174077952";
+  version = "1.0.13-5758107482193920";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.12-6156052174077952/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-fjB132jrrViqHPQiMenYuDvyiVtbBYqxc2sLY4PHUAg=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.13-5758107482193920/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-a/mQRYwRSvOzFz3LwbD7mrk76pHFO2Bf3Wmu3SmiHNk=";
   };
 
   # Tarball contains a single file `antigravity` at the root.

--- a/pkgs/google-antigravity-py/default.nix
+++ b/pkgs/google-antigravity-py/default.nix
@@ -25,15 +25,15 @@
 # Upstream: https://github.com/google-antigravity/antigravity-sdk-python
 buildPythonPackage rec {
   pname = "google-antigravity";
-  version = "0.1.1";
+  version = "0.1.5";
   format = "wheel";
 
   # fetchPypi gets the URL wrong for this package (constructs
   # google-antigravity- instead of google_antigravity-), so use fetchurl
   # with the canonical PyPI download URL.
   src = fetchurl {
-    url = "https://files.pythonhosted.org/packages/f3/21/9c3b3b59943b2f0c89c35282c8838b691a1e6b39f3801f40a23882ea45f6/google_antigravity-0.1.1-py3-none-manylinux_2_17_x86_64.whl";
-    hash = "sha256-ZMzXHZuaUIJ8aOTf20YFV1R9G6qr7OhD1OrlbBu7Ve4=";
+    url = "https://files.pythonhosted.org/packages/6e/18/d89abb1dafe906451c2bd13f0c32917e1d35ba95d2436a06907045a69cfd/google_antigravity-0.1.5-py3-none-manylinux_2_17_x86_64.whl";
+    hash = "sha256-7B6+QES5LkH28WMs+smLsp8D7wvlJEbLWmdXYUcUg2M=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Summary

Updates the local antigravity package set:

| Package | Old | New |
|---|---|---|
| antigravity-cli (`agy`) | 1.0.12-6156052174077952 | **1.0.13-5758107482193920** |
| google-antigravity-py (SDK) | 0.1.1 | **0.1.5** |
| antigravity-ide | 2.1.1 | _unchanged — already latest_ |

Versions cross-checked against the official CLI auto-updater manifest, PyPI, and the `Hy4ri/antigravity-flake` `version.json` tracker.

## Testing

- ✅ `agy --version` → 1.0.13
- ✅ `import google.antigravity` OK (SDK 0.1.5)
- ✅ p620 + razer toplevels build (p510 skipped — not an antigravity host)

## Notes

- The tracker also lists an `antigravity-hub` component (2.2.1) which this repo does **not** package — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)