### PR TITLE
feat(razer): DankMaterialShell as a selectable niri session (#1021)

### DIFF
--- a/home/desktop/noctalia/default.nix
+++ b/home/desktop/noctalia/default.nix
@@ -205,7 +205,10 @@ in
   # session env). swayidle works on niri (ext-idle-notify-v1): lock at 5 min,
   # monitors off at 10 min, and — laptops only — suspend at 30 min.
   programs.niri.settings.spawn-at-startup = lib.mkAfter [
-    { command = [ "noctalia" ]; }
+    # Which shell launches is chosen by the login session: the stock "Niri"
+    # session leaves DESK_SHELL unset → Noctalia; the "Niri (DankMaterialShell)"
+    # session (modules/desktop/dms-shell.nix) sets DESK_SHELL="dms run" → DMS.
+    { command = [ "sh" "-c" "exec \${DESK_SHELL:-noctalia}" ]; }
     { command = [ "swaybg" "-m" "fill" "-i" "${wallpaper}" ]; }
     { command = [ "gammastep" "-l" geo ]; }
     {

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -335,6 +335,10 @@ in
   desktop.labwc.enable = true;
   desktop.mangowm.enable = true;
 
+  # Adds a "Niri (DankMaterialShell)" login session next to the stock "Niri"
+  # (Noctalia) one — pick per login in the greeter. Trial on razer only.
+  desktop.dmsShell.enable = true;
+
   # ddcutil: software brightness/contrast control of external monitors (DDC/CI).
   modules.hardware.ddcutil.enable = true;
 

--- a/modules/desktop/default.nix
+++ b/modules/desktop/default.nix
@@ -6,6 +6,7 @@
     ./niri.nix
     ./labwc.nix
     ./mangowm.nix
+    ./dms-shell.nix
     ./ddcutil.nix
   ];
 

--- a/modules/desktop/dms-shell.nix
+++ b/modules/desktop/dms-shell.nix
@@ -1,0 +1,56 @@
+{ config, lib, pkgs, ... }:
+# DankMaterialShell (DMS) as a SECOND selectable niri login session, alongside
+# Noctalia. The stock "Niri" session (from programs.niri) spawns whatever
+# ${DESK_SHELL:-noctalia} resolves to — unset → Noctalia. This module adds a
+# parallel "Niri (DankMaterialShell)" session whose launcher exports
+# DESK_SHELL="dms run", so the same niri config starts DMS instead. Only one
+# shell ever runs per session, so Noctalia and DMS never collide.
+#
+# See home/desktop/noctalia/default.nix (niri spawn-at-startup) for the
+# ${DESK_SHELL:-noctalia} switch this pairs with.
+let
+  inherit (lib) mkEnableOption mkIf;
+  cfg = config.desktop.dmsShell;
+
+  # Start a normal niri session, but select the DMS shell via the env var the
+  # niri spawn reads. `dms run` launches quickshell with the DMS config.
+  niriDmsLauncher = pkgs.writeShellScript "niri-dms-session" ''
+    export DESK_SHELL="dms run"
+    exec niri-session
+  '';
+
+  # services.displayManager.sessionPackages requires passthru.providedSessions
+  # to match the .desktop basename ("niri-dms").
+  dmsSession = (pkgs.writeTextFile {
+    name = "niri-dms-wayland-session";
+    destination = "/share/wayland-sessions/niri-dms.desktop";
+    text = ''
+      [Desktop Entry]
+      Name=Niri (DankMaterialShell)
+      Comment=niri with the DankMaterialShell desktop shell
+      Exec=${niriDmsLauncher}
+      Type=Application
+      DesktopNames=niri
+    '';
+  }).overrideAttrs (_: { passthru.providedSessions = [ "niri-dms" ]; });
+in
+{
+  options.desktop.dmsShell.enable =
+    mkEnableOption "DankMaterialShell as a selectable niri login session (alongside Noctalia)";
+
+  config = mkIf cfg.enable {
+    programs.dms-shell = {
+      enable = true;
+      # Spawned per-session by niri (via DESK_SHELL), NOT globally — a global
+      # systemd service would also start DMS inside the Noctalia session.
+      systemd.enable = false;
+      # Keep Stylix/Gruvbox for the trial; set true to let DMS drive matugen
+      # Material You theming from the wallpaper instead.
+      enableDynamicTheming = false;
+    };
+
+    # Add "Niri (DankMaterialShell)" to the greeter's session picker. The stock
+    # "Niri" entry (from programs.niri) stays as the Noctalia session.
+    services.displayManager.sessionPackages = [ dmsSession ];
+  };
+}


### PR DESCRIPTION
Add DMS as a second niri login session alongside Noctalia, chosen in
noctalia-greeter's session picker. Only one shell runs per session.

- modules/desktop/dms-shell.nix: desktop.dmsShell.enable → programs.dms-shell
  (systemd off, dynamic-theming off for the Stylix trial) + a
  'Niri (DankMaterialShell)' wayland-session that exports DESK_SHELL='dms run'.
- home/desktop/noctalia niri spawn: 'noctalia' → sh -c 'exec ${DESK_SHELL:-noctalia}'
  (backward-compatible; p620/unset still launches Noctalia).
- razer: desktop.dmsShell.enable = true.

Verified: razer + p620 toplevels build; niri.desktop (Noctalia) + niri-dms.desktop
(DMS) both land in wayland-sessions; dms-shell-1.4.6 in closure.

Closes #1021

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VYbPi22s4wHbjK3xxwoE7C
