### PR TITLE
feat(razer): niri touchpad tap/natural-scroll/dwt

### DIFF
--- a/Users/olafkfreund/razer_home.nix
+++ b/Users/olafkfreund/razer_home.nix
@@ -14,6 +14,14 @@ in
 
   desktop.gnome.profile = "laptop";
 
+  # Laptop touchpad for the niri session: tap-to-click, natural scrolling,
+  # disable-while-typing. Host-scoped (razer only) — p620 has no touchpad.
+  programs.niri.settings.input.touchpad = {
+    tap = true;
+    natural-scroll = true;
+    dwt = true;
+  };
+
   # gscratch — i3/Sway-style scratchpad for GNOME (testing on razer first).
   # Configure bindings via: gnome-extensions prefs scratchpad@wastedintelligence.com
   programs.gnome-shell = {


### PR DESCRIPTION
Add laptop touchpad config to razer's niri session: tap-to-click, natural scrolling, disable-while-typing.

Host-scoped in `razer_home.nix` (p620 shares the noctalia niri config but has no touchpad). Renders the expected KDL:

```kdl
touchpad {
    tap
    dwt
    natural-scroll
}
```

Verified: razer evaluates clean, generated KDL confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)