### PR TITLE
chore: bump warp-terminal + repin lanzaboote to v1.1.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -150,11 +150,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1780532242,
-        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
+        "lastModified": 1781825982,
+        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
+        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
         "type": "github"
       },
       "original": {
@@ -790,17 +790,17 @@
         "rust-overlay": "rust-overlay_3"
       },
       "locked": {
-        "lastModified": 1781649287,
-        "narHash": "sha256-ycG9a7svaV/zF9G03waY7BqUcNQn2HODMN/lXy3C7Zc=",
+        "lastModified": 1782141370,
+        "narHash": "sha256-hqijVSEETttmo8Okql9/LG0Ua34hdciKW1a5zzlj8mU=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "001e560fffc8f0235e9db20ebeb4ccde0ade1caf",
+        "rev": "7c9a54a7f87b4539ddbd8bda09a8a5f5f9361aa9",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
+        "ref": "v1.1.0",
         "repo": "lanzaboote",
-        "rev": "001e560fffc8f0235e9db20ebeb4ccde0ade1caf",
         "type": "github"
       }
     },
@@ -1465,11 +1465,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
@@ -1581,11 +1581,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781407245,
-        "narHash": "sha256-VzJq4MmD0uyNDAceudSe1hHqcQMe9Tau0U4S+5iRGh0=",
+        "lastModified": 1782012058,
+        "narHash": "sha256-9mWUnReOUXfKjZuJAL/bAFH3LUyECTRtXgSNVjRw3UY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d5f483210eb016d66102eef22baa128b3b3233fc",
+        "rev": "8534567325bd8a8d2928e6afd81e0a87d19efd3c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -123,7 +123,7 @@
     # boot.bootspec.enable option, which throws against current nixpkgs
     # (bootspec is now always-on). Pinned to master past that fix.
     lanzaboote = {
-      url = "github:nix-community/lanzaboote/001e560fffc8f0235e9db20ebeb4ccde0ade1caf";
+      url = "github:nix-community/lanzaboote/v1.1.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/pkgs/warp-terminal/versions.json
+++ b/pkgs/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "linux_x86_64": {
-    "hash": "sha256-FeRAZAndQEwoQY2mVX8yBPjgYtY0HbVKfDwepHuU59w=",
-    "version": "0.2026.07.01.09.21.stable_01"
+    "hash": "sha256-6upQRXZB6X/ZjVg+c9b0u3s455+QcQjOQKu2MXVoKnQ=",
+    "version": "0.2026.07.08.17.54.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-3fkK46qu22KttMKXWalsWyphf3DaBXQmvYNgbANcqqM=",
-    "version": "0.2026.07.01.09.21.stable_01"
+    "hash": "sha256-mNqo2Ig/81xLImpl+nf5niHuo9IqMJyDIcGogld5vBQ=",
+    "version": "0.2026.07.08.17.54.stable_01"
   }
 }


### PR DESCRIPTION
Two chore bumps:

- **warp-terminal** `0.2026.07.01` → `0.2026.07.08.17.54.stable_01` (build-verified, ELF + version pin OK)
- **lanzaboote** repin from untagged master `001e560` → **v1.1.0** tag (razer toplevel builds clean; Secure Boot signer — deploy razer with rollback available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)