### PR TITLE
fix(claude-code): reset subagent counter on SessionStart, not Stop (#1161)

### DIFF
--- a/modules/programs/claude-code-managed.nix
+++ b/modules/programs/claude-code-managed.nix
@@ -357,7 +357,13 @@ let
     SubagentStop = [{
       hooks = [{ type = "command"; command = "${subagentScript} dec"; timeout = 5; }];
     }];
-    Stop = [{
+    # Reset on SessionStart, NOT Stop. Stop fires at the end of every assistant
+    # turn, but backgrounded subagents deliberately outlive the turn that
+    # launched them — resetting there cleared the token ~5s into a 10s agent
+    # run, killing the exact case this is meant to show. SessionStart still
+    # heals a counter leaked by a subagent that died without firing
+    # SubagentStop, just at the next session instead of the next turn.
+    SessionStart = [{
       hooks = [{ type = "command"; command = "${subagentScript} reset"; timeout = 5; }];
     }];
   };


### PR DESCRIPTION
The Stop hook fires at the end of every assistant turn, but backgrounded
subagents deliberately outlive the turn that launched them. Live test:
SubagentStart correctly set the token to 1, then Stop reset it to zero ~5s
into a 10s agent run — clearing the display for exactly the long-running
fan-out this feature exists to make visible.

The original rationale ("when a turn ends nothing can still be fanned out")
holds only for synchronous subagents, not backgrounded ones.

SessionStart keeps the self-healing property — a counter leaked by a
subagent that died without firing SubagentStop is cleared at the next
session — without clobbering agents that are still running.

Relates to #1161

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vn1yPQkGwa3WfJdHmQzbZ1
