### PR TITLE
feat(pkgs): package glab-tui 2.3.0 (GitLab TUI)

### DIFF
--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -170,6 +170,8 @@ in
     pkgs.customPkgs.github-copilot-app
     pkgs.customPkgs.kosli-cli
     pkgs.customPkgs.aurynk
+    # glab-tui — terminal UI for GitLab on top of the `glab` CLI.
+    pkgs.customPkgs.glab-tui
     pkgs.wayfarer
     # FlyCrys — GTK4-native Claude Code GUI. Wraps the local `claude`
     # binary (installed via programs.claude-code.enable in home/default.nix).

--- a/pkgs/glab-tui/default.nix
+++ b/pkgs/glab-tui/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, makeWrapper
+, glab
+, git
+}:
+# A terminal UI for GitLab built on top of the `glab` CLI. Browse issues,
+# merge requests, pipelines, runners and releases without leaving the terminal.
+# Upstream ships no LICENSE ("built for personal use") — treated as unfree.
+rustPlatform.buildRustPackage rec {
+  pname = "glab-tui";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "rcieri";
+    repo = "glab-tui";
+    rev = "v${version}";
+    hash = "sha256-CsLcOIosfx7BVWXlhknKHNZVMVi0OWJ77ohDn73of1s=";
+  };
+
+  cargoHash = "sha256-SFihRea0X0IIfBnfwVoFfptQCQEmLZU/ik46GK5q8+c=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # glab-tui shells out to the `glab` CLI (and git) at runtime; put them on PATH.
+  postInstall = ''
+    wrapProgram $out/bin/glab-tui \
+      --prefix PATH : ${lib.makeBinPath [ glab git ]}
+  '';
+
+  meta = {
+    description = "Terminal UI for GitLab built on top of glab (issues, MRs, pipelines, runners, releases)";
+    homepage = "https://github.com/rcieri/glab-tui";
+    license = lib.licenses.unfree;
+    maintainers = [ ];
+    platforms = lib.platforms.linux;
+    mainProgram = "glab-tui";
+  };
+}


### PR DESCRIPTION
New Rust package rcieri/glab-tui — a terminal UI on top of the `glab`
CLI for browsing issues, MRs, pipelines, runners and releases. Wrapped
so `glab` + `git` are on PATH at runtime. Installed on the interactive
hosts (p620 + razer) via the user profile.

Upstream ships no LICENSE ("built for personal use") — meta.license
set to unfree accordingly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VYbPi22s4wHbjK3xxwoE7C
