### PR TITLE
fix(razer): unbreak build on current nixpkgs (electron + gst-vaapi)

### DIFF
--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -530,7 +530,8 @@ in
     # gst-plugin-pipewire is NOT in gst_all_1 — the PipeWire GStreamer
     # plugin ships inside the pipewire package itself (libgstpipewire.so
     # under pipewire's lib output). The active services.pipewire wires it.
-    gst-vaapi
+    # gst-vaapi removed in GStreamer 1.28 — VA-API now lives in the `va`
+    # plugin inside gst-plugins-bad (already installed above).
     gst-plugins-rs
   ]) ++ (with pkgs;
     [
@@ -615,6 +616,7 @@ in
       "libsoup-2.74.3" # Temporary: Required by some GNOME packages until migration to libsoup-3
       "electron-35.7.5" # Temporary: Required until upstream packages migrate to newer electron
       "electron-39.8.10" # Newly marked EOL after nixpkgs bump on 2026-06-01 — still pulled in by some upstream package, audit + drop later
+      "electron-40.10.5" # Newly marked insecure after nixpkgs bump on 2026-07-15 — still pulled in by some upstream package, audit + drop later
     ];
   };
   system.stateVersion = "25.11";


### PR DESCRIPTION
## Summary

razer had drifted 136 commits behind `main` and no longer evaluated on current nixpkgs. Two independent breakages:

1. **electron-40.10.5** — marked insecure after the 2026-07-15 nixpkgs bump, but absent from razer's `permittedInsecurePackages`. p620 already permits it (added 2026-07-15); razer was missed.
2. **gst_all_1.gst-vaapi** — removed in GStreamer 1.28. VA-API support moved into the `va` plugin inside `gst-plugins-bad`, which razer already installs, so the entry is just dropped.

## Testing

- `nixosConfigurations.razer` closure builds clean (definitive `if nix build` check, no `tail`-masking)

Unblocks deploying razer, which its auto-upgrade timer (`nixos-upgrade.service`) had been failing on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159Di1skb1sq3kQZ613iZWm