### PR TITLE
fix(overlays): add typing-extensions to python3.12 icalendar

### DIFF
--- a/overlays/python-compat.nix
+++ b/overlays/python-compat.nix
@@ -24,6 +24,14 @@ _final: prev: {
           pyPrev.msrest
         ];
       });
+      # icalendar 7.2.0 requires typing-extensions on python < 3.13, but the
+      # python3.12 derivation omits it so pythonRuntimeDepsCheckHook fails.
+      # Add it (consumed via python312Packages in home/shell/mail).
+      icalendar = pyPrev.icalendar.overridePythonAttrs (oldAttrs: {
+        dependencies = (oldAttrs.dependencies or [ ]) ++ [
+          pyPrev.typing-extensions
+        ];
+      });
     };
   };
 


### PR DESCRIPTION
icalendar 7.2.0 requires typing-extensions on python < 3.13, but the python3.12 derivation omits it, so `pythonRuntimeDepsCheckHook` fails ("typing-extensions not installed"), breaking `home-manager-path`. Consumed via `python312Packages.icalendar` in home/shell/mail.

**Verified:** python312Packages.icalendar builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)