### PR TITLE
feat(mcp): add ollama-code delegation server

### DIFF
--- a/home/development/claude-code-mcp.nix
+++ b/home/development/claude-code-mcp.nix
@@ -63,6 +63,23 @@ let
             description = "Dynamic and reflective problem-solving through systematic thinking - helps break down complex problems into steps";
           };
 
+          # Ollama code-delegation: hand isolated, well-specified coding tasks
+          # to a local qwen2.5-coder model and review the output. Claude stays
+          # the supervisor; Ollama is the junior worker. Default backend is
+          # per-host — p620 has local Ollama; other hosts reach p620 over the
+          # tailnet. The tools also accept host="p510" for the bigctx coder.
+          ollama-code = {
+            command = "${pkgs.customPkgs.ollama-mcp}/bin/ollama-mcp";
+            args = [ ];
+            env = {
+              OLLAMA_HOST =
+                if osConfig.networking.hostName == "p620"
+                then "http://localhost:11434"
+                else "http://p620:11434";
+            };
+            description = "Delegate isolated coding tasks to local Ollama coder models (qwen2.5-coder on p620/p510) and review the output — Claude supervises, Ollama drafts";
+          };
+
           # NotebookLM MCP for Google NotebookLM interaction
           notebooklm = {
             command = "${pkgs.uv}/bin/uvx";

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -13,6 +13,7 @@
   audiobookbay-automated = pkgs.callPackage ./audiobookbay-automated { };
   m4b-tool = pkgs.callPackage ./m4b-tool { };
   audiobook-mcp = pkgs.callPackage ./audiobook-mcp { };
+  ollama-mcp = pkgs.callPackage ./ollama-mcp { };
 
   # media-bot — Telegram bot front-end for the *arr stack on p510.
   # Hybrid menu commands + local-LLM (Ollama) natural-language fallback.

--- a/pkgs/ollama-mcp/default.nix
+++ b/pkgs/ollama-mcp/default.nix
@@ -1,0 +1,19 @@
+# Ollama code-delegation MCP server.
+#
+# A stdio MCP server that lets Claude Code hand isolated coding tasks to a
+# local Ollama coder model (qwen2.5-coder on p620/p510) and review the output.
+# Stateless — spawned per session by Claude Code, no daemon or port.
+#
+# The server is ~40 lines of Python against nixpkgs' python3Packages.mcp
+# (FastMCP); it forwards to Ollama's OpenAI-compatible /v1 endpoint.
+{ python3, writeShellApplication }:
+let
+  pyEnv = python3.withPackages (ps: [ ps.mcp ]);
+in
+writeShellApplication {
+  name = "ollama-mcp";
+  runtimeInputs = [ pyEnv ];
+  text = ''
+    exec python3 ${./server.py} "$@"
+  '';
+}

--- a/pkgs/ollama-mcp/server.py
+++ b/pkgs/ollama-mcp/server.py
@@ -1,0 +1,86 @@
+"""Ollama code-delegation MCP server.
+
+Lets Claude Code delegate isolated, well-specified coding tasks to a local
+Ollama coder model over the OpenAI-compatible /v1 endpoint, then review the
+result. Claude stays the supervisor; Ollama is the junior worker.
+
+Stateless stdio server — spawned per Claude Code session, no daemon.
+"""
+
+import json
+import os
+import urllib.request
+from mcp.server.fastmcp import FastMCP
+
+DEFAULT_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+DEFAULT_MODEL = "qwen2.5-coder:14b"
+GEN_TIMEOUT = 300  # a 14b coder can take a while on a real task
+
+# ponytail: named backends so Claude can pick one without knowing URLs.
+HOSTS = {
+    "p620": "http://p620:11434",
+    "p510": "http://p510:11434",
+    "local": "http://localhost:11434",
+}
+
+mcp = FastMCP("ollama-code")
+
+
+def _resolve(host):
+    if not host:
+        return DEFAULT_HOST
+    return HOSTS.get(host, host)  # unknown -> treat as a raw URL
+
+
+@mcp.tool()
+def ollama_code(task, model=DEFAULT_MODEL, host=None):
+    """Delegate a self-contained coding task to a local Ollama coder model and
+    return only its output. Use for isolated, fully-specified units: write a
+    function, generate tests from a signature, convert a snippet, fill
+    boilerplate. Then review the result yourself — the local model is the
+    junior, you are the reviewer. Keep multi-file reasoning and anything
+    subtle on your own model.
+
+    task: the complete, specific instruction for the worker model.
+    model: qwen2.5-coder:14b (default), :7b (faster), or
+           qwen2.5-coder-bigctx:14b (large context, p510 only).
+    host: "p620", "p510", "local", or a full URL. Default from OLLAMA_HOST.
+    """
+    base = _resolve(host).rstrip("/")
+    payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are a coding assistant. Output only the requested "
+                    "code or answer. No preamble, no explanation unless asked."
+                ),
+            },
+            {"role": "user", "content": task},
+        ],
+        "stream": False,
+    }
+    req = urllib.request.Request(
+        base + "/v1/chat/completions",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=GEN_TIMEOUT) as r:
+        data = json.loads(r.read())
+    return data["choices"][0]["message"]["content"]
+
+
+@mcp.tool()
+def ollama_list_models(host=None):
+    """List models available on an Ollama backend ("p620", "p510", "local",
+    or a full URL). Use to discover which coder models a host can serve."""
+    base = _resolve(host).rstrip("/")
+    req = urllib.request.Request(base + "/v1/models")
+    with urllib.request.urlopen(req, timeout=30) as r:
+        data = json.loads(r.read())
+    return [m["id"] for m in data.get("data", [])]
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
Lets Claude Code supervise a local Ollama coder model: it hands isolated,
well-specified coding tasks (write a function, generate tests, convert a
snippet) to qwen2.5-coder and reviews the output. Claude stays the planner
and reviewer; Ollama is the junior worker.

Stateless stdio MCP server, ~40 lines of Python against nixpkgs'
python3Packages.mcp (FastMCP), forwarding to Ollama's OpenAI-compatible /v1
endpoint. No daemon, no port, no secret — matches the github/context7 stdio
pattern, not the p510 SSE-daemon pattern.

Tools:
- ollama_code(task, model=qwen2.5-coder:14b, host=None)
- ollama_list_models(host=None)
Named backends p620/p510/local; default OLLAMA_HOST is per-host (p620 ->
localhost, other hosts -> p620 over the tailnet). p510 also serves
qwen2.5-coder-bigctx:14b for large-context work.

Verified: package builds; MCP init + tools/list + both tool calls succeed
over stdio against live Ollama (qwen2.5-coder:7b returned correct code);
p620 + razer toplevels compose; ollama-code lands in the rendered
settings.local.json template.

Note: settings.local.json is seed-once (#398), so an existing install needs
a one-time `rm ~/.claude/settings.local.json && nixos-rebuild switch` to
pick up the new server.
