### PR TITLE
fix(stylix): explicitly enable home.pointerCursor

### DIFF
--- a/home/desktop/gnome/theme.nix
+++ b/home/desktop/gnome/theme.nix
@@ -14,6 +14,12 @@ in
     # Settings) intentionally ignore third-party themes by upstream policy.
     # Stylix's GTK target themes everything else; don't chase libadwaita.
 
+    # Stylix sets home.pointerCursor.{name,package,size} but not .enable, so
+    # HM warns about relying on the deprecated auto-enable. Make it explicit
+    # (stylix already auto-enables it — no behavior change, just silences the
+    # warning). Drop once stylix sets .enable itself.
+    home.pointerCursor.enable = true;
+
     # Fonts that GNOME-specific bits rely on. Stylix already supplies the
     # mono/sans/serif packages declared in modules/desktop/stylix-theme.nix.
     home.packages = with pkgs; [


### PR DESCRIPTION
Stylix sets home.pointerCursor.{name,package,size} but not .enable, so
Home Manager warns about the deprecated auto-enable. Set it explicitly in
the GNOME theme HM module (no behavior change — stylix already auto-enables
it). Silences the olafkfreund-profile eval warning.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LHmRWuHZnKUWqGNTFpeabV
