### PR TITLE
fix(dns): tier 0 — kill switch-race + dead .222 primary resolver

### DIFF
--- a/hosts/p620/nixos/dns-fallback.nix
+++ b/hosts/p620/nixos/dns-fallback.nix
@@ -15,4 +15,14 @@
   };
 
   networking.networkmanager.dns = lib.mkForce "systemd-resolved";
+
+  # DHCP advertises 192.168.1.222 (p620's OWN IP, nothing listening on :53) as a
+  # DNS server — a dead primary that every cold lookup times out on before
+  # falling back. Ignore DHCP-provided DNS and pin fast public resolvers (Quad9
+  # measured fastest here ~18ms, Cloudflare next). Tier 1 will prepend the p510
+  # LAN cache (192.168.1.175) in front of these as the fallback.
+  networking.networkmanager.connectionConfig = {
+    "ipv4.ignore-auto-dns" = true;
+    "ipv4.dns" = "9.9.9.9;1.1.1.1;";
+  };
 }

--- a/modules/common/networking.nix
+++ b/modules/common/networking.nix
@@ -24,6 +24,18 @@ let inherit (lib) mkOption mkIf mkEnableOption mkForce mkMerge types; in {
   };
 
   config = mkMerge [
+    # Switch-time DNS stability (all hosts). systemd-resolved / NetworkManager
+    # restarting mid-`nixos-rebuild switch` briefly kills DNS, causing transient
+    # "no such host" failures during activation (the ollama model-pull was the
+    # visible symptom). Keep them running across a switch; new DNS config applies
+    # at next boot/logout. Root fix — supersedes the per-service ollama guard.
+    {
+      systemd.services.systemd-resolved.restartIfChanged =
+        mkIf config.services.resolved.enable false;
+      systemd.services.NetworkManager.restartIfChanged =
+        mkIf config.networking.networkmanager.enable false;
+    }
+
     (mkIf (config.networking.profile == "desktop") {
       # Desktop networking configuration with NetworkManager
       networking = {


### PR DESCRIPTION
Two low-risk Starlink DNS fixes surfaced by a full audit:

1. Switch-time DNS race (all hosts): systemd-resolved / NetworkManager
   restarting mid-`nixos-rebuild switch` briefly kills DNS → transient
   "no such host" during activation (the ollama model-pull symptom).
   Set restartIfChanged=false on both (guarded by their enable flags) in
   the shared networking module. Root fix — supersedes the per-service
   ollama-model-loader guard.

2. Dead primary resolver on p620: DHCP advertises 192.168.1.222 (p620's
   OWN IP, nothing on :53) as a DNS server — every cold lookup times out on
   it before falling back. Ignore DHCP DNS and pin fast public resolvers
   (Quad9 measured fastest here ~18ms, then Cloudflare) via NM
   connectionConfig. Tier 1 will prepend the p510 LAN cache.

Verified: p620 builds + deploys clean (0 failed units); generated
NetworkManager.conf has ipv4.dns=9.9.9.9;1.1.1.1; + ignore-auto-dns=true.
Applies at next reboot/NM restart (the restart guard defers it, by design).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RzWtLhmwzU5R6YWVygmYBm
