### PR TITLE
fix(p620): enable Chrome WebGL with modern ANGLE flags

### DIFF
--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -86,16 +86,12 @@
     commandLineArgs = lib.mkForce [
       "--enable-features=UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer,WebUIDarkMode"
       "--ozone-platform=wayland"
-      "--disable-features=VizDisplayCompositor"
       "--force-dark-mode"
-      "--use-gl=desktop"
+      # ANGLE-on-OpenGL (Mesa/AMD). Replaces the removed --use-gl=desktop;
+      # do NOT disable VizDisplayCompositor — that kills GPU compositing and WebGL.
+      "--use-angle=gl"
       "--enable-gpu-rasterization"
       "--enable-zero-copy"
-      "--ignore-gpu-blocklist"
-      "--disable-gpu-driver-bug-workarounds"
-      "--enable-accelerated-2d-canvas"
-      "--enable-accelerated-video-decode"
-      "--use-vulkan"
       "--enable-quic"
       "--enable-tcp-fast-open"
       "--aggressive-cache-discard"


### PR DESCRIPTION
Chrome WebGL was disabled by legacy flags: --use-gl=desktop (removed from
Chrome ~v110), --disable-features=VizDisplayCompositor (kills the GPU
compositor WebGL runs behind), and the invalid --use-vulkan. Replace with
--use-angle=gl (ANGLE-on-OpenGL for Mesa/AMD) and drop the Viz-disable and
GPU-blocklist-override flags.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LHmRWuHZnKUWqGNTFpeabV
