### PR TITLE
feat(herdr): add herdr agent multiplexer (p620 + razer)

### DIFF
--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -172,6 +172,9 @@ in
     pkgs.customPkgs.aurynk
     # glab-tui — terminal UI for GitLab on top of the `glab` CLI.
     pkgs.customPkgs.glab-tui
+    # herdr — TUI "agent multiplexer": run multiple AI coding agents in one
+    # terminal workspace (tmux/zellij-style). From github:ogulcancelik/herdr.
+    pkgs.herdr
     pkgs.wayfarer
     # FlyCrys — GTK4-native Claude Code GUI. Wraps the local `claude`
     # binary (installed via programs.claude-code.enable in home/default.nix).

--- a/flake.lock
+++ b/flake.lock
@@ -704,6 +704,29 @@
         "type": "github"
       }
     },
+    "herdr": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784425797,
+        "narHash": "sha256-4G0GTjPFgmQko5EDeyiRynRVYRzCLM7tWw9pErPDd20=",
+        "owner": "ogulcancelik",
+        "repo": "herdr",
+        "rev": "b580103b956ef9cdf39798947a46ce4e8b78c322",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ogulcancelik",
+        "repo": "herdr",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -1488,6 +1511,7 @@
         "gnome-quick-web-apps": "gnome-quick-web-apps",
         "gogmail": "gogmail",
         "gscratch": "gscratch",
+        "herdr": "herdr",
         "home-manager": "home-manager_2",
         "lan-mouse": "lan-mouse",
         "lanzaboote": "lanzaboote",

--- a/flake.nix
+++ b/flake.nix
@@ -203,6 +203,18 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # herdr — TUI "agent multiplexer" (tmux/zellij for AI coding agents).
+    # Single Rust binary, local Unix-socket API, no daemon/root/network.
+    # Its flake builds a vendored libghostty-vt via zig (deps pre-fetched
+    # offline in-repo), exposed as packages.default. Consumed via overlay
+    # as pkgs.herdr on the interactive-host developer profile (p620 + razer).
+    # Bump with `nix flake update herdr`.
+    herdr = {
+      url = "github:ogulcancelik/herdr";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.rust-overlay.follows = "rust-overlay";
+    };
+
   };
 
   outputs =

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -33,6 +33,11 @@
     cosmic-applet-spotify = inputs.cosmic-applet-spotify.packages.${prev.stdenv.hostPlatform.system}.default;
   })
 
+  # herdr — TUI agent multiplexer for AI coding agents (see flake input).
+  (_final: prev: {
+    herdr = inputs.herdr.packages.${prev.stdenv.hostPlatform.system}.default;
+  })
+
   # Rust toolchain overlay — exposes `rust-bin.*` on `final` so packages
   # that need a newer rustc than nixpkgs ships (e.g. splashboard) can
   # build with `makeRustPlatform`. Doesn't replace the default `rustc`.


### PR DESCRIPTION
Add github:ogulcancelik/herdr 0.7.4 — a TUI "agent multiplexer" that runs
multiple AI coding agents side-by-side in one terminal workspace
(tmux/zellij-style). Single Rust binary, local Unix-socket API, no daemon,
no root, no network listener. AGPL-3.0-or-later.

- flake input follows our nixpkgs + rust-overlay (no closure duplication)
- exposed via overlay as pkgs.herdr
- added to the interactive-host developer profile (Users/.../profile.nix),
  which p620 + razer import; p510 (headless) does not

Verified: herdr package builds (zig+rust vendored libghostty-vt, offline),
`herdr --version` = 0.7.4, p620 + razer toplevel closures compose.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gw5vtQiq5LZKr5x79wRVVz
