### PR TITLE
fix(p510): pin ollama-cuda to 0.31.2 (0.32.1 CUDA build broken)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1144,6 +1144,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-ollama": {
+      "locked": {
+        "lastModified": 1783915482,
+        "narHash": "sha256-FmieJB8/OUvNxbkboi7+IGfIuSXY3nF/hZQm8kD0r50=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1782847189,
@@ -1527,6 +1543,7 @@
         "nixpkgs": "nixpkgs_8",
         "nixpkgs-f2k": "nixpkgs-f2k",
         "nixpkgs-master": "nixpkgs-master",
+        "nixpkgs-ollama": "nixpkgs-ollama",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "noctalia": "noctalia",
         "noctalia-greeter": "noctalia-greeter",

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,11 @@
     # hasn't reached the nixos-unstable channel yet. Grafted in via overlay
     # (overlays/default.nix). Remove this input + the graft once unstable catches up.
     nixpkgs-master.url = "github:nixos/nixpkgs/master";
+    # Pinned solely for ollama 0.31.2 (last version whose CUDA build works in
+    # nixpkgs — 0.32.1's llama.cpp CUDA ExternalProject can't find nvcc, an active
+    # upstream bug). Grafted as pkgs.ollama-cuda for p510 via overlays/default.nix.
+    # Remove this input + the graft once nixpkgs 0.32.x CUDA builds again.
+    nixpkgs-ollama.url = "github:nixos/nixpkgs/6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee";
 
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
     flake-utils.url = "github:numtide/flake-utils";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -16,6 +16,19 @@
     dms-shell = inputs.nixpkgs-master.legacyPackages.${prev.stdenv.hostPlatform.system}.dms-shell;
   })
 
+  # ponytail: temporary graft. ollama-cuda 0.32.1's CUDA build is broken in
+  # current nixpkgs (llama.cpp ExternalProject can't find nvcc — active upstream
+  # bug, nixpkgs #303046/#432731). Pin ollama-cuda to 0.31.2 (last working CUDA
+  # build; what p510 already runs) from the nixpkgs-ollama input. allowUnfree is
+  # required because the CUDA closure is unfree. Drop this + the input once
+  # nixpkgs 0.32.x CUDA builds again.
+  (final: _prev: {
+    ollama-cuda = (import inputs.nixpkgs-ollama {
+      inherit (final.stdenv.hostPlatform) system;
+      config.allowUnfree = true;
+    }).ollama-cuda;
+  })
+
   (_final: prev: {
     gogmail = inputs.gogmail.packages.${prev.stdenv.hostPlatform.system}.gogmail;
   })


### PR DESCRIPTION
ollama-cuda 0.32.1 fails to build in current nixpkgs: llama.cpp's CUDA
ExternalProject can't find nvcc (CUDAToolkit_ROOT points at cuBLAS/cudart
dirs, no bin/nvcc) → "CUDA Toolkit not found". This is an active, unresolved
upstream nixpkgs bug (#303046, #305583, #432731), not our config — it blocks
a full p510 build. Setting CUDAToolkit_ROOT=$CUDA_PATH doesn't reach the
sub-cmake.

Pin ollama-cuda to 0.31.2 — the last version whose CUDA build works, and
exactly what p510 already runs — via a dedicated nixpkgs-ollama input
(commit 6cdc7fc) grafted over pkgs.ollama-cuda in overlays/default.nix
(same pattern as the dms-shell graft; allowUnfree set for the CUDA closure).
p620 (ollama-rocm) is untouched. Drop the input + graft once nixpkgs 0.32.x
CUDA builds again.

Verified: p510's ollama resolves to 0.31.2 and the full p510 toplevel builds
clean (with the cheetah3 fix from #1151, nhs p510 now works end to end).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RzWtLhmwzU5R6YWVygmYBm
