### PR TITLE
chore(claude-desktop): update to 1.18286.2 (#1023)

### DIFF
--- a/pkgs/claude-desktop-beta/default.nix
+++ b/pkgs/claude-desktop-beta/default.nix
@@ -52,7 +52,7 @@
 # then update `version` + `sha256` below (hex sha256 from the index is accepted
 # by fetchurl as-is).
 let
-  version = "1.18286.0";
+  version = "1.18286.2";
 
   # dlopen'd at runtime (not in DT_NEEDED) — appended to RUNPATH.
   runtimeLibs = [
@@ -69,7 +69,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_${version}_amd64.deb";
-    sha256 = "8f314ad1a80aab52711a8eaabc06aae48fb341f0adea4a0d7264db5cab9d0536";
+    sha256 = "56fa5de053e0a68dc7583677857bedcf4219b19d90201400e0237b7d74d512f1";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Bump official Anthropic Linux beta .deb 1.18286.0 -> 1.18286.2 (apt index).
Verified: package builds, p620/razer/p510 toplevels build.

Closes #1023

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LHmRWuHZnKUWqGNTFpeabV
