### PR TITLE
fix(git): stop the result ignore matching any name containing "result"

### DIFF
--- a/Users/olafkfreund/private.nix
+++ b/Users/olafkfreund/private.nix
@@ -69,7 +69,15 @@
     ignores = [
       "*~"
       "*.swp"
-      "*result*"
+      # Nix build outputs. NOT "*result*": the wildcards also matched source
+      # files such as classify_result_test.go, which then never appeared in
+      # `git status` and were silently left out of commits while local builds
+      # and tests still passed. Unanchored and unwildcarded, so these match a
+      # file named exactly "result" at any depth (nix build from a subdir) but
+      # never a name that merely contains it. "result-*" covers multi-output
+      # derivations (result-1, result-2, ...).
+      "result"
+      "result-*"
       ".direnv"
       "node_modules"
     ];


### PR DESCRIPTION
The global gitignore had "*result*", intended for Nix build-output symlinks.
The wildcards also matched any source file with "result" in its name.

That is a silent failure, which is what makes it worth fixing: a new file
called classify_result_test.go never appeared in `git status`, so it was
left out of its commit while local builds and tests kept passing. The
absence only surfaced by chance, via `git check-ignore -v`.

The defect was the wildcards, not the lack of anchoring, so the patterns are
left unanchored: "result" matches a path component named exactly "result" at
any depth, which keeps `nix build` output ignored when it is run from a
subdirectory. Anchoring to "/result" would have fixed the reported bug but
silently dropped that coverage, leaving untracked store symlinks in every
subdir build. "result-*" covers multi-output derivations (result-1, ...).

Verified against the built hm gitignore: result, result-1, sub/result and
sub/result-2 are ignored; classify_result_test.go, my_result.py and
sub/parse_result.go are not.
