### PR TITLE
feat(cloudflared): install the cloudflared CLI on tunnel hosts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783065973,
-        "narHash": "sha256-cl6+ATJ3wni26HQSIJJ+zK1yTEVdKXoSOhr1NeybbPY=",
+        "lastModified": 1783497076,
+        "narHash": "sha256-NMMOfgLJPZU6yimIOVk8LnM5+SZlWwz6XG9zdDbZ/2c=",
         "owner": "jacopone",
         "repo": "antigravity-nix",
-        "rev": "d7eb4913b4f0bcb12023956bbc969c6bad5f7328",
+        "rev": "4f034162ad799768a372e4ce32bc6a95f7d056d5",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1783395319,
-        "narHash": "sha256-L9nucc6xpvFUZO0LI74Ru303ajfXW/KjfEF36w4WJ+U=",
+        "lastModified": 1783480927,
+        "narHash": "sha256-S5bOGxxrYcFRVIIxqaEsjSwyIQjTjdjX3hCeAMAWiq0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c51e9cef5ddf3a439d0ac7f8b026cf3e5d3d26a7",
+        "rev": "5f712bbd17df232fb4900e8fc236516c4d854d84",
         "type": "github"
       },
       "original": {
@@ -689,11 +689,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783388784,
-        "narHash": "sha256-w+YU5vatysjLZIg1wOKSzo/RL9Z66eBQuIjVnBM/1Zg=",
+        "lastModified": 1783479733,
+        "narHash": "sha256-d/JatqgG+Pmo+IuCTZfnrEAPWU3fdha48GQeXuFO+bE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "63d02d1c19f1c2b47a5bc7e55c620b6af7b218a6",
+        "rev": "cee3f0e7fec85d80c149c7afc29926747f7bd3c2",
         "type": "github"
       },
       "original": {
@@ -770,11 +770,11 @@
         "scenefx": "scenefx"
       },
       "locked": {
-        "lastModified": 1783315258,
-        "narHash": "sha256-07Tmtkw3MP0M6VxwpP3pFSPW4wwTyaQsFVP8I8Gv40A=",
+        "lastModified": 1783493363,
+        "narHash": "sha256-UZD/ppWEn/eAKYqyw98fEmyD8HoOsrSB9XGETG2mqyA=",
         "owner": "mangowm",
         "repo": "mango",
-        "rev": "9d4f4fd46baa096e20e2cb98e629fde10fd7be38",
+        "rev": "6d3f7b4abb909cec25914a5e386e7fe9efb98057",
         "type": "github"
       },
       "original": {
@@ -809,11 +809,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1783378761,
-        "narHash": "sha256-/hH3g4xODR+eS4x3WVOW/TsCWAGjKC+dc81Me5fam/U=",
+        "lastModified": 1783451207,
+        "narHash": "sha256-6+I67Kj47Ljwj8JGi8P3fSTxCBR+L0AauZTTmrrwLTs=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "048907feb47e523f02923c9ceae1c75b9315fc67",
+        "rev": "c5a04bcc9d1f5a6ccafdcdf607bf49f70d5f7f20",
         "type": "github"
       },
       "original": {
@@ -964,11 +964,11 @@
         "parts": "parts"
       },
       "locked": {
-        "lastModified": 1783404794,
-        "narHash": "sha256-PF4odTRSNB4zMj/WRokrYC/1OOeFuwT4DOGMGJG5iJ0=",
+        "lastModified": 1783488358,
+        "narHash": "sha256-/8Vy58LWYrCF1Xk4XVnQ2S8r3R0Me4QyLdEiLWHu+UU=",
         "owner": "moni-dz",
         "repo": "nixpkgs-f2k",
-        "rev": "fcb44dabd0bd252994959e1dca02a58bbb4914fd",
+        "rev": "0ad156baa7437fd5528119f276ae72bb432263e4",
         "type": "github"
       },
       "original": {
@@ -1078,11 +1078,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1783148766,
-        "narHash": "sha256-uslt2pqShTIXDdAHRHv2QkYLsVdY8Oqwz0EA48/RSM8=",
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a50de1b7d8a586adc18d2395c19de7d6058e6030",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       },
       "original": {
@@ -1110,11 +1110,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1783402289,
-        "narHash": "sha256-Z4VkqgkN/8Er7dtX2/Vr2RloqTz5QvpgRUG6Fyxnbqk=",
+        "lastModified": 1783487603,
+        "narHash": "sha256-+vQiUJaoRNv32rDUWyPgs7cAfGZyAEgOPHlp0R0Lb3E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5f22a66963db1e8bbb14d052941ed62f9866a52a",
+        "rev": "ff487301c877b8aadcd1550cd2b4226114bc8a27",
         "type": "github"
       },
       "original": {
@@ -1300,11 +1300,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783398147,
-        "narHash": "sha256-D4Rug29rQuvFey2BHuOb/haBfLd/8i7CrmmavbytARE=",
+        "lastModified": 1783495226,
+        "narHash": "sha256-+Qg4wlqjEf4CRxkLtQ4tvsk5U2CAbWDZfCdXuyLBoo8=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "831c513f1ea0396ed4671b8d4704c0ed6bab83f4",
+        "rev": "b9b4bc3408a906f392a8d277d172ef440debc5cc",
         "type": "github"
       },
       "original": {
@@ -1320,11 +1320,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783267606,
-        "narHash": "sha256-GhnfGnxzD1Fp1sbY0I2b9gNIBT298dw8ijk5s5ffZIo=",
+        "lastModified": 1783497237,
+        "narHash": "sha256-AQSgjkL0f4X03mhcRm8D47l99ux2LTXMhRSDTAVGuz0=",
         "owner": "noctalia-dev",
         "repo": "noctalia-greeter",
-        "rev": "48fc6d22b54efd62df83e3d1266feb89c291115a",
+        "rev": "c346f1d9db2e574c061b74449e943d4d2d1a7883",
         "type": "github"
       },
       "original": {
@@ -1339,11 +1339,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1783419004,
-        "narHash": "sha256-/ogRiQIoDwRZLqeaf5kObIZvfJwhazB5evx5qm4cmvc=",
+        "lastModified": 1783499458,
+        "narHash": "sha256-28/adOt67VkPez43jmeBk34CXKdC1H6rHOa2MRQLhn4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9d5474f70879b105a602f0fabb5637a0499c89bd",
+        "rev": "7fc79d5e1e78b94646ddfed2301dbb82de747fee",
         "type": "github"
       },
       "original": {
@@ -1539,11 +1539,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783404876,
-        "narHash": "sha256-DAh1CfiRVwr8Szkj5PiHmsqh10NHPb8SKPx7w/B+l9E=",
+        "lastModified": 1783488441,
+        "narHash": "sha256-jmWf+H3iC/0z7/mmvTovaJx1E/LME1QyHkyk+AFfJPk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3c161f20193bd91a73913b417e5b06d41860336d",
+        "rev": "7dc3a177a239ed879c5581a80f6dc246c7e102f1",
         "type": "github"
       },
       "original": {
@@ -1617,9 +1617,9 @@
     "spectrum": {
       "flake": false,
       "locked": {
-        "lastModified": 1783352983,
-        "narHash": "sha256-JAjT/fAdbllpOUkqTWbELWqKLe+NnOBHPsTO1imLqd4=",
-        "rev": "354ddce6df843ea8179e017b3533ef7d39fc3c3d",
+        "lastModified": 1783423582,
+        "narHash": "sha256-4z10q9MX1irpGhLe+uYC6k7evEnyhb/z1eNeIf71B+g=",
+        "rev": "0adfbcb6c12f35b33b8f47dc527587d4d20eeb93",
         "revCount": 1400,
         "type": "git",
         "url": "https://spectrum-os.org/git/spectrum"

--- a/modules/services/cloudflared.nix
+++ b/modules/services/cloudflared.nix
@@ -139,6 +139,14 @@ in
       };
     };
 
+    # Make the cloudflared CLI available on hosts running the tunnel, for
+    # tunnel/route management and debugging — e.g.
+    #   cloudflared tunnel route dns <tunnel> <hostname>
+    # (route dns also needs the origin cert; on this host it lives at
+    # config.age.secrets.cloudflared-cert.path, exported as TUNNEL_ORIGIN_CERT).
+    # Version-matched to the running daemon via services.cloudflared.package.
+    environment.systemPackages = [ config.services.cloudflared.package ];
+
     # Origin keepalive — sweep each ingress URL on a timer so idle apps
     # (Node SPAs, gunicorn, JVMs) don't cold-start on the first public
     # hit and render a blank page while they boot. Hits LOCAL origins


### PR DESCRIPTION
## Summary
Adds the `cloudflared` CLI to `environment.systemPackages` inside `modules/services/cloudflared.nix`'s `config = mkIf cfg.enable` block, so any host running the tunnel (today: **p510**) has the version-matched CLI for tunnel/route management and debugging — e.g. `cloudflared tunnel route dns p510-home <hostname>`.

Uses `config.services.cloudflared.package` so the CLI always matches the running daemon. Feature-gated → p620/razer unaffected.

Note: `tunnel route dns` also needs the origin cert; on p510 it's the agenix secret `cloudflared-cert` (`TUNNEL_ORIGIN_CERT=/run/agenix/cloudflared-cert`).

## Testing
- `nix eval`: `cloudflared-2026.6.1` present on p510, **absent** on p620 ✅
- `nix build` of the p510 toplevel ✅
- Not deployed (p510 flaky tailnet + never-auto-deploy policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)