### PR TITLE
fix(ci): reap superseded claude-desktop tracking issues

### DIFF
--- a/.github/workflows/claude-desktop-watch.yml
+++ b/.github/workflows/claude-desktop-watch.yml
@@ -141,3 +141,24 @@ jobs:
             --label claude-desktop-update \
             --title "chore(claude-desktop): update to $VERSION" \
             --body "$body"
+
+      # Dedup keeps us to one issue per version, but nothing closed the
+      # issues for versions we skipped past — a 1.19367 -> 1.22209.3 jump
+      # left 8 open (#1062..#1095). Reap them on every drift run so at most
+      # one tracking issue is ever open. Runs regardless of the dedup skip:
+      # the issue for $VERSION exists either way, older ones are dead.
+      - name: Close superseded tracking issues
+        if: steps.v.outputs.latest_ver != steps.v.outputs.pinned_ver
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.v.outputs.latest_ver }}
+        run: |
+          set -euo pipefail
+          gh issue list --label claude-desktop-update --state open \
+            --json number,title \
+            | jq -r --arg v "$VERSION" '.[] | select(.title | endswith($v) | not) | .number' \
+            | while read -r n; do
+                echo "closing superseded #$n"
+                gh issue close "$n" --reason "not planned" \
+                  --comment "Superseded by a newer Claude Desktop release (**$VERSION**)."
+              done


### PR DESCRIPTION
## Problem

`claude-desktop-watch.yml` dedups **one issue per version** — correct by design — but nothing ever closed the issues for versions we skipped past.

Bumping 1.19367.0 → 1.22209.3 in a single PR (#1114) left 8 stale open issues (#1062, #1067, #1073, #1075, #1081, #1087, #1088, #1095). I closed them manually today; without this fix they just accumulate again.

`claude-code-watch.yml` has the same latent gap but hasn't shown it — we bump the CLI same-day and the PR's `Closes #N` cleans up. Not pre-fixing it.

## Fix

One step, runs on every drift check: close open `claude-desktop-update` issues whose title doesn't end with the current latest version.

- Runs regardless of the dedup `skip` output — the issue for `$VERSION` exists either way, older ones are dead either way. Self-healing.
- `endswith` not `contains`, so `1.22209.3` doesn't false-match `1.22209.31`.

## Testing

- YAML parses (`yq`), 6 steps in expected order
- jq selector verified against a fixture including the `.3` / `.31` edge case: reaps superseded, spares current

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gw5vtQiq5LZKr5x79wRVVz