### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -813,11 +813,11 @@
         "scenefx": "scenefx"
       },
       "locked": {
-        "lastModified": 1783596530,
-        "narHash": "sha256-axtsgyIobVzhwdsiI3yrRQIUkgPX2g7kPHLWPuPPJ9g=",
+        "lastModified": 1783609292,
+        "narHash": "sha256-LeAHQjnDfD/PV7MZ9kHQtDPWPcN2qHEGdQ5g968XGX4=",
         "owner": "mangowm",
         "repo": "mango",
-        "rev": "049ec6e0b89f5bbccc7065f78da934125d76406a",
+        "rev": "deecb4ca33935b3c82326d7522b30eb3a27120ca",
         "type": "github"
       },
       "original": {
@@ -1105,11 +1105,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1783597113,
-        "narHash": "sha256-2EeVKdiSAFHydpFWJGD0grAdEt6kB0NRFvLz/PxFnac=",
+        "lastModified": 1783615922,
+        "narHash": "sha256-QxveHAEeF+tPX71wGohBno9DiiJ94pE/DUxfOT0PwcU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "991bbfe33bd0a8a9e2fa5299ac88376d2ed5aa7e",
+        "rev": "38a3664e5ad15df673342919388f46b73f52de87",
         "type": "github"
       },
       "original": {
@@ -1399,11 +1399,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1783595916,
-        "narHash": "sha256-vZb1rDx1w2kMpwJHJHjp2coGhBLW0yFinmW7z3kAeRc=",
+        "lastModified": 1783616231,
+        "narHash": "sha256-n4B9YNJb2bNJszCMwg9Di4rc9komUnGmg/LHsMqXTKI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8bb432a8032504497e0776deaa1ea89255b399f4",
+        "rev": "9005dd6105559432e272fad52162c68fdddd089b",
         "type": "github"
       },
       "original": {
@@ -1601,11 +1601,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783577481,
-        "narHash": "sha256-EWMxOWrJ031f8f/lrcEmhTRs4npw1/5N3Hcjin846c8=",
+        "lastModified": 1783614422,
+        "narHash": "sha256-zSX553aXiIKJHWzUF6nrDKgeNRlfNK/SdyNYSbs2nkM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4cdea398dc491b082dccdce0fad1ed0b75fa3394",
+        "rev": "e8e9d70b96113fd49ccde6c3e08fb260b6ef5dd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=p620, scope=all).

Built and verified locally against nixosConfigurations.p620 before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)