### PR TITLE
chore(claude-code): update to 2.1.212 (#1096)

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -31,7 +31,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.211";
+  version = "2.1.212";
 
   # Claude Code reads clipboard images by shelling out to:
   #   xclip -selection clipboard -t TARGETS -o ... || wl-paste -l ...   (detect)
@@ -63,11 +63,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-gnLIpHSsnqG8NfGbn3x+fcTcTrbVrT5ISxkzWsckRrI=";
+      hash = "sha256-BEqIzzpRgHdmF/09oSONy/kUHd7ESaOc99KvGseOaE4=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-H/9+j5R8B7GdELH79xS35UfpU2JTubWCMNitvEYk+Gc=";
+      hash = "sha256-ZuiGNKhXOgAnAuap3g2Ay5u3yQcvnm9EhneFOQV9/Tw=";
     };
   };
 


### PR DESCRIPTION
## Summary

Bump `claude-code-native` 2.1.211 → 2.1.212 from Anthropic's `latest` GCS channel, plus refreshed SRI hashes for both architectures.

Three-line diff: `version`, x86_64 hash, aarch64 hash.

## Testing

- `nix build .#claude-code-native` → `claude --version` reports `2.1.212`
- `ldd` on the binary → no missing shared libs
- `nixosConfigurations.p620` closure builds clean
- `nixosConfigurations.razer` closure builds clean

p510 not tested — it doesn't pull claude-code into its closure (headless media server).

Closes #1096

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159Di1skb1sq3kQZ613iZWm