### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -813,11 +813,11 @@
         "scenefx": "scenefx"
       },
       "locked": {
-        "lastModified": 1784270170,
+        "lastModified": 1784275188,
         "narHash": "sha256-53KZsMTRhXX1xyBLjWXtMiZntQis0UYlYNx6u56iC7Q=",
         "owner": "mangowm",
         "repo": "mango",
-        "rev": "e2018ddffc9d540e2d9dfb2a6fe4c0c75d69c7da",
+        "rev": "242ffe8548b18e333e1e20d41e6d658bada761be",
         "type": "github"
       },
       "original": {
@@ -1105,11 +1105,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1784270527,
-        "narHash": "sha256-cg6xaOydbM7j2iy/9oOJOY5zn1ChX4K92slykhbi8Zw=",
+        "lastModified": 1784306530,
+        "narHash": "sha256-ayOeJh4fSZrvfzxh5LyNAjX14e+AqjJ1pUVh8bZ8geA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "705ffce919a7e034ee360b870dd7ed51f0cd8ca8",
+        "rev": "bb2d8cc3ee72362ec43b3db1c55988ee9207f0ad",
         "type": "github"
       },
       "original": {
@@ -1399,11 +1399,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1784272033,
-        "narHash": "sha256-qcC5+mkjPcaWAQn+t386Saq/+8AKMbwW/+K9/RbduG8=",
+        "lastModified": 1784304874,
+        "narHash": "sha256-w03Wui9OHRtYSVIBjwpF3N64xuo/99qBa81Yxm3YJgM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "950644cefdd4fa438da93c40697c4df9159a798d",
+        "rev": "70653c1506d00bbb6c04efa4554121c77f8760cb",
         "type": "github"
       },
       "original": {
@@ -2054,11 +2054,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783782670,
-        "narHash": "sha256-rPoIWtn1QMexX71S3ggoP0kIl49jVQ6Vy8ItakshKBQ=",
+        "lastModified": 1784282969,
+        "narHash": "sha256-gBsN0qhCt/5bUWGILMiaLO08WK/+c2jBMJ9NDL6v4YY=",
         "owner": "Benexl",
         "repo": "yt-x",
-        "rev": "eb86330a5f9eefc8493eb6cafe8a2a02648dd975",
+        "rev": "3875b4fd16ca96d384e0a124b14db700479d3294",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=p620, scope=all).

Built and verified locally against nixosConfigurations.p620 before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)