### PR TITLE
fix(overlays): skip click-threading pytest on python3.14 + bump inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -732,11 +732,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783689750,
-        "narHash": "sha256-iMO/Ypany7DPXD6D7sQgH7METtEUihnOvdb+A9ehn8k=",
+        "lastModified": 1783711151,
+        "narHash": "sha256-232L3Nku2nLch/TQHsJEIhiZJKr+VTehnVUs1NZ0SNc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "79e6082586b3680ff32c8e75127545058f074fa4",
+        "rev": "f938277527aa084929261879d50d9832b9eab6d3",
         "type": "github"
       },
       "original": {
@@ -877,11 +877,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1783526091,
-        "narHash": "sha256-Zkkil0e8Wg5BcBmJkWJwBXlETefYQbYKw72xJUIBPLE=",
+        "lastModified": 1783691974,
+        "narHash": "sha256-6iB3Ti6I1aCkOZO5mtkteEse/DAEoQVtLJGcGBgNNLU=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "a24d4c0dce53fd8dbeb9ad20411e282c7b9875f1",
+        "rev": "8341f767e055e216343f2383b7c7618b9215b193",
         "type": "github"
       },
       "original": {
@@ -968,11 +968,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1783673680,
-        "narHash": "sha256-ardRVG+ipnyyxVdIsbLMy5foO6gDqN/yIi8v10HTJqs=",
+        "lastModified": 1783692676,
+        "narHash": "sha256-6FXlRphexzMo3HpoN0NxEl7uQoE8llWeNJrD8NMA/CY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0b655af52b5b89bcceb88737efdc3a7498e751ee",
+        "rev": "4471c6a218fe813ad4838c400866c8845d3eba6b",
         "type": "github"
       },
       "original": {
@@ -1105,11 +1105,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1783691465,
-        "narHash": "sha256-XHB3LvQni64rfkGVGhYXBk98ZpBlpn9w7FTiwNAoraI=",
+        "lastModified": 1783711253,
+        "narHash": "sha256-+uqr6CckcujYQPzyhrzwx57DsUX45EpPzw3T9qxgE98=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e85917e5f32408a7ec5c2f4eaf354be161a22061",
+        "rev": "c981de056c91f645f9b879d055fa5de93ba82bfe",
         "type": "github"
       },
       "original": {
@@ -1399,11 +1399,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1783690992,
-        "narHash": "sha256-gryJ6X0mdrN+fW9+l6K72XTLsmHpg5w04XXEwV+VBK0=",
+        "lastModified": 1783712791,
+        "narHash": "sha256-zFFk+PfOoMFjUa/p0aH1g1n0zk/7hRj+0dwg47VvVDY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "cbde5e9c0fd8f2710ecfa1a05ee8414090d11e17",
+        "rev": "6f0ceb8a103bfb79c55c4163f42b0154f6194172",
         "type": "github"
       },
       "original": {

--- a/overlays/python-compat.nix
+++ b/overlays/python-compat.nix
@@ -53,4 +53,17 @@ _final: prev: {
       });
     };
   };
+
+  # python3 default advanced to 3.14 (nixpkgs 0bb7ec54c8). click-threading's
+  # pytestCheckPhase collects docs/conf.py, which imports pkg_resources —
+  # removed from setuptools on 3.14 — so the test errors out. Skip the check;
+  # the pythonImportsCheck (import click_threading) still passes. Unblocks
+  # vdirsyncer -> khal. Drop once nixpkgs fixes the test collection upstream.
+  python314 = prev.python314.override {
+    packageOverrides = _pyFinal: pyPrev: {
+      click-threading = pyPrev.click-threading.overridePythonAttrs (_old: {
+        doCheck = false;
+      });
+    };
+  };
 }


### PR DESCRIPTION
Recovers the failed `update-commit-deploy` run.

**click-threading** fails its `pytestCheckPhase` on Python 3.14 — `docs/conf.py` imports `pkg_resources` (removed from setuptools on 3.14) — cascading to vdirsyncer → khal → p620 `system-path`. Override with `doCheck = false` in the `python314` set (`pythonImportsCheck` still passes), matching the existing plotly/wandb pattern.

Also lands the run's input bump (**root nixpkgs unchanged** `0bb7ec54c8`): home-manager, niri-flake, nixos-hardware, nixpkgs-master, nur.

**Verified:** p620 toplevel builds; razer/p510 eval clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)