### PR TITLE
chore(antigravity): bump cli 1.1.7->1.1.8, hub 2.3.1->2.4.2

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.1.7-5951805767680000";
+  version = "1.1.8-5636713813508096";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.7-5951805767680000/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-lGzQYljQ7ectAxFVDJFDFXmIIfajl/U6x2CRmCahmvQ=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.8-5636713813508096/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-6S5iFVMrPOhEVeNBlEBndTrZD20kzrzsgALOE35RYs4=";
   };
 
   # Tarball contains a single file `antigravity` at the root.

--- a/pkgs/antigravity-hub/default.nix
+++ b/pkgs/antigravity-hub/default.nix
@@ -98,11 +98,11 @@ let
 in
 stdenv.mkDerivation {
   pname = "antigravity-hub";
-  version = "2.3.1-5358163105546240";
+  version = "2.4.2-6711062033203200";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.3.1-5358163105546240/linux-x64/Antigravity.tar.gz";
-    hash = "sha256-ehmSFJ45bswS56QrFVY4lYcB2qplvtB83P5jm4Jnx0U=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.4.2-6711062033203200/linux-x64/Antigravity.tar.gz";
+    hash = "sha256-K+gVLqgPFuzpLpZxQL/rLZ4kAaPR6g3pmfZZrg3Sz7I=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Versions and hashes taken from the Hy4ri/antigravity-flake tracker, which
mirrors Google's auto-updater manifests. ide (2.1.1) and sdk (0.1.8) were
already current and are untouched.

Verified on p620: all four customPkgs build, full closure composes,
agy --version reports 1.1.8, the Python SDK imports, and the hub's
Electron binary resolves every shared library (0 "not found") despite
the minor-version jump.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn
