### PR TITLE
feat(claude-code): surface Task-subagent count in herdr sidebar (#1161)

### DIFF
--- a/home/development/herdr.nix
+++ b/home/development/herdr.nix
@@ -59,8 +59,15 @@ _: {
 
     # Claude panes get an extra row showing the stripped terminal title, which
     # is where Claude Code reports what it is currently doing.
+    #
+    # $agents is a pane-metadata token published by the managed-scope
+    # PreToolUse/PostToolUse hooks in modules/programs/claude-code-managed.nix.
+    # Claude Code's Task subagents run in-process with no PTY, so herdr can
+    # never show them as their own agent rows (it detects one agent per pane).
+    # This surfaces the live count on the parent row instead. The token is
+    # cleared at zero, so the row stays clean when nothing is fanned out.
     [ui.sidebar.agents.rows_by_agent]
-    claude = [["state_icon", "workspace", "tab"], ["terminal_title_stripped"], ["agent"]]
+    claude = [["state_icon", "workspace", "tab"], ["terminal_title_stripped"], ["agent", "$agents"]]
 
     [worktrees]
     directory = "~/.herdr/worktrees"

--- a/modules/programs/claude-code-managed.nix
+++ b/modules/programs/claude-code-managed.nix
@@ -297,6 +297,71 @@ let
     }];
   };
 
+  # Claude Code's Task subagents run in-process with no PTY, so herdr cannot
+  # show them as agent rows (it detects exactly one agent per pane). Publish the
+  # live count as a pane-metadata token instead, rendered by the $agents entry
+  # in [ui.sidebar.agents.rows_by_agent] (home/development/herdr.nix).
+  #
+  # `reset` on Stop is what keeps this honest: a subagent killed without firing
+  # PostToolUse would otherwise leak the counter upward forever. When a turn
+  # ends nothing can still be fanned out, so zero is always correct there.
+  #
+  # No-ops entirely outside herdr (HERDR_ENV guard), so p510 and plain terminals
+  # are unaffected.
+  subagentScript = pkgs.writeShellScript "claude-herdr-subagents.sh" ''
+    action="''${1:-}"
+    cat >/dev/null 2>&1 || true   # drain hook stdin; the payload is not needed
+
+    [ "''${HERDR_ENV:-}" = "1" ] || exit 0
+    [ -n "''${HERDR_PANE_ID:-}" ] || exit 0
+    command -v herdr >/dev/null 2>&1 || exit 0
+
+    dir="''${XDG_RUNTIME_DIR:-/tmp}/claude-herdr-subagents"
+    mkdir -p "$dir" 2>/dev/null || exit 0
+    # Pane-scoped so two Claude panes never share a counter.
+    f="$dir/$(printf '%s' "$HERDR_PANE_ID" | tr -c 'A-Za-z0-9_' '_').count"
+
+    # flock: subagents are dispatched in parallel, so a plain read/modify/write
+    # loses updates. Verified with 20 concurrent increments.
+    exec 9>"$f.lock" 2>/dev/null || exit 0
+    ${pkgs.util-linux}/bin/flock -w 2 9 2>/dev/null || exit 0
+
+    n=$(cat "$f" 2>/dev/null)
+    case "$n" in ""|*[!0-9]*) n=0 ;; esac
+    case "$action" in
+      inc)   n=$((n + 1)) ;;
+      dec)   n=$((n - 1)); [ "$n" -lt 0 ] && n=0 ;;
+      reset) n=0 ;;
+      *)     exit 0 ;;
+    esac
+    printf '%s' "$n" >"$f" 2>/dev/null
+
+    if [ "$n" -gt 0 ]; then
+      herdr pane report-metadata "$HERDR_PANE_ID" \
+        --source claude-subagents --token "agents=$n" >/dev/null 2>&1
+    else
+      herdr pane report-metadata "$HERDR_PANE_ID" \
+        --source claude-subagents --clear-token agents >/dev/null 2>&1
+    fi
+    exit 0
+  '';
+
+  # SubagentStart/SubagentStop, NOT PreToolUse/PostToolUse on Task: PostToolUse
+  # fires when the *tool call* returns, which for a backgrounded agent is
+  # immediately — the counter would drop to zero while the agent still had
+  # minutes of work left, i.e. exactly the case this is meant to show.
+  subagentHooks = lib.optionalAttrs cfg.subagentMetadata.enable {
+    SubagentStart = [{
+      hooks = [{ type = "command"; command = "${subagentScript} inc"; timeout = 5; }];
+    }];
+    SubagentStop = [{
+      hooks = [{ type = "command"; command = "${subagentScript} dec"; timeout = 5; }];
+    }];
+    Stop = [{
+      hooks = [{ type = "command"; command = "${subagentScript} reset"; timeout = 5; }];
+    }];
+  };
+
   formatHooks = lib.optionalAttrs cfg.formatOnEdit.enable {
     PostToolUse = [{
       matcher = "Write|Edit|MultiEdit";
@@ -351,6 +416,7 @@ let
         notifyHooks
         formatHooks
         deployGuardHooks
+        subagentHooks
         tmuxCcmHooks
       ];
     })
@@ -404,6 +470,20 @@ in
         routine repo operations never trigger a permission prompt. System-
         mutating commands (deploys, nixos-rebuild, git commit/push, sudo, rm)
         are deliberately excluded and still require explicit approval.
+      '';
+    };
+
+    subagentMetadata.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Publish the live Claude Code Task-subagent count to herdr as a pane
+        metadata token, rendered by the $agents entry in the sidebar row
+        config (home/development/herdr.nix).
+
+        Subagents run in-process with no PTY, so herdr cannot represent them as
+        their own agent rows; this makes an otherwise invisible fan-out visible
+        on the parent pane. No-ops outside a herdr pane.
       '';
     };
 


### PR DESCRIPTION
Claude Code's Task subagents run in-process with no PTY. herdr detects
exactly one agent per pane by watching a terminal, so a fan-out of 3-5
subagents is completely invisible in the agent panel — confirmed live:
`herdr agent list` showed zero extra rows while three research subagents
were running.

That cannot be fixed by making them real herdr agents; there is no process
or pane to attach to. Publish the live count as a pane-metadata token on the
parent Claude row instead:

    w1:p1  claude  working  Fix goobook simplejson…  agents 3

SubagentStart -> inc, SubagentStop -> dec, Stop -> reset, from managed scope
so it applies everywhere without touching the syncthing-synced user settings.
The $agents token is rendered by [ui.sidebar.agents.rows_by_agent].claude.

Three things this gets right:

- SubagentStart/Stop, NOT PreToolUse/PostToolUse on Task. PostToolUse fires
  when the tool call returns, which for a backgrounded agent is immediately;
  the counter would drop to zero while the agent still had minutes of work
  left — exactly the case this exists to show.

- flock, not a plain counter. Subagents dispatch in parallel, so a
  read/modify/write loses updates. Verified against the nix-built script:
  20 concurrent increments -> exactly 20, 20 concurrent decrements -> 0.

- reset on Stop makes it self-healing. A subagent killed without firing
  SubagentStop would leak the counter upward forever. When a turn ends
  nothing can still be fanned out, so zero is always correct there.

The counter is pane-scoped so two Claude panes never share state, and the
token is cleared at zero so the row stays clean when nothing is fanned out.
Guarded on HERDR_ENV, so it no-ops in plain terminals and on p510.

Verified the rendered managed-settings.json keeps all 14 hook events and
coexists with the tmux-ccm hooks on Stop/SubagentStart/SubagentStop.

Closes #1161

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vn1yPQkGwa3WfJdHmQzbZ1
