### PR TITLE
feat(claude-desktop): switch to Anthropic's official Linux beta

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,26 +110,6 @@
         "type": "github"
       }
     },
-    "claude-desktop-linux": {
-      "inputs": {
-        "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1782362306,
-        "narHash": "sha256-s5cSeHUQIuvWJGaCt+vXwzDAfF6LvW9KcOPao6bpdDo=",
-        "owner": "aaddrick",
-        "repo": "claude-desktop-debian",
-        "rev": "cdf934a06185f7f6564606071044139760cae090",
-        "type": "github"
-      },
-      "original": {
-        "owner": "aaddrick",
-        "repo": "claude-desktop-debian",
-        "rev": "cdf934a06185f7f6564606071044139760cae090",
-        "type": "github"
-      }
-    },
     "claude-skills-borghei": {
       "flake": false,
       "locked": {
@@ -243,7 +223,7 @@
     },
     "emacs": {
       "inputs": {
-        "nixpkgs": "nixpkgs_10",
+        "nixpkgs": "nixpkgs_9",
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
@@ -334,24 +314,6 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
-      },
-      "locked": {
         "lastModified": 1749398372,
         "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
         "owner": "hercules-ci",
@@ -365,9 +327,9 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_2": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_3"
+        "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
         "lastModified": 1767609335,
@@ -383,9 +345,9 @@
         "type": "github"
       }
     },
-    "flake-parts_4": {
+    "flake-parts_3": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_4"
+        "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
         "lastModified": 1760948891,
@@ -401,7 +363,7 @@
         "type": "github"
       }
     },
-    "flake-parts_5": {
+    "flake-parts_4": {
       "inputs": {
         "nixpkgs-lib": [
           "nur",
@@ -422,7 +384,7 @@
         "type": "github"
       }
     },
-    "flake-parts_6": {
+    "flake-parts_5": {
       "inputs": {
         "nixpkgs-lib": [
           "stylix",
@@ -663,7 +625,7 @@
     "gogmail": {
       "inputs": {
         "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1781367918,
@@ -758,7 +720,7 @@
     },
     "lan-mouse": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
@@ -801,7 +763,7 @@
     },
     "mango": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -824,8 +786,8 @@
     "mcp-nixos": {
       "inputs": {
         "devshell": "devshell",
-        "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_5"
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1778979290,
@@ -843,7 +805,7 @@
     },
     "microvm": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_5",
         "spectrum": "spectrum"
       },
       "locked": {
@@ -941,8 +903,8 @@
     "nix-snapd": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-parts": "flake-parts_4",
-        "nixpkgs": "nixpkgs_7"
+        "flake-parts": "flake-parts_3",
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1761703712,
@@ -960,7 +922,7 @@
     },
     "nixos-hardware": {
       "inputs": {
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1782562157,
@@ -997,7 +959,7 @@
       "inputs": {
         "emacs": "emacs",
         "infuse": "infuse",
-        "nixpkgs": "nixpkgs_11",
+        "nixpkgs": "nixpkgs_10",
         "nixpkgs-fmt": "nixpkgs-fmt",
         "parts": "parts"
       },
@@ -1040,21 +1002,6 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib_2": {
-      "locked": {
         "lastModified": 1748740939,
         "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
         "owner": "nix-community",
@@ -1068,7 +1015,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_3": {
+    "nixpkgs-lib_2": {
       "locked": {
         "lastModified": 1765674936,
         "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
@@ -1083,7 +1030,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_4": {
+    "nixpkgs-lib_3": {
       "locked": {
         "lastModified": 1754788789,
         "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
@@ -1098,7 +1045,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_5": {
+    "nixpkgs-lib_4": {
       "locked": {
         "lastModified": 1777168982,
         "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
@@ -1163,22 +1110,6 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_11": {
-      "locked": {
         "lastModified": 1782887135,
         "narHash": "sha256-uYfp/sOhZotHLzfWEXvUWc8CMQUBwybdoPGB4vnYg7E=",
         "owner": "NixOS",
@@ -1193,7 +1124,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_12": {
+    "nixpkgs_11": {
       "locked": {
         "lastModified": 1782723713,
         "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
@@ -1209,7 +1140,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_13": {
+    "nixpkgs_12": {
       "locked": {
         "lastModified": 1782467914,
         "narHash": "sha256-inDx/w70OSJoJPqtKh0BrzAsbZZhpya7YgS43jHnhwg=",
@@ -1222,7 +1153,7 @@
         "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
-    "nixpkgs_14": {
+    "nixpkgs_13": {
       "locked": {
         "lastModified": 1781607440,
         "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
@@ -1240,22 +1171,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1781607440,
-        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1780749050,
         "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
@@ -1270,7 +1185,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1772963539,
         "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
@@ -1286,7 +1201,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1776548001,
         "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
@@ -1302,7 +1217,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1782467914,
         "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
@@ -1318,7 +1233,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1761442529,
         "narHash": "sha256-8aDps5fCt0Ndw56ZgeBvdT7E5zeUSFi3CJaNR7ZJKnA=",
@@ -1333,7 +1248,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1767892417,
         "narHash": "sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U=",
@@ -1346,7 +1261,7 @@
         "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
-    "nixpkgs_9": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1782723713,
         "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
@@ -1357,6 +1272,22 @@
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -1404,8 +1335,8 @@
     },
     "nur": {
       "inputs": {
-        "flake-parts": "flake-parts_5",
-        "nixpkgs": "nixpkgs_12"
+        "flake-parts": "flake-parts_4",
+        "nixpkgs": "nixpkgs_11"
       },
       "locked": {
         "lastModified": 1782885849,
@@ -1448,7 +1379,7 @@
     },
     "parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_5"
+        "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
         "lastModified": 1778716662,
@@ -1491,7 +1422,6 @@
       "inputs": {
         "agenix": "agenix",
         "antigravity-nix": "antigravity-nix",
-        "claude-desktop-linux": "claude-desktop-linux",
         "claude-skills-borghei": "claude-skills-borghei",
         "cosmic-applet-spotify": "cosmic-applet-spotify",
         "flake-utils": "flake-utils_3",
@@ -1508,7 +1438,7 @@
         "nix-index-database": "nix-index-database",
         "nix-snapd": "nix-snapd",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_9",
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-f2k": "nixpkgs-f2k",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "noctalia": "noctalia",
@@ -1702,7 +1632,7 @@
     },
     "spicetify-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_13",
+        "nixpkgs": "nixpkgs_12",
         "systems": "systems_7"
       },
       "locked": {
@@ -1726,7 +1656,7 @@
         "base16-helix": "base16-helix",
         "base16-vim": "base16-vim",
         "firefox-gnome-theme": "firefox-gnome-theme",
-        "flake-parts": "flake-parts_6",
+        "flake-parts": "flake-parts_5",
         "gnome-shell": "gnome-shell",
         "nixpkgs": [
           "nixpkgs"
@@ -2024,7 +1954,7 @@
       "inputs": {
         "crane": "crane_2",
         "flake-utils": "flake-utils_8",
-        "nixpkgs": "nixpkgs_14",
+        "nixpkgs": "nixpkgs_13",
         "rust-overlay": "rust-overlay_5"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -110,29 +110,10 @@
     # Additional tools
     lan-mouse.url = "github:feschber/lan-mouse";
     zjstatus.url = "github:dj95/zjstatus";
-    # = tag v2.0.16+claude1.9255.2, commit 5dd948e9 (2026-05-28).
-    # Claude binary bump 1.9255.0 -> 1.9255.2. Picks up:
-    #   - #660 capture $-prefixed minified names in cowork spawn guard
-    #     (refinement to cowork patch from v2.0.15)
-    # Carries forward from v2.0.15:
-    #   - #657 anchor tray-var extraction on .Tray() literal
-    #   - #650 filter .asar paths from --add-dir dispatch + session restore
-    # Known caveat carried in: #605 (Electron holds systemd-inhibit
-    # forever, blocking suspend while app runs). Razer-relevant.
-    # Workaround: close claude-desktop entirely to release inhibitor,
-    # or set CLAUDE_KEEP_AWAKE=0 (#645).
-    # Bump via /update-claude-code.
-    # = tag v2.0.22+claude1.15200.0 (commit cdf934a061, 2026-06-25)
-    # Delta from previous pin (v2.0.19+claude1.11847.5): cowork renderer
-    # support-gate fix (#743) and upstream tracking up to Claude Desktop
-    # 1.15200.0.
-    # NOTE: pin to the latest *release* tag, NOT main HEAD — historically main
-    # can fail to build (e.g. upstream issue #718). Bump via /update-claude-code.
-    # Known open upstream runtime bugs at this pin (UI-only, not build blockers):
-    # menu-bar icon glitch on 1.15200.0 (#746), launcher.log O(n²) hang on large
-    # logs (#726/#747). We consume upstream's claude-desktop-fhs as-is (no local
-    # patch); node-pty/asar handling lives in upstream build.sh.
-    claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/cdf934a06185f7f6564606071044139760cae090";
+    # NOTE: Claude Desktop is no longer a flake input — as of #986 we package
+    # Anthropic's OFFICIAL Linux beta .deb ourselves (pkgs/claude-desktop-beta,
+    # exposed via overlays/default.nix as pkgs.claude-desktop-linux). The old
+    # aaddrick/claude-desktop-debian Windows-repackage input was removed.
 
     # GogMail — keyboard-driven Google Workspace TUI (Gmail/Calendar/Tasks/
     # Drive/Contacts/Chat) built on the gog CLI. Consumed via overlays as

--- a/modules/ai/default.nix
+++ b/modules/ai/default.nix
@@ -19,10 +19,11 @@ in
       pkgs.yai
     ]
     ++ optionals cfg.claude-desktop [
+      # Official Claude Desktop (Anthropic Linux beta). Cowork/Local Agent Mode
+      # runs in a QEMU microVM; its runtime (qemu/ovmf/virtiofsd/bubblewrap) is
+      # carried in the package's own wrapper PATH — see pkgs/claude-desktop-beta.
+      # KVM acceleration for Cowork needs /dev/kvm (virtualisation + kvm group).
       pkgs.customPkgs.claude-desktop
-      # Claude Desktop's Cowork/Local Agent Mode runtime deps (aaddrick --doctor)
-      pkgs.bubblewrap # namespace sandbox (default backend)
-      pkgs.socat # Unix-socket relay the cowork daemon uses for IPC
     ];
   };
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -12,10 +12,13 @@
     gogmail = inputs.gogmail.packages.${prev.stdenv.hostPlatform.system}.gogmail;
   })
 
-  # Claude Desktop (FHS variant from aaddrick/claude-desktop-debian).
-  # See /update-claude-code for the bump workflow.
-  (_final: prev: {
-    claude-desktop-linux = inputs.claude-desktop-linux.packages.${prev.stdenv.hostPlatform.system}.claude-desktop-fhs;
+  # Claude Desktop — Anthropic's OFFICIAL Linux beta, packaged from the signed
+  # apt-repo .deb (pkgs/claude-desktop-beta). Replaced the aaddrick Windows-
+  # repackage in #986. Attribute name kept as `claude-desktop-linux` so
+  # downstream refs (pkgs/default.nix, modules/ai) are unchanged.
+  # Bump: see the header comment in pkgs/claude-desktop-beta/default.nix.
+  (final: _prev: {
+    claude-desktop-linux = final.callPackage ../pkgs/claude-desktop-beta { };
   })
 
   (_final: prev: {

--- a/pkgs/claude-desktop-beta/default.nix
+++ b/pkgs/claude-desktop-beta/default.nix
@@ -1,0 +1,162 @@
+{ lib
+, stdenv
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, wrapGAppsHook3
+, makeWrapper
+, # Electron / Chromium runtime
+  glib
+, gtk3
+, nss
+, nspr
+, atk
+, at-spi2-atk
+, at-spi2-core
+, cairo
+, pango
+, gdk-pixbuf
+, cups
+, dbus
+, expat
+, libdrm
+, mesa
+, libgbm
+, libxkbcommon
+, alsa-lib
+, libnotify
+, libsecret
+, libuuid
+, systemd
+, libseccomp
+, libcap_ng
+, libpulseaudio
+, libGL
+, vulkan-loader
+, wayland
+, xorg
+, # Cowork (Local Agent Mode) runtime — spawned as subprocesses at runtime
+  qemu_kvm
+, virtiofsd
+, OVMF
+, bubblewrap
+,
+}:
+# Official Claude Desktop for Linux (beta) — Anthropic's own build, packaged
+# from the signed apt repo `.deb` (github/app equivalent for Claude). Replaces
+# the aaddrick/claude-desktop-debian Windows-repackage we used until #986.
+#
+# Bump: read the apt Packages index for the latest version + SHA256:
+#   curl -fsSL https://downloads.claude.ai/claude-desktop/apt/stable/dists/stable/main/binary-amd64/Packages \
+#     | awk '/^Version:/{v=$2} /^Filename:/{f=$2} /^SHA256:/{print v, $2, f}' | sort -V | tail -1
+# then update `version` + `sha256` below (hex sha256 from the index is accepted
+# by fetchurl as-is).
+let
+  version = "1.17377.1";
+
+  # dlopen'd at runtime (not in DT_NEEDED) — appended to RUNPATH.
+  runtimeLibs = [
+    libGL
+    vulkan-loader
+    libpulseaudio
+    libnotify
+    libsecret
+  ];
+in
+stdenv.mkDerivation {
+  pname = "claude-desktop";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_${version}_amd64.deb";
+    sha256 = "f4bd78545200877b591179838de7ad7a577df6ed2e845969dd25690efc5c85c7";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    wrapGAppsHook3
+    makeWrapper
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    nss
+    nspr
+    atk
+    at-spi2-atk
+    at-spi2-core
+    cairo
+    pango
+    gdk-pixbuf
+    cups
+    dbus
+    expat
+    libdrm
+    mesa
+    libgbm
+    libxkbcommon
+    alsa-lib
+    libnotify
+    libsecret
+    libuuid
+    systemd
+    libseccomp
+    libcap_ng
+    wayland
+  ]
+  ++ (with xorg; [
+    libX11
+    libXcomposite
+    libXdamage
+    libXext
+    libXfixes
+    libXrandr
+    libxcb
+    libXtst
+    libXScrnSaver
+    libxshmfence
+  ])
+  ++ runtimeLibs;
+
+  runtimeDependencies = map lib.getLib runtimeLibs;
+
+  unpackCmd = "dpkg-deb -x $curSrc .";
+  sourceRoot = ".";
+
+  # Electron apps must not have their asar/native tree stripped or rewritten.
+  dontStrip = true;
+  dontWrapGApps = true; # we compose the wrapper flags ourselves below
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib $out/bin $out/share
+    cp -r usr/lib/claude-desktop $out/lib/claude-desktop
+
+    # Desktop entry + icons
+    cp -r usr/share/applications $out/share/
+    cp -r usr/share/icons $out/share/
+
+    # Wrapper: Wayland-aware ozone, GApps/GTK env (gappsWrapperArgs), and PATH
+    # for the Cowork helper's subprocesses (qemu/virtiofsd/ovmf/bwrap).
+    makeWrapper $out/lib/claude-desktop/claude-desktop $out/bin/claude-desktop \
+      "''${gappsWrapperArgs[@]}" \
+      --add-flags "--ozone-platform-hint=auto" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeLibs}" \
+      --prefix PATH : "${lib.makeBinPath [ qemu_kvm virtiofsd bubblewrap ]}" \
+      --set-default OVMF_PATH "${OVMF.fd}/FV"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Anthropic's official Claude Desktop app for Linux (beta)";
+    homepage = "https://claude.ai";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "claude-desktop";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
Replace the aaddrick/claude-desktop-debian Windows-repackage with Anthropic's
OFFICIAL Claude Desktop for Linux (beta), packaged from the signed apt-repo
.deb (v1.17377.1) as pkgs/claude-desktop-beta.

- pkgs/claude-desktop-beta/default.nix: dpkg-extract + autoPatchelfHook +
  wrapGAppsHook3 Electron package; binary claude-desktop; Wayland ozone hint;
  wrapper PATH carries the Cowork microVM runtime (qemu/ovmf/virtiofsd/bwrap).
- overlays/default.nix: source pkgs.claude-desktop-linux from the new package
  (attribute name kept, so pkgs/default.nix + modules/ai are unchanged).
- flake.nix + flake.lock: drop the aaddrick claude-desktop-linux input.
- modules/ai/default.nix: Cowork runtime now lives in the package wrapper;
  drop the aaddrick-specific bubblewrap/socat systemPackages.

Built + verified: package (libs incl. bundled virtiofsd resolved), p620 +
razer toplevels. p510 unaffected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VYbPi22s4wHbjK3xxwoE7C
