### PR TITLE
fix(codex-cli): align module with nixpkgs Rust codex; drop dead config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -402,9 +402,6 @@
             inherit (pkgs) lib buildNpmPackage fetchurl nodejs makeWrapper writeShellScriptBin;
           };
           claude-code-native = pkgs.callPackage ./pkgs/claude-code-native { };
-          codex-cli = pkgs.callPackage ./home/development/codex-cli {
-            inherit (pkgs) nodejs_24;
-          };
           glim = pkgs.callPackage ./overlays/glim { };
           intune-portal = pkgs.callPackage ./pkgs/intune-portal { };
           kosli-cli = pkgs.callPackage ./pkgs/kosli-cli { };

--- a/home/development/codex-cli.nix
+++ b/home/development/codex-cli.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ pkgs, ... }:
 
 {
   imports = [ ./codex-cli/module.nix ];
@@ -6,166 +6,35 @@
   programs.codex-cli = {
     enable = true;
 
-    # Configuration settings
-    defaultModel = "gpt-4";
-    temperature = 0.1; # Lower temperature for more deterministic code generation
-    maxTokens = 4096; # Increased for longer code responses
-    timeout = 60; # Longer timeout for complex requests
-
-    # Feature settings
-    autoSave = true;
-    syntaxHighlighting = true;
-    interactiveMode = true;
-
-    # API key integration (use agenix secret)
+    # API key for the headless path. codex (Rust) reads OPENAI_API_KEY, or use
+    # `codex login` for ChatGPT auth. Sourced from the agenix secret.
     apiKeyFile = "/run/agenix/api-openai";
 
-    # Enhanced shell aliases for convenience. `codex` is the real binary
-    # name from nixpkgs#codex — no need to alias it. The rest stay so
-    # existing muscle memory keeps working.
+    # `codex` is the real binary name from nixpkgs#codex. The rest are
+    # convenience aliases so existing muscle memory keeps working.
     shellAliases = {
       ai-code = "codex";
       openai-codex = "codex";
-      cx = "codex"; # Short alias
+      cx = "codex";
       code-ai = "codex";
-
-      # Project-specific aliases
       codex-project = "codex-project";
       cx-project = "codex-project";
       cx-analyze = "codex-project analyze";
       cx-ask = "codex-project ask";
     };
-
-    # Additional configuration
-    extraConfig = {
-      # Editor integration
-      editor = "nvim";
-
-      # Project features
-      project_templates = true;
-      git_integration = true;
-
-      # Code analysis
-      static_analysis = true;
-      security_scan = true;
-
-      # Output preferences
-      color_output = true;
-      verbose_logging = false;
-
-      # Performance settings
-      cache_responses = true;
-      parallel_requests = false;
-    };
   };
 
-  # Home configuration block
-  home = {
-    # Additional packages that work well with Codex
-    packages = with pkgs; [
-      # Code formatting and linting tools that complement AI code generation
-      prettier
-      eslint
-      black # Python formatter
-      rustfmt # Rust formatter
-      nixpkgs-fmt # Nix formatter
-
-      # Development utilities
-      jq # JSON processing for API responses
-      curl # API testing
-      httpie # User-friendly HTTP client
-    ];
-
-    # Environment variables for enhanced integration
-    sessionVariables = {
-      # Codex-specific environment
-      CODEX_CONFIG_DIR = "${config.xdg.configHome}/codex";
-      CODEX_CACHE_DIR = "${config.xdg.cacheHome}/codex";
-
-      # Integration with other tools
-      CODEX_EDITOR = "nvim";
-      CODEX_PROJECT_ROOT = "$(git rev-parse --show-toplevel 2>/dev/null || pwd)";
-    };
-  };
-
-  # XDG configuration for proper file organization
-  xdg.configFile = {
-    "codex/prompts/system.txt" = {
-      text = ''
-        You are an expert software engineer assistant integrated into a NixOS development environment.
-
-        Context:
-        - Operating System: NixOS (declarative Linux distribution)
-        - Development setup: Comprehensive development environment with multiple languages
-        - Editor: Neovim with LazyVim configuration
-        - Shell: Zsh with advanced configuration
-        - Package Management: Nix with flakes
-
-        When generating code:
-        1. Follow the established patterns in the project
-        2. Consider NixOS-specific requirements when applicable
-        3. Use modern, idiomatic code practices
-        4. Include appropriate error handling
-        5. Add helpful comments for complex logic
-        6. Consider security implications
-
-        Available languages and tools in this environment:
-        - Nix (primary configuration language)
-        - Python, Node.js, Go, Rust, Java, C/C++
-        - Shell scripting (bash, zsh)
-        - Configuration formats (YAML, JSON, TOML)
-
-        Please provide clear, production-ready code with explanations.
-      '';
-    };
-
-    # Create helpful scripts and integrations
-    "codex/templates/nix-module.nix" = {
-      text = ''
-        { config, lib, pkgs, ... }:
-
-        with lib;
-
-        let
-          cfg = config.services.SERVICENAME;
-        in {
-          options.services.SERVICENAME = {
-            enable = mkEnableOption "SERVICENAME";
-
-            # Add your options here
-          };
-
-          config = mkIf cfg.enable {
-            # Add your configuration here
-          };
-        }
-      '';
-    };
-
-    "codex/templates/python-project.py" = {
-      text = ''
-        #!/usr/bin/env python3
-        """
-        Module docstring describing the purpose of this module.
-        """
-
-        import logging
-        from typing import Optional, Dict, Any
-
-        # Configure logging
-        logging.basicConfig(level=logging.INFO)
-        logger = logging.getLogger(__name__)
-
-
-        def main() -> None:
-            """Main entry point."""
-            logger.info("Starting application...")
-            # Add your code here
-
-
-        if __name__ == "__main__":
-            main()
-      '';
-    };
-  };
+  # Complementary dev tooling that pairs well with AI-assisted coding.
+  # codex itself configures via ~/.codex/config.toml, which it self-manages —
+  # nothing declarative is written there from Nix.
+  home.packages = with pkgs; [
+    prettier
+    eslint
+    black # Python formatter
+    rustfmt # Rust formatter
+    nixpkgs-fmt # Nix formatter
+    jq # JSON processing for API responses
+    curl # API testing
+    httpie # User-friendly HTTP client
+  ];
 }

--- a/home/development/codex-cli/module.nix
+++ b/home/development/codex-cli/module.nix
@@ -9,18 +9,6 @@ let
   # OpenAI rewrote codex in Rust mid-2025 and nixpkgs tracks it, so we
   # just consume that and stop maintaining our own packaging.
   codex-cli = pkgs.codex;
-
-  # Note: Configuration template available but using inline generation instead
-  # configFile = pkgs.writeText "codex-config.json" (builtins.toJSON {
-  #   model = cfg.defaultModel;
-  #   temperature = cfg.temperature;
-  #   max_tokens = cfg.maxTokens;
-  #   timeout = cfg.timeout;
-  #   auto_save = cfg.autoSave;
-  #   syntax_highlighting = cfg.syntaxHighlighting;
-  #   interactive_mode = cfg.interactiveMode;
-  # });
-
 in
 {
   options.programs.codex-cli = {
@@ -30,49 +18,6 @@ in
       type = types.package;
       default = codex-cli;
       description = "The codex-cli package to use";
-    };
-
-    defaultModel = mkOption {
-      type = types.str;
-      default = "gpt-4";
-      description = "Default model to use for code generation";
-      example = "gpt-3.5-turbo";
-    };
-
-    temperature = mkOption {
-      type = types.float;
-      default = 0.1;
-      description = "Temperature setting for code generation (0.0-1.0)";
-    };
-
-    maxTokens = mkOption {
-      type = types.int;
-      default = 2048;
-      description = "Maximum tokens per response";
-    };
-
-    timeout = mkOption {
-      type = types.int;
-      default = 30;
-      description = "Request timeout in seconds";
-    };
-
-    autoSave = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Automatically save generated code";
-    };
-
-    syntaxHighlighting = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Enable syntax highlighting in output";
-    };
-
-    interactiveMode = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Enable interactive mode by default";
     };
 
     apiKeyFile = mkOption {
@@ -91,16 +36,6 @@ in
         openai-codex = "codex";
       };
       description = "Shell aliases for codex";
-    };
-
-    extraConfig = mkOption {
-      type = types.attrs;
-      default = { };
-      description = "Additional configuration options";
-      example = {
-        editor = "nvim";
-        project_templates = true;
-      };
     };
   };
 
@@ -160,7 +95,9 @@ in
               echo "Query: $query"
             } > "$context_file"
 
-            "$CODEX_BIN" --context-file "$context_file" "$query"
+            # Rust codex has no --context-file; it appends piped stdin to the
+            # prompt as a <stdin> block. Feed the gathered context that way.
+            "$CODEX_BIN" exec "$query" < "$context_file"
             rm "$context_file"
           }
 
@@ -191,20 +128,11 @@ in
       sessionPath = [ "$HOME/.local/bin" ];
     };
 
-    # Create configuration directory and file
-    xdg.configFile."codex/config.json" = {
-      source = pkgs.writeText "codex-config.json" (builtins.toJSON (
-        {
-          model = cfg.defaultModel;
-          inherit (cfg) temperature;
-          max_tokens = cfg.maxTokens;
-          inherit (cfg) timeout;
-          auto_save = cfg.autoSave;
-          syntax_highlighting = cfg.syntaxHighlighting;
-          interactive_mode = cfg.interactiveMode;
-        } // cfg.extraConfig
-      ));
-    };
+    # NOTE: codex (the Rust CLI) self-manages its config + state under
+    # $CODEX_HOME (~/.codex/config.toml), which it writes itself (personality,
+    # per-project trust_level, sessions, auth.json). We deliberately do NOT
+    # generate a config file here — the old ~/.config/codex/config.json was
+    # silently ignored by this codex. Settings belong in ~/.codex/config.toml.
 
     # Shell aliases
     programs = {


### PR DESCRIPTION
## Summary

codex now comes from nixpkgs' Rust `codex` (`pkgs.codex` 0.142). That binary reads `~/.codex/config.toml` (which it **self-manages** — personality, per-project trust, auth.json) and `CODEX_HOME` — **not** `~/.config/codex`. The home-manager `codex-cli` module was still writing a JSON config + prompts/templates there and setting `CODEX_CONFIG_DIR`/`CACHE_DIR`, all silently ignored.

## Changes
- Drop the ignored `~/.config/codex/config.json` + its dead options (defaultModel/temperature/maxTokens/…)
- Drop ignored `~/.config/codex` prompts/templates + wrong `CODEX_*` env vars
- Fix `codex-project` helper: Rust codex has no `--context-file` → pipe context via stdin (`codex exec "$q" < ctx`)
- `flake.nix`: remove the broken `codex-cli` package output (callPackage of a dir with no `default.nix`)
- Keep: `pkgs.codex` install, `OPENAI_API_KEY` from agenix, aliases, helper

## Testing
- ✅ p620 builds; `codex exec "…"` works (auth + model gpt-5.5)
- ✅ Net −233/+27 lines; both files parse; shellcheck/markdownlint N/A

codex keeps self-managing `~/.codex/config.toml` — nothing declarative written there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)