### PR TITLE
fix(overlays): drop mesa 26.1.1 pin — upstream fixed the GBM crash

### DIFF
--- a/overlays/upstream-fixes.nix
+++ b/overlays/upstream-fixes.nix
@@ -21,24 +21,6 @@ _final: prev: {
       (oldAttrs.patches or [ ]);
   });
 
-  # mesa 26.1.2 regressed the GBM back-buffer path: gnome-shell/mutter on
-  # amdgpu segfaults in gbm_bo_destroy (reached via get_back_bo during
-  # eglMakeCurrent / frame presentation). mesa 26.1.1 + libgbm 26.0.3 ran
-  # crash-free for weeks; the 26.1.1 -> 26.1.2 bump (nixpkgs 14dbea35565,
-  # 2026-06-03) is the regression. Revert mesa to 26.1.1 against current
-  # build deps; libgbm stays 26.0.3 (unchanged, matching the known-good combo).
-  # Remove once a fixed mesa (>= 26.1.3) lands upstream.
-  mesa = prev.mesa.overrideAttrs (_old: {
-    version = "26.1.1";
-    src = prev.fetchFromGitLab {
-      domain = "gitlab.freedesktop.org";
-      owner = "mesa";
-      repo = "mesa";
-      rev = "mesa-26.1.1";
-      hash = "sha256-OmhBmBGR12Tl+5msiyL8lYQ3XYcDYCqUUjQObEqjytI=";
-    };
-  });
-
   # nixpkgs-unstable ships nix-prefetch-git as `nix-prefetch-git-VERSION`,
   # breaking fetchCargoVendor which calls the binary by its short name.
   # Symlink the short name to the versioned binary.


### PR DESCRIPTION
Closes #892.

## Evidence the upstream bug is fixed

The coredump in #892 was:

```
#0  gbm_bo_destroy             (libgbm)
#1  get_back_bo                (mesa / libEGL_mesa)
...
#11 eglMakeCurrent
#15 maybe_post_next_frame      (mutter)
```

mesa **26.1.3** release notes contain exactly those two functions:

```
egl/gbm: Ignore buffers with no BO for destroying excess BOs   -> #0 gbm_bo_destroy
egl/gbm: Ignore current front buffer in get_back_bo            -> #1 get_back_bo
```

Our channel is at **26.1.5**, two releases past the fix. #892's stated exit condition was "mesa >= 26.1.3 reaches our channel" — met, with a matching-symbol trail rather than just a version comparison.

## Extra reason to drop it now

`libgbm` has moved **26.0.3 -> 26.1.3** since the pin was written. The pin's documented known-good pair was mesa 26.1.1 + libgbm 26.0.3 — that pair no longer exists. We have been running mesa 26.1.1 against libgbm 26.1.3, an unvalidated mismatched combo, and the crash was *inside* libgbm. Dropping the pin restores a matched post-fix pairing (26.1.5 + 26.1.3).

## Testing

| Host | Result |
|---|---|
| p620 (amdgpu — the affected host) | builds, `rc=0`, closure contains **mesa-26.1.5** only |
| razer | builds, `rc=0`, closure contains **mesa-26.1.5** only |

p510 not built (headless, standing rule).

## Caveat for the deploy

The original symptom was a runtime gnome-shell/mutter segfault, so a green build proves the closure composes, **not** that the crash is gone. Watch for it after switching p620:

```
coredumpctl list gnome-shell
```

Rollback is `sudo nixos-rebuild switch --rollback`, or revert this commit and redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gw5vtQiq5LZKr5x79wRVVz