### PR TITLE
chore(antigravity): bump hub to 2.3.0-5214728084127744

### DIFF
--- a/pkgs/antigravity-hub/default.nix
+++ b/pkgs/antigravity-hub/default.nix
@@ -98,11 +98,11 @@ let
 in
 stdenv.mkDerivation {
   pname = "antigravity-hub";
-  version = "2.2.1-5287492581195776";
+  version = "2.3.0-5214728084127744";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.2.1-5287492581195776/linux-x64/Antigravity.tar.gz";
-    hash = "sha256-prp3BG+SqhziHYoMZ0lUca9MK+EbpiTl2TWCGWmyCYk=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.3.0-5214728084127744/linux-x64/Antigravity.tar.gz";
+    hash = "sha256-wY1/whU9j3Fm87wV42daehFRJBgtLxGpPC9/3CJHt7g=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Bump antigravity-hub 2.2.1 -> 2.3.0 (via Hy4ri/antigravity-flake tracker).
cli/ide/sdk already current. Built + composed into p620 toplevel; launcher OK.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0159Di1skb1sq3kQZ613iZWm
