### PR TITLE
chore(antigravity): bump cli 1.1.6 + sdk 0.1.8

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.1.5-5958982624477184";
+  version = "1.1.6-6535449645285376";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.5-5958982624477184/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-HVhlAbihPRRuiqPH8AY09QxgNOLEKOp9ATN302MVppo=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.6-6535449645285376/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-JEi5ux00lgY6YzXQIdyrkMQtcf2q1jRu+KOV8MoP6dA=";
   };
 
   # Tarball contains a single file `antigravity` at the root.

--- a/pkgs/google-antigravity-py/default.nix
+++ b/pkgs/google-antigravity-py/default.nix
@@ -25,15 +25,15 @@
 # Upstream: https://github.com/google-antigravity/antigravity-sdk-python
 buildPythonPackage rec {
   pname = "google-antigravity";
-  version = "0.1.7";
+  version = "0.1.8";
   format = "wheel";
 
   # fetchPypi gets the URL wrong for this package (constructs
   # google-antigravity- instead of google_antigravity-), so use fetchurl
   # with the canonical PyPI download URL.
   src = fetchurl {
-    url = "https://files.pythonhosted.org/packages/41/55/c5e11b0f91c70540a0e247c53de117c0986b167e94e205c131dc8fadcf76/google_antigravity-0.1.7-py3-none-manylinux_2_17_x86_64.whl";
-    hash = "sha256-CVj0SB3UcAoKMqy5SPlZ+xhYZXA48QPFoNBncnAQ9x4=";
+    url = "https://files.pythonhosted.org/packages/93/54/9972ecf8e0b5e3d12067550462078be9babf8dc0f686e80ffe70daef0cad/google_antigravity-0.1.8-py3-none-manylinux_2_17_x86_64.whl";
+    hash = "sha256-vZEswKx0/vgCbCJ1ALfeBrN0mnjwFIuZ2QM+jJUnh+A=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Bump via update-antigravity.sh (Hy4ri/antigravity-flake tracker):
- antigravity-cli: 1.1.5 -> 1.1.6
- google-antigravity-py (SDK): 0.1.7 -> 0.1.8
ide (2.1.1) + hub (2.3.1) already current.

Verified: both packages build, full p620 closure composes, agy --version =
1.1.6, `import google.antigravity` OK.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RzWtLhmwzU5R6YWVygmYBm
