### PR TITLE
fix(users): authorize odin-dashboard pod SSH key fleet-wide

### DIFF
--- a/modules/common/base-user.nix
+++ b/modules/common/base-user.nix
@@ -14,6 +14,16 @@ let inherit (lib) mkDefault; in {
     # (nixpkgs#451). The vim package is still in environment.systemPackages
     # via modules/nixos/packages/core.nix for sudo / root / other users.
     packages = with pkgs; [ wally-cli ];
+
+    # SSH keys authorized to log in as this user across the fleet.
+    # odin-dashboard@factory: the Odin homelab portal pod (k3s/factory ns)
+    # SSHes into p510/p620/razer to collect host metrics. Without this key
+    # authorized, sshd PerSourcePenalties penalises the pod's repeated auth
+    # failures and drops its connections ("Not allowed at this time"),
+    # making every host render OFFLINE in the dashboard.
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAXf9GfUzBSKmfIQcDmaEcG3rmorOzGSOFXqMbHvlWSH odin-dashboard@factory"
+    ];
   };
 
   # Common shell setup


### PR DESCRIPTION
Declares the Odin portal pod's SSH key (`odin-dashboard@factory`) in the shared `base-user` module.

The portal collects host metrics by SSHing into p510/p620/razer as `olafkfreund`. Without this key authorized, sshd `PerSourcePenalties` penalised the pod's repeated auth failures and dropped its connections (*"Not allowed at this time"*), so every host rendered OFFLINE. Runtime `authorized_keys` were already patched on all three hosts; this makes it durable across rebuilds.

Additive only — NixOS writes it to `/etc/ssh/authorized_keys.d/olafkfreund`, so it does not touch the existing mutable `~/.ssh/authorized_keys`. Activates on each host's next `nh os switch`.