### PR TITLE
fix(pkgs): register glab-tui in customPkgs

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -46,6 +46,9 @@
   # Reddit TUI client
   reddix = pkgs.callPackage ./reddix { };
 
+  # GitLab TUI — terminal UI on top of the `glab` CLI (rcieri/glab-tui).
+  glab-tui = pkgs.callPackage ./glab-tui { };
+
   # Claude Code native binary (alternative to npm-based package)
   claude-code-native = pkgs.callPackage ./claude-code-native { };
 


### PR DESCRIPTION
The glab-tui package dir + profile reference landed in #997 but the
customPkgs registration line in pkgs/default.nix was dropped from that
commit, leaving main broken (profile references an unregistered attr).
Re-add the registration.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VYbPi22s4wHbjK3xxwoE7C
