### PR TITLE
feat(p510): harden against the SSH-storm/k3d hard-freeze

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -26,6 +26,7 @@ in
       ../common/nixos/inotify-limits.nix
       ./nixos/cpu.nix
       ./nixos/memory.nix
+      ./nixos/resilience.nix # Watchdog + sshd limits + oomd (post-2026-07-08 freeze)
       ../common/nixos/hosts.nix
       ./nixos/plex.nix
       ./flaresolverr.nix # Cloudflare-bypass proxy for Prowlarr (used by 1337x and any other CF-protected indexer)

--- a/hosts/p510/nixos/resilience.nix
+++ b/hosts/p510/nixos/resilience.nix
@@ -1,0 +1,53 @@
+_:
+# Resilience hardening for p510 (headless media / k3d-factory server).
+#
+# Added after a 2026-07-08 hard freeze: the Odin metrics pod hammered sshd in a
+# reconnect loop (each connection spawning a login shell) on top of k3d pod
+# churn, wedging the host with no safety net — it sat dead ~2h until a manual
+# power-cycle. earlyoom (memory.nix) exists but only fires on absolute free
+# memory + swap, and is a userspace process a hard hang can starve, so it never
+# acted.
+#
+# Defense in depth (each layer is independent):
+#   1. Hardware watchdog  — a hung kernel auto-reboots in ~2min.
+#   2. sshd rate-limiting — bound a login storm at the door.
+#   3. systemd-oomd       — cgroup-pressure OOM management over system.slice
+#                           (docker/k3d), killing the offending pod before the
+#                           whole host deadlocks.
+{
+  # ── 1. Intel TCO hardware watchdog (Xeon C61x PCH) ──────────────────────
+  # systemd pets /dev/watchdog every runtimeTime; if the kernel hangs, the chip
+  # hardware-resets the box. rebootTime bounds a graceful reboot before that.
+  boot.kernelModules = [ "iTCO_wdt" ];
+  systemd.settings.Manager = {
+    RuntimeWatchdogSec = "30s"; # ping /dev/watchdog; hang -> hardware reset
+    RebootWatchdogSec = "2min"; # graceful-reboot deadline before hard reset
+  };
+
+  # ── 2. sshd throttling ──────────────────────────────────────────────────
+  # Caps how fast/many any single source can open sessions, so a looping client
+  # (or a scanner) cannot fork-storm the host. Merges with the shared openssh
+  # module (which only sets enable + X11Forwarding).
+  services.openssh.settings = {
+    LoginGraceTime = 20;
+    MaxStartups = "10:30:60";
+    MaxSessions = 20;
+    PerSourceMaxStartups = 10;
+  };
+
+  # ── 3. systemd-oomd (cgroup-pressure OOM management) ─────────────────────
+  # Kills the heaviest cgroup under sustained memory pressure (typically a
+  # runaway k3d pod) instead of letting the host deadlock. Complements earlyoom
+  # in memory.nix (an absolute-free-memory backstop).
+  systemd.oomd = {
+    enable = true;
+    enableSystemSlice = true;
+  };
+  # Act on docker (and thus its k3d containers) when the cgroup's memory
+  # pressure stays high, capping the cluster's blast radius without a brittle
+  # hard MemoryMax that could kill the cluster under normal load.
+  systemd.services.docker.serviceConfig = {
+    ManagedOOMMemoryPressure = "kill";
+    ManagedOOMMemoryPressureLimit = "80%";
+  };
+}

--- a/modules/common/base-user.nix
+++ b/modules/common/base-user.nix
@@ -15,15 +15,11 @@ let inherit (lib) mkDefault; in {
     # via modules/nixos/packages/core.nix for sudo / root / other users.
     packages = with pkgs; [ wally-cli ];
 
-    # SSH keys authorized to log in as this user across the fleet.
-    # odin-dashboard@factory: the Odin homelab portal pod (k3s/factory ns)
-    # SSHes into p510/p620/razer to collect host metrics. Without this key
-    # authorized, sshd PerSourcePenalties penalises the pod's repeated auth
-    # failures and drops its connections ("Not allowed at this time"),
-    # making every host render OFFLINE in the dashboard.
-    openssh.authorizedKeys.keys = [
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAXf9GfUzBSKmfIQcDmaEcG3rmorOzGSOFXqMbHvlWSH odin-dashboard@factory"
-    ];
+    # NOTE: the Odin dashboard metrics-collector key used to live here, which
+    # gave that Kubernetes pod passwordless-sudo (wheel) access and spawned a
+    # zsh login per scrape — a tight reconnect loop hard-froze p510 (2026-07-08).
+    # It now lives on the dedicated unprivileged `metrics` user; see
+    # modules/common/metrics-user.nix.
   };
 
   # Common shell setup

--- a/modules/common/default.nix
+++ b/modules/common/default.nix
@@ -1,6 +1,7 @@
 _: {
   imports = [
     ./base-user.nix
+    ./metrics-user.nix
     ./user-avatar.nix
     ./features.nix
     ./features-impl.nix

--- a/modules/common/metrics-user.nix
+++ b/modules/common/metrics-user.nix
@@ -1,0 +1,33 @@
+{ pkgs, ... }:
+# Dedicated least-privilege login for the Odin homelab-portal metrics collector
+# (the odin-dashboard@factory pod, k3s/factory ns). It SSHes into each host to
+# scrape system metrics.
+#
+# Previously its key sat on `olafkfreund` — a wheel user with passwordless sudo
+# — so a Kubernetes pod effectively had root on every host, and every scrape
+# spawned a full zsh login shell. On 2026-07-08 a tight reconnect loop from that
+# pod hard-froze p510. This user fixes both problems: it is unprivileged (no
+# wheel/sudo), uses a cheap bash shell (no interactive rc on `bash -c`), and can
+# only read the journal (systemd-journal group) for log-based metrics. The key
+# is `restrict`-ed to command execution — no forwarding — while still permitting
+# a PTY, which the collector requests today.
+#
+# ⚠️ The Odin pod MUST connect as `metrics@<host>`, not `olafkfreund@<host>`.
+let
+  odinKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAXf9GfUzBSKmfIQcDmaEcG3rmorOzGSOFXqMbHvlWSH odin-dashboard@factory";
+in
+{
+  users.groups.metrics = { };
+  users.users.metrics = {
+    isSystemUser = true;
+    group = "metrics";
+    # Read-only journal access for log-based metrics; deliberately NOT wheel.
+    extraGroups = [ "systemd-journal" ];
+    shell = pkgs.bash;
+    home = "/var/lib/metrics";
+    createHome = true;
+    openssh.authorizedKeys.keys = [
+      "restrict,pty ${odinKey}"
+    ];
+  };
+}


### PR DESCRIPTION
## Summary
On **2026-07-08** p510 hard-froze and sat dead ~2 h until a manual power-cycle. Root cause (from `journalctl -b -1`): the **Odin metrics pod** (`172.18.0.4`, inside p510's own k3d cluster — authenticated, internal, not an intruder) hammered sshd in a **tight reconnect loop**, each connection spawning a full **zsh login as `olafkfreund`**, on top of **k3d pod churn**. `earlyoom` never acted (it needs absolute free-mem+swap low and is a userspace process a hard hang starves), and there was **no watchdog**, so the box stayed wedged until reset.

This PR is defense-in-depth so this class of failure can't recur or persist.

## Changes
**Fleet-wide (security + root cause)**
- New unprivileged **`metrics`** user (`modules/common/metrics-user.nix`): cheap `bash` shell, `systemd-journal` read only, **not wheel**. Carries the Odin collector key with `restrict,pty`. Previously that key was on `olafkfreund` (wheel + passwordless sudo) — i.e. a k8s pod had **effective root on every host** and spawned a zsh login per scrape. Removed from `base-user.nix`.

**p510-only (`hosts/p510/nixos/resilience.nix`)**
- **Hardware watchdog** (`iTCO_wdt` + `RuntimeWatchdogSec=30s`/`RebootWatchdogSec=2min`) — a hung kernel auto-reboots in ~2 min. *This is the fix for the ~2 h downtime.*
- **sshd rate-limiting** (`MaxStartups`/`PerSourceMaxStartups`/`MaxSessions`/`LoginGraceTime`) — a looping client can't fork-storm the host.
- **systemd-oomd** over `system.slice` + docker cgroup **pressure-kill at 80%** — memory pressure kills the offending k3d pod before the host deadlocks (earlyoom stays as an absolute-free-memory backstop).

## Testing
- `nix build` of the p510 toplevel ✅ (clean, no obsolete/watchdog warnings)
- `nix eval` of the `metrics` user on p620 + razer ✅ (fleet-wide change valid)
- Verified resolved values: watchdog 30s, oomd enabled, MaxStartups `10:30:60`, docker `ManagedOOMMemoryPressure=kill`, Odin key removed from `olafkfreund`, `metrics` not in wheel.

## ⚠️ Required follow-up (breaking for the collector)
The Odin dashboard pod **must switch its SSH target to `metrics@<host>`** (was `olafkfreund@<host>`). Until it does, host metrics show offline — but no host outage. Ideally also fix the pod to hold **one persistent SSH connection** (ControlMaster/ControlPersist) or poll on an interval instead of reconnecting in a loop (the actual trigger; lives in the Odin repo).

## Deploy
Not deployed here — p510's tailnet is flaky and per policy it's never auto-deployed. Apply with a manual p510 switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)