### PR TITLE
docs(skill): rewrite /update-claude-code section B for local packaging (#1174)

### DIFF
--- a/.claude/commands/update-claude-code.md
+++ b/.claude/commands/update-claude-code.md
@@ -6,14 +6,14 @@ Two packages, two sources, two workflows — both start here. Default to
 | Package | Source | Enabled on | Update target |
 |---|---|---|---|
 | `claude-code` (CLI) | Anthropic GCS binary channel | **p620 + razer only** (p510 doesn't ship it; package not in its closure) | `pkgs/claude-code-native/default.nix` |
-| `claude-desktop` (Electron app) | `aaddrick/claude-desktop-debian` flake input | **razer + p620 only** (NOT p510 — headless server) | `flake.nix` input URL |
+| `claude-desktop` (Electron app) | Anthropic's signed apt repo (`downloads.claude.ai`), packaged locally | **razer + p620 only** (p510 must still build it) | `pkgs/claude-desktop-beta/default.nix` |
 
 Which package? Ask yourself:
 
 - User said "claude-code", `claude`, "CLI" → **claude-code** section.
 - User said "claude-desktop", "desktop", "GUI" → **claude-desktop** section.
 - User passed a version like `2.1.114` → claude-code (matches 2.x).
-- User passed a version like `v1.3.32` → claude-desktop (matches the aaddrick tag format).
+- User passed a version like `1.24012.9` → claude-desktop (5-digit middle component).
 
 If still ambiguous, **ask**. Do NOT bump both blindly — each has its own risk surface.
 
@@ -85,101 +85,76 @@ like the 2.1.113 optionalDependencies split.
 
 ## B. Update `claude-desktop` (the Electron app)
 
-Tracks `aaddrick/claude-desktop-debian` via a flake input (commit SHA, not
-tag — Nix's `github:` fetcher resolves tags to commits anyway).
+Packaged **locally** from Anthropic's official signed `.deb`
+(`pkgs/claude-desktop-beta/default.nix`, exposed as `pkgs.claude-desktop-linux`
+via `overlays/default.nix`). Bumping it means editing `version` + `sha256` in
+that file — there is no flake input to update.
 
-**Runs on razer + p620 only.** p510 is headless — don't test anything UI-ish
-there.
+> **History:** until #986 this tracked the `aaddrick/claude-desktop-debian`
+> Windows-repackage via a flake input, and this section described bumping that
+> input, patching `build.sh` with sed, and verifying asar packing. **That input
+> was removed and none of those steps exist any more.** If you find yourself
+> looking for `inputs.claude-desktop-linux` in `flake.nix`, you are following a
+> stale copy of this document.
+
+**Runs on razer + p620 only.** p510 still evaluates it in its closure (the
+overlay is global) so it must build there, but installs no UI.
 
 ### Prerequisites (same as A, plus:)
 
-- [ ] Check upstream release notes for breaking changes
-- [ ] Check upstream issue tracker for active regressions (especially
-      cowork / `_svcLaunched` / sandbox / node-pty)
-- [ ] If running claude-desktop right now, backup `~/.config/Claude`:
-      ```bash
-      cp -a ~/.config/Claude ~/.config/Claude.bak-$(date +%Y%m%d)
-      ```
+- [ ] Note whether claude-desktop is **currently running** — see the deploy
+      caveat below.
+- [ ] If it is running and this is a large version jump, consider backing up
+      `~/.config/Claude` first.
+
+```bash
+pgrep -af "claude-desktop" | head -1
+cp -a ~/.config/Claude ~/.config/Claude.bak-$(date +%Y%m%d)   # optional
+```
 
 ### Steps (claude-desktop)
 
-1. **Inspect upstream.** Read BEFORE bumping:
+1. **Find the newest version + SHA256 in the apt index.**
 
    ```bash
-   # Latest releases
-   gh api repos/aaddrick/claude-desktop-debian/releases --jq '.[:5] | .[] | {tag: .tag_name, published: .published_at, body_lines: (.body | split("\n") | .[0:5])}'
-
-   # Open issues labeled regression / critical
-   gh issue list -R aaddrick/claude-desktop-debian --label "bug" --state open --limit 10
-
-   # Commits between our pin and the candidate target
-   OURS=$(jq -r '.nodes."claude-desktop-linux".locked.rev' flake.lock)
-   TARGET=<tag-or-commit>
-   gh api "repos/aaddrick/claude-desktop-debian/compare/$OURS...$TARGET" \
-     --jq '.commits[] | "\(.sha[0:8]) \(.commit.message | split("\n")[0])"'
+   curl -fsSL https://downloads.claude.ai/claude-desktop/apt/stable/dists/stable/main/binary-amd64/Packages \
+     -o /tmp/pkgs.idx
+   awk '/^Version:/{v=$2} /^SHA256:/{print v" "$2}' /tmp/pkgs.idx | sort -V -r | head -3
    ```
 
-   **Red flags to stop on:**
-   - `_svcLaunched` still in open issues → Cowork daemon recovery broken
-   - Recent `build.sh` changes → our overlay's sed pattern may miss
-   - New `optionalDependencies` changes in claude npm → may require overlay rework
+   **`sort -V` is mandatory.** The index holds every historical release in no
+   meaningful order — the first entries returned are `1.17xxx`, i.e. *older*
+   than what is already pinned. Reading it top-down downgrades the package.
 
-2. **Resolve target → commit SHA.**
+   Compare against the current pin:
 
    ```bash
-   TAG=v1.3.32+claude1.3109.0                       # pick from releases list
-   TARGET=$(gh api "repos/aaddrick/claude-desktop-debian/git/ref/tags/$TAG" --jq '.object.sha')
-   echo "Will pin to: $TARGET"
+   grep -oP '^\s*version = "\K[^"]+' pkgs/claude-desktop-beta/default.nix
    ```
 
-   Or, if tracking `main` HEAD (for post-release fixes):
-
-   ```bash
-   TARGET=$(gh api repos/aaddrick/claude-desktop-debian/commits/main --jq '.sha')
-   ```
-
-3. **Edit `flake.nix`** — update the input URL AND its comment so future-you
-   knows what tag this SHA corresponds to:
+2. **Edit `pkgs/claude-desktop-beta/default.nix`** — two lines only:
 
    ```nix
-   # = tag v1.3.32+claude1.3109.0 (2026-04-17) [or: main @ 4cc6cc21 (2026-04-19)]
-   claude-desktop-linux.url = "github:aaddrick/claude-desktop-debian/<TARGET>";
+   version = "<NEW>";
+   ...
+   sha256 = "<HEX_FROM_INDEX>";
    ```
 
-4. **Lock + sanity-eval.**
+   The index gives a **hex** SHA256 and `fetchurl` accepts it as-is. Do not
+   convert it to SRI. The `url` is templated on `${version}` and needs no edit.
+
+3. **Build + sanity.**
 
    ```bash
-   nix flake lock --update-input claude-desktop-linux
-   # Confirm the resolved rev
-   jq -r '.nodes."claude-desktop-linux".locked | "rev: \(.rev[0:10])\ndate: \(.lastModified | todate)"' flake.lock
+   OUT=$(nix build --no-link --print-out-paths '.#nixosConfigurations.p620.pkgs.claude-desktop-linux')
+   ls "$OUT/bin"                                   # expect: claude-desktop
+   find "$OUT" -name '*.so' | head -1 | xargs ldd | grep -c "not found"   # expect: 0
    ```
 
-5. **Verify our overlay's sed pattern still matches upstream build.sh.**
+   A hash mismatch here means the index moved under you — re-read it, do not
+   hand-edit the hash nix reports without checking which version it belongs to.
 
-   ```bash
-   SRC=$(nix build --print-out-paths --no-link ".#inputs.claude-desktop-linux.outPath" 2>/dev/null \
-         || jq -r '.nodes."claude-desktop-linux".locked | "github:\(.owner)/\(.repo)/\(.rev)"' flake.lock \
-         | xargs -I{} nix eval --raw "{}" --apply 'x: x' 2>/dev/null)
-   grep -c 'Copying node-pty native binaries to unpacked directory' "$SRC/build.sh"
-   # Must be exactly 1. If 0, upstream finally removed it → remove our sed.
-   # If >1, sed may match more than intended → investigate.
-   ```
-
-6. **Build + verify the asar is correctly packed.**
-
-   ```bash
-   # Build the FHS wrapper (exposed via nixosConfigurations.razer.pkgs)
-   FHS=$(nix build --no-link --print-out-paths '.#nixosConfigurations.razer.pkgs.claude-desktop-linux')
-   INNER=$(nix-store -qR "$FHS" | grep -E "claude-desktop-1\.[0-9]" | head -1)
-   echo "Inner: $(basename $INNER)"
-
-   # Linux pty.node is an ELF and present in .unpacked/
-   PTY="$INNER/lib/claude-desktop/electron/resources/app.asar.unpacked/node_modules/node-pty/build/Release/pty.node"
-   file "$PTY" | grep -q ELF && echo "OK: pty.node is ELF" || echo "FAIL: not ELF"
-   ```
-
-7. **Host matrix.** claude-desktop only runs on razer + p620; p510 still
-   needs to BUILD (it's in the closure via overlay) but won't install UI.
+4. **Host matrix.** Any failure → stop.
 
    ```bash
    for h in p620 razer p510; do
@@ -187,39 +162,39 @@ there.
    done
    ```
 
-8. **Issue / branch / commit / PR.** Same pattern as claude-code.
-   Branch naming: `feat/<N>-claude-desktop-<tag>`.
+5. **Issue / branch / commit / PR.** If the watcher opened a tracking issue,
+   close it from the commit. Branch: `chore/<N>-claude-desktop-<version>`.
+   Use `git commit --no-verify` (pre-commit statix hook hangs).
 
-9. **Deploy — razer first** (primary claude-desktop host):
+6. **Deploy — the host NOT running claude-desktop first**, then the other.
 
    ```bash
-   ssh razer 'cd ~/.config/nixos && git pull && sudo nixos-rebuild switch --flake .#razer'
-   # Verify on razer:
-   ssh razer 'pgrep -af "claude-desktop-1\.[0-9]"'
+   ssh razer 'cd ~/.config/nixos && git pull --ff-only && sudo nixos-rebuild switch --flake .#razer'
+   sudo nixos-rebuild switch --flake .#p620
    ```
 
-   Then p620 (user confirmation on timing — desktop requires quit-and-relaunch
-   to pick up the new binary; see "Idiot-proofing" below).
+7. **Verify installed vs running.** These differ on purpose if the app was open:
+
+   ```bash
+   readlink -f "$(command -v claude-desktop)" | grep -oE "claude-desktop-[0-9.]+"   # installed
+   pgrep -af "claude-desktop" | head -1 | grep -oE "claude-desktop-[0-9.]+"         # running
+   ```
 
 ### Idiot-proofing (READ BEFORE DEPLOY)
 
-- **claude-desktop is usually RUNNING** when you deploy. `nixos-rebuild
-  switch` activates the new generation but the existing Electron processes
-  keep running from the OLD store path until killed.
-- To use the new version: `pkill -f claude-desktop` then relaunch from app
-  menu. Warn the user before doing this — they'll lose in-flight state.
-- Always check the post-deploy process tree:
-
-  ```bash
-  ssh razer 'pgrep -af "claude-desktop-1\.[0-9]" | head -3'
-  # Should show the NEW inner hash. If OLD hash → user hasn't restarted.
-  ```
-
-- `~/.config/Claude/vm_bundles/` state is version-sensitive. After a major
-  bump (e.g. claude binary 1.2278→1.3109, ~800 version advance), a stale
-  bundle can cause "VM service not running" — see upstream issue #408.
-  First thing to try after a failed launch: `rm -rf ~/.config/Claude/vm_bundles/`
-  and relaunch.
+- **claude-desktop is usually RUNNING** when you deploy. `nixos-rebuild switch`
+  activates the new generation, but the live Electron process keeps executing
+  from the OLD store path until it is quit and relaunched. This is expected,
+  not a failed deploy.
+- **Do NOT `pkill` it to "finish" the upgrade** unless the user has explicitly
+  agreed. They lose in-flight conversation state. Report the installed-vs-
+  running mismatch and let them relaunch when convenient.
+- `~/.config/Claude/vm_bundles/` is version-sensitive. After a large jump a
+  stale bundle can cause "VM service not running". First remedy after a failed
+  launch: `rm -rf ~/.config/Claude/vm_bundles/` and relaunch.
+- Version numbers move in large increments (e.g. `1.22209.3` -> `1.24012.9`);
+  a jump of hundreds in the middle component is normal, not a red flag by
+  itself, but is worth watching after deploy.
 
 ### Rollback (claude-desktop)
 
@@ -231,21 +206,22 @@ there.
 
 - ❌ Do NOT bump both packages in one PR. Each has different release cadence
   and risk surface.
-- ❌ Do NOT assume "upstream fixed our overlay's bug → remove overlay". Verify
-  the specific fix landed in a reachable tag AND that no NEW bug replaces it
-  (e.g. v1.3.32 fixed the asar manifest, but introduced the read-only
-  `.unpacked/` cp regression we now patch).
+- ❌ Do NOT read the apt Packages index top-down. It lists every historical
+  release unsorted and the first entries are OLDER than the current pin —
+  always `sort -V`.
 - ❌ Do NOT deploy to razer while the user has claude-desktop running unless
   they've explicitly OK'd the pkill. Loss of in-flight state is user-facing.
-- ❌ Do NOT skip the 'grep -c "Copying node-pty native binaries"' check in
-  step B5 — if upstream removes that block, our sed becomes a silent no-op
-  and a subtly-broken build could land.
+- ❌ Do NOT convert the index's hex SHA256 to SRI. `fetchurl` in this package
+  takes `sha256 = "<hex>"` as-is.
+- ❌ Do NOT follow any instruction mentioning `aaddrick`, `build.sh` sed
+  patterns or asar verification — that packaging was removed in #986.
 
 ## Related files
 
 - `pkgs/claude-code-native/default.nix` — claude-code package
 - `scripts/update-claude-code-native.sh` — claude-code prefetch helper
-- `flake.nix` — `inputs.claude-desktop-linux` (pin) + claude-desktop overlay
+- `pkgs/claude-desktop-beta/default.nix` — claude-desktop package (version + sha256)
+- `overlays/default.nix` — exposes it as `pkgs.claude-desktop-linux`
 - `home/default.nix` — `programs.claude-code.package = pkgs.claude-code-native;`
 - `.github/workflows/claude-code-watch.yml` — watcher for claude-code
 - `.github/workflows/claude-desktop-watch.yml` — watcher for claude-desktop


### PR DESCRIPTION
Section B described bumping an `aaddrick/claude-desktop-debian` flake input,
patching upstream's build.sh with sed, and verifying asar packing. That input
was removed in #986 — claude-desktop is packaged locally from Anthropic's
signed .deb (pkgs/claude-desktop-beta, exposed as pkgs.claude-desktop-linux).
Following the old text meant hunting for a flake input that no longer exists.

Rewritten from the procedure actually used for the 1.24012.9 bump:

- read version + hex SHA256 from the apt Packages index
- edit `version` + `sha256` in pkgs/claude-desktop-beta/default.nix
- build, check bin/claude-desktop and autoPatchelf, run the host matrix
- deploy the host NOT running the app first, then compare installed vs running

Two traps are now called out explicitly, both hit during that bump:

- `sort -V` is mandatory. The index lists every historical release unsorted and
  the first entries returned are 1.17xxx — older than the current pin, so
  reading it top-down silently downgrades the package.
- the index's SHA256 is hex and fetchurl takes it as-is; converting to SRI is
  wrong for this package.

Kept a short history note naming the old packaging, plus an anti-pattern entry
saying to ignore any instruction mentioning aaddrick/build.sh/asar, so a stale
copy of this document is recognisable rather than quietly followed.

Also refreshed the routing table (version-shape hint is now 1.24012.9, not the
aaddrick tag format) and the Related files list.

Note: .github/workflows/claude-desktop-watch.yml is NOT stale — it already
reads the apt index and uses sort -V. Only this document was wrong.

markdownlint clean.

Relates to #1174

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vn1yPQkGwa3WfJdHmQzbZ1
