### PR TITLE
fix(claude-desktop): force gnome-libsecret password store

### DIFF
--- a/pkgs/claude-desktop-beta/default.nix
+++ b/pkgs/claude-desktop-beta/default.nix
@@ -141,9 +141,13 @@ stdenv.mkDerivation {
 
     # Wrapper: Wayland-aware ozone, GApps/GTK env (gappsWrapperArgs), and PATH
     # for the Cowork helper's subprocesses (qemu/virtiofsd/ovmf/bwrap).
+    # --password-store=gnome-libsecret: Electron picks its secret backend from
+    # XDG_CURRENT_DESKTOP; under non-GNOME/KDE compositors (niri/labwc/mango)
+    # it falls back to the plaintext "basic" store and reports "sign-in won't
+    # be saved". Force libsecret so it uses the (unlocked) gnome-keyring.
     makeWrapper $out/lib/claude-desktop/claude-desktop $out/bin/claude-desktop \
       "''${gappsWrapperArgs[@]}" \
-      --add-flags "--ozone-platform-hint=auto" \
+      --add-flags "--ozone-platform-hint=auto --password-store=gnome-libsecret" \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeLibs}" \
       --prefix PATH : "${lib.makeBinPath [ qemu_kvm virtiofsd bubblewrap ]}" \
       --set-default OVMF_PATH "${OVMF.fd}/FV"


### PR DESCRIPTION
Claude Desktop (Electron) reported 'sign-in won't be saved / unlock a system
keyring' under niri. Root cause: Electron selects its secret backend from
XDG_CURRENT_DESKTOP; on non-GNOME/KDE compositors (niri/labwc/mango) it falls
back to the plaintext 'basic' store instead of libsecret — even though
gnome-keyring is running and unlocked. Add --password-store=gnome-libsecret
to the wrapper so it uses the keyring.

Diagnosed: p620 default collection (login) is unlocked, so this is a backend-
selection issue, not a keyring one.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VYbPi22s4wHbjK3xxwoE7C
