### PR TITLE
fix: unbreak eval after nixpkgs bump (mango module collision, overseerr removal)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1785036536,
-        "narHash": "sha256-y/njxRdBS2E+3XIx5XXFui3evQ0qx9sqjzrVDMNLyoE=",
+        "lastModified": 1785122868,
+        "narHash": "sha256-N1ahn2aUePx/9YIyuUyIPeFF04SsB/N56Q+M6eZTIIs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4ed71f48c0194ed33e92ae7aa61c80d11b58ad23",
+        "rev": "c4988af836837d97f8660dbedbf01e50f982d5e7",
         "type": "github"
       },
       "original": {
@@ -423,24 +423,6 @@
         "type": "github"
       }
     },
-    "flake-utils_10": {
-      "inputs": {
-        "systems": "systems_12"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flake-utils_2": {
       "inputs": {
         "systems": "systems_3"
@@ -552,10 +534,7 @@
     },
     "flake-utils_8": {
       "inputs": {
-        "systems": [
-          "scenefx",
-          "systems"
-        ]
+        "systems": "systems_10"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -758,11 +737,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784913159,
-        "narHash": "sha256-JWq0BfjO4ktpH5USfQNQzdvHpIDT8fSKD5K7LvdMRFs=",
+        "lastModified": 1785119578,
+        "narHash": "sha256-3VMVuOJ6fK+RNOXVmqusqUwQ1sDfPeddNKaM2JR/4Y0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "079a3b5d1aa6a719920a51316253b7d6dd22738d",
+        "rev": "e83dffa86cccb6237fe194d4eeb47f41557749d1",
         "type": "github"
       },
       "original": {
@@ -839,11 +818,11 @@
         "scenefx": "scenefx"
       },
       "locked": {
-        "lastModified": 1785069193,
-        "narHash": "sha256-QzfC7QF4WFSaxgD6uyFKOUF4/iJNSDC+TgZnGYlZYOk=",
+        "lastModified": 1785123014,
+        "narHash": "sha256-9TYx3jL6dBNlCTphXeTICNbQ1HkVgFegRC4YHbI3hxw=",
         "owner": "mangowm",
         "repo": "mango",
-        "rev": "cc4fdecee677e0b4ea5acb595a5f4a4689e9ab53",
+        "rev": "a2172525fe066e7ff550f1f4c8dbeb42ab3bff6c",
         "type": "github"
       },
       "original": {
@@ -903,11 +882,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1784874881,
-        "narHash": "sha256-u4jhSIf/Un0qZB+Cn3hTTaHSI20XeAxYbA5o4faqdJs=",
+        "lastModified": 1785133905,
+        "narHash": "sha256-cXE11IuEJe+Oqk+gnNIxUSfHW+ekrc8Mx48pNv0RvuI=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "ef7a2a3d719af46b906c22a3ebfb7d65627b2cd2",
+        "rev": "81b9856c2f1f5a425e5048219c0899cb48c52d3f",
         "type": "github"
       },
       "original": {
@@ -1010,11 +989,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
         "type": "github"
       },
       "original": {
@@ -1033,11 +1012,11 @@
         "parts": "parts"
       },
       "locked": {
-        "lastModified": 1785044177,
-        "narHash": "sha256-ZudMehNRvB63tMri24KGFE9vhvvtpxQjLH5fy5PRlxE=",
+        "lastModified": 1785131684,
+        "narHash": "sha256-8dxDbbhCVtuBJLNH3wyq8KpM8EtxPeSYlVRvn42NUWU=",
         "owner": "moni-dz",
         "repo": "nixpkgs-f2k",
-        "rev": "2068f0c39de3d57a77ed9460d7c42dd76cb9bf02",
+        "rev": "53a35007fde8fb52c4e87c4f5e8ae9834124925d",
         "type": "github"
       },
       "original": {
@@ -1131,11 +1110,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1785091252,
-        "narHash": "sha256-Yz0VWDx3YLrU9kZMTtfhIHMTSL1pXwzWqQ39+rtbcDs=",
+        "lastModified": 1785140188,
+        "narHash": "sha256-O8XtA7rOj6cGcNcJxpAAAJFnWK8OSOZqrH91XCdxJVA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "76ceb2fc11045456cba10d4f2641b4e261b77cde",
+        "rev": "287583e16a8c76e82b9023bff543bd516ce13d98",
         "type": "github"
       },
       "original": {
@@ -1179,11 +1158,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1784856561,
-        "narHash": "sha256-J+Bx1Z6Oeoj2FgnBhRMKyUhhtDoOpTgXYaVLZpDjW4A=",
+        "lastModified": 1785002762,
+        "narHash": "sha256-Y0BbgB3BLLHEUK88g4oSp3DerIx7rCX0iwICKJcY7/c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "597283ad8aa0b331c788e97c4c262d58877074ef",
+        "rev": "f7a2e428f5d71c47a5a938a3c5ad7138bb291093",
         "type": "github"
       },
       "original": {
@@ -1195,11 +1174,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
         "type": "github"
       },
       "original": {
@@ -1211,11 +1190,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1785043702,
-        "narHash": "sha256-Cf88HFD9jv2Bvln9Udt1cYrSnT+okzaTG4QM4we2Ju0=",
+        "lastModified": 1785130450,
+        "narHash": "sha256-hhX9PPPA4UFaww7rLkz1otVZkq5K4ivm53j1igII1vA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13d18f03e3944e3ca1af9d8110c27c69c848bc1d",
+        "rev": "f53be8b554554b80b9a04e6338204b5a148e2b6a",
         "type": "github"
       },
       "original": {
@@ -1227,11 +1206,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
         "type": "github"
       },
       "original": {
@@ -1364,11 +1343,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
         "type": "github"
       },
       "original": {
@@ -1441,11 +1420,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1785090969,
-        "narHash": "sha256-+lZbM3W2FkSIzMf8yGimScT9DJxHTIE1iJwkvnJfhbM=",
+        "lastModified": 1785138165,
+        "narHash": "sha256-JMQ1L59Z4M0KPKou9gS+rbYYhGEXIGtdPTX0kbbRx2o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f2a4cceb29bc4f899f689b024757de65917cdac4",
+        "rev": "15544328ef656ca54155e43fc73fb664e5b993c8",
         "type": "github"
       },
       "original": {
@@ -1550,7 +1529,6 @@
         "noctalia-greeter": "noctalia-greeter",
         "nur": "nur",
         "rust-overlay": "rust-overlay_4",
-        "scenefx": "scenefx_2",
         "sops-nix": "sops-nix",
         "spicetify-nix": "spicetify-nix",
         "stylix": "stylix",
@@ -1645,11 +1623,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785044261,
-        "narHash": "sha256-ehF/c4fLdgmNu7YXEClnmwhoBYddhYIVoSQpsZoorC4=",
+        "lastModified": 1785131767,
+        "narHash": "sha256-VNbQv2P0zgaNh96mT4LrnX7hdXgiC5nBH+uvyrrVX7U=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "fe2124391e739e7b3e8720cd8a73f06edd0aceba",
+        "rev": "c67ce00525464a710971351c183ce67acb6ca827",
         "type": "github"
       },
       "original": {
@@ -1702,29 +1680,6 @@
         "type": "github"
       }
     },
-    "scenefx_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_8",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "systems": "systems_8"
-      },
-      "locked": {
-        "lastModified": 1782624992,
-        "narHash": "sha256-vUjLG6eubEhJJVa9LPygIcVmNoHwYbSUTJcWEcbxnU4=",
-        "owner": "wlrfx",
-        "repo": "scenefx",
-        "rev": "37ccd723bef49e6891156ffafce8f549f01446cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "wlrfx",
-        "ref": "0.5",
-        "repo": "scenefx",
-        "type": "github"
-      }
-    },
     "sops-nix": {
       "inputs": {
         "nixpkgs": [
@@ -1764,7 +1719,7 @@
     "spicetify-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_12",
-        "systems": "systems_9"
+        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1785048222,
@@ -1793,7 +1748,7 @@
           "nixpkgs"
         ],
         "nur": "nur_2",
-        "systems": "systems_10",
+        "systems": "systems_9",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
@@ -1844,21 +1799,6 @@
       }
     },
     "systems_11": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_12": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1965,16 +1905,16 @@
     },
     "systems_8": {
       "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default-linux",
+        "repo": "default",
         "type": "github"
       }
     },
@@ -2092,7 +2032,7 @@
     },
     "yt-x": {
       "inputs": {
-        "flake-utils": "flake-utils_9",
+        "flake-utils": "flake-utils_8",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -2114,7 +2054,7 @@
     "zjstatus": {
       "inputs": {
         "crane": "crane_2",
-        "flake-utils": "flake-utils_10",
+        "flake-utils": "flake-utils_9",
         "nixpkgs": "nixpkgs_13",
         "rust-overlay": "rust-overlay_5"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -89,24 +89,14 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # mango — dwl-based Wayland compositor (wlroots + scenefx). Its flake
-    # provides the NixOS module (programs.mango, wired below) and the
+    # mango — dwl-based Wayland compositor (wlroots + scenefx). nixpkgs now
+    # ships the NixOS module and package (programs.mango), so we only take the
     # home-manager config option (wayland.windowManager.mango, added to
-    # home-manager.sharedModules). Third Noctalia session alongside niri/labwc.
+    # home-manager.sharedModules) from this flake. Wiring both NixOS modules
+    # collides on the programs.mango option. Third Noctalia session alongside
+    # niri/labwc.
     mango = {
       url = "github:mangowm/mango";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    # scenefx 0.5 — mango's meson.build requires scenefx-0.5, but mango's own
-    # flake pins/exposes scenefx 0.4.1 (its `inherit (inputs.scenefx.packages.*)
-    # scenefx` only resolves against the 0.4.1 output layout, which 0.5 renamed
-    # to `default`). So we can't just make mango follow this; instead we build
-    # scenefx 0.5 here and inject it via `programs.mango.package.override`
-    # (see modules/desktop/mangowm.nix). Pinned to tag 0.5; revisit when mango
-    # upstream wires scenefx 0.5 itself.
-    scenefx = {
-      url = "github:wlrfx/scenefx/0.5";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -333,7 +323,6 @@
               inputs.agenix.nixosModules.default
               inputs.lanzaboote.nixosModules.lanzaboote
               inputs.niri-flake.nixosModules.niri
-              inputs.mango.nixosModules.mango
               inputs.noctalia-greeter.nixosModules.default
               nix-index-database.nixosModules.nix-index
               ./home/shell/zellij/zjstatus.nix

--- a/home/desktop/noctalia/default.nix
+++ b/home/desktop/noctalia/default.nix
@@ -578,9 +578,8 @@ in
     in
     {
       enable = true;
-      # Reuse the scenefx-0.5-overridden package from the NixOS module
-      # (modules/desktop/mangowm.nix) so the HM side doesn't rebuild mango
-      # against scenefx 0.4.1 (which fails: "scenefx-0.5 not found").
+      # Reuse the system mango (nixpkgs, via programs.mango) so the HM side
+      # doesn't build the mango flake's own package on top of it.
       package = osConfig.programs.mango.package;
 
       extraConfig = ''

--- a/hosts/p510/nixos/plex.nix
+++ b/hosts/p510/nixos/plex.nix
@@ -3,12 +3,17 @@
 , ...
 }: {
   services = {
-    # Overseerr - Request management and media discovery for Plex
-    overseerr = {
+    # Seerr - Request management and media discovery for Plex. Overseerr and
+    # Jellyseerr merged upstream into Seerr; nixpkgs dropped services.overseerr
+    # with it. Port is unchanged, so the reverse proxy and tailscale serve
+    # paths still work. State moved: /var/lib/private/overseerr ->
+    # /var/lib/private/jellyseerr/config (seerr keeps the jellyseerr state dir
+    # below stateVersion 26.05).
+    seerr = {
       enable = true;
       port = 5055;
       openFirewall = true;
-      package = pkgs-unstable.overseerr;
+      package = pkgs-unstable.seerr;
     };
     plex = {
       enable = true;
@@ -313,8 +318,8 @@
 
   # Ensure media services start before Tailscale Serve to prevent port conflicts
   systemd.services.tailscale-serve = {
-    after = [ "overseerr.service" "audiobookshelf.service" "sabnzbd.service" ];
-    wants = [ "overseerr.service" "audiobookshelf.service" "sabnzbd.service" ];
+    after = [ "seerr.service" "audiobookshelf.service" "sabnzbd.service" ];
+    wants = [ "seerr.service" "audiobookshelf.service" "sabnzbd.service" ];
   };
 
   # Note: Firewall ports are now comprehensively configured in configuration.nix

--- a/modules/desktop/mangowm.nix
+++ b/modules/desktop/mangowm.nix
@@ -1,11 +1,10 @@
-{ config, lib, pkgs, inputs, ... }:
+{ config, lib, ... }:
 # mango — dwl-based (wlroots + scenefx) Wayland compositor, exposed as a
-# selectable login session. The mango flake's NixOS module (programs.mango) is
-# wired in flake.nix; this feature module just turns it on. programs.mango
-# handles the rest — it installs share/wayland-sessions/mango.desktop (so
-# greetd/GDM list "mango"), enables built-in XWayland, wlr/gtk portals and
-# polkit. Session config (keybinds, env, autostart) lands in the Noctalia home
-# profile, the same place niri/labwc are configured.
+# selectable login session. programs.mango comes from nixpkgs; this feature
+# module just turns it on. programs.mango handles the rest — it installs
+# share/wayland-sessions/mango.desktop (so greetd/GDM list "mango") and wires
+# the wlr/gtk portals. Session config (keybinds, env, autostart) lands in the
+# Noctalia home profile, the same place niri/labwc are configured.
 let
   inherit (lib) mkEnableOption mkIf;
   cfg = config.desktop.mangowm;
@@ -16,12 +15,10 @@ in
 
   config = mkIf cfg.enable {
     programs.mango.enable = true;
-    # mango's meson.build requires scenefx-0.5, but its flake builds the package
-    # against scenefx 0.4.1. Rebuild the mango package with the scenefx 0.5 we
-    # pin in flake.nix. Drop this override once mango wires scenefx 0.5 upstream.
-    programs.mango.package =
-      inputs.mango.packages.${pkgs.stdenv.hostPlatform.system}.mango.override {
-        scenefx = inputs.scenefx.packages.${pkgs.stdenv.hostPlatform.system}.default;
-      };
+    # nixpkgs' programs.mango module doesn't set these; the mango flake's module
+    # (which we no longer import) did, and mango needs both: XWayland for X11
+    # clients, and the wlr portal backend it routes ScreenCast/Screenshot to.
+    programs.xwayland.enable = true;
+    xdg.portal.wlr.enable = true;
   };
 }


### PR DESCRIPTION
## Summary

The nixpkgs bump to `624af6654` (2026-07-26) broke evaluation of every host in two independent ways, so `nhs` / `just update-commit-deploy` aborted with the misleading `could not eval target closure outPath. Is p620 listed in nixosConfigurations?` (the script `2>/dev/null`s the real error).

### 1. `programs.mango` declared twice

nixpkgs added `nixos/modules/programs/wayland/mango.nix`, colliding with `inputs.mango.nixosModules.mango`.

- **`flake.nix`** — drop `inputs.mango.nixosModules.mango`; remove the now-unneeded `scenefx` 0.5 input. The `mango` input stays for `hmModules.mango`.
- **`modules/desktop/mangowm.nix`** — drop the `programs.mango.package` override (nixpkgs builds mango 0.14.4 against scenefx 0.4.1 fine). Add `programs.xwayland.enable` + `xdg.portal.wlr.enable`, two `mkDefault`s nixpkgs' module omits that the flake's module supplied — without these, p620/razer silently lost XWayland and the wlr screencast backend.
- **`home/desktop/noctalia/default.nix`** — comment only; `package = osConfig.programs.mango.package` still follows the system module.

### 2. `services.overseerr` removed

Overseerr and Jellyseerr merged upstream into Seerr; nixpkgs dropped the module with a removal assertion rather than a rename, so p510 failed its assertion check.

- **`hosts/p510/nixos/plex.nix`** — `services.overseerr` → `services.seerr` (seerr 3.3.0), same port 5055, so the reverse-proxy host and tailscale serve path are unchanged. Also renames the `overseerr.service` references in `tailscale-serve`'s `after`/`wants`, since the unit name changed with the module.

## ⚠️ Required before deploying p510

The state directory changed. p510 is on `stateVersion = "25.11"`, so seerr keeps the `jellyseerr` state dir (`configDir = /var/lib/jellyseerr/config`) — verified by eval, not assumed. Run on p510 **before** the deploy:

```bash
sudo systemctl stop overseerr
sudo mkdir -p /var/lib/private/jellyseerr
sudo mv /var/lib/private/overseerr /var/lib/private/jellyseerr/config
```

Existing data is 5.5M (`db`, `settings.json`, `logs`). Skipping this starts Seerr with an empty database.

## Testing

- `nix build .#nixosConfigurations.p620...toplevel` — passed locally
- `nix eval .#nixosConfigurations.p510...toplevel.outPath` — passed (forces assertions)
- Mango options after the switch:

```
p620:  {"mango":"mango-0.14.4","wlr":true,"xw":true}
razer: {"mango":"mango-0.14.4","wlr":true,"xw":true}
p510:  {"mango":"mango-0.14.4","wlr":false,"xw":false}   # mangowm disabled, as expected
```

- CI: all 7 checks green (p620, razer, p510).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn