### PR TITLE
fix(virt): repair EFI firmware autoselection and libvirt group access

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -455,6 +455,7 @@ in
       "networkmanager"
       "render"
       "ydotool" # /run/ydotoold/socket access for the voice-input client
+      "libvirtd" # read-write libvirt socket; without it virt-manager gets "access denied by policy"
     ];
     shell = pkgs.zsh;
     # Run user services even when not logged in so headless user units

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -499,6 +499,7 @@ in
       "wheel"
       "networkmanager"
       "ydotool" # /run/ydotoold/socket access for the voice-input client
+      "libvirtd" # read-write libvirt socket; without it virt-manager gets "access denied by policy"
     ];
     shell = pkgs.zsh;
     # Only use secret-managed password if the secret exists

--- a/modules/virt/virt.nix
+++ b/modules/virt/virt.nix
@@ -59,7 +59,6 @@ in
     systemd = {
       tmpfiles.rules = [
         "r /etc/ssh/ssh_config.d/30-libvirt-ssh-proxy.conf"
-        "L+ /var/lib/qemu/firmware - - - - ${pkgs.qemu}/share/qemu/firmware"
       ];
       services.libvirtd.restartIfChanged = false;
       # Fix virt-secret-init-encryption on hosts without working TPM2.


### PR DESCRIPTION
Two independent libvirt breakages found while getting p620's `win11` VM running again.

## 1. EFI firmware autoselection broken by a stale store path

`sudo virsh start win11` failed with:

```
error: operation failed: Unable to find 'efi' firmware that is compatible with the current configuration
```

The domain's persistent XML cached a `<loader>` at `…-qemu-10.0.2/share/qemu/edk2-x86_64-secure-code.fd`. The host runs qemu 11.0.2 and that store path has been garbage-collected, so autoselection had nothing to match.

**Root cause:** `modules/virt/virt.nix` carried

```nix
"L+ /var/lib/qemu/firmware - - - - ${pkgs.qemu}/share/qemu/firmware"
```

which overrode the same-path rule nixpkgs' libvirtd module already ships:

```nix
"L+ /var/lib/qemu/firmware - - - - ${qemuOvmfMetadata}"
```

`qemuOvmfMetadata` rewrites the firmware JSONs' `.fd` paths to `/run/libvirt/nix-ovmf/` — a stable symlink farm regenerated on every libvirtd start. Our override handed libvirt raw `/nix/store/…-qemu-<ver>/…` paths, which libvirt then bakes into each domain XML. Every qemu bump + GC cycle therefore breaks any EFI domain. Our rule predates the nixpkgs one; it is now pure redundancy with a failure mode.

Verified the resolved rule after deletion:

```
L+ /var/lib/qemu/firmware - - - - /nix/store/…-qemu-ovmf-metadata
```

## 2. `libvirtd` group missing on p620 and razer

virt-manager failed with:

```
Unable to connect to libvirt qemu:///system.
authentication failed: access denied by policy
```

`olafkfreund` was in neither host's `libvirtd` group, so libvirt only granted the world-readable **read-only** socket. virt-viewer worked (read-only suffices); virt-manager needs read-write.

`shared-variables.nix`'s `baseUserGroups` has contained `libvirtd` all along, but p620 and razer hardcode their own `extraGroups` in `configuration.nix` instead of consuming `vars.userGroups` the way p510 does. The other groups (`docker`, `video`, `scanner`, `lp`) are contributed by their own modules, which masked the gap.

Added `libvirtd` to both lists rather than switching to `vars.userGroups`, which would also pull in `podman`/`lxd`/`incus-admin` groups these hosts don't define.

## Testing

- `nix build .#nixosConfigurations.p620.config.system.build.toplevel`: pass
- `nix build .#nixosConfigurations.razer.config.system.build.toplevel`: pass
- p620 `extraGroups` now evaluates with `libvirtd` present; same for razer
- `win11` confirmed booted to the Windows lock screen after clearing its stale cached loader (host-state fix, not in this diff)

## Follow-up

Existing EFI domains still carry a store-path loader in their XML. Clearing `<loader>` / `nvram template=` once per domain lets libvirt re-resolve to `/run/libvirt/nix-ovmf/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vn1yPQkGwa3WfJdHmQzbZ1