### PR TITLE
chore(antigravity): bump cli 1.0.13 → 1.0.14

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.0.13-5758107482193920";
+  version = "1.0.14-6049473256882176";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.13-5758107482193920/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-a/mQRYwRSvOzFz3LwbD7mrk76pHFO2Bf3Wmu3SmiHNk=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.14-6049473256882176/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-cXDVmBk+4K3cq6fYw6LC4weuhiLaz3SYMRKL0a08pFg=";
   };
 
   # Tarball contains a single file `antigravity` at the root.


### PR DESCRIPTION
Via Hy4ri/antigravity-flake tracker. ide/hub/sdk already current. Build-
verified: agy --version → 1.0.14, p620 toplevel clean. No deploy (bump only).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VYbPi22s4wHbjK3xxwoE7C
