### PR TITLE
fix(niri): add dwt to touchpad in the actual config source

### DIFF
--- a/Users/olafkfreund/razer_home.nix
+++ b/Users/olafkfreund/razer_home.nix
@@ -14,14 +14,6 @@ in
 
   desktop.gnome.profile = "laptop";
 
-  # Laptop touchpad for the niri session: tap-to-click, natural scrolling,
-  # disable-while-typing. Host-scoped (razer only) — p620 has no touchpad.
-  programs.niri.settings.input.touchpad = {
-    tap = true;
-    natural-scroll = true;
-    dwt = true;
-  };
-
   # gscratch — i3/Sway-style scratchpad for GNOME (testing on razer first).
   # Configure bindings via: gnome-extensions prefs scratchpad@wastedintelligence.com
   programs.gnome-shell = {

--- a/home/desktop/noctalia/default.nix
+++ b/home/desktop/noctalia/default.nix
@@ -268,7 +268,7 @@ in
             repeat-delay 600
             repeat-rate 25
         }
-        touchpad { tap; natural-scroll; }
+        touchpad { tap; natural-scroll; dwt; }
     }
     prefer-no-csd
     screenshot-path "~/Pictures/Screenshots/Screenshot from %Y-%m-%d %H-%M-%S.png"


### PR DESCRIPTION
The niri config.kdl is hand-written raw KDL via xdg.configFile in
noctalia/default.nix, which bypasses programs.niri.settings entirely. So the
earlier razer_home.nix settings.input.touchpad block was dead code — the
deployed config only had `touchpad { tap; natural-scroll; }`.

Add dwt to the real source (the raw KDL touchpad line) and drop the dead
settings block. Generated config.kdl now renders:
  touchpad { tap; natural-scroll; dwt; }

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RzWtLhmwzU5R6YWVygmYBm
