### PR TITLE
chore(warp-terminal): bump to v0.2026.07.15.08.55.stable_01

### DIFF
--- a/pkgs/warp-terminal/versions.json
+++ b/pkgs/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "linux_x86_64": {
-    "hash": "sha256-V3JOpewD6cLx+k/8pvfYQYDevoZTWEhh+Azk3fc0DR4=",
-    "version": "0.2026.07.08.17.54.stable_02"
+    "hash": "sha256-S8mcscl9I9AnKIPHrTNJQYNVYtRACc7jrPDQ0UOB8hY=",
+    "version": "0.2026.07.15.08.55.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-IKzDyuVYpxQ6GdTVKifwVUvTC1cO4Q0TNHWsjtj+7e8=",
-    "version": "0.2026.07.08.17.54.stable_02"
+    "hash": "sha256-EznnYYZGhxxCZEtUpC+Bq1xAMY/AWfVEI30O1YdzlT8=",
+    "version": "0.2026.07.15.08.55.stable_01"
   }
 }


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gw5vtQiq5LZKr5x79wRVVz
