### PR TITLE
feat(obsidian): package obsidian-cli + Claude Code vault skill (#1170)

### DIFF
--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -172,6 +172,12 @@ in
     pkgs.customPkgs.aurynk
     # glab-tui — terminal UI for GitLab on top of the `glab` CLI.
     pkgs.customPkgs.glab-tui
+    # obsidian-cli (binary: `notesmd-cli`) — link-aware vault operations.
+    # Reading/writing notes needs no tool; this is here for `move`, which
+    # rewrites every [[wikilink]], [markdown](link.md) target and #heading
+    # anchor pointing at a renamed note across ~2950 files. Paired with the
+    # `obsidian` Claude Code skill in home/development/claude-code-skills.
+    pkgs.customPkgs.obsidian-cli
     # herdr — TUI "agent multiplexer": run multiple AI coding agents in one
     # terminal workspace (tmux/zellij-style). From github:ogulcancelik/herdr.
     pkgs.herdr

--- a/home/development/claude-code-skills/default.nix
+++ b/home/development/claude-code-skills/default.nix
@@ -40,5 +40,13 @@ in
       source = ./dns/scripts/dns.sh;
       executable = true;
     };
+
+    # Local obsidian skill — playbook for the three vaults under ~/Documents.
+    # Deliberately steers most work to the plain file tools (a vault is just
+    # Markdown) and reserves notesmd-cli for renames, which must rewrite links
+    # across ~2950 notes. The conventions it documents were measured from the
+    # vaults, not assumed — notably that links here are 6:1 Markdown-style
+    # over [[wikilinks]] and that frontmatter is rare.
+    home.file.".claude/skills/obsidian/SKILL.md".source = ./obsidian/SKILL.md;
   };
 }

--- a/home/development/claude-code-skills/obsidian/SKILL.md
+++ b/home/development/claude-code-skills/obsidian/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: obsidian
+description: Read, write, search and reorganise notes in the local Obsidian vaults. Use for anything touching ~/Documents/R3_vault, ~/Documents/Synechron or ~/Documents/My_Obsidian_Vault/Privat — finding notes, adding or editing content, renaming/moving notes without breaking links, and daily notes. Triggers on "my notes", "my vault", "Obsidian", "write this up in my notes", or a request to look something up in personal documentation.
+---
+
+# Obsidian vaults
+
+Three vaults, ~2950 notes. They are plain Markdown directories, so **`Read`,
+`Write`, `Edit`, `Grep` and `Glob` are the primary tools** — use them directly.
+The CLI below exists for the two things file tools cannot do safely.
+
+| Vault | Path | Notes | Registered in Obsidian? |
+|---|---|---|---|
+| R3 | `~/Documents/R3_vault` | 872 | **No** |
+| Work | `~/Documents/Synechron` | 996 | Yes |
+| Private | `~/Documents/My_Obsidian_Vault/Privat` | 1085 | Yes |
+
+Ask which vault if the request is ambiguous. Content hints: Synechron holds
+work/Jira/Confluence material and a `NixOS/` folder; Privat holds `AI/`,
+`Linux/`, `Nixos/`, `CV/` and the only `Daily Notes/` folder; R3 holds
+`Chats/`, `Context/`, `GitHub/`, `Interview/`.
+
+## Conventions that actually hold here
+
+These were measured across the real vaults, not assumed. Do not impose
+conventions the vaults do not use.
+
+- **Links are mostly standard Markdown, not wikilinks.** 2039 `[text](file.md)`
+  vs 357 `[[wikilink]]`. Match whatever the file you are editing already uses;
+  do not convert one style to the other.
+- **Frontmatter is rare** — about 5% of notes have any, and most of what exists
+  is plugin residue (`sticker`, `copilot-command-*`) or Kubernetes manifests
+  (`apiVersion`/`kind`/`spec`). **Do not add YAML frontmatter to a note that
+  has none.** Only touch frontmatter if the note already has it or the user asks.
+- **No tag taxonomy.** `#word` occurrences are markdown headings and shell
+  comments, not Obsidian tags. Do not invent tags.
+- **Filenames** are mostly descriptive with no spaces and no date prefix.
+  Follow the naming of sibling files in the target folder.
+- `.obsidian/` is app state — never edit it.
+
+## Normal work: just use the file tools
+
+- Find a note: `Glob` `**/*keyword*.md`, or `Grep` for content
+- Read: `Read`
+- Create: `Write` (place it beside similar notes; match their heading style)
+- Edit: `Edit`
+
+Nothing about a vault makes these unsafe. Prefer them.
+
+## Use `notesmd-cli` for these two things only
+
+Installed as **`notesmd-cli`** (upstream renamed the binary; the repo is still
+called obsidian-cli).
+
+### 1. Renaming or moving a note
+
+This is the one operation that is genuinely unsafe by hand: a rename must
+rewrite every reference across ~2950 files, including heading anchors.
+
+```bash
+notesmd-cli move --vault Synechron "Old Note Name" "New Note Name"
+```
+
+Verified behaviour:
+
+| Before | After |
+|---|---|
+| `[[Old]]` | `[[New]]` |
+| `[Old](Old.md)` | `[Old](New.md)` — target rewritten, display text kept |
+| `[[Old#Heading]]` | `[[New#Heading]]` |
+
+Display text is deliberately preserved; if the user wants it renamed too, that
+is a separate `Edit`.
+
+**Never** do a rename with `mv` + `sed`. It misses heading anchors, block refs
+and aliases, and corrupts links silently.
+
+### 2. Daily notes
+
+```bash
+notesmd-cli daily --vault Privat
+```
+
+Only the Privat vault has a `Daily Notes/` folder. For the others, create a
+dated note by hand in a sensible location.
+
+## Constraint: `move` needs the vault registered with Obsidian
+
+`move` reads `~/.config/obsidian/obsidian.json`, not just the CLI's own
+registry. **R3_vault is not in it**, so `move` fails there with:
+
+```text
+Vault not found in Obsidian config file. Please ensure vault has been set up in Obsidian.
+```
+
+Options when that happens, in order of preference:
+
+1. Use the vault's registered name exactly as it appears in `obsidian.json`
+   (`notesmd-cli list-vaults` shows what the CLI knows).
+2. Tell the user R3_vault must be opened once in the Obsidian app to register
+   it — do not try to hand-edit `obsidian.json`.
+3. Do the rename manually only if the user accepts the link-breakage risk, and
+   say so explicitly first.
+
+## Other subcommands
+
+`create`, `delete`, `open`, `print`, `search`, `search-content`, `frontmatter`,
+`list`, `list-vaults`, `add-vault`, `remove-vault`, `set-default-vault`.
+
+Most duplicate what the file tools already do better in this context —
+`search-content` is a plain substring search, so `Grep` is usually a better
+choice. `open` launches the desktop app and should only be used when the user
+asks to see a note in Obsidian.
+
+## Safety
+
+- Renames touch many files at once. State which vault and which note before
+  running `move`.
+- Never bulk-rewrite links with `sed` across a vault.
+- Deleting notes: prefer confirming with the user; `delete` is not reversible
+  from here and these vaults hold years of work.

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -102,6 +102,11 @@
   # multiplexing tmux still owns the ergonomics here.
   rmux = pkgs.callPackage ./rmux { };
 
+  # obsidian-cli — link-aware vault operations (rename updates every
+  # [[wikilink]] pointing at the note). Installs as `notesmd-cli`; upstream
+  # renamed the binary but kept the repo name. Not in nixpkgs.
+  obsidian-cli = pkgs.callPackage ./obsidian-cli { };
+
   # Note: gnome-ext-* packages are NOT registered here. They're exposed
   # at top-level pkgs.* via overlays/custom-packages.nix so that home
   # configs can reference them with `with pkgs;` (matching the rudra /

--- a/pkgs/obsidian-cli/default.nix
+++ b/pkgs/obsidian-cli/default.nix
@@ -1,0 +1,61 @@
+# obsidian-cli — vault operations that plain file tools cannot do safely.
+#
+# Reading, writing and editing notes needs no tool: an Obsidian vault is a
+# directory of Markdown files. What this provides is the part that is genuinely
+# hard from the outside — `move` is documented upstream as "Move or rename note
+# in vault and updated corresponding links", i.e. it rewrites every [[wikilink]],
+# heading link and block reference pointing at the note. Doing that with
+# grep+sed across ~2950 notes silently corrupts aliases and block refs.
+#
+# NOTE ON NAMING: the repo is still Yakitrak/obsidian-cli, but the Go module and
+# the installed binary were renamed to `notesmd-cli`. mainProgram reflects the
+# binary, not the repo. Neither name exists in nixpkgs as of 2026-07.
+#
+# Bump: check `gh release view --repo Yakitrak/obsidian-cli`, update version +
+# hash, then set vendorHash to lib.fakeHash and take the value nix reports.
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "obsidian-cli";
+  version = "0.3.6";
+
+  src = fetchFromGitHub {
+    owner = "Yakitrak";
+    repo = "obsidian-cli";
+    rev = "v${version}";
+    hash = "sha256-TubUNSpLvv3Q8dixeCf7otG6CSlb8haIGqkMFXAsqYI=";
+  };
+
+  vendorHash = null;
+
+  # Upstream tests shell out to a real vault and an $EDITOR; they are not
+  # hermetic and fail in the sandbox.
+  doCheck = false;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/Yakitrak/notesmd-cli/cmd.version=${version}"
+  ];
+
+  meta = {
+    description = "Interact with Obsidian vaults from the terminal";
+    longDescription = ''
+      CLI for Obsidian vaults. The operations worth having over plain file
+      access are link-aware: `move` renames a note and rewrites every link that
+      referenced it, `search-content` searches note bodies, `frontmatter` reads
+      and writes YAML properties, and `daily` resolves periodic notes.
+
+      Installed as `notesmd-cli` — upstream renamed the binary while keeping
+      the repository name.
+    '';
+    homepage = "https://github.com/Yakitrak/obsidian-cli";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    mainProgram = "notesmd-cli";
+  };
+}


### PR DESCRIPTION
Reading, writing and editing Obsidian notes needs no tooling — a vault is a
directory of Markdown files and the agent's file tools already cover it. Two
things they cannot do safely.

1. Package Yakitrak/obsidian-cli (1.56k stars, MIT, Go)

Not in nixpkgs under either name. The binary is `notesmd-cli`; upstream
renamed it while keeping the repository name, so mainProgram reflects the
binary rather than the repo.

The operation that justifies packaging it is `move`, verified end-to-end
against a real registered vault:

    [[Old]]           -> [[New]]
    [Old](Old.md)     -> [Old](New.md)      target rewritten, display text kept
    [[Old#Heading]]   -> [[New#Heading]]

That matters more here than expected: measured across the three vaults, links
run 2039 Markdown-style to 357 wikilinks, and move handles both. `mv` + `sed`
would miss heading anchors and corrupt links silently across ~2950 notes.

2. `obsidian` Claude Code skill

Documents the three vaults and deliberately steers routine work back to the
plain file tools; the CLI is reserved for renames and daily notes.

Its conventions were measured from the vaults rather than assumed, which
changed what the skill says:

- links are 6:1 Markdown-style over wikilinks, so it instructs matching the
  file being edited instead of converting between styles
- frontmatter appears in ~5% of notes and is mostly plugin residue (sticker,
  copilot-command-*) or Kubernetes manifests, so it says explicitly NOT to add
  frontmatter to notes that have none
- the `#word` hits are markdown headings, not tags — there is no taxonomy to
  invent
- only the Privat vault has a Daily Notes/ folder

Known constraint, documented in the skill: `move` reads
~/.config/obsidian/obsidian.json, not just the CLI's own registry, and
R3_vault is absent from it. The skill tells the agent to surface that and ask
for the vault to be opened once in Obsidian rather than hand-editing that file
or falling back to an unsafe manual rename.

Tested: package builds, `notesmd-cli --help` lists the expected subcommands,
move verified on temp notes in a registered vault with zero residue, p620 and
razer both build.

Closes #1170

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vn1yPQkGwa3WfJdHmQzbZ1
