### PR TITLE
feat(commands): add /update-antigravity

### DIFF
--- a/.claude/commands/update-antigravity.md
+++ b/.claude/commands/update-antigravity.md
@@ -1,0 +1,160 @@
+# Update Antigravity
+
+One-shot bump of **every locally-packaged Google Antigravity component** to
+the latest version, followed by a verification **build** (no `switch`, no
+deploy). Stops short of activating so you can review and deploy on your own
+schedule with `nhs <host>`.
+
+Packaged components (all live under `pkgs/`):
+
+| Key | Package | Binary / module | Source |
+|---|---|---|---|
+| `cli` | `pkgs/antigravity-cli/default.nix` | `agy` | GCS tarball |
+| `ide` | `pkgs/antigravity-ide/package.nix` | `antigravity-ide` (the desktop app) | edgedl CDN |
+| `sdk` | `pkgs/google-antigravity-py/default.nix` | `google.antigravity` (Python) | PyPI wheel |
+
+Single source of truth for versions+hashes is the community tracker
+`Hy4ri/antigravity-flake` (`version.json`), which mirrors the official
+auto-updater manifests and carries cli/ide/hub/sdk in one file. The repo has
+referenced this tracker since the 2.1.1 IDE bump (#962).
+
+> The tracker also lists `hub` (antigravity-hub). This repo does **not**
+> package hub — the script reports it as info and ignores it. If hub is ever
+> added under `pkgs/antigravity-hub`, extend the `COMPONENTS` table in
+> `scripts/update-antigravity.sh`.
+
+## When to use
+
+- You want the latest Antigravity CLI / IDE / SDK but haven't bumped in a while.
+- A watcher or release note says Antigravity moved.
+- Clean-baseline check at the start of a session.
+
+## Prerequisites
+
+- [ ] Working tree clean enough to commit (no unrelated edits to the three
+      `pkgs/antigravity-*` / `pkgs/google-antigravity-py` files).
+- [ ] On an x86_64-linux host that can build closures (p620 or razer —
+      **not p510**, which doesn't ship Antigravity).
+- [ ] `gh auth status` OK (only needed for the PR step).
+
+## Steps
+
+1. **Check first — early-exit if already current.**
+
+   ```bash
+   ./scripts/update-antigravity.sh --check
+   ```
+
+   Prints a `CURRENT / LATEST / STATUS` table for cli, ide, sdk. Exit 0 →
+   everything current; stop, tell the user, do nothing else. Exit 1 → one or
+   more updates available; continue.
+
+2. **Apply the bumps.**
+
+   ```bash
+   ./scripts/update-antigravity.sh
+   ```
+
+   Rewrites `version` + `url` + `hash` in place for each out-of-date
+   component (cli/ide use the tracker's nix32 hash converted to SRI; sdk uses
+   the tracker's PyPI url + SRI directly). Idempotent — safe to re-run. Does
+   NOT build, commit, or deploy.
+
+3. **Show the diff.**
+
+   ```bash
+   git --no-pager diff -- pkgs/antigravity-cli pkgs/antigravity-ide pkgs/google-antigravity-py
+   ```
+
+   Sanity check: only `version`, `url`, and `hash` should change. Anything
+   else moved → stop and investigate.
+
+4. **Build-verify (no switch). Skip p510.**
+
+   ```bash
+   HOST=$(hostname)   # use p620 or razer
+   # the changed packages, fast:
+   nix build --no-link --print-out-paths \
+     ".#nixosConfigurations.${HOST}.pkgs.customPkgs.antigravity-cli" \
+     ".#nixosConfigurations.${HOST}.pkgs.customPkgs.antigravity-ide" \
+     ".#nixosConfigurations.${HOST}.pkgs.customPkgs.google-antigravity-py"
+   # full closure composes:
+   nix build --no-link .#nixosConfigurations.${HOST}.config.system.build.toplevel
+   ```
+
+   All must succeed. A `hash mismatch` means the tracker hash was stale —
+   re-run step 2 (or prefetch the URL yourself) and rebuild.
+
+5. **Sanity-check the binaries.**
+
+   ```bash
+   CLI=$(nix build --no-link --print-out-paths ".#nixosConfigurations.$(hostname).pkgs.customPkgs.antigravity-cli")
+   "$CLI/bin/agy" --version
+   PY=$(nix build --no-link --print-out-paths ".#nixosConfigurations.$(hostname).pkgs.customPkgs.google-antigravity-py")
+   "$PY/bin/python3" -c "import google.antigravity; print('SDK import OK')"
+   ```
+
+6. **Commit (branch + PR — issue-driven workflow).**
+
+   ```bash
+   git checkout -b chore/antigravity-bump
+   git add pkgs/antigravity-cli pkgs/antigravity-ide pkgs/google-antigravity-py
+   git commit --no-verify -m "chore(antigravity): bump packages to latest"
+   git push -u origin chore/antigravity-bump
+   gh pr create --fill
+   ```
+
+   Use `git commit --no-verify` — the pre-commit statix hook hangs (established
+   workaround).
+
+7. **Tell the user how to deploy.** Do NOT `switch` from this command.
+
+   ```text
+   Antigravity bumped. To deploy (p620 + razer only):
+       nhs p620        # local
+       nhs razer       # remote
+   ```
+
+   razer note: `nh --target-host` can fail reading sudo over non-TTY even
+   though razer has passwordless sudo. If so, activate the already-copied
+   closure directly on razer:
+
+   ```bash
+   ssh razer 'sudo nix-env -p /nix/var/nix/profiles/system --set <toplevel> \
+     && sudo <toplevel>/bin/switch-to-configuration switch'
+   ```
+
+## Failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `--check` exits 0 | All current. | Tell user, stop. Not an error. |
+| tracker fetch fails | Network / repo moved. | Check `curl -fsSL https://raw.githubusercontent.com/Hy4ri/antigravity-flake/main/version.json \| jq`. |
+| `nix build` `hash mismatch` | Tracker hash stale vs the served file. | Re-run step 2; if it persists, `nix store prefetch-file <url>` and paste the SRI manually. |
+| `rewrite failed (... subs=0)` | A package file's `version`/`url`/`hash` layout changed. | Inspect the file; the script expects one `version = "...";` and a `url`→`hash` fetchurl block. |
+| IDE build fails on `autoPatchelfHook` | New IDE release added a runtime dep. | Add the missing lib to `runtimeLibs` in `pkgs/antigravity-ide/package.nix`. |
+
+## Anti-patterns to avoid
+
+- ❌ Do NOT chain a `switch`/deploy into this command — bump + build only.
+- ❌ Do NOT skip the `--check` early-exit.
+- ❌ Do NOT build/deploy p510 — it doesn't ship Antigravity.
+- ❌ Do NOT hand-edit the three package files when the script can do it —
+   keep the blast radius to `pkgs/antigravity-*` + `pkgs/google-antigravity-py`.
+
+## Related files
+
+- `scripts/update-antigravity.sh` — the worker this command drives.
+- `pkgs/antigravity-cli/default.nix` — `agy` CLI derivation.
+- `pkgs/antigravity-ide/package.nix` — Electron IDE derivation.
+- `pkgs/google-antigravity-py/default.nix` — Python SDK wheel.
+- `pkgs/default.nix` — exposes all three as `customPkgs.*`.
+- `Users/olafkfreund/profile.nix` — home-manager consumer (p620 + razer).
+
+## Why this exists
+
+Antigravity ships outside nixpkgs via Google CDNs with unguessable build-id
+suffixes; the `Hy4ri/antigravity-flake` tracker is the practical way to learn
+the current version+hash for every component. This command + script bump all
+of them in one shot, matching the `/update-warp` and `/update-waveterm`
+pattern.

--- a/scripts/update-antigravity.sh
+++ b/scripts/update-antigravity.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# update-antigravity.sh [--check]
+#
+# Bump every locally-packaged Google Antigravity component to the latest
+# version. Single source of truth is the community version tracker
+# `Hy4ri/antigravity-flake` (`version.json`), which the repo already
+# cross-references — it carries cli / ide / hub / sdk versions + hashes in
+# one place and tracks the official auto-updater manifests.
+#
+# Components WE package (others in the tracker are ignored):
+#   cli  -> pkgs/antigravity-cli/default.nix       (`agy`, GCS tarball)
+#   ide  -> pkgs/antigravity-ide/package.nix       (Electron IDE, edgedl CDN)
+#   sdk  -> pkgs/google-antigravity-py/default.nix (PyPI wheel)
+#
+# NOT packaged here: `hub` (antigravity-hub). The tracker lists it; if you
+# ever add pkgs/antigravity-hub, extend the COMPONENTS table below.
+#
+# Modes:
+#   --check   report current vs latest for each component; exit 1 if any
+#             update is available, exit 0 if all current. Edits nothing.
+#   (default) rewrite version + url + hash in place for each out-of-date
+#             component. Idempotent. Does NOT build, commit, or deploy.
+#
+# After a default run: build-verify, then commit + deploy on your schedule.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+CHECK=0
+[ "${1:-}" = "--check" ] && CHECK=1
+
+TRACKER="https://raw.githubusercontent.com/Hy4ri/antigravity-flake/main/version.json"
+
+log() { printf ">> \033[1;34m%s\033[0m\n" "$*"; }
+ok() { printf ">> \033[1;32m%s\033[0m\n" "$*"; }
+warn() { printf ">> \033[1;33m%s\033[0m\n" "$*" >&2; }
+die() {
+  printf "!! \033[1;31m%s\033[0m\n" "$*" >&2
+  exit 1
+}
+
+command -v jq >/dev/null || die "jq not found"
+command -v curl >/dev/null || die "curl not found"
+
+log "fetching version tracker: $TRACKER"
+VJSON="$(curl -fsSL --max-time 30 "$TRACKER")" || die "could not fetch tracker version.json"
+
+# to_sri <nix32-or-sri-hash> : normalise any hash to SRI sha256
+to_sri() {
+  local h="$1"
+  case "$h" in
+    sha256-*) printf '%s' "$h" ;;
+    *) nix hash convert --hash-algo sha256 --to sri "$h" 2>/dev/null \
+      || nix hash to-sri --type sha256 "$h" ;;
+  esac
+}
+
+# current_version <file> : the `version = "...";` value
+current_version() { grep -m1 -oE 'version = "[^"]*"' "$1" | sed -E 's/version = "([^"]*)"/\1/'; }
+
+# rewrite_pkg <file> <new_version> <new_url> <new_sri>
+# Replaces the version line and the fetchurl url+hash block in place.
+rewrite_pkg() {
+  python3 - "$@" <<'PY'
+import re, sys
+f, ver, url, sri = sys.argv[1:5]
+s = open(f).read()
+s, nv = re.subn(r'version = "[^"]*";', f'version = "{ver}";', s, count=1)
+# Replace the first `url = "...";` followed (any whitespace) by `hash = "...";`
+s, nb = re.subn(r'url = "[^"]*";(\s*)hash = "[^"]*";',
+                f'url = "{url}";\\1hash = "{sri}";', s, count=1)
+if nv != 1 or nb != 1:
+    sys.exit(f"rewrite failed for {f} (version subs={nv}, url/hash subs={nb})")
+open(f, 'w').write(s)
+PY
+}
+
+# --- component definitions -------------------------------------------------
+# Each: tracker-key | nix file | url template (uses $V) | tracker hash path
+declare -A FILE URLT HASHKEY
+COMPONENTS=(cli ide sdk)
+
+# URLT[*] carry a literal `__V__` token, replaced with the resolved version
+# below via bash substitution (no eval).
+FILE[cli]="pkgs/antigravity-cli/default.nix"
+URLT[cli]="https://storage.googleapis.com/antigravity-public/antigravity-cli/__V__/linux-x64/cli_linux_x64.tar.gz"
+HASHKEY[cli]='.cli.hashes."x86_64-linux"'
+
+FILE[ide]="pkgs/antigravity-ide/package.nix"
+URLT[ide]="https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/__V__/linux-x64/Antigravity%20IDE.tar.gz"
+HASHKEY[ide]='.ide.hashes."x86_64-linux"'
+
+FILE[sdk]="pkgs/google-antigravity-py/default.nix"
+URLT[sdk]='' # sdk url comes straight from the tracker (PyPI wheel)
+HASHKEY[sdk]='.sdk.hashes."x86_64-linux"'
+
+updates=0
+printf "\n%-6s %-26s %-26s %s\n" "COMP" "CURRENT" "LATEST" "STATUS"
+printf "%-6s %-26s %-26s %s\n" "----" "-------" "------" "------"
+
+declare -A NEWVER NEWURL NEWSRI
+for c in "${COMPONENTS[@]}"; do
+  file="${FILE[$c]}"
+  [ -f "$file" ] || {
+    warn "$c: $file missing — skipping"
+    continue
+  }
+  cur="$(current_version "$file")"
+  latest="$(jq -r ".${c}.version" <<<"$VJSON")"
+  [ "$latest" = "null" ] && {
+    warn "$c: not in tracker — skipping"
+    continue
+  }
+
+  if [ "$cur" = "$latest" ]; then
+    printf "%-6s %-26s %-26s %s\n" "$c" "$cur" "$latest" "current"
+    continue
+  fi
+  updates=$((updates + 1))
+  printf "%-6s %-26s %-26s %s\n" "$c" "$cur" "$latest" "UPDATE"
+
+  # resolve url
+  if [ "$c" = "sdk" ]; then
+    url="$(jq -r '.sdk.urls."x86_64-linux"' <<<"$VJSON")"
+  else
+    url="${URLT[$c]//__V__/$latest}"
+  fi
+  sri="$(to_sri "$(jq -r "${HASHKEY[$c]}" <<<"$VJSON")")"
+  [ -n "$url" ] && [ -n "$sri" ] || die "$c: could not resolve url/hash"
+  NEWVER[$c]="$latest"
+  NEWURL[$c]="$url"
+  NEWSRI[$c]="$sri"
+done
+echo
+
+# tracker also tracks `hub` (not packaged here) — surface it as info only
+HUB="$(jq -r '.hub.version // empty' <<<"$VJSON")"
+[ -n "$HUB" ] && log "tracker also lists hub=$HUB (not packaged in this repo — ignored)"
+
+if [ "$updates" -eq 0 ]; then
+  ok "all packaged antigravity components are current — nothing to do"
+  exit 0
+fi
+
+if [ "$CHECK" -eq 1 ]; then
+  warn "$updates update(s) available — re-run without --check to apply"
+  exit 1
+fi
+
+for c in "${COMPONENTS[@]}"; do
+  [ -n "${NEWVER[$c]:-}" ] || continue
+  log "rewriting ${FILE[$c]} -> ${NEWVER[$c]}"
+  rewrite_pkg "${FILE[$c]}" "${NEWVER[$c]}" "${NEWURL[$c]}" "${NEWSRI[$c]}"
+done
+
+ok "applied $updates update(s). Next:"
+cat <<EOF
+
+  # build-verify (current host; skip p510 — not an antigravity host)
+  HOST=\$(hostname)
+  nix build --no-link .#nixosConfigurations.\$HOST.config.system.build.toplevel
+
+  # commit + deploy on your schedule
+  git add pkgs/antigravity-cli pkgs/antigravity-ide pkgs/google-antigravity-py
+  git commit --no-verify -m "chore(antigravity): bump packages"
+  nhs \$HOST     # or: nh os switch --hostname \$HOST .
+EOF


### PR DESCRIPTION
## Summary

Adds a `/update-antigravity` slash-command + worker script that bumps **all
locally-packaged Antigravity components** in one shot:

- **cli** (`agy`) — `pkgs/antigravity-cli/default.nix`
- **ide** (desktop) — `pkgs/antigravity-ide/package.nix`
- **sdk** (Python) — `pkgs/google-antigravity-py/default.nix`

Versions/hashes come from the `Hy4ri/antigravity-flake` `version.json` tracker
(mirrors the official auto-updater manifests). Modeled on `/update-warp` and
`/update-waveterm`: check → apply → build → PR, **no auto-switch**.

## Files

- `scripts/update-antigravity.sh` — `--check` (report, exit 1 if updates) and
  default (rewrite version+url+hash in place; idempotent).
- `.claude/commands/update-antigravity.md` — the command doc.

## Testing

- ✅ `--check` reports cli/ide/sdk all current against the live tracker (exit 0)
- ✅ rewrite path tested on a temp copy (file still parses)
- ✅ shellcheck clean, markdownlint clean, pre-push hooks pass
- ℹ️ The tracker's `hub` component is surfaced as info and ignored (not packaged here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)