### PR TITLE
feat(herdr): declarative config + disable self-updater polling (#1157)

### DIFF
--- a/home/development/default.nix
+++ b/home/development/default.nix
@@ -18,6 +18,7 @@ _: {
     ./claude-powerline.nix
     ./claude-code-skills
     ./claude-code-commands
+    ./herdr.nix # herdr agent-multiplexer config (p620 + razer)
 
     # Version control and CI/CD
     ./gitlab/default.nix

--- a/home/development/herdr.nix
+++ b/home/development/herdr.nix
@@ -1,0 +1,91 @@
+# herdr — terminal workspace manager for AI coding agents (agent multiplexer).
+#
+# The binary comes from the flake input (see overlays/default.nix) and is
+# installed on the interactive hosts only (Users/olafkfreund/profile.nix).
+# This module owns its config so p620 and razer stay identical; ~/.config/herdr
+# is NOT syncthing-managed (only ~/.claude and ~/.gemini are), so without this
+# razer would run on stock defaults.
+#
+# Every option below was taken from `herdr --default-config` — the schema
+# embedded in the installed binary. Do NOT copy config from herdr.dev/docs:
+# that site documents the master branch and disagrees with 0.7.5 on ~12 keys
+# (`herdr config check` rejects the documented `keys.split_right` outright).
+# Validate any change with:
+#   HERDR_CONFIG_PATH=<file> herdr config check   # must print "config: ok"
+#
+# Trade-off: herdr's in-app settings UI (prefix+s) and `herdr config reset-keys`
+# cannot write to a Nix store symlink. Config changes go through this file.
+# Only config.toml is a symlink — herdr still owns the directory for its
+# sockets, logs, session.json and .plugins.lock.
+_: {
+  xdg.configFile."herdr/config.toml".text = ''
+    onboarding = false
+
+    # The binary is read-only in /nix/store and tracked by the flake input.
+    # Left enabled, herdr polls herdr.dev 48x/day and offers to install a
+    # binary that the next deploy would silently revert — the same collision
+    # the Claude Code self-updater caused in #936. Bump with:
+    #   nix flake update herdr
+    [update]
+    version_check = false
+    # Agent-detection manifest only; writes no binary, keeps Claude/codex
+    # state detection current between herdr releases.
+    manifest_check = true
+
+    [theme]
+    name = "gruvbox"
+    auto_switch = false
+
+    # "herdr" delivery only draws a toast while herdr is on screen, so an agent
+    # blocked on a question goes unnoticed. "system" hands it to the desktop
+    # notification service instead.
+    [ui.toast]
+    delivery = "system"
+    delay_seconds = 1
+
+    [ui.sound]
+    enabled = true
+
+    [ui]
+    show_agent_labels_on_pane_borders = true
+    # "priority" orders the agent panel as an attention queue, so a blocked
+    # agent surfaces above idle ones instead of sorting by workspace.
+    agent_panel_sort = "priority"
+
+    # Space rows carry git context, which is what distinguishes one worktree
+    # workspace from another at a glance.
+    [ui.sidebar.spaces]
+    rows = [["state_icon", "workspace"], ["branch", "git_status"]]
+
+    # Claude panes get an extra row showing the stripped terminal title, which
+    # is where Claude Code reports what it is currently doing.
+    [ui.sidebar.agents.rows_by_agent]
+    claude = [["state_icon", "workspace", "tab"], ["terminal_title_stripped"], ["agent"]]
+
+    [worktrees]
+    directory = "~/.herdr/worktrees"
+
+    # Only bindings that are unset in 0.7.5 defaults are added here, so nothing
+    # upstream is shadowed. Checked against: goto=prefix+g, close_tab=
+    # prefix+shift+x, close_pane=prefix+x, settings=prefix+s, detach=prefix+q.
+    [keys]
+    previous_workspace = "prefix+["
+    next_workspace = "prefix+]"
+    open_worktree = "prefix+shift+o"
+
+    [[keys.command]]
+    key = "prefix+alt+g"
+    type = "popup"
+    command = "lazygit"
+    width = "90%"
+    height = "90%"
+
+    # Claude Code emits far more output than the 10MB default retains.
+    [advanced]
+    scrollback_limit_bytes = 50000000
+
+    # Keeps pane screens across herdr server restarts.
+    [experimental]
+    pane_history = true
+  '';
+}


### PR DESCRIPTION
Closes #1157

## Summary

Makes herdr's config declarative so p620 and razer are identical, and stops the self-updater from fighting Nix.

## Why

`~/.config/herdr` is **not** syncthing-managed (only `~/.claude` and `~/.gemini` are), so the hand-written 6-line config existed on p620 only — razer ran on stock defaults.

## Key changes

| Setting | Before | After | Why |
|---|---|---|---|
| `[update] version_check` | `true` (default) | `false` | herdr polled herdr.dev 48x/day offering to install a binary over the flake-managed one in `/nix/store` — same collision as the Claude Code self-updater (#936) |
| `[ui.toast] delivery` | `herdr` | `system` | `herdr` only draws a toast while herdr is on screen; a blocked agent went unnoticed |
| `agent_panel_sort` | `spaces` | `priority` | blocked agents surface above idle ones |
| `scrollback_limit_bytes` | 10MB (default) | 50MB | Claude Code out-scrolls the default |

Plus Claude-specific sidebar rows, git branch/status per space, worktree/workspace keybinds, and `pane_history`.

## Source of truth

Every option came from `herdr --default-config` — the schema embedded in the installed 0.7.5 binary — **not** herdr.dev/docs, which documents the master branch and disagrees with 0.7.5 on ~12 keys. `herdr config check` rejects the documented `keys.split_right` outright.

## Testing

```
HERDR_CONFIG_PATH=<generated> herdr config check   ->  config: ok
nix build .#nixosConfigurations.p620...toplevel    ->  ✅
nix build .#nixosConfigurations.razer...toplevel   ->  ✅
```

Added keybinds are only ones **unset** in 0.7.5 defaults, verified non-conflicting against `goto=prefix+g`, `close_tab=prefix+shift+x`, `close_pane=prefix+x`, `settings=prefix+s`, `detach=prefix+q`.

## Out of scope

- p510 (headless, no herdr)
- Plugins — installed imperatively; herdr pins them in its own `.plugins.lock`

## Note

Trade-off accepted: herdr's in-app settings UI (`prefix+s`) can't write to a Nix store symlink. Config changes go through the module. Only `config.toml` is a symlink — herdr still owns the directory for sockets, logs, `session.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vn1yPQkGwa3WfJdHmQzbZ1