### PR TITLE
fix(scripts): abort if flake.lock changes between build and commit

### DIFF
--- a/scripts/update-commit-deploy.sh
+++ b/scripts/update-commit-deploy.sh
@@ -198,6 +198,13 @@ if ! git diff --quiet flake.lock; then
   LOCK_CHANGED=1
 fi
 
+# Fingerprint the lock we are about to evaluate, build and commit. Everything
+# downstream assumes this exact file. If it changes underneath us mid-run — a
+# concurrent `nix flake update`, an editor, a stray `git checkout -- flake.lock`
+# — we must abort rather than commit a lock we never built. Checked again just
+# before `git add` (step 10).
+LOCK_SHA_AT_UPDATE=$(sha256sum flake.lock | cut -d' ' -f1)
+
 # --- 5. Freshness check: is HOST already on the closure our lock would build?
 # Use `nix eval --raw` to get the expected outPath WITHOUT triggering a build —
 # cheap probe that tells us if the target is stale. We only do the expensive
@@ -291,6 +298,19 @@ ok "build succeeded"
 # closes this PR and discards the local lock change, so a broken upstream
 # never lands on main.
 if [ $LOCK_CHANGED -eq 1 ]; then
+  # Guard: the lock must still be the one we evaluated and built above. Checked
+  # before creating the branch so this failure needs no cleanup. Catches both a
+  # revert (nothing staged -> opaque "commit failed") and, more dangerously, a
+  # DIFFERENT lock written mid-run, which would otherwise be committed and
+  # deployed as though it had been verified.
+  lock_sha_now=$(sha256sum flake.lock | cut -d' ' -f1)
+  if [ "$lock_sha_now" != "$LOCK_SHA_AT_UPDATE" ]; then
+    err "flake.lock changed after the build (expected ${LOCK_SHA_AT_UPDATE:0:12}…, found ${lock_sha_now:0:12}…).
+Something wrote to it mid-run — a concurrent 'nix flake update', an editor, or a
+manual 'git checkout -- flake.lock'. Refusing to commit a lock that was never
+built. Nothing was committed or deployed; re-run from a clean tree."
+  fi
+
   # Build a commit message with the nixpkgs delta + scope
   msg_subject="chore(flake): bump ${SCOPE} — nixpkgs ${old_rev:0:8} → ${new_rev:0:8}"
   if [ "$old_rev" = "$new_rev" ]; then


### PR DESCRIPTION
## Summary

`update-commit-deploy.sh` only checked the working tree at pre-flight, so nothing stopped `flake.lock` being rewritten mid-run. When that happened, `git add flake.lock` staged nothing and the run died with an opaque `commit failed` — after an 18-minute build, and with no indication of why.

This fingerprints the lock where `LOCK_CHANGED` is computed and re-checks it before creating the branch.

## Why a checksum rather than a dirty-check

A plain "is `flake.lock` still dirty?" test only catches a revert. It would miss the more dangerous case: a **different** lock written mid-run, which would then be committed and deployed as though it had been verified. Same line count to compare a hash, so the guard covers both.

Placed before `git checkout -b`, so the failure path needs no branch cleanup.

## Testing

- `bash -n` clean; `shellcheck -S warning` silent
- Guard simulated against both paths: fires on a changed lock, passes on an untouched one
- `LOCK_SHA_AT_UPDATE` is assigned unconditionally at step 4, before the step-10 guard — no path reaches the check with it unset (relevant under `set -euo pipefail`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn