### PR TITLE
chore(antigravity): bump cli 1.1.3, hub 2.3.1, sdk 0.1.7

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.1.2-5174998495789056";
+  version = "1.1.3-5723946948100096";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.2-5174998495789056/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-B1QBA0eSba8AyWc0z89Z7mBD6rI+/DW5my1iqthNxvA=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.3-5723946948100096/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-enI5pptl08869+dfJ7L/TpzOaWp7mp5cN8aV8cdO7DQ=";
   };
 
   # Tarball contains a single file `antigravity` at the root.

--- a/pkgs/antigravity-hub/default.nix
+++ b/pkgs/antigravity-hub/default.nix
@@ -98,11 +98,11 @@ let
 in
 stdenv.mkDerivation {
   pname = "antigravity-hub";
-  version = "2.3.0-5214728084127744";
+  version = "2.3.1-5358163105546240";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.3.0-5214728084127744/linux-x64/Antigravity.tar.gz";
-    hash = "sha256-wY1/whU9j3Fm87wV42daehFRJBgtLxGpPC9/3CJHt7g=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.3.1-5358163105546240/linux-x64/Antigravity.tar.gz";
+    hash = "sha256-ehmSFJ45bswS56QrFVY4lYcB2qplvtB83P5jm4Jnx0U=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/google-antigravity-py/default.nix
+++ b/pkgs/google-antigravity-py/default.nix
@@ -25,15 +25,15 @@
 # Upstream: https://github.com/google-antigravity/antigravity-sdk-python
 buildPythonPackage rec {
   pname = "google-antigravity";
-  version = "0.1.6";
+  version = "0.1.7";
   format = "wheel";
 
   # fetchPypi gets the URL wrong for this package (constructs
   # google-antigravity- instead of google_antigravity-), so use fetchurl
   # with the canonical PyPI download URL.
   src = fetchurl {
-    url = "https://files.pythonhosted.org/packages/5b/ef/fc44bdeccd962f81bbbe57fd28ebd847313ecf4d030938b6d4d240ae660e/google_antigravity-0.1.6-py3-none-manylinux_2_17_x86_64.whl";
-    hash = "sha256-4eq7om22987ieGE2U5P2XctWf4PbKqxzgq2sA3Lo0JM=";
+    url = "https://files.pythonhosted.org/packages/41/55/c5e11b0f91c70540a0e247c53de117c0986b167e94e205c131dc8fadcf76/google_antigravity-0.1.7-py3-none-manylinux_2_17_x86_64.whl";
+    hash = "sha256-CVj0SB3UcAoKMqy5SPlZ+xhYZXA48QPFoNBncnAQ9x4=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Summary

Bump locally-packaged Google Antigravity components to latest (per the `Hy4ri/antigravity-flake` tracker):

- `antigravity-cli`: 1.1.2 → **1.1.3**
- `antigravity-hub`: 2.3.0 → **2.3.1**
- `google-antigravity` (SDK): 0.1.6 → **0.1.7**
- IDE unchanged — already current at 2.1.1

Only `version`/`url`/`hash` changed in each file.

## Testing

- All three changed packages build clean on p620
- Full `nixosConfigurations.p620` closure builds clean
- `agy --version` → `1.1.3`
- `python3 -c "import google.antigravity"` → SDK import OK

Not built/deployed on p510 (doesn't ship Antigravity). No switch performed — deploy on schedule with `nhs p620` / `nhs razer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159Di1skb1sq3kQZ613iZWm