### PR TITLE
fix(p620): resolve duplicate systemd.services definition breaking CI

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -379,10 +379,6 @@ in
     compositor.name = "niri";
   };
 
-  # Don't restart greetd on rebuild — a switch shouldn't tear down the login
-  # manager mid-session. The new greeter applies at next reboot/logout.
-  systemd.services.greetd.restartIfChanged = false;
-
   # Phase 1: niri + labwc + mango as selectable login sessions (alongside GNOME).
   desktop.niri.enable = true;
   desktop.labwc.enable = true;
@@ -667,6 +663,10 @@ in
     services = {
       # Network wait services now handled by desktop profile
       fwupd.serviceConfig.LimitNOFILE = 524288;
+
+      # Don't restart greetd on rebuild — a switch shouldn't tear down the login
+      # manager mid-session. The new greeter applies at next reboot/logout.
+      greetd.restartIfChanged = false;
     };
 
     # User services


### PR DESCRIPTION
hosts/p620/configuration.nix mixed an attrpath def
(systemd.services.greetd.restartIfChanged) with an explicit
`systemd = { services = { … }; }` block. Newer Nix (local 2.31/2.34)
merges the two; the older Nix in CI (cachix/install-nix-action@v27)
rejects it as `attribute 'services' already defined`, failing both
check-configurations (p620) and security-check.

Fold the greetd line into the existing systemd.services block so
`systemd` is defined once. Behaviour-preserving: p620 toplevel evaluates
to the identical store path and greetd.restartIfChanged stays false.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XG2Q6rjs6zxNNuRpuLwNWY
