### PR TITLE
feat(dms): labwc+mango DMS sessions; niri uses managed dms.service (#1021)

### DIFF
--- a/home/desktop/noctalia/default.nix
+++ b/home/desktop/noctalia/default.nix
@@ -329,7 +329,7 @@ in
       timeout 300 '${lockCmd}' \
       timeout 600 "wlopm --off '*'" resume "wlopm --on '*'" \
       ${lib.optionalString isLaptop "timeout 1800 'systemctl suspend' \\\n      "}before-sleep '${lockCmd}' &
-    noctalia &
+    ''${DESK_SHELL:-noctalia} &
   '';
 
   # Session environment, read at labwc startup. XKB layout for the keyboard,
@@ -564,7 +564,7 @@ in
           timeout 300 '${lockCmd}' \
           timeout 600 "wlopm --off '*'" resume "wlopm --on '*'" \
           ${lib.optionalString isLaptop "timeout 1800 'systemctl suspend' \\\n      "}before-sleep '${lockCmd}' &
-        noctalia &
+        ''${DESK_SHELL:-noctalia} &
       '';
     }
   );

--- a/modules/desktop/dms-shell.nix
+++ b/modules/desktop/dms-shell.nix
@@ -1,56 +1,82 @@
 { config, lib, pkgs, ... }:
-# DankMaterialShell (DMS) as a SECOND selectable niri login session, alongside
-# Noctalia. The stock "Niri" session (from programs.niri) spawns whatever
-# ${DESK_SHELL:-noctalia} resolves to — unset → Noctalia. This module adds a
-# parallel "Niri (DankMaterialShell)" session whose launcher exports
-# DESK_SHELL="dms run", so the same niri config starts DMS instead. Only one
-# shell ever runs per session, so Noctalia and DMS never collide.
+# DankMaterialShell (DMS) as extra selectable login sessions, one per WM we run
+# (niri, labwc, mango), alongside the stock Noctalia sessions. Each compositor's
+# shell launch reads ${DESK_SHELL:-noctalia}: the stock session leaves it unset
+# → Noctalia; the "(DankMaterialShell)" session sets it → DMS. Only one shell
+# ever runs per session, so Noctalia and DMS never collide.
 #
-# See home/desktop/noctalia/default.nix (niri spawn-at-startup) for the
-# ${DESK_SHELL:-noctalia} switch this pairs with.
+# niri has systemd session integration (graphical-session.target + env import),
+# so its DMS session prefers the managed dms.service (doctor-clean, restart on
+# failure, journald logs) and only falls back to a direct `dms run` spawn if the
+# service can't start. labwc/mango launch bare (no systemd session), so their
+# DMS sessions run `dms run` directly — a fully supported DMS launch mode.
+#
+# Pairs with the ${DESK_SHELL:-noctalia} switch in home/desktop/noctalia
+# (niri spawn-at-startup, labwc autostart, mango autostart_sh).
 let
-  inherit (lib) mkEnableOption mkIf;
+  inherit (lib) mkEnableOption mkIf optional;
   cfg = config.desktop.dmsShell;
 
-  # Start a normal niri session, but select the DMS shell via the env var the
-  # niri spawn reads. `dms run` launches quickshell with the DMS config.
-  niriDmsLauncher = pkgs.writeShellScript "niri-dms-session" ''
-    export DESK_SHELL="dms run"
+  # niri: try the managed service first (keeps `dms doctor` clean), fall back to
+  # a direct spawn if graphical-session.target isn't ready.
+  dmsNiriShell = pkgs.writeShellScript "dms-niri-shell" ''
+    if systemctl --user start dms.service 2>/dev/null; then exit 0; fi
+    exec dms run
+  '';
+  niriLauncher = pkgs.writeShellScript "niri-dms-session" ''
+    export DESK_SHELL="${dmsNiriShell}"
     exec niri-session
   '';
+  labwcLauncher = pkgs.writeShellScript "labwc-dms-session" ''
+    export DESK_SHELL="dms run"
+    exec labwc
+  '';
+  mangoLauncher = pkgs.writeShellScript "mango-dms-session" ''
+    export DESK_SHELL="dms run"
+    exec mango
+  '';
 
-  # services.displayManager.sessionPackages requires passthru.providedSessions
-  # to match the .desktop basename ("niri-dms").
-  dmsSession = (pkgs.writeTextFile {
-    name = "niri-dms-wayland-session";
-    destination = "/share/wayland-sessions/niri-dms.desktop";
-    text = ''
-      [Desktop Entry]
-      Name=Niri (DankMaterialShell)
-      Comment=niri with the DankMaterialShell desktop shell
-      Exec=${niriDmsLauncher}
-      Type=Application
-      DesktopNames=niri
-    '';
-  }).overrideAttrs (_: { passthru.providedSessions = [ "niri-dms" ]; });
+  # services.displayManager.sessionPackages requires passthru.providedSessions to
+  # match the .desktop basename.
+  mkDmsSession = { name, label, exec }:
+    (pkgs.writeTextFile {
+      name = "${name}-wayland-session";
+      destination = "/share/wayland-sessions/${name}.desktop";
+      text = ''
+        [Desktop Entry]
+        Name=${label}
+        Comment=${label} with the DankMaterialShell desktop shell
+        Exec=${exec}
+        Type=Application
+        DesktopNames=${name}
+      '';
+    }).overrideAttrs (_: { passthru.providedSessions = [ name ]; });
+
+  niriDmsSession = mkDmsSession { name = "niri-dms"; label = "Niri (DankMaterialShell)"; exec = "${niriLauncher}"; };
+  labwcDmsSession = mkDmsSession { name = "labwc-dms"; label = "labwc (DankMaterialShell)"; exec = "${labwcLauncher}"; };
+  mangoDmsSession = mkDmsSession { name = "mango-dms"; label = "mango (DankMaterialShell)"; exec = "${mangoLauncher}"; };
 in
 {
   options.desktop.dmsShell.enable =
-    mkEnableOption "DankMaterialShell as a selectable niri login session (alongside Noctalia)";
+    mkEnableOption "DankMaterialShell as selectable login sessions per WM (alongside Noctalia)";
 
   config = mkIf cfg.enable {
     programs.dms-shell = {
       enable = true;
-      # Spawned per-session by niri (via DESK_SHELL), NOT globally — a global
-      # systemd service would also start DMS inside the Noctalia session.
+      # The unit ships with the package (linked); niri's DMS session starts it on
+      # demand. NOT wantedBy graphical-session.target (systemd.enable = false) so
+      # it never auto-starts inside the Noctalia session.
       systemd.enable = false;
       # Keep Stylix/Gruvbox for the trial; set true to let DMS drive matugen
       # Material You theming from the wallpaper instead.
       enableDynamicTheming = false;
     };
 
-    # Add "Niri (DankMaterialShell)" to the greeter's session picker. The stock
-    # "Niri" entry (from programs.niri) stays as the Noctalia session.
-    services.displayManager.sessionPackages = [ dmsSession ];
+    # Add a "(DankMaterialShell)" entry per enabled WM. The stock niri/labwc/mango
+    # entries stay as the Noctalia sessions.
+    services.displayManager.sessionPackages =
+      [ niriDmsSession ]
+      ++ optional config.desktop.labwc.enable labwcDmsSession
+      ++ optional config.desktop.mangowm.enable mangoDmsSession;
   };
 }


### PR DESCRIPTION
Extend the selectable-shell pattern to all three WMs and quiet the
'dms.service not started' warning dms setup showed on niri.

- niri DMS session now prefers the managed dms.service (doctor-clean,
  restart-on-failure, journald) via a launcher that starts it and falls
  back to 'dms run' if graphical-session.target isn't ready. niri imports
  session env into systemd, so the service gets the wayland env.
- labwc + mango get 'labwc (DankMaterialShell)' / 'mango (DankMaterialShell)'
  sessions (dms run — they launch bare, no systemd session; a fully
  supported DMS launch mode). Gated on desktop.labwc/mangowm.enable.
- labwc autostart + mango autostart_sh now honor ${DESK_SHELL:-noctalia}
  (backward-compatible; unset → Noctalia).

Verified: razer + p620 build; niri/labwc/mango each expose a stock
(Noctalia) and a -dms (DankMaterialShell) wayland-session.

Relates to #1021

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VYbPi22s4wHbjK3xxwoE7C
