### PR TITLE
fix: resolve nixpkgs 0bb7ec54c8 build breakage for p620

### DIFF
--- a/home/development/codex-cli.nix
+++ b/home/development/codex-cli.nix
@@ -30,7 +30,7 @@
   home.packages = with pkgs; [
     prettier
     eslint
-    black # Python formatter
+    python313Packages.black # Python formatter (pin py3.13 to match languages.nix/nvim.nix; bare `black` is py3.14 now and collides in home-manager-path)
     rustfmt # Rust formatter
     nixpkgs-fmt # Nix formatter
     jq # JSON processing for API responses

--- a/home/media/reddit.nix
+++ b/home/media/reddit.nix
@@ -43,9 +43,11 @@
 
   # Standalone clients alongside newsboat:
   #   - reddit-tui : modern Go-based read-only browser (uses public JSON)
-  #   - headlines  : GTK4 / Libadwaita GUI client when you want a window
+  #   - headlines  : GTK4 / Libadwaita GUI client (DROPPED — depends on
+  #     youtube-dl 2021.12.17, which fails to build on Python 3.14:
+  #     `spawn() got an unexpected keyword argument 'dry_run'`. Restore once
+  #     nixpkgs fixes youtube-dl for 3.14 or headlines moves to yt-dlp.)
   home.packages = with pkgs; [
     reddit-tui
-    headlines
   ];
 }

--- a/overlays/python-compat.nix
+++ b/overlays/python-compat.nix
@@ -32,6 +32,11 @@ _final: prev: {
           pyPrev.typing-extensions
         ];
       });
+      # inline-snapshot 0.32.5 has 3 failing tests (of 1428) on this nixpkgs;
+      # it's a test-only dep pulled in via fastapi -> mcp. Skip its checks.
+      inline-snapshot = pyPrev.inline-snapshot.overridePythonAttrs (_old: {
+        doCheck = false;
+      });
     };
   };
 
@@ -70,6 +75,12 @@ _final: prev: {
   python314 = prev.python314.override {
     packageOverrides = _pyFinal: pyPrev: {
       click-threading = pyPrev.click-threading.overridePythonAttrs (_old: {
+        doCheck = false;
+      });
+      # frictionless 5.18.1: 11/1646 tests fail on this nixpkgs — locale/encoding
+      # detection (cp1252 vs iso8859-1) and remote-URL fetches in the sandbox.
+      # Not real defects; skip the check.
+      frictionless = pyPrev.frictionless.overridePythonAttrs (_old: {
         doCheck = false;
       });
     };

--- a/overlays/upstream-fixes.nix
+++ b/overlays/upstream-fixes.nix
@@ -5,6 +5,14 @@ _final: prev: {
     doInstallCheck = false;
   });
 
+  # ollama 0.31.1: the Go scheduler test suite fails in the sandbox — it mocks
+  # GPU memory (library=Metal on Linux, simulated cudaMalloc OOM) and is
+  # environment-sensitive, not a real defect. Skip checks. Override both the
+  # base package and ollama-rocm (p620 uses ollama-rocm; p510 ollama-cuda).
+  ollama = prev.ollama.overrideAttrs (_old: { doCheck = false; });
+  ollama-rocm = prev.ollama-rocm.overrideAttrs (_old: { doCheck = false; });
+  ollama-cuda = prev.ollama-cuda.overrideAttrs (_old: { doCheck = false; });
+
   # gnome-shell's shell_remove_dark_mode.patch fails to apply on GNOME 49.1.
   # Strip it until nixpkgs catches up. Keep the rest of nixpkgs' patches.
   gnome-shell = prev.gnome-shell.overrideAttrs (oldAttrs: {


### PR DESCRIPTION
Batch of build fixes surfaced by the nixpkgs bump (python3.14 default, new test envs):

- **headlines** dropped — its youtube-dl 2021.12.17 can't build on py3.14 (`spawn() dry_run` removed); reddit-tui remains.
- **inline-snapshot**, **frictionless**: `doCheck = false` (sandbox-flaky tests).
- **ollama/ollama-rocm/ollama-cuda**: `doCheck = false` (Go scheduler tests mock GPU, fail in sandbox).
- **codex-cli black**: pin `python313Packages.black` to match languages.nix/nvim.nix — bare `black` is py3.14 now and collided in home-manager-path.

**Verified:** p620 toplevel builds clean (NIX_EXIT=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)