### PR TITLE
feat(antigravity): package antigravity-hub (desktop launcher)

### DIFF
--- a/.claude/commands/update-antigravity.md
+++ b/.claude/commands/update-antigravity.md
@@ -10,18 +10,14 @@ Packaged components (all live under `pkgs/`):
 | Key | Package | Binary / module | Source |
 |---|---|---|---|
 | `cli` | `pkgs/antigravity-cli/default.nix` | `agy` | GCS tarball |
-| `ide` | `pkgs/antigravity-ide/package.nix` | `antigravity-ide` (the desktop app) | edgedl CDN |
+| `ide` | `pkgs/antigravity-ide/package.nix` | `antigravity-ide` (the IDE app) | edgedl CDN |
+| `hub` | `pkgs/antigravity-hub/default.nix` | `antigravity-hub` (desktop launcher) | GCS tarball |
 | `sdk` | `pkgs/google-antigravity-py/default.nix` | `google.antigravity` (Python) | PyPI wheel |
 
 Single source of truth for versions+hashes is the community tracker
 `Hy4ri/antigravity-flake` (`version.json`), which mirrors the official
 auto-updater manifests and carries cli/ide/hub/sdk in one file. The repo has
 referenced this tracker since the 2.1.1 IDE bump (#962).
-
-> The tracker also lists `hub` (antigravity-hub). This repo does **not**
-> package hub — the script reports it as info and ignores it. If hub is ever
-> added under `pkgs/antigravity-hub`, extend the `COMPONENTS` table in
-> `scripts/update-antigravity.sh`.
 
 ## When to use
 
@@ -56,14 +52,15 @@ referenced this tracker since the 2.1.1 IDE bump (#962).
    ```
 
    Rewrites `version` + `url` + `hash` in place for each out-of-date
-   component (cli/ide use the tracker's nix32 hash converted to SRI; sdk uses
-   the tracker's PyPI url + SRI directly). Idempotent — safe to re-run. Does
-   NOT build, commit, or deploy.
+   component (cli/ide/hub use the tracker's nix32 hash converted to SRI; sdk
+   uses the tracker's PyPI url + SRI directly). Idempotent — safe to re-run.
+   Does NOT build, commit, or deploy.
 
 3. **Show the diff.**
 
    ```bash
-   git --no-pager diff -- pkgs/antigravity-cli pkgs/antigravity-ide pkgs/google-antigravity-py
+   git --no-pager diff -- pkgs/antigravity-cli pkgs/antigravity-ide \
+     pkgs/antigravity-hub pkgs/google-antigravity-py
    ```
 
    Sanity check: only `version`, `url`, and `hash` should change. Anything
@@ -77,6 +74,7 @@ referenced this tracker since the 2.1.1 IDE bump (#962).
    nix build --no-link --print-out-paths \
      ".#nixosConfigurations.${HOST}.pkgs.customPkgs.antigravity-cli" \
      ".#nixosConfigurations.${HOST}.pkgs.customPkgs.antigravity-ide" \
+     ".#nixosConfigurations.${HOST}.pkgs.customPkgs.antigravity-hub" \
      ".#nixosConfigurations.${HOST}.pkgs.customPkgs.google-antigravity-py"
    # full closure composes:
    nix build --no-link .#nixosConfigurations.${HOST}.config.system.build.toplevel
@@ -98,7 +96,8 @@ referenced this tracker since the 2.1.1 IDE bump (#962).
 
    ```bash
    git checkout -b chore/antigravity-bump
-   git add pkgs/antigravity-cli pkgs/antigravity-ide pkgs/google-antigravity-py
+   git add pkgs/antigravity-cli pkgs/antigravity-ide pkgs/antigravity-hub \
+     pkgs/google-antigravity-py
    git commit --no-verify -m "chore(antigravity): bump packages to latest"
    git push -u origin chore/antigravity-bump
    gh pr create --fill
@@ -139,7 +138,7 @@ referenced this tracker since the 2.1.1 IDE bump (#962).
 - ❌ Do NOT chain a `switch`/deploy into this command — bump + build only.
 - ❌ Do NOT skip the `--check` early-exit.
 - ❌ Do NOT build/deploy p510 — it doesn't ship Antigravity.
-- ❌ Do NOT hand-edit the three package files when the script can do it —
+- ❌ Do NOT hand-edit the package files when the script can do it —
    keep the blast radius to `pkgs/antigravity-*` + `pkgs/google-antigravity-py`.
 
 ## Related files
@@ -147,8 +146,9 @@ referenced this tracker since the 2.1.1 IDE bump (#962).
 - `scripts/update-antigravity.sh` — the worker this command drives.
 - `pkgs/antigravity-cli/default.nix` — `agy` CLI derivation.
 - `pkgs/antigravity-ide/package.nix` — Electron IDE derivation.
+- `pkgs/antigravity-hub/default.nix` — Electron Hub (desktop launcher) derivation.
 - `pkgs/google-antigravity-py/default.nix` — Python SDK wheel.
-- `pkgs/default.nix` — exposes all three as `customPkgs.*`.
+- `pkgs/default.nix` — exposes all four as `customPkgs.*`.
 - `Users/olafkfreund/profile.nix` — home-manager consumer (p620 + razer).
 
 ## Why this exists

--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -164,6 +164,8 @@ in
     # Local derivation in pkgs/antigravity-ide/. See pkgs/default.nix
     # for the rationale (upstream antigravity-nix is still on 1.x).
     pkgs.customPkgs.antigravity-ide
+    # Antigravity Hub — Google's Antigravity desktop launcher (`antigravity-hub`).
+    pkgs.customPkgs.antigravity-hub
     pkgs.customPkgs.kosli-cli
     pkgs.customPkgs.aurynk
     pkgs.wayfarer

--- a/pkgs/antigravity-hub/default.nix
+++ b/pkgs/antigravity-hub/default.nix
@@ -1,0 +1,172 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, makeWrapper
+, alsa-lib
+, at-spi2-atk
+, at-spi2-core
+, atk
+, cairo
+, cups
+, dbus
+, expat
+, glib
+, gtk3
+, libdrm
+, libgbm
+, libglvnd
+, libnotify
+, libsecret
+, libuuid
+, libxkbcommon
+, nspr
+, nss
+, pango
+, systemdLibs
+, vulkan-loader
+, libx11
+, libxscrnsaver
+, libxcomposite
+, libxcursor
+, libxdamage
+, libxext
+, libxfixes
+, libxi
+, libxrandr
+, libxrender
+, libxtst
+, libxcb
+, libxshmfence
+, libxkbfile
+, zlib
+,
+}:
+# Antigravity Hub — Google's Antigravity launcher/desktop "hub".
+#
+# Distinct from antigravity-ide: the IDE rebranded off this CDN at 2.0.0 and
+# moved to edgedl, but the `antigravity-hub` product line continues on the
+# original GCS bucket and tracks its own version (2.2.x as of writing).
+#
+#   - CDN:    storage.googleapis.com/antigravity-public/antigravity-hub/...
+#   - Tarball root: `Antigravity-x64/`
+#   - Binary: top-level `antigravity` (exposed here as `bin/antigravity-hub`)
+#
+# Version + hash come from the Hy4ri/antigravity-flake version.json tracker,
+# same source the `/update-antigravity` command uses. Standard Electron app.
+let
+  runtimeLibs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    glib
+    gtk3
+    libdrm
+    libgbm
+    libuuid
+    libxkbcommon
+    nspr
+    nss
+    pango
+    stdenv.cc.cc.lib
+    libx11
+    libxscrnsaver
+    libxcomposite
+    libxcursor
+    libxdamage
+    libxext
+    libxfixes
+    libxi
+    libxrandr
+    libxrender
+    libxtst
+    libxcb
+    libxshmfence
+    libxkbfile
+    zlib
+    libglvnd
+    vulkan-loader
+    systemdLibs
+    libnotify
+    libsecret
+  ];
+in
+stdenv.mkDerivation {
+  pname = "antigravity-hub";
+  version = "2.2.1-5287492581195776";
+
+  src = fetchurl {
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.2.1-5287492581195776/linux-x64/Antigravity.tar.gz";
+    hash = "sha256-prp3BG+SqhziHYoMZ0lUca9MK+EbpiTl2TWCGWmyCYk=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = runtimeLibs;
+
+  runtimeDependencies = [
+    libglvnd
+    vulkan-loader
+    systemdLibs
+    libnotify
+    libsecret
+  ];
+
+  # Optional bundled deps — ignore if absent (mirrors antigravity-ide).
+  autoPatchelfIgnoreMissingDeps = [
+    "libwebkit2gtk-4.1.so.0"
+    "libsoup-3.0.so.0"
+    "libcurl.so.4"
+    "libcrypto.so.3"
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  # Tarball unpacks to `Antigravity-x64/` (the single source root).
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/antigravity-hub
+    cp -r ./* $out/lib/antigravity-hub/
+
+    # EPIPE-safe launcher (GNOME .desktop closes the child's stdout, which
+    # trips electron-log on first console write — same fix as antigravity-ide).
+    mkdir -p $out/bin
+    makeWrapper $out/lib/antigravity-hub/antigravity $out/bin/antigravity-hub \
+      --add-flags "--password-store=basic"
+
+    mkdir -p $out/share/applications
+    cat > $out/share/applications/com.google.antigravity-hub.desktop <<EOF
+    [Desktop Entry]
+    Name=Antigravity Hub
+    Comment=Google Antigravity desktop hub
+    Exec=$out/bin/antigravity-hub --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto %U
+    Icon=antigravity-hub
+    Terminal=false
+    Type=Application
+    Categories=Development;
+    StartupWMClass=Antigravity
+    MimeType=x-scheme-handler/antigravity;
+    EOF
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Google Antigravity Hub — Antigravity desktop launcher";
+    homepage = "https://antigravity.google";
+    license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "antigravity-hub";
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -55,6 +55,11 @@
   # (URL, layout, binary location, product name). Pinned to 2.0.4-6381998…
   antigravity-ide = pkgs.callPackage ./antigravity-ide/package.nix { };
 
+  # Antigravity Hub — Google's Antigravity desktop launcher (`antigravity-hub`).
+  # Separate product line from the IDE, still on the original GCS bucket.
+  # Version/hash tracked via Hy4ri/antigravity-flake (see /update-antigravity).
+  antigravity-hub = pkgs.callPackage ./antigravity-hub { };
+
   # Antigravity CLI (agy) — Gemini CLI's successor per Google's
   # 2026-05-20 transition. Single Go binary fetched from Google's manifest
   # URL. Replaces the npm-based gemini-cli package we used until #560.

--- a/scripts/update-antigravity.sh
+++ b/scripts/update-antigravity.sh
@@ -78,7 +78,7 @@ PY
 # --- component definitions -------------------------------------------------
 # Each: tracker-key | nix file | url template (uses $V) | tracker hash path
 declare -A FILE URLT HASHKEY
-COMPONENTS=(cli ide sdk)
+COMPONENTS=(cli ide hub sdk)
 
 # URLT[*] carry a literal `__V__` token, replaced with the resolved version
 # below via bash substitution (no eval).
@@ -89,6 +89,10 @@ HASHKEY[cli]='.cli.hashes."x86_64-linux"'
 FILE[ide]="pkgs/antigravity-ide/package.nix"
 URLT[ide]="https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/__V__/linux-x64/Antigravity%20IDE.tar.gz"
 HASHKEY[ide]='.ide.hashes."x86_64-linux"'
+
+FILE[hub]="pkgs/antigravity-hub/default.nix"
+URLT[hub]="https://storage.googleapis.com/antigravity-public/antigravity-hub/__V__/linux-x64/Antigravity.tar.gz"
+HASHKEY[hub]='.hub.hashes."x86_64-linux"'
 
 FILE[sdk]="pkgs/google-antigravity-py/default.nix"
 URLT[sdk]='' # sdk url comes straight from the tracker (PyPI wheel)
@@ -132,10 +136,6 @@ for c in "${COMPONENTS[@]}"; do
   NEWSRI[$c]="$sri"
 done
 echo
-
-# tracker also tracks `hub` (not packaged here) — surface it as info only
-HUB="$(jq -r '.hub.version // empty' <<<"$VJSON")"
-[ -n "$HUB" ] && log "tracker also lists hub=$HUB (not packaged in this repo — ignored)"
 
 if [ "$updates" -eq 0 ]; then
   ok "all packaged antigravity components are current — nothing to do"


### PR DESCRIPTION
## Summary

Packages **antigravity-hub** — Google's Antigravity Hub Electron desktop
launcher (v2.2.1-5287492581195776), a separate product line from
`antigravity-ide` that stays on the original GCS bucket. Also wires it into
the `/update-antigravity` command so it's tracked alongside cli/ide/sdk.

## Changes

- `pkgs/antigravity-hub/default.nix` — new derivation (autoPatchelf + Electron
  runtime libs, `bin/antigravity-hub`, `.desktop` entry), modeled on antigravity-ide
- `pkgs/default.nix` — expose `customPkgs.antigravity-hub`
- `Users/olafkfreund/profile.nix` — install on interactive hosts (p620 + razer)
- `scripts/update-antigravity.sh` — add `hub` to `COMPONENTS`; remove the
  old "not packaged" note
- `.claude/commands/update-antigravity.md` — document hub as a 4th component

## Testing

- ✅ builds; binary is a patched ELF, `ldd` clean
- ✅ `./scripts/update-antigravity.sh --check` → cli/ide/hub/sdk all current
- ✅ p620 + razer toplevels build (p510 skipped — not an antigravity host)
- ✅ shellcheck + markdownlint clean, pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)