### PR TITLE
feat(obsidian-cli): add short `ob` alias (#1170)

### DIFF
--- a/home/development/claude-code-skills/obsidian/SKILL.md
+++ b/home/development/claude-code-skills/obsidian/SKILL.md
@@ -49,8 +49,13 @@ Nothing about a vault makes these unsafe. Prefer them.
 
 ## Use `notesmd-cli` for these two things only
 
-Installed as **`notesmd-cli`** (upstream renamed the binary; the repo is still
-called obsidian-cli).
+Installed as **`notesmd-cli`**, with **`ob`** as a short alias (upstream
+renamed the binary; the repo is still called obsidian-cli).
+
+Do not reach for `obsidian-cli` — that name belongs to a *different* tool
+bundled inside `pkgs.obsidian`, which drives the running desktop app and
+currently fails on NixOS with "unable to find Obsidian". Likewise `obs` is OBS
+Studio.
 
 ### 1. Renaming or moving a note
 

--- a/pkgs/obsidian-cli/default.nix
+++ b/pkgs/obsidian-cli/default.nix
@@ -41,6 +41,19 @@ buildGoModule rec {
     "-X=github.com/Yakitrak/notesmd-cli/cmd.version=${version}"
   ];
 
+  # Short alias. Deliberately `ob`, NOT `obs`: obs is OBS Studio's launcher
+  # (pkgs.obs-studio, enabled here via home/desktop/obs) and shadowing it would
+  # break screen recording. `obsidian-cli` is likewise unavailable — that name
+  # is already taken by the CLI bundled inside pkgs.obsidian, which is a
+  # different tool entirely (it drives the running desktop app and currently
+  # fails on NixOS with "unable to find Obsidian").
+  #
+  # A symlink rather than a shell alias so it also resolves from scripts,
+  # non-interactive shells and the `obsidian` Claude Code skill.
+  postInstall = ''
+    ln -s notesmd-cli $out/bin/ob
+  '';
+
   meta = {
     description = "Interact with Obsidian vaults from the terminal";
     longDescription = ''


### PR DESCRIPTION
`notesmd-cli` is a mouthful. Adds a symlink rather than a shell alias so it
also resolves from scripts, non-interactive shells and the obsidian skill.

Deliberately `ob`, not the requested `obs`: obs is OBS Studio's launcher
(pkgs.obs-studio, enabled here via home/desktop/obs), and shadowing it would
break screen recording on both hosts. Verified taken on p620 and razer before
picking a name.

`obsidian-cli` is unavailable for the same class of reason — that name is
already provided by the CLI bundled inside pkgs.obsidian, which is a different
tool that drives the running desktop app and currently fails on NixOS with
"The CLI is unable to find Obsidian". Aliasing onto it would have silently
shadowed a binary already in the user profile.

Skill updated to name both collisions so the agent doesn't try either.

Relates to #1170

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
