### PR TITLE
feat(update): always show installed/upgraded/removed pkg diff

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -55,6 +55,15 @@ preview-updates HOST="$(hostname)":
     @echo "🔍 Previewing updates for {{HOST}}..."
     ./scripts/preview-updates.sh {{HOST}}
 
+# Show what the LAST update changed: Added / Removed / Upgraded packages
+# between the two most recent system generations (nvd-backed; local or remote).
+# Complements nh's built-in diff, which is version-level only and skips remote
+# --target-host deploys.
+#   just system-diff            # this host, last two generations
+#   just system-diff razer      # remote host over SSH
+system-diff HOST="-":
+    ./scripts/system-diff.sh {{HOST}}
+
 # Find newly added packages in nixpkgs
 new-packages:
     @echo "🆕 Finding new packages in nixpkgs..."

--- a/home/shell/zsh.nix
+++ b/home/shell/zsh.nix
@@ -620,6 +620,19 @@ in
         nhsb() {
           (cd ~/.config/nixos && just update-commit "$@")
         }
+
+        # sysdiff: show what the last NixOS update changed — Added / Removed /
+        # Upgraded packages between the two most recent system generations
+        # (nvd-backed; works local AND remote, unlike nh's built-in diff which
+        # is version-level only and skips remote --target-host deploys).
+        #
+        # Usage:
+        #   sysdiff                # this host, last two generations
+        #   sysdiff razer          # remote host over SSH
+        #   sysdiff razer 40 41    # explicit generation numbers
+        sysdiff() {
+          (cd ~/.config/nixos && ./scripts/system-diff.sh "$@")
+        }
       '';
 
       # oh-my-zsh removed (2026-06): it added ~500ms startup and its plugins were

--- a/scripts/system-diff.sh
+++ b/scripts/system-diff.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# system-diff.sh [HOST] [OLD NEW]
+#
+# Show what a NixOS switch changed — Added / Removed / Upgraded packages —
+# between two system generations, using nvd. This is the "what was installed,
+# updated and deleted" view that `nh os switch` only shows partially (nh's
+# --diff is version-level only, and it skips the diff entirely on remote
+# --target-host deploys). Run it any time to inspect the last update.
+#
+# Usage:
+#   system-diff.sh                # local: the two most recent generations
+#                                 # (i.e. what the last `nhs`/rebuild changed)
+#   system-diff.sh razer          # remote HOST over SSH: its two most recent
+#   system-diff.sh razer 40 41    # remote HOST: explicit generation numbers
+#   system-diff.sh - 2250 2251    # local, explicit generations ('-' = local)
+#
+# No sudo needed: generation symlinks under /nix/var/nix/profiles are readable,
+# and nvd ships in every host's system closure.
+set -euo pipefail
+
+host="local"
+remote=0
+if [ "${1:-}" ] && [ "$1" != "-" ] && ! [[ "$1" =~ ^[0-9]+$ ]]; then
+  host="$1"
+  remote=1
+  shift
+elif [ "${1:-}" = "-" ]; then
+  shift
+fi
+
+# Run a single shell-command string locally or on $host (one arg to ssh — no
+# arg-flattening surprises).
+sh_run() {
+  if [ "$remote" -eq 1 ]; then
+    ssh "$host" "$1"
+  else
+    bash -c "$1"
+  fi
+}
+
+if ! sh_run 'command -v nvd >/dev/null 2>&1'; then
+  echo "error: nvd not found on ${host}" >&2
+  exit 1
+fi
+
+if [ "$#" -ge 2 ]; then
+  old_n="$1"
+  new_n="$2"
+else
+  mapfile -t gens < <(sh_run 'ls -d /nix/var/nix/profiles/system-*-link 2>/dev/null | sed -E "s#.*/system-([0-9]+)-link#\1#" | sort -n')
+  if [ "${#gens[@]}" -lt 2 ]; then
+    echo "error: need at least 2 system generations on ${host} (found ${#gens[@]})" >&2
+    exit 1
+  fi
+  old_n="${gens[-2]}"
+  new_n="${gens[-1]}"
+fi
+
+old="/nix/var/nix/profiles/system-${old_n}-link"
+new="/nix/var/nix/profiles/system-${new_n}-link"
+
+printf '\033[1;34m>> %s: package changes  gen %s -> %s\033[0m\n' "$host" "$old_n" "$new_n"
+sh_run "nvd diff '$old' '$new'"

--- a/scripts/update-commit-deploy.sh
+++ b/scripts/update-commit-deploy.sh
@@ -401,6 +401,35 @@ nh_switch_or_boot() {
   return "$rc"
 }
 
+# Print an explicit Added / Removed / Upgraded package report via nvd.
+#
+# nh's own `--diff` is `auto`: it prints a version-level table for LOCAL
+# switches but SKIPS it entirely for remote (--target-host) deploys, and it
+# only lists name-version changes (a nixpkgs-unchanged lock bump shows just a
+# size delta). We want a reliable "what was installed / upgraded / removed"
+# view on EVERY deploy — so diff the pre-switch generation ($1) against the new
+# closure ($2) with nvd directly. Both paths exist on the target after the
+# switch (nh --target-host copies the closure across), and nvd ships in every
+# host's system closure.
+show_pkg_diff() {
+  local old="$1" new="$2"
+  if [ -z "$old" ]; then
+    warn "no previous generation captured — skipping package diff (first-time deploy?)"
+    return 0
+  fi
+  if [ "$old" = "$new" ]; then
+    log "package diff: closure unchanged (nothing added / removed / upgraded)."
+    return 0
+  fi
+  log "package changes on ${HOST} (nvd — added / removed / upgraded):"
+  printf '\033[2m%s\033[0m\n' "------------------------------------------------------------"
+  case "$MODE" in
+    local) nvd diff "$old" "$new" || warn "nvd diff failed (non-fatal)" ;;
+    remote) ssh "$HOST" "nvd diff '$old' '$new'" || warn "remote nvd diff failed (non-fatal)" ;;
+  esac
+  printf '\033[2m%s\033[0m\n' "------------------------------------------------------------"
+}
+
 # --no-deploy: build is done, lock is on a feature branch + PR is OPEN but
 # UNMERGED (since merge is gated on the post-deploy health check that we're
 # now skipping). Tell the user. The cached closure means stage 2 — the
@@ -501,6 +530,10 @@ case "$MODE" in
     fi
     ;;
 esac
+
+# --- 10d. Package diff: what was installed / upgraded / removed ------------
+# Explicit nvd report (works local AND remote, unlike nh's auto diff).
+show_pkg_diff "$current" "$expected"
 
 # --- 11. Post-deploy health check -----------------------------------------
 #


### PR DESCRIPTION
The idiot-proof update flow (nhs / update-commit-deploy.sh) now prints an
explicit nvd Added/Removed/Upgraded package report after every switch —
local AND remote. This fills the gap in nh's own `--diff auto`, which is
version-level only and skips remote --target-host deploys entirely (so a
`nhs razer` or a nixpkgs-unchanged lock bump showed no package detail).

Also adds:
- scripts/system-diff.sh — standalone, on-demand nvd diff of the two most
  recent system generations (local or remote over SSH).
- `sysdiff` zsh function + `just system-diff` recipe wrapping it.

Answers "what was installed, updated and deleted?" three ways: automatic
(deploy flow), `sysdiff [HOST]`, and `just system-diff [HOST]`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VYbPi22s4wHbjK3xxwoE7C
