### PR TITLE
chore(agents): complete frontmatter + tier models on all project agents

### DIFF
--- a/.claude/agents/config-drift-detective.md
+++ b/.claude/agents/config-drift-detective.md
@@ -1,4 +1,10 @@
 ---
+name: config-drift-detective
+description: |
+  Detects configuration drift between the declared NixOS config and the actual running system state, and reports
+  how to re-converge. Use when a host behaves oddly after manual changes, before a deploy to confirm the tree
+  matches reality, or when auditing declarative-state integrity. Reports findings; enforce with a deploy.
+model: sonnet
 context: fork
 ---
 
@@ -602,20 +608,20 @@ networking.nameservers = [ "192.168.1.1" ];
 
 ### Today (HIGH)
 
-3. ✅ Remove imperative packages, add to config
-4. ✅ Commit or discard uncommitted changes
-5. ✅ Review untracked configuration files
+1. ✅ Remove imperative packages, add to config
+2. ✅ Commit or discard uncommitted changes
+3. ✅ Review untracked configuration files
 
 ### This Week (MEDIUM)
 
-6. ⏭️ Add video group to user declaration
-7. ⏭️ Clean up local override files
-8. ⏭️ Document acceptable drift
+1. ⏭️ Add video group to user declaration
+2. ⏭️ Clean up local override files
+3. ⏭️ Document acceptable drift
 
 ### Optional (LOW)
 
-9. ⏭️ Fix DNS configuration
-10. ⏭️ Review and update network settings
+1. ⏭️ Fix DNS configuration
+2. ⏭️ Review and update network settings
 
 ## Automated Fix Script
 

--- a/.claude/agents/deployment-coordinator.md
+++ b/.claude/agents/deployment-coordinator.md
@@ -1,4 +1,10 @@
 ---
+name: deployment-coordinator
+description: |
+  Plans and orchestrates multi-host NixOS deployments with dependency ordering, parallelism, and rollback
+  awareness. Use when rolling changes across p620/p510/razer, sequencing a dependent rollout, or deciding safe
+  deploy order. Recommends the plan; you run the switch.
+model: sonnet
 context: fork
 ---
 

--- a/.claude/agents/documentation-sync.md
+++ b/.claude/agents/documentation-sync.md
@@ -1,3 +1,12 @@
+---
+name: documentation-sync
+description: |
+  Generates and refreshes documentation for NixOS modules and infrastructure so docs track the code. Use when
+  module options changed, a README is stale, or you want docs regenerated from the current config. Mechanical
+  sync work.
+model: haiku
+---
+
 # Documentation Sync Agent
 
 > **Automated Documentation Generation and Synchronization**

--- a/.claude/agents/issue-checker.md
+++ b/.claude/agents/issue-checker.md
@@ -1,3 +1,11 @@
+---
+name: issue-checker
+description: |
+  Read-only scan of NixOS/nixpkgs GitHub issues for known bugs affecting packages in your closure. Use before a
+  flake bump or when an update feels risky, to surface breaking issues early. Reports only, changes nothing.
+model: haiku
+---
+
 # Issue Checker Subagent
 
 ## Overview

--- a/.claude/agents/local-logs.md
+++ b/.claude/agents/local-logs.md
@@ -1,3 +1,12 @@
+---
+name: local-logs
+description: |
+  Analyzes systemd/journal logs, traces failures to root cause, and drafts NixOS config fixes. Use when a
+  service is failing, after a bad boot, or when diagnosing an error you can't place. Generates fixes for your
+  review.
+model: sonnet
+---
+
 # Local Logs Subagent
 
 ## Overview

--- a/.claude/agents/module-refactor.md
+++ b/.claude/agents/module-refactor.md
@@ -1,4 +1,10 @@
 ---
+name: module-refactor
+description: |
+  Detects duplication and anti-patterns across NixOS modules and proposes/applies refactors following
+  docs/NIXOS-ANTI-PATTERNS.md. Use when consolidating repeated config, cleaning a grown module, or acting on an
+  anti-pattern finding.
+model: sonnet
 context: fork
 ---
 

--- a/.claude/agents/nix-check.md
+++ b/.claude/agents/nix-check.md
@@ -1,3 +1,11 @@
+---
+name: nix-check
+description: |
+  Runs deadnix/statix and related linters on NixOS files and applies mechanical fixes. Use before committing,
+  after editing a module, or to sweep dead code and lint violations. Fast, rule-based checking.
+model: haiku
+---
+
 # nix-check Subagent
 
 A specialized subagent for checking, linting, and correcting NixOS configuration code using deadnix, statix, and other validation tools to ensure best practices.

--- a/.claude/agents/package-resolver.md
+++ b/.claude/agents/package-resolver.md
@@ -1,4 +1,9 @@
 ---
+name: package-resolver
+description: |
+  Diagnoses and resolves package conflicts, version mismatches, and dependency collisions in the config. Use
+  when a build fails on a collision, two modules pull conflicting versions, or an override needs untangling.
+model: sonnet
 context: fork
 ---
 

--- a/.claude/agents/performance-analyzer.md
+++ b/.claude/agents/performance-analyzer.md
@@ -1,4 +1,9 @@
 ---
+name: performance-analyzer
+description: |
+  Profiles build times and evaluation cost and pinpoints bottlenecks with optimization suggestions. Use when a
+  rebuild feels slow, eval time crept up, or you're tuning closure size. Analysis and recommendations only.
+model: sonnet
 context: fork
 ---
 
@@ -488,17 +493,17 @@ Impact: -5s evaluation time
 
 ### Phase 2: Configuration (30 minutes)
 
-4. Increase parallel jobs (-20s)
-5. Optimize binary caches (-15s)
-6. Configure automated cleanup
+1. Increase parallel jobs (-20s)
+2. Optimize binary caches (-15s)
+3. Configure automated cleanup
 
 **Total Impact**: -35s additional (15% faster)
 
 ### Phase 3: Deep Optimization (2 hours)
 
-7. Refactor slow modules (-5s eval)
-8. Implement lazy loading (-8s eval)
-9. Optimize dependency chains
+1. Refactor slow modules (-5s eval)
+2. Implement lazy loading (-8s eval)
+3. Optimize dependency chains
 
 **Total Impact**: -13s additional (5.8% faster)
 

--- a/.claude/agents/security-patrol.md
+++ b/.claude/agents/security-patrol.md
@@ -1,4 +1,10 @@
 ---
+name: security-patrol
+description: |
+  Audits NixOS hosts for security weaknesses, missing systemd hardening, and exposure, and proposes fixes per
+  the repo's hardening patterns. Use for a periodic security sweep, after adding a service, or before exposing
+  something.
+model: sonnet
 context: fork
 ---
 

--- a/.claude/agents/test-generator.md
+++ b/.claude/agents/test-generator.md
@@ -1,4 +1,9 @@
 ---
+name: test-generator
+description: |
+  Generates unit/integration/smoke tests for NixOS modules and configs. Use when a module has no coverage, after
+  adding a feature flag, or to scaffold a NixOS VM test. Produces tests for your review.
+model: sonnet
 context: fork
 ---
 
@@ -265,7 +270,7 @@ NixOS VM Tests:
    })
 ````
 
-2. Multi-Host Network Test:
+1. Multi-Host Network Test:
 
    ```python
    # Generated test: tests/multi-host-network.nix

--- a/.claude/agents/update.md
+++ b/.claude/agents/update.md
@@ -1,3 +1,11 @@
+---
+name: update
+description: |
+  Orchestrates a safe NixOS update cycle: flake bump, issue check, test build, and completion alert. Use for a
+  routine guarded update rather than a raw nix flake update. Reports results and stops before the switch.
+model: haiku
+---
+
 # Update Subagent
 
 > **Automated NixOS system updates with safety checks and notifications**


### PR DESCRIPTION
Only 1 of 13 project agents (nix-anti-pattern-auditor) had complete
frontmatter; the other 12 either had just `context: fork` or were plain
markdown with no frontmatter at all. Those 12 inherited the session model
(Opus) and — lacking a `description` — could not be auto-routed.

Give every agent name + description + model:
- model tiers by job: haiku for mechanical lookup/parse/report
  (issue-checker, documentation-sync, update, nix-check); sonnet for
  reasoning/code/security (the rest). None need Opus — deep architecture
  stays in the main loop.
- descriptions written as "Use when ..." triggers so the main model routes
  tasks to the right (cheap) agent automatically. The description is the
  router; the model pin is the choice.
- existing `context: fork` preserved on the 8 that had it; bodies untouched.

Effect: 12 agents move off inherited-Opus (haiku ~1/15, sonnet ~1/5 of Opus
per token), and the 5 previously-unroutable markdown agents become real,
auto-selectable subagents. Read live from .claude/agents/ — no deploy.
