### PR TITLE
chore(claude-desktop): update to 1.24012.9 (#1174)

### DIFF
--- a/pkgs/claude-desktop-beta/default.nix
+++ b/pkgs/claude-desktop-beta/default.nix
@@ -52,7 +52,7 @@
 # then update `version` + `sha256` below (hex sha256 from the index is accepted
 # by fetchurl as-is).
 let
-  version = "1.22209.3";
+  version = "1.24012.9";
 
   # dlopen'd at runtime (not in DT_NEEDED) — appended to RUNPATH.
   runtimeLibs = [
@@ -69,7 +69,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_${version}_amd64.deb";
-    sha256 = "d427f46ac9233dbc4d8a441a602f09f750b8a5f05d1fc7a00285d7a6ce07655c";
+    sha256 = "302e6d208dd8c8e9e52067daa28ef3b1171a1613586fd0e10bedc642225b6ee1";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
1.22209.3 -> 1.24012.9 from Anthropic's signed apt repo, following the bump
procedure documented in the package itself. Sizeable jump (~1800 in the middle
component), so worth watching after deploy.

    Version: 1.24012.9
    SHA256:  302e6d208dd8c8e9e52067daa28ef3b1171a1613586fd0e10bedc642225b6ee1

The apt Packages index lists 18 entries in no meaningful order; `sort -V` is
needed to find the newest — the first entries returned are 1.17xxx, older than
what we already pin.

Note: Section B of the /update-claude-code skill is stale. It describes bumping
an aaddrick/claude-desktop-debian flake input plus build.sh sed and asar checks.
That input was removed in #986 and claude-desktop is now packaged locally from
the official .deb, so none of those steps apply. Flagged in #1174 for a separate
skill fix rather than silently following dead instructions.

Verified: builds, produces bin/claude-desktop, autoPatchelf clean, and p620 /
razer / p510 all build.

Closes #1174

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vn1yPQkGwa3WfJdHmQzbZ1
