### PR TITLE
feat(net): shared BBR/fq + latency sysctl baseline (all hosts)

### DIFF
--- a/modules/common/networking.nix
+++ b/modules/common/networking.nix
@@ -36,6 +36,21 @@ let inherit (lib) mkOption mkIf mkEnableOption mkForce mkMerge types; in {
         mkIf config.networking.networkmanager.enable false;
     }
 
+    # TCP / qdisc baseline for the high-jitter Starlink uplink (all hosts).
+    # BBR + fq handle satellite jitter/random-loss far better than CUBIC; the
+    # latency sysctls pair with BBR on the long-RTT CGNAT path. mkDefault so any
+    # host keeps its own override — this closes the razer gap (was kernel-default
+    # CUBIC) and makes the CLAUDE.md "applied everywhere" claim actually true.
+    {
+      boot.kernel.sysctl = {
+        "net.core.default_qdisc" = lib.mkDefault "fq";
+        "net.ipv4.tcp_congestion_control" = lib.mkDefault "bbr";
+        "net.ipv4.tcp_notsent_lowat" = lib.mkDefault 16384; # cut local send-queue latency
+        "net.ipv4.tcp_mtu_probing" = lib.mkDefault 1; # survive PMTU black holes on CGNAT
+        "net.ipv4.tcp_fastopen" = lib.mkDefault 3; # shave 1 RTT on new connections
+      };
+    }
+
     (mkIf (config.networking.profile == "desktop") {
       # Desktop networking configuration with NetworkManager
       networking = {


### PR DESCRIPTION
Audit found razer running kernel-default CUBIC while CLAUDE.md claimed
BBR+fq "applied everywhere" — only true on p620/p510. Add a shared
boot.kernel.sysctl baseline (mkDefault, so host overrides win):
  bbr + fq, tcp_notsent_lowat=16384, tcp_mtu_probing=1, tcp_fastopen=3.

razer now gets BBR+fq (verified via nix eval); p620/p510 keep theirs and
gain notsent_lowat + mtu_probing. BBR handles Starlink jitter/random-loss
far better than CUBIC. Verified: all 3 host closures build.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RzWtLhmwzU5R6YWVygmYBm
