### PR TITLE
chore(antigravity): bump CLI to 1.1.7

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.1.6-6535449645285376";
+  version = "1.1.7-5951805767680000";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.6-6535449645285376/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-JEi5ux00lgY6YzXQIdyrkMQtcf2q1jRu+KOV8MoP6dA=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.7-5951805767680000/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-lGzQYljQ7ectAxFVDJFDFXmIIfajl/U6x2CRmCahmvQ=";
   };
 
   # Tarball contains a single file `antigravity` at the root.


### PR DESCRIPTION
## Summary

Bumps `pkgs/antigravity-cli` from `1.1.6-6535449645285376` to `1.1.7-5951805767680000` via `./scripts/update-antigravity.sh`.

`antigravity-ide` (2.1.1), `antigravity-hub` (2.3.1), and `google-antigravity-py` (0.1.8) were already current per the `Hy4ri/antigravity-flake` tracker — untouched.

## Testing

- `nix build` of all four `customPkgs.antigravity-*` / `google-antigravity-py` derivations: pass
- `nix build .#nixosConfigurations.p620.config.system.build.toplevel`: pass
- `agy --version` → `1.1.7`
- `python3 -c "import google.antigravity"` → OK

Not deployed. Deploy with `nhs p620` / `nhs razer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vn1yPQkGwa3WfJdHmQzbZ1