### PR TITLE
chore(antigravity): bump cli to 1.1.5-5958982624477184

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.1.4-6277569641840640";
+  version = "1.1.5-5958982624477184";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.4-6277569641840640/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-qqtC45XLTjv+WuiJlKNAhl2Un3qefwYE/6Kj8eiq2/o=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.5-5958982624477184/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-HVhlAbihPRRuiqPH8AY09QxgNOLEKOp9ATN302MVppo=";
   };
 
   # Tarball contains a single file `antigravity` at the root.


### PR DESCRIPTION
Only the CLI moved on the Hy4ri/antigravity-flake tracker; ide
(2.1.1-6123990880747520), hub (2.3.1-5358163105546240) and the Python SDK
(0.1.7) are unchanged. Version + url + hash only.

Verified:
- `agy --version` -> 1.1.5
- `import google.antigravity` OK
- all four packages build; p620 + razer toplevels compose
- p510 not built (does not ship antigravity)
