### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -62,7 +62,7 @@
     # gnome-quick-web-apps — GTK4 web-app manager (PWA install, scope
     # confinement, CEF rendering). Native GNOME alternative to
     # cosmic-utils/web-apps.
-    inputs.gnome-quick-web-apps.packages.${pkgs.system}.default
+    inputs.gnome-quick-web-apps.packages.${pkgs.stdenv.hostPlatform.system}.default
 
     # Libation — Audible library downloader/DRM-decrypter. Books location is set
     # to /mnt/media/Media/Audiobooks (P510 ABS library, NFS-mounted here) so

--- a/Users/olafkfreund/razer_home.nix
+++ b/Users/olafkfreund/razer_home.nix
@@ -26,7 +26,7 @@ in
   programs.gnome-shell = {
     enable = true;
     extensions = [
-      { package = inputs.gscratch.packages.${pkgs.system}.default; }
+      { package = inputs.gscratch.packages.${pkgs.stdenv.hostPlatform.system}.default; }
     ];
   };
 
@@ -34,7 +34,7 @@ in
   # confinement, CEF rendering). Native GNOME alternative to
   # cosmic-utils/web-apps.
   home.packages = [
-    inputs.gnome-quick-web-apps.packages.${pkgs.system}.default
+    inputs.gnome-quick-web-apps.packages.${pkgs.stdenv.hostPlatform.system}.default
   ];
 
   # Laptop: enable zellij (session management for mobile use)

--- a/flake.lock
+++ b/flake.lock
@@ -920,11 +920,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1785133905,
-        "narHash": "sha256-cXE11IuEJe+Oqk+gnNIxUSfHW+ekrc8Mx48pNv0RvuI=",
+        "lastModified": 1785360640,
+        "narHash": "sha256-fg8SdA1SbiY1QhEuHLd9mSc99PIesiHEwf31O7oO044=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "81b9856c2f1f5a425e5048219c0899cb48c52d3f",
+        "rev": "014fda2da9e9667b8da9c5d6258743415456fba4",
         "type": "github"
       },
       "original": {
@@ -1150,11 +1150,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1785355918,
-        "narHash": "sha256-Otp1oWzR4BdAIr6mx+sv7/LzaFYHdZGrFVbP0oN5Zmo=",
+        "lastModified": 1785363334,
+        "narHash": "sha256-UNxUUeAYqg/wszP2XcZtRIzhZlhMhmvQAtiP/Pwx8JA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2f17f342be39fe38645413e3f87cebd900db3cfa",
+        "rev": "8794901db9f3d93e4fe3bf1d612cc18df9182d27",
         "type": "github"
       },
       "original": {
@@ -1430,11 +1430,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785356383,
-        "narHash": "sha256-QRN2SkyhcQXkIgl3izTyDixct5v22ZGGHng2pC2F1tQ=",
+        "lastModified": 1785363297,
+        "narHash": "sha256-zUR685kCPiRRximuANtQIpXITc8utP5ATr2OvhiclzM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ddf5052368c177f2eb244a6646502f277672515",
+        "rev": "a1f0c7ccdccb8dcb7939ff64d2523c5fe755d54e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1027,11 +1027,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785090369,
-        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
+        "lastModified": 1785318670,
+        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "624af665418d3c65d544145b4d34ad696439570e",
+        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
         "type": "github"
       },
       "original": {
@@ -1045,7 +1045,9 @@
       "inputs": {
         "emacs": "emacs",
         "infuse": "infuse",
-        "nixpkgs": "nixpkgs_10",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "nixpkgs-fmt": "nixpkgs-fmt",
         "parts": "parts"
       },
@@ -1148,11 +1150,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1785311550,
-        "narHash": "sha256-Ga8YauX8AKxnO2h0z7cBoVQutLKieSTfAwBnzJAymY4=",
+        "lastModified": 1785355918,
+        "narHash": "sha256-Otp1oWzR4BdAIr6mx+sv7/LzaFYHdZGrFVbP0oN5Zmo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b7d25bf0012df3f2ae4f9d5593d04eb29effec10",
+        "rev": "2f17f342be39fe38645413e3f87cebd900db3cfa",
         "type": "github"
       },
       "original": {
@@ -1212,11 +1214,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1785090369,
-        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
+        "lastModified": 1785318670,
+        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "624af665418d3c65d544145b4d34ad696439570e",
+        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
         "type": "github"
       },
       "original": {
@@ -1227,38 +1229,6 @@
       }
     },
     "nixpkgs_10": {
-      "locked": {
-        "lastModified": 1785301185,
-        "narHash": "sha256-eoS3KQTO0aPWXZvIaRbRAzSSHW3l5wdMFXtT1ISfoKA=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "master",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_11": {
-      "locked": {
-        "lastModified": 1785090369,
-        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "624af665418d3c65d544145b4d34ad696439570e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_12": {
       "locked": {
         "lastModified": 1784796856,
         "narHash": "sha256-vwxWgF+Gj276WznzGb1LxGsK/39HaQwgQXiU3EkC844=",
@@ -1271,7 +1241,7 @@
         "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
-    "nixpkgs_13": {
+    "nixpkgs_11": {
       "locked": {
         "lastModified": 1781607440,
         "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
@@ -1381,11 +1351,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1785090369,
-        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
+        "lastModified": 1785318670,
+        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "624af665418d3c65d544145b4d34ad696439570e",
+        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
         "type": "github"
       },
       "original": {
@@ -1439,11 +1409,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785312679,
-        "narHash": "sha256-vI4tP77tNKD0WGbfIK/rSYcwVbuCsQEYG6QLcMskaFI=",
+        "lastModified": 1785316169,
+        "narHash": "sha256-7iBE9aITWeYBC5YdRcY9F9y29dtlNhwg7eLar+CYLgc=",
         "owner": "noctalia-dev",
         "repo": "noctalia-greeter",
-        "rev": "ec4dcc72a05d18a4fcacecc56e4496f1d467c790",
+        "rev": "d6275cbcb5b9acae2348bed16e358aa6c2cf8188",
         "type": "github"
       },
       "original": {
@@ -1455,14 +1425,16 @@
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_4",
-        "nixpkgs": "nixpkgs_11"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1785312492,
-        "narHash": "sha256-JVyk8b5nQpbP6qLA4TVolYcVHostKc9CAOw8GeAKeEQ=",
+        "lastModified": 1785356383,
+        "narHash": "sha256-QRN2SkyhcQXkIgl3izTyDixct5v22ZGGHng2pC2F1tQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "25d6d59754b7a077ea08178f66570f4a9b901753",
+        "rev": "0ddf5052368c177f2eb244a6646502f277672515",
         "type": "github"
       },
       "original": {
@@ -1757,7 +1729,7 @@
     },
     "spicetify-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_12",
+        "nixpkgs": "nixpkgs_10",
         "systems": "systems_8"
       },
       "locked": {
@@ -2094,7 +2066,7 @@
       "inputs": {
         "crane": "crane_2",
         "flake-utils": "flake-utils_9",
-        "nixpkgs": "nixpkgs_13",
+        "nixpkgs": "nixpkgs_11",
         "rust-overlay": "rust-overlay_5"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -174,8 +174,14 @@
     # Hardware specific (removed unused razer-laptop-control)
 
     # Package collections
-    nur.url = "github:nix-community/NUR";
-    nixpkgs-f2k.url = "github:moni-dz/nixpkgs-f2k";
+    nur = {
+      url = "github:nix-community/NUR";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nixpkgs-f2k = {
+      url = "github:moni-dz/nixpkgs-f2k";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     nix-index-database = {
       url = "github:nix-community/nix-index-database";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/home/development/workflow.nix
+++ b/home/development/workflow.nix
@@ -93,7 +93,7 @@ let
       (optional cfg.taskRunners.make gnumake)
       (optional cfg.taskRunners.ninja ninja)
       (optional cfg.taskRunners.bazel bazel)
-      (optional cfg.taskRunners.earthly earthly)
+      (optional cfg.taskRunners.earthly earthbuild)
     ];
 
   testingPackages = with pkgs;

--- a/modules/containers/docker.nix
+++ b/modules/containers/docker.nix
@@ -49,7 +49,7 @@ in
       docker-compose
       docker-gc
       lazydocker
-      earthly
+      earthbuild
     ];
 
     # Docker configuration

--- a/modules/desktop/stylix-theme.nix
+++ b/modules/desktop/stylix-theme.nix
@@ -67,6 +67,14 @@ in
         # matters here), so disable the target until upstream stylix updates.
         kmscon.enable = false;
 
+        # regreet: stylix's regreet target still writes `programs.regreet.*`,
+        # renamed in nixpkgs to `services.displayManager.regreet`, so every
+        # eval prints 8 rename warnings (one per option it sets). The target
+        # auto-enables on all Linux hosts, but this fleet greets with
+        # dms-greeter / cosmic-greeter and never uses regreet. Disable until
+        # upstream stylix migrates to the new option path.
+        regreet.enable = false;
+
         # COSMIC's GTK theme sync is disabled on this fleet, so cosmic-comp
         # does NOT clobber ~/.config/gtk-{3,4}.0/gtk.css at runtime. Stylix
         # can own that file safely and theme GTK3 / non-libadwaita GTK4 apps

--- a/modules/packages/sets.nix
+++ b/modules/packages/sets.nix
@@ -135,7 +135,7 @@
       docui
       docker-gc
       lazydocker
-      earthly
+      earthbuild
     ];
 
     vm = with pkgs; [

--- a/overlays/upstream-fixes.nix
+++ b/overlays/upstream-fixes.nix
@@ -1,4 +1,4 @@
-final: prev: {
+_final: prev: {
   # azure-cli 2.81.0 expects azure-mgmt-web v2024_11_01 which isn't packaged yet;
   # disable installCheck until nixpkgs catches up.
   azure-cli = prev.azure-cli.overrideAttrs (_old: {
@@ -64,28 +64,6 @@ final: prev: {
       (patch: builtins.match ".*shell_remove_dark_mode.*" (toString patch) == null)
       (oldAttrs.patches or [ ]);
   });
-
-  # libdisplay-info 0.3.0 -> 0.4.0 (nixpkgs #545480) broke every Rust package
-  # vendoring libdisplay-info-sys 0.3.0, whose build.rs asks pkg-config for
-  # `libdisplay-info < 0.4.0`. niri and lact both fail to build on p620.
-  # Upstream fixed this by adding a versioned libdisplay-info_0_3 attribute and
-  # pinning both packages to it (#546004 for niri, #546155 for lact), but those
-  # landed on master after nixos-unstable's current rev, so reproduce it here.
-  # Drop this whole block once the channel advances past those merges — the
-  # check is `pkgs.libdisplay-info_0_3` existing upstream.
-  libdisplay-info_0_3 = prev.libdisplay-info.overrideAttrs (_oldAttrs: {
-    version = "0.3.0";
-    src = prev.fetchFromGitLab {
-      domain = "gitlab.freedesktop.org";
-      owner = "emersion";
-      repo = "libdisplay-info";
-      rev = "0.3.0";
-      hash = "sha256-nXf2KGovNKvcchlHlzKBkAOeySMJXgxMpbi5z9gLrdc=";
-    };
-  });
-
-  niri = prev.niri.override { libdisplay-info = final.libdisplay-info_0_3; };
-  lact = prev.lact.override { libdisplay-info = final.libdisplay-info_0_3; };
 
   # nixpkgs-unstable ships nix-prefetch-git as `nix-prefetch-git-VERSION`,
   # breaking fetchCargoVendor which calls the binary by its short name.


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=p620, scope=all).

Built and verified locally against nixosConfigurations.p620 before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)