### PR TITLE
fix(p510): cheetah3 metadata check on pkgs-unstable sabnzbd

### DIFF
--- a/hosts/p510/nixos/plex.nix
+++ b/hosts/p510/nixos/plex.nix
@@ -60,7 +60,21 @@
       enable = true;
       user = "olafkfreund";
       group = "users";
-      package = pkgs-unstable.sabnzbd;
+      # sabnzbd builds its own python env via python3.withPackages. pkgs-unstable's
+      # cheetah3 installs .dist-info as "Cheetah3" (not pname "cheetah3"), so
+      # pythonMetadataCheckPhase throws PackageNotFoundError under python 3.14 and
+      # the whole p510 build fails. Our overlays only patch `pkgs`, not the
+      # separate `pkgs-unstable` instance — so override sabnzbd's python3 here,
+      # where it's actually consumed. Drop once upstream renames the dist-info.
+      package = pkgs-unstable.sabnzbd.override {
+        python3 = pkgs-unstable.python3.override (old: {
+          packageOverrides = pkgs-unstable.lib.composeExtensions
+            (old.packageOverrides or (_: _: { }))
+            (_pf: pp: {
+              cheetah3 = pp.cheetah3.overridePythonAttrs (_: { dontCheckPythonMetadata = true; });
+            });
+        });
+      };
       # P510 is on stateVersion 25.11, where configFile defaults to the legacy
       # /var/lib path — which makes the module IGNORE `settings`. Force null so
       # our declarative settings + secretFiles are actually used.


### PR DESCRIPTION
The real root cause of the recurring p510 cheetah3 failure: p510's sabnzbd
is pkgs-unstable.sabnzbd (plex.nix), a SEPARATE nixpkgs instance our overlays
never touch. Every prior cheetah3 fix patched `pkgs` (via upstream-fixes.nix),
so it never reached p510's actual sabnzbd — which is why `nhs p510` kept
failing on cheetah3 after each `nix flake update`.

sabnzbd builds its python env via python3.withPackages; pkgs-unstable's
cheetah3 installs .dist-info as "Cheetah3" (not pname "cheetah3"), failing
pythonMetadataCheckPhase under 3.14. Override sabnzbd's python3 here, where
it's consumed, to skip that one dep's metadata check.

Verified under a flake-updated lock (the nhs scenario): the p510 closure no
longer pulls the unfixed cheetah3; sabnzbd rebuilds to a new, passing drv.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RzWtLhmwzU5R6YWVygmYBm
