### PR TITLE
fix(music): drop broken Spicetify, run native Spotify

### DIFF
--- a/home/media/music.nix
+++ b/home/media/music.nix
@@ -1,10 +1,7 @@
-{ pkgs, spicetify-nix, ... }:
-let
-  spicePkgs = spicetify-nix.legacyPackages.${pkgs.stdenv.hostPlatform.system};
-in
+{ pkgs, ... }:
 {
   home.packages = [
-    # Spotify provided by programs.spicetify below
+    pkgs.spotify
     pkgs.plexamp
     pkgs.vlc
     pkgs.cava
@@ -19,28 +16,8 @@ in
     (pkgs.callPackage ../../pkgs/mpris-album-art { })
   ];
 
-  # Opt out of stylix's auto-generated spicetify theme so the explicit
-  # Gruvbox choice below wins (same pattern as stylix.targets.firefox).
-  stylix.targets.spicetify.enable = false;
-
-  programs.spicetify = {
-    enable = true;
-    theme = spicePkgs.themes.text;
-    colorScheme = "Gruvbox";
-    # Force Xwayland so mutter draws server-side decorations.
-    wayland = false;
-    enabledExtensions = with spicePkgs.extensions; [
-      adblock
-      hidePodcasts
-      shuffle
-      fullAppDisplay
-    ];
-  };
-
-  # spicetify-nix's spotifyLaunchFlags only writes to config-xpui.ini and
-  # never reaches the runtime wrapper. Override the desktop entry instead
-  # so Chromium delegates decoration drawing to the compositor (combined
-  # with --ozone-platform=x11 from `wayland = false` above).
+  # Native Spotify runs under Xwayland so mutter draws server-side
+  # decorations; delegate decoration drawing to the compositor.
   xdg.desktopEntries.spotify = {
     name = "Spotify";
     genericName = "Music Player";


### PR DESCRIPTION
Spicetify's injected app patch (via spicetify-nix, which has upstream
breakage) caused Spotify to boot to a blank page. Replace programs.spicetify
with stock pkgs.spotify; keep the Xwayland decoration desktop entry.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LHmRWuHZnKUWqGNTFpeabV
