### PR TITLE
fix(ollama): rename models -> modelsDir (upstream option rename)

### DIFF
--- a/modules/services/ollama.nix
+++ b/modules/services/ollama.nix
@@ -138,7 +138,7 @@ in
       inherit (cfg) host;
       port = 11434;
       loadModels = cfg.persistentModels ++ cfg.onDemandModels;
-      models = lib.mkIf (cfg.modelsDir != null) cfg.modelsDir;
+      modelsDir = lib.mkIf (cfg.modelsDir != null) cfg.modelsDir;
       environmentVariables = {
         # Required for RX 7900 XTX (gfx1100) ROCm — also set globally in
         # hosts/p620/nixos/amd.nix, restated here for unit-local clarity.


### PR DESCRIPTION
nixpkgs renamed services.ollama.models -> services.ollama.modelsDir;
update our assignment in modules/services/ollama.nix to silence the
eval-time deprecation warning. Value (cfg.modelsDir) unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VYbPi22s4wHbjK3xxwoE7C
