### PR TITLE
fix(desktop): unbreak mango (scenefx 0.5) + pin noctalia past broken rev

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -512,7 +512,10 @@
     },
     "flake-utils_7": {
       "inputs": {
-        "systems": "systems_9"
+        "systems": [
+          "scenefx",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1731533236,
@@ -531,6 +534,24 @@
     "flake-utils_8": {
       "inputs": {
         "systems": "systems_10"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_9": {
+      "inputs": {
+        "systems": "systems_11"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -770,11 +791,11 @@
         "scenefx": "scenefx"
       },
       "locked": {
-        "lastModified": 1783493363,
-        "narHash": "sha256-UZD/ppWEn/eAKYqyw98fEmyD8HoOsrSB9XGETG2mqyA=",
+        "lastModified": 1783521133,
+        "narHash": "sha256-Y3NUvUYck+EErTseufbNT3oM7zP5w/MUnHxdNL9gjLo=",
         "owner": "mangowm",
         "repo": "mango",
-        "rev": "6d3f7b4abb909cec25914a5e386e7fe9efb98057",
+        "rev": "7acdbb0ade77ff0e6e826e40828b6923c8898576",
         "type": "github"
       },
       "original": {
@@ -834,11 +855,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1783267733,
-        "narHash": "sha256-DTvaM+0vanneOcKg3NKXV7ilf0ShY4BOBz/nde5GHos=",
+        "lastModified": 1783510829,
+        "narHash": "sha256-VtZC3AiKp3w6oCTRlEaraI9Fi2T8CmdDuhzGf3lNG9M=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "74053f79cad0f6c3a4a0be6b7928795d2e6a9f4b",
+        "rev": "ba8fc95733e53354e82dd1a821d8391dcd56e4bc",
         "type": "github"
       },
       "original": {
@@ -867,11 +888,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1783248941,
-        "narHash": "sha256-citgYJbvR1iUKXpiWlFq3NO+fw6hXGL3Qk1ampU7lhA=",
+        "lastModified": 1783506058,
+        "narHash": "sha256-LyuNO/1BM7GphVyt4C4Qj2OkdHZvM/9Hxs7mQ5ExjYc=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "a30ca7983b2f1fc3ddeb209b3fe18fa78e0dbd25",
+        "rev": "ef5b7379dc444d33b01a7faec2bd6592d3188357",
         "type": "github"
       },
       "original": {
@@ -1310,6 +1331,7 @@
       "original": {
         "owner": "noctalia-dev",
         "repo": "noctalia",
+        "rev": "b9b4bc3408a906f392a8d277d172ef440debc5cc",
         "type": "github"
       }
     },
@@ -1339,11 +1361,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1783499458,
-        "narHash": "sha256-28/adOt67VkPez43jmeBk34CXKdC1H6rHOa2MRQLhn4=",
+        "lastModified": 1783518605,
+        "narHash": "sha256-QVxNyLM7mOTeHehELPkDq6PS+Uziv8TKVbWt10X91FY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7fc79d5e1e78b94646ddfed2301dbb82de747fee",
+        "rev": "e9423d28116d4e917181bdee77b662af4ca39d38",
         "type": "github"
       },
       "original": {
@@ -1445,6 +1467,7 @@
         "noctalia-greeter": "noctalia-greeter",
         "nur": "nur",
         "rust-overlay": "rust-overlay_4",
+        "scenefx": "scenefx_2",
         "sops-nix": "sops-nix",
         "spicetify-nix": "spicetify-nix",
         "stylix": "stylix",
@@ -1594,6 +1617,29 @@
         "type": "github"
       }
     },
+    "scenefx_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_7",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_7"
+      },
+      "locked": {
+        "lastModified": 1782624992,
+        "narHash": "sha256-vUjLG6eubEhJJVa9LPygIcVmNoHwYbSUTJcWEcbxnU4=",
+        "owner": "wlrfx",
+        "repo": "scenefx",
+        "rev": "37ccd723bef49e6891156ffafce8f549f01446cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wlrfx",
+        "ref": "0.5",
+        "repo": "scenefx",
+        "type": "github"
+      }
+    },
     "sops-nix": {
       "inputs": {
         "nixpkgs": [
@@ -1632,7 +1678,7 @@
     "spicetify-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_12",
-        "systems": "systems_7"
+        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1783303713,
@@ -1661,7 +1707,7 @@
           "nixpkgs"
         ],
         "nur": "nur_2",
-        "systems": "systems_8",
+        "systems": "systems_9",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
@@ -1697,6 +1743,21 @@
       }
     },
     "systems_10": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_11": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1788,16 +1849,16 @@
     },
     "systems_7": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default",
+        "repo": "default-linux",
         "type": "github"
       }
     },
@@ -1930,7 +1991,7 @@
     },
     "yt-x": {
       "inputs": {
-        "flake-utils": "flake-utils_7",
+        "flake-utils": "flake-utils_8",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -1952,7 +2013,7 @@
     "zjstatus": {
       "inputs": {
         "crane": "crane_2",
-        "flake-utils": "flake-utils_8",
+        "flake-utils": "flake-utils_9",
         "nixpkgs": "nixpkgs_13",
         "rust-overlay": "rust-overlay_5"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -53,8 +53,12 @@
     # provides programs.noctalia. Follows nixpkgs: the package is a light QML
     # wrapper over pkgs.quickshell (already cached in nixpkgs), so this avoids
     # duplicating the Qt closure and needs no extra cachix.
+    # Pinned to a known-good rev: noctalia HEAD (b87c8acf) fails to compile — its
+    # mango workspace backend has a type error (mango_workspace_backend.cpp:162,
+    # `TagInfo` vs `uint32_t`). Unpin (back to a bare branch url) once upstream
+    # noctalia fixes the mango backend build.
     noctalia = {
-      url = "github:noctalia-dev/noctalia";
+      url = "github:noctalia-dev/noctalia/b9b4bc3408a906f392a8d277d172ef440debc5cc";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -82,6 +86,18 @@
     # home-manager.sharedModules). Third Noctalia session alongside niri/labwc.
     mango = {
       url = "github:mangowm/mango";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    # scenefx 0.5 — mango's meson.build requires scenefx-0.5, but mango's own
+    # flake pins/exposes scenefx 0.4.1 (its `inherit (inputs.scenefx.packages.*)
+    # scenefx` only resolves against the 0.4.1 output layout, which 0.5 renamed
+    # to `default`). So we can't just make mango follow this; instead we build
+    # scenefx 0.5 here and inject it via `programs.mango.package.override`
+    # (see modules/desktop/mangowm.nix). Pinned to tag 0.5; revisit when mango
+    # upstream wires scenefx 0.5 itself.
+    scenefx = {
+      url = "github:wlrfx/scenefx/0.5";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/home/desktop/noctalia/default.nix
+++ b/home/desktop/noctalia/default.nix
@@ -578,6 +578,10 @@ in
     in
     {
       enable = true;
+      # Reuse the scenefx-0.5-overridden package from the NixOS module
+      # (modules/desktop/mangowm.nix) so the HM side doesn't rebuild mango
+      # against scenefx 0.4.1 (which fails: "scenefx-0.5 not found").
+      package = osConfig.programs.mango.package;
 
       extraConfig = ''
         # Electron apps → Wayland (same fix as niri/labwc).

--- a/modules/desktop/mangowm.nix
+++ b/modules/desktop/mangowm.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, inputs, ... }:
 # mango — dwl-based (wlroots + scenefx) Wayland compositor, exposed as a
 # selectable login session. The mango flake's NixOS module (programs.mango) is
 # wired in flake.nix; this feature module just turns it on. programs.mango
@@ -16,5 +16,12 @@ in
 
   config = mkIf cfg.enable {
     programs.mango.enable = true;
+    # mango's meson.build requires scenefx-0.5, but its flake builds the package
+    # against scenefx 0.4.1. Rebuild the mango package with the scenefx 0.5 we
+    # pin in flake.nix. Drop this override once mango wires scenefx 0.5 upstream.
+    programs.mango.package =
+      inputs.mango.packages.${pkgs.stdenv.hostPlatform.system}.mango.override {
+        scenefx = inputs.scenefx.packages.${pkgs.stdenv.hostPlatform.system}.default;
+      };
   };
 }


### PR DESCRIPTION
A routine flake lock bump broke the p620 build in two independent ways:

- mango's meson.build requires scenefx-0.5, but its flake builds the mango
  package against scenefx 0.4.1 (its `inherit (inputs.scenefx.packages.*)
  scenefx` only resolves the 0.4.1 output layout; scenefx 0.5 renamed the
  attr to `default`). Add scenefx 0.5 as a top-level input and inject it via
  `programs.mango.package.override { scenefx = ...; }`. The home-manager side
  (wayland.windowManager.mango) reuses that package through
  osConfig.programs.mango.package so it doesn't rebuild against 0.4.1.

- noctalia HEAD (b87c8acf) fails to compile: its mango workspace backend has
  a type error (mango_workspace_backend.cpp:162, TagInfo vs uint32_t). Pin
  noctalia to the last-good rev b9b4bc34 until upstream fixes the build.

Verified: nix build .#nixosConfigurations.p620...toplevel succeeds.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VYbPi22s4wHbjK3xxwoE7C
