### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782979602,
-        "narHash": "sha256-o/v/wXdmBUT4mRqhExg7AV9XW+moGISeQbG2tj13uBo=",
+        "lastModified": 1783065973,
+        "narHash": "sha256-cl6+ATJ3wni26HQSIJJ+zK1yTEVdKXoSOhr1NeybbPY=",
         "owner": "jacopone",
         "repo": "antigravity-nix",
-        "rev": "df5fb92fb91600b47fa88811553c48a4f50973b1",
+        "rev": "d7eb4913b4f0bcb12023956bbc969c6bad5f7328",
         "type": "github"
       },
       "original": {
@@ -1339,11 +1339,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1783062595,
-        "narHash": "sha256-d+8rgYXZB29fLXMmqjIEQc+i/O08q1zsidQRD423Bqk=",
+        "lastModified": 1783064219,
+        "narHash": "sha256-Zu8bQIPjQkeTXFitCgn0GoE8nXe4XYJGknua2tXvP/4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8b6e70e6adf9bea17399d4ce21414995d7e7b1ea",
+        "rev": "3fee22e04e5d9c5e4ecfe0e7d7b264fc17562cd5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=p620, scope=all).

Built and verified locally against nixosConfigurations.p620 before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)