### PR TITLE
fix(overlay): pin libdisplay-info 0.3 for niri and lact

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1110,11 +1110,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1785140188,
-        "narHash": "sha256-O8XtA7rOj6cGcNcJxpAAAJFnWK8OSOZqrH91XCdxJVA=",
+        "lastModified": 1785142250,
+        "narHash": "sha256-F1+ervaoD/w2HJ3tRR2YRjc5wVFBV/osmUbUfORL14I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "287583e16a8c76e82b9023bff543bd516ce13d98",
+        "rev": "466a092c0e1aafe8d90c43aed89ddd37cbdafc88",
         "type": "github"
       },
       "original": {
@@ -1420,11 +1420,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1785138165,
-        "narHash": "sha256-JMQ1L59Z4M0KPKou9gS+rbYYhGEXIGtdPTX0kbbRx2o=",
+        "lastModified": 1785141676,
+        "narHash": "sha256-k8xC0fhbi5SWeXr9MBOLsd05LXRFHLgC63iZFXDGlao=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "15544328ef656ca54155e43fc73fb664e5b993c8",
+        "rev": "b69a6a5648ace6d9b5ba0a08baf743d6cce633a4",
         "type": "github"
       },
       "original": {

--- a/overlays/upstream-fixes.nix
+++ b/overlays/upstream-fixes.nix
@@ -1,4 +1,4 @@
-_final: prev: {
+final: prev: {
   # azure-cli 2.81.0 expects azure-mgmt-web v2024_11_01 which isn't packaged yet;
   # disable installCheck until nixpkgs catches up.
   azure-cli = prev.azure-cli.overrideAttrs (_old: {
@@ -64,6 +64,28 @@ _final: prev: {
       (patch: builtins.match ".*shell_remove_dark_mode.*" (toString patch) == null)
       (oldAttrs.patches or [ ]);
   });
+
+  # libdisplay-info 0.3.0 -> 0.4.0 (nixpkgs #545480) broke every Rust package
+  # vendoring libdisplay-info-sys 0.3.0, whose build.rs asks pkg-config for
+  # `libdisplay-info < 0.4.0`. niri and lact both fail to build on p620.
+  # Upstream fixed this by adding a versioned libdisplay-info_0_3 attribute and
+  # pinning both packages to it (#546004 for niri, #546155 for lact), but those
+  # landed on master after nixos-unstable's current rev, so reproduce it here.
+  # Drop this whole block once the channel advances past those merges — the
+  # check is `pkgs.libdisplay-info_0_3` existing upstream.
+  libdisplay-info_0_3 = prev.libdisplay-info.overrideAttrs (_oldAttrs: {
+    version = "0.3.0";
+    src = prev.fetchFromGitLab {
+      domain = "gitlab.freedesktop.org";
+      owner = "emersion";
+      repo = "libdisplay-info";
+      rev = "0.3.0";
+      hash = "sha256-nXf2KGovNKvcchlHlzKBkAOeySMJXgxMpbi5z9gLrdc=";
+    };
+  });
+
+  niri = prev.niri.override { libdisplay-info = final.libdisplay-info_0_3; };
+  lact = prev.lact.override { libdisplay-info = final.libdisplay-info_0_3; };
 
   # nixpkgs-unstable ships nix-prefetch-git as `nix-prefetch-git-VERSION`,
   # breaking fetchCargoVendor which calls the binary by its short name.


### PR DESCRIPTION
## Summary

nixpkgs [#545480](https://github.com/NixOS/nixpkgs/pull/545480) bumped `libdisplay-info` 0.3.0 → 0.4.0. Every Rust package vendoring `libdisplay-info-sys` 0.3.0 then fails to build, because its `build.rs` asks pkg-config for `libdisplay-info < 0.4.0`:

```
pkg-config --libs --cflags libdisplay-info 'libdisplay-info >= 0.1.0' 'libdisplay-info < 0.4.0'
Requested 'libdisplay-info < 0.4.0' but version of libdisplay-info is 0.4.0
```

The crate's `HINT: you may need to install libdisplay-info-dev` is misleading — the library *is* on `PKG_CONFIG_PATH`, it's just too new. This broke `niri` and `lact`, which took down the entire p620 closure (`system-path` → `nixos-system-p620`).

## Why an overlay rather than a bump

Upstream already fixed this, both times *after* our channel rev:

| PR | Fix | Merged |
|---|---|---|
| [#546004](https://github.com/NixOS/nixpkgs/pull/546004) | adds `libdisplay-info_0_3`, pins `niri` | 2026-07-26 20:26 |
| [#546155](https://github.com/NixOS/nixpkgs/pull/546155) | pins `lact` | 2026-07-27 03:39 |

We are already on `nixos-unstable` HEAD (`624af66`, 2026-07-26 18:26), so there is no newer rev to bump to. This overlay reproduces upstream's fix locally.

**This block is temporary.** Drop it once the channel advances past those merges — the check is whether `pkgs.libdisplay-info_0_3` exists upstream.

## Changes

- **`overlays/upstream-fixes.nix`** — add `libdisplay-info_0_3` (0.3.0 via `overrideAttrs`), and override `niri` / `lact` to use it. Both take `libdisplay-info` as a package argument, so no patching is needed. The overlay's first parameter is renamed `_final` → `final` since it is now referenced.
- **`flake.lock`** — the two inputs (`nixpkgs-master` + one other) bumped by the `nhs` run that hit this. Core `nixpkgs` is unchanged.

## Testing

```
/nix/store/fw5vnl9mlkfp9kdl9za7a3z0y21c552f-libdisplay-info-0.3.0
/nix/store/m6wfq6h1r2pac2bnbxarmy1z6ifj3l4l-lact-0.9.1
/nix/store/8drqxm2h3b0n1apyh79vmzc4aviw545w-niri-26.04
EXIT=0
```

Full `p620` closure build verified before merge.

> Note: an earlier PR in this session reported a local closure build as passing when it had not — `nix build` was piped through `tail` without `pipefail`, so `tail`'s exit status was read instead of nix's. Exit codes here are checked directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn