### PR TITLE
feat(p620): add DankCalendar (dcal) as the DMS calendar backend

### DIFF
--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -6,6 +6,7 @@
   imports = [
     ./profile.nix
     ../../home/desktop/noctalia # Noctalia shell for niri/labwc sessions
+    ../../home/desktop/dank-calendar # dcal daemon backing the DMS calendar card
   ];
 
   desktop.gnome.profile = "workstation";

--- a/flake.lock
+++ b/flake.lock
@@ -178,6 +178,44 @@
         "type": "github"
       }
     },
+    "dank-qml-common": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784074596,
+        "narHash": "sha256-/rCqHgC39mHvBDxb/dZLWCQ3W4ev94y3/1KtCRSPDp8=",
+        "owner": "AvengeMedia",
+        "repo": "dank-qml-common",
+        "rev": "b50afcf549f7e9c8f07c85b7f3fbba867701650d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "AvengeMedia",
+        "repo": "dank-qml-common",
+        "type": "github"
+      }
+    },
+    "dankcalendar": {
+      "inputs": {
+        "dank-qml-common": "dank-qml-common",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784903686,
+        "narHash": "sha256-mWUBNtlABsMlSoo3b7a5ht8MSOZiCMZt3/78fYpCwhw=",
+        "owner": "AvengeMedia",
+        "repo": "dankcalendar",
+        "rev": "3b221fa14807892c2ec23d4fe362ffa0ad034c53",
+        "type": "github"
+      },
+      "original": {
+        "owner": "AvengeMedia",
+        "ref": "v0.2.7",
+        "repo": "dankcalendar",
+        "type": "github"
+      }
+    },
     "darwin": {
       "inputs": {
         "nixpkgs": [
@@ -1505,6 +1543,7 @@
         "antigravity-nix": "antigravity-nix",
         "claude-skills-borghei": "claude-skills-borghei",
         "cosmic-applet-spotify": "cosmic-applet-spotify",
+        "dankcalendar": "dankcalendar",
         "flake-utils": "flake-utils_3",
         "gnome-quick-web-apps": "gnome-quick-web-apps",
         "gogmail": "gogmail",

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,24 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # DankCalendar (dcal) — calendar daemon by the DankMaterialShell authors.
+    # Connects Local/Google/Microsoft/CalDAV/iCloud accounts and serves them
+    # over a unix socket; DMS's CalendarDankBackend discovers
+    # $XDG_RUNTIME_DIR/dankcal-*.sock and prefers it over the khal backend,
+    # which is read-only. Provides homeModules.dank-calendar (used by
+    # home/desktop/dank-calendar) and packages.default, a buildGoModule whose
+    # Go version is parsed out of core/go.mod so it cannot drift. The
+    # dank-qml-common git submodule is upstream's own flake input, so nothing
+    # here needs fetchSubmodules.
+    #
+    # Pinned to a release tag: this is a fast-moving 0.x (v0.2.7, 2026-07-24).
+    # Requires DMS >= 1.5 for the dankcal backend to exist at all — do not drop
+    # the nixpkgs-master DMS graft above until unstable carries 1.5+.
+    dankcalendar = {
+      url = "github:AvengeMedia/dankcalendar/v0.2.7";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # niri — scrollable-tiling Wayland compositor. niri-flake provides the
     # NixOS module (programs.niri) + the home-manager config option
     # (programs.niri.settings). We pin the package to pkgs.niri (nixpkgs) and
@@ -348,6 +366,10 @@
                     # Noctalia shell (programs.noctalia). Enabled per-user only
                     # where the niri/labwc home profile turns it on.
                     inputs.noctalia.homeModules.default
+                    # DankCalendar daemon (programs.dank-calendar). Enabled
+                    # per-user via home/desktop/dank-calendar; the module is
+                    # inert until that profile turns it on.
+                    inputs.dankcalendar.homeModules.dank-calendar
                     # mango compositor config (wayland.windowManager.mango),
                     # enabled per-user in the same niri/labwc home profile.
                     inputs.mango.hmModules.mango

--- a/home/desktop/dank-calendar/default.nix
+++ b/home/desktop/dank-calendar/default.nix
@@ -1,0 +1,30 @@
+{ ... }:
+# DankCalendar (dcal) — the calendar daemon behind the DankMaterialShell
+# calendar card. It syncs Local/Google/Microsoft/CalDAV/iCloud accounts and
+# serves them over a unix socket; DMS's CalendarDankBackend discovers
+# $XDG_RUNTIME_DIR/dankcal-*.sock and prefers it over the khal backend, which
+# is read-only and needs a vdirsyncer pipeline to feed it.
+#
+# Unlike Noctalia (see ../noctalia), this DOES run from its systemd user
+# service on graphical-session.target, GNOME included. The rule that keeps
+# Noctalia out of systemd is about a *shell* spawning a second time over
+# gnome-shell; dcal is a headless sync daemon, so a GNOME session just keeps
+# the calendars warm and nothing collides.
+#
+# Accounts are attached imperatively, once per machine — OAuth refresh tokens
+# rotate, so they live in the login keyring (org.freedesktop.secrets) rather
+# than agenix:
+#
+#   dcal account add evolution        # reuse GNOME Online Accounts via EDS
+#   dcal account add google --credentials ~/.config/gogcli/credentials.json
+#
+# The second form works because gogcli's client is an "installed" (Desktop)
+# OAuth app: Google accepts any loopback port for those, so dcal's callback
+# needs no registered redirect URI, and that project already has the Calendar
+# and Tasks APIs enabled.
+{
+  programs.dank-calendar = {
+    enable = true;
+    systemd.enable = true;
+  };
+}


### PR DESCRIPTION
Wires DankCalendar (dcal) in as the DMS calendar backend on p620.

See the commit message for the full reasoning, and #1198 for the research.

## Testing

- p620 builds
- razer + p510 evaluate (the module lands in `sharedModules`, so it is seen by every HM user on every host and had to stay inert where unused)
- generated unit verified:

```
ExecStart: .../dankcalendar-0.2.0/bin/dcal run --session --hidden
After/PartOf: graphical-session.target
WantedBy: graphical-session.target
```

Deploy + account attach to follow in this PR.

Relates to #1198

🤖 Generated with [Claude Code](https://claude.com/claude-code)