### PR TITLE
feat(pkgs): package GitHub Copilot desktop app (#github-copilot-app)

### DIFF
--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -166,6 +166,8 @@ in
     pkgs.customPkgs.antigravity-ide
     # Antigravity Hub — Google's Antigravity desktop launcher (`antigravity-hub`).
     pkgs.customPkgs.antigravity-hub
+    # GitHub Copilot desktop app — agent-native desktop experience (Tauri).
+    pkgs.customPkgs.github-copilot-app
     pkgs.customPkgs.kosli-cli
     pkgs.customPkgs.aurynk
     pkgs.wayfarer

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -72,6 +72,11 @@
     (ps.callPackage ./google-antigravity-py { })
   ]);
 
+  # GitHub Copilot desktop app — agent-native desktop experience from the
+  # public github/app release repo (Tauri AppImage). Bump via the latest
+  # github/app release tag (see header comment in the derivation).
+  github-copilot-app = pkgs.callPackage ./github-copilot-app { };
+
   # FlyCrys — GTK4-native GUI for Claude Code (Rust). Not in nixpkgs yet;
   # custom buildRustPackage derivation. Wraps the local `claude` binary.
   flycrys = pkgs.callPackage ./flycrys { };

--- a/pkgs/github-copilot-app/default.nix
+++ b/pkgs/github-copilot-app/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, appimageTools
+, fetchurl
+, makeWrapper
+, webkitgtk_4_1
+, glib-networking
+, libsoup_3
+,
+}:
+# GitHub Copilot desktop app — agent-native desktop experience for GitHub.
+# Distributed as a Tauri AppImage from the public `github/app` release repo.
+# Bump: see /update-* pattern — `gh release view --repo github/app` for the
+# latest tag, then re-prefetch the linux-x64 AppImage and update version+hash.
+let
+  pname = "github-copilot-app";
+  version = "1.0.10";
+
+  src = fetchurl {
+    url = "https://github.com/github/app/releases/download/v${version}/GitHub-Copilot-linux-x64.AppImage";
+    hash = "sha256-VOtxGsIj8m/QBgiI2rowoYeUBbbl6Ks/lRFxrUKdAIk=";
+  };
+
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # Tauri webview runtime: the AppImage bundles most libs, but webkit's TLS
+  # backend (glib-networking) and libsoup must be resolvable for HTTPS in the
+  # embedded webview.
+  extraPkgs = _: [ webkitgtk_4_1 glib-networking libsoup_3 ];
+
+  extraInstallCommands = ''
+    # Desktop entry + icon names vary by release; glob them robustly.
+    # The upstream Exec line names the AppImage's internal binary ("github");
+    # rewrite the whole line to our wrapper, preserving the %u arg so the
+    # x-scheme-handler/github-app deep links keep working.
+    desktop=$(ls ${appimageContents}/*.desktop | head -1)
+    install -m444 -D "$desktop" "$out/share/applications/${pname}.desktop"
+    substituteInPlace "$out/share/applications/${pname}.desktop" \
+      --replace-quiet 'Exec=AppRun' "Exec=${pname}"
+    sed -i -E "s|^Exec=.*|Exec=${pname} %u|" "$out/share/applications/${pname}.desktop"
+
+    if icon=$(ls ${appimageContents}/*.png 2>/dev/null | head -1); then
+      install -m444 -D "$icon" \
+        "$out/share/icons/hicolor/512x512/apps/${pname}.png"
+    fi
+    if [ -d ${appimageContents}/usr/share/icons ]; then
+      cp -r ${appimageContents}/usr/share/icons "$out/share/" || true
+    fi
+
+    wrapProgram "$out/bin/${pname}" \
+      --set XDG_CURRENT_DESKTOP GNOME
+  '';
+
+  meta = {
+    description = "GitHub Copilot agent-native desktop app";
+    homepage = "https://github.com/features/ai/github-app";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = pname;
+  };
+}


### PR DESCRIPTION
Package the GitHub Copilot agent-native desktop app (Tauri AppImage from
the public github/app release repo, v1.0.10) via appimageTools.wrapType2.
Exposed as customPkgs.github-copilot-app and installed on the interactive
hosts (p620 + razer) via Users/olafkfreund/profile.nix. Headless p510 is
excluded.

- pkgs/github-copilot-app/default.nix: wrapType2 derivation, webkit/glib
  TLS runtime deps for the Tauri webview, desktop entry Exec rewritten to
  the wrapper binary (preserving %u for the github-app scheme handlers).
- pkgs/default.nix: register customPkgs.github-copilot-app.
- Users/olafkfreund/profile.nix: add to interactive-host home.packages.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VYbPi22s4wHbjK3xxwoE7C
