### PR TITLE
feat(claude-code): p510 deploy guard + drop dead npx statusline wrapper (#1159)

### DIFF
--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -45,12 +45,10 @@
     account = "olaf@freundcloud.com";
   };
 
-  # Claude Code statusline with Gruvbox Dark theme
-  programs.claude-powerline = {
-    enable = true;
-    theme = "custom";
-    style = "powerline";
-  };
+  # Claude Code statusline with Gruvbox Dark theme.
+  # theme/style dropped in #1159 — they only ever configured the removed
+  # @owloops/claude-powerline npx wrapper, never the gruvbox script in use.
+  programs.claude-powerline.enable = true;
 
   # Workstation-specific additional packages
   home.packages = [

--- a/home/development/claude-powerline.nix
+++ b/home/development/claude-powerline.nix
@@ -1,187 +1,29 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkOption mkIf mkEnableOption types;
+  inherit (lib) mkIf mkEnableOption;
   cfg = config.programs.claude-powerline;
-  inherit (config.lib.stylix) colors;
-
-  # Gruvbox Dark theme configuration
-  themeConfig = {
-    theme = "custom";
-    colors = {
-      # Background colors
-      background = "#${colors.base00}"; # dark0 (main background)
-      backgroundAlt = "#${colors.base01}"; # dark1
-      backgroundDark = "#${colors.base00}"; # dark0_hard
-
-      # Foreground colors
-      foreground = "#${colors.base06}"; # light1 (main foreground)
-      foregroundAlt = "#${colors.base05}"; # light2
-      foregroundDark = "#${colors.base04}"; # light3
-
-      # Accent colors (bright variants)
-      red = "#${colors.base08}"; # bright_red
-      redDim = "#${colors.base08}"; # normal_red
-      green = "#${colors.base0B}"; # bright_green
-      greenDim = "#${colors.base0B}"; # normal_green
-      yellow = "#${colors.base0A}"; # bright_yellow
-      yellowDim = "#${colors.base0A}"; # normal_yellow
-      blue = "#${colors.base0D}"; # bright_blue
-      blueDim = "#${colors.base0D}"; # normal_blue
-      purple = "#${colors.base0E}"; # bright_purple
-      purpleDim = "#${colors.base0E}"; # normal_purple
-      aqua = "#${colors.base0C}"; # bright_aqua
-      aquaDim = "#${colors.base0C}"; # normal_aqua
-      orange = "#${colors.base09}"; # bright_orange
-      orangeDim = "#${colors.base0F}"; # normal_orange
-      gray = "#${colors.base03}"; # gray
-
-      # UI elements
-      separator = "#${colors.base02}"; # dark2
-      border = "#${colors.base03}"; # dark3
-    };
-
-    display = {
-      inherit (cfg) style;
-      charset = "unicode";
-      autoWrap = true;
-
-      # Single-line layout focused on development context (MAX subscription - no budget monitoring needed)
-      lines = [
-        {
-          segments = {
-            directory = {
-              enabled = true;
-              style = {
-                background = "#${colors.base0D}"; # Blue - current directory
-                foreground = "#${colors.base00}"; # Dark background for contrast
-              };
-            };
-            git = {
-              enabled = true;
-              style = {
-                background = "#${colors.base0B}"; # Green - git status
-                foreground = "#${colors.base00}";
-              };
-            };
-            model = {
-              enabled = true;
-              style = {
-                background = "#${colors.base0E}"; # Purple - Claude model
-                foreground = "#${colors.base00}";
-              };
-            };
-          };
-        }
-      ];
-    };
-
-    # Budget monitoring disabled (MAX subscription with unlimited usage)
-  };
-
-  # Write theme configuration to JSON file
-  themeFile = pkgs.writeText "claude-powerline-gruvbox.json"
-    (builtins.toJSON themeConfig);
 in
 {
   options.programs.claude-powerline = {
     enable = mkEnableOption "Claude Powerline statusline with Gruvbox Dark theme";
-
-    theme = mkOption {
-      type = types.enum [ "dark" "light" "nord" "tokyo-night" "rose-pine" "gruvbox" "custom" ];
-      default = "custom";
-      description = ''
-        Theme to use for Claude Powerline.
-
-        Built-in themes: dark, light, nord, tokyo-night, rose-pine, gruvbox
-        Custom theme uses Gruvbox Dark color palette defined in this module.
-      '';
-    };
-
-    style = mkOption {
-      type = types.enum [ "minimal" "powerline" "capsule" ];
-      default = "powerline";
-      description = ''
-        Separator style for statusline segments.
-
-        - minimal: Simple separators
-        - powerline: Vim-style powerline separators (recommended)
-        - capsule: Rounded capsule separators
-      '';
-    };
-
-    budget = {
-      session = mkOption {
-        type = types.float;
-        default = 10.0;
-        description = ''
-          Session budget limit in USD (5-hour rolling window).
-
-          Recommended values:
-          - Conservative: 5-10
-          - Moderate: 10-20
-          - Aggressive: 20-50
-        '';
-      };
-
-      daily = mkOption {
-        type = types.float;
-        default = 25.0;
-        description = ''
-          Daily budget limit in USD.
-
-          Recommended values:
-          - Conservative: 10-25
-          - Moderate: 25-50
-          - Aggressive: 50-100
-        '';
-      };
-
-      block = mkOption {
-        type = types.float;
-        default = 15.0;
-        description = ''
-          Block budget limit in USD.
-
-          Used for tracking costs within specific time blocks.
-        '';
-      };
-    };
   };
 
   config = mkIf cfg.enable {
-    # Create theme configuration file
-    xdg.configFile."claude-powerline/config.json".source = themeFile;
-
-    # NOTE: ~/.claude/settings.json is NOT managed by Home Manager
-    # It contains user-specific plugin settings that should not be overwritten.
-    # Users must manually add the statusLine configuration to their existing settings.json:
+    # ~/.claude/settings.json is NOT managed by Home Manager — it is
+    # syncthing-synced and holds runtime plugin state. It points at
+    # statusline-gruvbox.sh below; that wiring is done once, by hand.
     #
-    # {
-    #   "enabledPlugins": { ... },  // Keep existing plugin settings
-    #   "statusLine": {
-    #     "type": "command",
-    #     "command": "$HOME/.claude/statusline-powerline.sh"
-    #   }
-    # }
+    # An @owloops/claude-powerline npx wrapper used to be generated here too,
+    # but nothing ever referenced it: settings.json has always pointed at the
+    # gruvbox script. It was also the wrong tool for this repo — it ran
+    # `npx -y @owloops/claude-powerline@latest` on *every* statusline render,
+    # i.e. an unpinned network fetch in the hot path of a NixOS config, and it
+    # rendered no hostname segment (the one thing that matters most across
+    # p620/razer/p510). Removed in #1159 along with its theme file and
+    # CLAUDE_POWERLINE_CONFIG env var.
 
     home = {
-      # Create wrapper script for Claude Code statusLine
-      file.".claude/statusline-powerline.sh" = {
-        text = ''
-          #!/usr/bin/env bash
-          # Claude Powerline statusline wrapper
-          # Ensures proper environment and paths for npx
-
-          # Set PATH to include nix profile binaries
-          export PATH="${pkgs.nodejs_24}/bin:$PATH"
-
-          # Pass stdin to claude-powerline with built-in gruvbox theme
-          ${pkgs.nodejs_24}/bin/npx -y @owloops/claude-powerline@latest --style=${cfg.style} --theme=gruvbox
-        '';
-        executable = true;
-      };
-
       # Gruvbox statusline script — mirrors your Starship prompt layout:
       # OS icon · hostname · user · dir · shell · git branch/status · model · context
       file.".claude/statusline-gruvbox.sh" = {
@@ -363,17 +205,6 @@ in
         '';
       };
 
-      # Ensure Node.js is available for npx
-      packages = with pkgs; [
-        nodejs_24
-      ];
-
-      # Environment variables for Claude Powerline configuration
-      sessionVariables = {
-        CLAUDE_POWERLINE_THEME = cfg.theme;
-        CLAUDE_POWERLINE_STYLE = cfg.style;
-        CLAUDE_POWERLINE_CONFIG = "${config.xdg.configHome}/claude-powerline/config.json";
-      };
     };
   };
 }

--- a/home/profiles/developer/default.nix
+++ b/home/profiles/developer/default.nix
@@ -189,10 +189,6 @@
 
     # Claude Powerline - AI-powered statusline for Claude Code
     # Single-line layout: Directory | Git | Model (budget monitoring disabled for MAX subscription)
-    claude-powerline = {
-      enable = true;
-      theme = "custom"; # Gruvbox Dark theme
-      style = "powerline"; # Vim-style powerline separators
-    };
+    claude-powerline.enable = true;
   };
 }

--- a/modules/programs/claude-code-managed.nix
+++ b/modules/programs/claude-code-managed.nix
@@ -253,6 +253,50 @@ let
     exit 0
   '';
 
+  # p510 is the headless media server: a bad switch takes Plex/*arr/k3d/
+  # cloudflared down and it is painful to recover remotely (see the 2026-07
+  # disk-full incident). The standing rule is "never deploy p510 unless the
+  # user explicitly asks", which until now lived only in CLAUDE.md and agent
+  # memory — i.e. it held only as long as the model remembered it. PreToolUse
+  # can veto a call, so this turns the convention into an actual guardrail.
+  #
+  # Blocks only *activating* commands (nixos-rebuild switch/boot/test, nh os,
+  # nhs, just deploy) aimed at p510. Deliberately does NOT block `nix build
+  # .#nixosConfigurations.p510...` or plain `ssh p510 <read-only>`, so
+  # testing and inspection stay frictionless. Exit 2 = deny + feed stderr
+  # back to the model so it knows to ask instead of retrying.
+  #
+  # This only constrains Claude Code's own tool calls; the user's interactive
+  # shell is untouched and can always deploy p510 directly.
+  deployGuardScript = pkgs.writeShellScript "claude-p510-deploy-guard.sh" ''
+    payload="$(cat)"
+    cmd="$(${pkgs.jq}/bin/jq -r '.tool_input.command // empty' <<<"$payload" 2>/dev/null)"
+    [ -n "$cmd" ] || exit 0
+
+    # No \b adjacent to the alternation group: GNU grep -E silently fails to
+    # match `\b(switch|boot|test)\b[^|;]*\bp510\b` against
+    # "nixos-rebuild switch --flake .#p510". Verified against 13 cases.
+    deploy_verb='nixos-rebuild[[:space:]]+[^|;]*(switch|boot|test)|nh[[:space:]]+os[[:space:]]+(switch|boot|test)|(^|[[:space:]])nhs([[:space:]]|$)|just[[:space:]]+[a-z-]*deploy'
+    if printf '%s' "$cmd" | ${pkgs.gnugrep}/bin/grep -qE "($deploy_verb)[^|;]*p510|p510[^|;]*($deploy_verb)"; then
+      echo "BLOCKED by managed-settings deploy guard: this command would activate a new generation on p510." >&2
+      echo "p510 is the headless media server (Plex, *arr, k3d, cloudflared). Deploying it requires the user's explicit approval." >&2
+      echo "Ask the user first. Building (nix build .#nixosConfigurations.p510...) and read-only ssh are allowed." >&2
+      exit 2
+    fi
+    exit 0
+  '';
+
+  deployGuardHooks = lib.optionalAttrs cfg.deployGuard.enable {
+    PreToolUse = [{
+      matcher = "Bash";
+      hooks = [{
+        type = "command";
+        command = toString deployGuardScript;
+        timeout = 5;
+      }];
+    }];
+  };
+
   formatHooks = lib.optionalAttrs cfg.formatOnEdit.enable {
     PostToolUse = [{
       matcher = "Write|Edit|MultiEdit";
@@ -306,6 +350,7 @@ let
         parrHooks
         notifyHooks
         formatHooks
+        deployGuardHooks
         tmuxCcmHooks
       ];
     })
@@ -359,6 +404,20 @@ in
         routine repo operations never trigger a permission prompt. System-
         mutating commands (deploys, nixos-rebuild, git commit/push, sudo, rm)
         are deliberately excluded and still require explicit approval.
+      '';
+    };
+
+    deployGuard.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Veto Claude Code Bash calls that would activate a new generation on
+        p510 (the headless media server), via a managed-scope PreToolUse hook.
+        Enforces the standing "never deploy p510 without explicit approval"
+        rule mechanically instead of relying on the model remembering it.
+
+        Building (`nix build .#nixosConfigurations.p510...`) and read-only ssh
+        are unaffected, as is the user's own interactive shell.
       '';
     };
 


### PR DESCRIPTION
Two changes, both about removing reliance on something remembering to do
the right thing.

1. p510 deploy guard (managed scope, default on)

The rule "never deploy p510 unless the user explicitly asks" lived only in
CLAUDE.md and agent memory, so it held only as long as the model recalled
it. p510 is the headless media server (Plex, *arr, k3d, cloudflared) and a
bad switch is painful to recover remotely — see the 2026-07 disk-full
incident. PreToolUse can veto a call, so the convention is now a guardrail
rendered into /etc/claude-code/managed-settings.json, which the CLI cannot
modify.

Blocks only activating commands aimed at p510: nixos-rebuild switch/boot/
test, nh os switch, nhs, just *deploy. Leaves builds, read-only ssh and
`herdr --remote p510` alone. Verified against 13 cases plus an end-to-end
run of the built script.

The regex deliberately avoids \b next to the alternation group: GNU grep -E
silently fails to match `\b(switch|boot|test)\b[^|;]*\bp510\b` against
"nixos-rebuild switch --flake .#p510", which let the most common form
through in the first draft. Comment kept so it is not "tidied" back.

Only Claude Code's tool calls are constrained; the user's shell is untouched.

2. Remove the dead npx statusline wrapper

claude-powerline.nix generated two scripts. settings.json has always pointed
at statusline-gruvbox.sh; statusline-powerline.sh was referenced by nothing
and shelled out to `npx -y @owloops/claude-powerline@latest` on every
statusline render — an unpinned network fetch in the hot path of a NixOS
config — while rendering no hostname segment, the one that matters most
across three hosts.

Removed it with its orphaned themeConfig/themeFile, CLAUDE_POWERLINE_* env
vars, redundant nodejs_24 (the developer profile already provides it) and 5
options nothing consumed. 379 -> 209 lines. The gruvbox script in actual use
is byte-for-byte unchanged.

Deliberately not done: `model` in managed scope (would break /model
switching, since managed settings are unmodifiable) and `autoMemoryEnabled`
(already defaults true — a no-op).

Closes #1159

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vn1yPQkGwa3WfJdHmQzbZ1
