### PR TITLE
feat(p620): DMS greeter + DMS sessions; make dmsShell self-contained

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -367,26 +367,30 @@ in
   # cosmic module; the unified DM module defaults to "none" without it).
   # NOTE: must live at top-level, NOT inside the features = {...} block above —
   # the option path is `desktop.displayManager`, not `features.desktop.displayManager`.
-  # Login manager: Noctalia greeter (greetd). backend="none" turns GDM off; the
-  # noctalia-greeter module below auto-enables greetd + its bundled wlroots
-  # compositor. GNOME/niri/labwc remain selectable SESSIONS in the greeter.
+  # Login manager: DankMaterialShell greeter (greetd). backend="none" turns GDM
+  # off; the dms-greeter module auto-enables greetd and runs the greeter inside
+  # a niri compositor. Chosen over noctalia-greeter (more mature); it enumerates
+  # the same wayland-sessions, so GNOME + all niri/labwc/mango (stock + -dms)
+  # entries stay selectable. noctalia-greeter input kept available for revert.
   desktop.displayManager.backend = "none";
 
-  programs.noctalia-greeter = {
+  services.displayManager.dms-greeter = {
     enable = true;
-    package = inputs.noctalia-greeter.packages.${pkgs.system}.default;
-    # Match the login cursor to the Stylix (bibata) theme used everywhere else.
-    settings.cursor = {
-      theme = config.stylix.cursor.name;
-      size = config.stylix.cursor.size;
-      package = config.stylix.cursor.package;
-    };
+    compositor.name = "niri";
   };
+
+  # Don't restart greetd on rebuild — a switch shouldn't tear down the login
+  # manager mid-session. The new greeter applies at next reboot/logout.
+  systemd.services.greetd.restartIfChanged = false;
 
   # Phase 1: niri + labwc + mango as selectable login sessions (alongside GNOME).
   desktop.niri.enable = true;
   desktop.labwc.enable = true;
   desktop.mangowm.enable = true;
+
+  # Adds "(DankMaterialShell)" login sessions for niri/labwc/mango next to the
+  # stock (Noctalia) ones — pick per login in the greeter.
+  desktop.dmsShell.enable = true;
 
   # ddcutil: software brightness/contrast control of external monitors (DDC/CI).
   modules.hardware.ddcutil.enable = true;

--- a/modules/desktop/dms-shell.nix
+++ b/modules/desktop/dms-shell.nix
@@ -52,6 +52,11 @@ let
   niriDmsSession = mkDmsSession { name = "niri-dms"; label = "Niri (DankMaterialShell)"; exec = "${niriLauncher}"; };
   labwcDmsSession = mkDmsSession { name = "labwc-dms"; label = "labwc (DankMaterialShell)"; exec = "${labwcLauncher}"; };
   mangoDmsSession = mkDmsSession { name = "mango-dms"; label = "mango (DankMaterialShell)"; exec = "${mangoLauncher}"; };
+
+  dmsSessions =
+    [ niriDmsSession ]
+    ++ optional config.desktop.labwc.enable labwcDmsSession
+    ++ optional config.desktop.mangowm.enable mangoDmsSession;
 in
 {
   options.desktop.dmsShell.enable =
@@ -70,10 +75,12 @@ in
     };
 
     # Add a "(DankMaterialShell)" entry per enabled WM. The stock niri/labwc/mango
-    # entries stay as the Noctalia sessions.
-    services.displayManager.sessionPackages =
-      [ niriDmsSession ]
-      ++ optional config.desktop.labwc.enable labwcDmsSession
-      ++ optional config.desktop.mangowm.enable mangoDmsSession;
+    # entries stay as the Noctalia sessions. These packages must also be in
+    # environment.systemPackages so their share/wayland-sessions/*.desktop files
+    # land in /run/current-system/sw/share/wayland-sessions, where greetd greeters
+    # (dms-greeter / noctalia-greeter) actually look — sessionPackages alone does
+    # not populate that dir on NixOS.
+    services.displayManager.sessionPackages = dmsSessions;
+    environment.systemPackages = dmsSessions;
   };
 }


### PR DESCRIPTION
Mirror razer's DMS setup on p620 and fix session propagation.

- hosts/p620: swap noctalia-greeter -> services.displayManager.dms-greeter
  (compositor.name = niri); desktop.dmsShell.enable = true. Add
  systemd.services.greetd.restartIfChanged = false so a rebuild doesn't tear
  down the login manager mid-session (new greeter applies at next reboot).
- modules/desktop/dms-shell.nix: also add the -dms session packages to
  environment.systemPackages, not just services.displayManager.sessionPackages
  — on NixOS the latter alone doesn't populate
  /run/current-system/sw/share/wayland-sessions where greetd greeters look.
  Previously the -dms sessions only appeared on razer (which had a host-local
  systemPackages line); the module is now self-contained.

Verified: p620 + razer build; both expose niri/labwc/mango stock + -dms
sessions; p620 greetd -> dms-greeter with restartIfChanged=false.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VYbPi22s4wHbjK3xxwoE7C
