### PR TITLE
fix(graphics): drop broken vulkan-validation-layers from all hosts

### DIFF
--- a/hosts/p510/nixos/nvidia.nix
+++ b/hosts/p510/nixos/nvidia.nix
@@ -8,7 +8,8 @@
     enable32Bit = true;
     extraPackages = with pkgs; [
       # Vulkan support
-      vulkan-validation-layers
+      # vulkan-validation-layers dropped: debug-only layer, broken build on
+      # nixpkgs 1.4.350.0 (update_deps.py git-clones in the sandbox).
       vulkan-loader
       vulkan-tools
 

--- a/hosts/p620/nixos/amd.nix
+++ b/hosts/p620/nixos/amd.nix
@@ -13,7 +13,9 @@
       # libglvnd - REQUIRED for COSMIC compositor (provides libEGL.so.1)
       libglvnd
       # Vulkan and video acceleration
-      vulkan-validation-layers
+      # vulkan-validation-layers dropped: debug-only layer, broken build on
+      # nixpkgs 1.4.350.0 (update_deps.py git-clones in the sandbox). RADV
+      # Vulkan works via mesa + vulkan-loader without it.
       libva-vdpau-driver
       # amdvlk removed - RADV (Mesa Vulkan) is now default
       rocmPackages.clr.icd

--- a/hosts/razer/nixos/nvidia.nix
+++ b/hosts/razer/nixos/nvidia.nix
@@ -28,7 +28,8 @@
       enable32Bit = true;
       extraPackages = with pkgs; [
         # Vulkan support
-        vulkan-validation-layers
+        # vulkan-validation-layers dropped: debug-only layer, broken build on
+        # nixpkgs 1.4.350.0 (update_deps.py git-clones in the sandbox).
         vulkan-loader
         vulkan-tools
 


### PR DESCRIPTION
vulkan-validation-layers 1.4.350.0 (current nixpkgs) fails to build — its `update_deps.py` git-clones deps at build time, rejected by the sandbox → cascades to `graphics-drivers`/`graphics-driver.conf`.

It's a **debug-only** layer (`VK_LAYER_KHRONOS_validation`), not part of the runtime Vulkan path. Removed from `hardware.graphics.extraPackages` on p620/razer/p510; `vulkan-loader` + ICDs still provide Vulkan.

**Verified:** p620 toplevel builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)