### PR TITLE
fix(gc): start generation cleanup; rate-limit Plex journal (#1165)

### DIFF
--- a/hosts/p510/nixos/plex.nix
+++ b/hosts/p510/nixos/plex.nix
@@ -285,6 +285,22 @@
   # Render NZBGet's secret include file at preStart, populated from the
   # agenix-decrypted env. NZBGet then reads it as part of its config-load
   # chain. ControlPassword stays out of the systemd ExecStart.
+  # Plex relays its transcoder's ffmpeg output back through its own HTTP log
+  # endpoint, and journald records every request/response pair. A single
+  # Android client that stalled mid-transcode on 2026-07-25 produced ~9,200
+  # lines in one burst ("Too many packets buffered for output stream 0:0" /
+  # "Error submitting a packet to the muxer"), which was most of p510's
+  # 25,888 daily journal errors. The transcode itself was not broken — the
+  # client stopped consuming and ffmpeg spammed until the session was reaped.
+  #
+  # Rate-limit the unit's journal so one runaway session can't drown the log
+  # again. 2000 messages per 30s is far above normal Plex chatter and still
+  # caps a burst at a few thousand lines instead of ten thousand.
+  systemd.services.plex.serviceConfig = {
+    LogRateLimitIntervalSec = "30s";
+    LogRateLimitBurst = 2000;
+  };
+
   systemd.services.nzbget = {
     serviceConfig.EnvironmentFile = config.age.secrets."nzbget-password".path;
     preStart = ''

--- a/modules/storage/garbage-collection.nix
+++ b/modules/storage/garbage-collection.nix
@@ -146,6 +146,13 @@ in
         nix-generation-cleanup = mkIf (!cfg.aggressiveCleanup) {
           description = "Clean up old NixOS generations";
           after = [ "nix-gc.service" ];
+          # `after` is ordering ONLY — without this the unit has no timer and
+          # nothing pulling it in, so it never ran. That is why p620 reached 73
+          # system generations despite --delete-older-than 14d: the age rule
+          # cannot bound COUNT when the host is deployed several times a day,
+          # and the count-based cleanup that was supposed to catch it was
+          # never started. Bind it to the GC timer's target.
+          wantedBy = [ "nix-gc.service" ];
           serviceConfig = {
             Type = "oneshot";
             User = "root";


### PR DESCRIPTION
1. nix-generation-cleanup never ran

p620 reached 73 system generations (back to 2026-07-05) despite
--delete-older-than 14d. An age rule cannot bound COUNT: the host is deployed
several times a day, so generations accumulate well inside the 14d window and
each one pins a full system closure. p510, deployed rarely, has 2.

A count-based cleanup for exactly this already exists — nix-generation-cleanup,
using the long-standing keepGenerations = 5 — but it declared only
`after = [ "nix-gc.service" ]`. `after` is ordering, not a dependency: with no
wantedBy and no timer of its own, nothing ever pulled the unit in, so it has
never executed since the module was written. One line fixes it.

(First attempt at this added a second, parallel trim service before noticing
the existing one — reverted in favour of starting the unit that was already
there.)

2. Plex journal flood

One Android client stalled mid-transcode on 2026-07-25 and emitted ~9,200
journal lines in a single burst ("Too many packets buffered for output stream
0:0" / "Error submitting a packet to the muxer"), most of p510's 25,888 daily
journal errors.

The transcoder is not broken: the client stopped consuming and ffmpeg spammed
until the session was reaped. Both GPUs are healthy and idle, and there have
been zero such errors in the past 6 hours. The volume comes from Plex relaying
its transcoder's ffmpeg output through its own HTTP log endpoint, with journald
recording every request/response pair.

Rate-limit the unit's journal so a single runaway session cannot drown the log
again. 2000 messages per 30s sits far above normal Plex chatter.

Closes #1165

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vn1yPQkGwa3WfJdHmQzbZ1
