### PR TITLE
chore(claude-code): update to 2.1.214 (#1102)

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -31,7 +31,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.212";
+  version = "2.1.214";
 
   # Claude Code reads clipboard images by shelling out to:
   #   xclip -selection clipboard -t TARGETS -o ... || wl-paste -l ...   (detect)
@@ -63,11 +63,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-BEqIzzpRgHdmF/09oSONy/kUHd7ESaOc99KvGseOaE4=";
+      hash = "sha256-PAKRNvfIH1TtSjjp1S5lWq1TZDPbveUFGcjDG7ZGrRQ=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-ZuiGNKhXOgAnAuap3g2Ay5u3yQcvnm9EhneFOQV9/Tw=";
+      hash = "sha256-TDjyalekJhnugT8V3Dn8H6T+C7QDIVw83DQrWPponDw=";
     };
   };
 


### PR DESCRIPTION
## Summary

Bump `claude-code-native` 2.1.212 → 2.1.214 from Anthropic's `latest` GCS channel, plus refreshed SRI hashes for both architectures.

Three-line diff: `version`, x86_64 hash, aarch64 hash.

## Testing

- `nix build .#claude-code-native` → `claude --version` reports `2.1.214`
- `ldd` on the binary → no missing shared libs
- `nixosConfigurations.p620` closure builds clean
- `nixosConfigurations.razer` closure builds clean

p510 not tested — doesn't pull claude-code into its closure (headless media server).

Closes #1102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159Di1skb1sq3kQZ613iZWm