### PR TITLE
chore(antigravity): bump cli 1.1.3 -> 1.1.4

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.1.3-5723946948100096";
+  version = "1.1.4-6277569641840640";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.3-5723946948100096/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-enI5pptl08869+dfJ7L/TpzOaWp7mp5cN8aV8cdO7DQ=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.4-6277569641840640/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-qqtC45XLTjv+WuiJlKNAhl2Un3qefwYE/6Kj8eiq2/o=";
   };
 
   # Tarball contains a single file `antigravity` at the root.


### PR DESCRIPTION
Only the CLI (agy) moved; ide/hub/sdk already current (PR #1106).
Verified: antigravity-cli builds, p620 toplevel composes, agy --version = 1.1.4.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gw5vtQiq5LZKr5x79wRVVz
