### PR TITLE
chore(home): silence fzf + windsurf eval deprecation warnings

### DIFF
--- a/home/development/windsurf.nix
+++ b/home/development/windsurf.nix
@@ -56,9 +56,11 @@ in
 
   config = mkIf cfg.enable {
     # Install windsurf and related packages
+    # NOTE: upstream rebranded `windsurf` → `devin-desktop` (same app); the old
+    # attr is now a deprecation-warning alias, so reference the new name directly.
     home.packages = with pkgs;
       [
-        windsurf
+        devin-desktop
         alejandra
         deadnix
         statix

--- a/home/shell/fzf/default.nix
+++ b/home/shell/fzf/default.nix
@@ -21,12 +21,12 @@ in
       enableZshIntegration = true;
 
       defaultCommand = "fd --hidden --strip-cwd-prefix --exclude .git";
-      fileWidgetOptions = [
+      fileWidget.options = [
         "--preview 'if [ -d {} ]; then eza --tree --color=always {} | head -200; else bat -n --color=always --line-range :500 {}; fi'"
       ];
 
-      changeDirWidgetCommand = "fd --type=d --hidden --strip-cwd-prefix --exclude .git";
-      changeDirWidgetOptions = [
+      changeDirWidget.command = "fd --type=d --hidden --strip-cwd-prefix --exclude .git";
+      changeDirWidget.options = [
         "--preview 'eza --tree --color=always {} | head -200'"
       ];
 


### PR DESCRIPTION
Two ours-owned eval warnings resolved:
- fzf: migrate to nested option names (home-manager rename)
  fileWidgetOptions      -> fileWidget.options
  changeDirWidgetCommand -> changeDirWidget.command
  changeDirWidgetOptions -> changeDirWidget.options
- windsurf: upstream rebranded `windsurf` -> `devin-desktop` (same app,
  same 3.3.18 version; old attr is now a deprecation alias). Reference
  the new name directly.

Build-verified on p620: toplevel builds clean, all 4 warnings gone.
Remaining eval warnings (xorg.* x12, `system` x1) originate in upstream
input/nixpkgs derivations and are not actionable in this repo.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VYbPi22s4wHbjK3xxwoE7C
