### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1110,11 +1110,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1785144088,
-        "narHash": "sha256-JcRO+kGPkh/OTGr0tlcl8yNDt6tot+QdAcmA75QpDQc=",
+        "lastModified": 1785145038,
+        "narHash": "sha256-fzlY5aLbl8ohN/6cWvcKMouOff/taWf0TCjaWjFFEDY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e6a6d331a6580ef497459932690eaafdccf28f40",
+        "rev": "30a757453fe3d44c5bf3b201eb2a27a6ff4cba9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=razer, scope=all).

Built and verified locally against nixosConfigurations.razer before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)