### PR TITLE
chore(claude-desktop): bump to 1.22209.3

### DIFF
--- a/pkgs/claude-desktop-beta/default.nix
+++ b/pkgs/claude-desktop-beta/default.nix
@@ -52,7 +52,7 @@
 # then update `version` + `sha256` below (hex sha256 from the index is accepted
 # by fetchurl as-is).
 let
-  version = "1.18286.2";
+  version = "1.22209.3";
 
   # dlopen'd at runtime (not in DT_NEEDED) — appended to RUNPATH.
   runtimeLibs = [
@@ -69,7 +69,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_${version}_amd64.deb";
-    sha256 = "56fa5de053e0a68dc7583677857bedcf4219b19d90201400e0237b7d74d512f1";
+    sha256 = "d427f46ac9233dbc4d8a441a602f09f750b8a5f05d1fc7a00285d7a6ce07655c";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Bump the official Anthropic Claude Desktop .deb from 1.18286.2 to
1.22209.3 (version + sha256 from the apt Packages index).

Verified: package builds, version = 1.22209.3, binary is patched ELF,
p620 + razer toplevel closures compose.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gw5vtQiq5LZKr5x79wRVVz
