### PR TITLE
fix(desktop): replace themes removed with gtk-engine-murrine (#1211)

### DIFF
--- a/home/desktop/gnome/default.nix
+++ b/home/desktop/gnome/default.nix
@@ -80,7 +80,9 @@ in
       gnome-tweaks
       dconf-editor
       gnome-extension-manager
-      gruvbox-gtk-theme
+      # Was gruvbox-gtk-theme, removed from nixpkgs 2026-07 with
+      # gtk-engine-murrine (GTK2, unmaintained upstream).
+      gruvbox-dark-gtk
 
       # Additional utilities
       gnome-screenshot

--- a/home/desktop/gnome/theme.nix
+++ b/home/desktop/gnome/theme.nix
@@ -37,11 +37,10 @@ in
       # rebuild. mkForce wins over Stylix's dconf entries. (Icons + cursor are
       # driven through Stylix itself in modules/desktop/stylix-theme.nix.)
       "org/gnome/desktop/interface" = {
-        gtk-theme = lib.mkForce "Gruvbox-Dark";
+        gtk-theme = lib.mkForce "gruvbox-dark";
       };
-      "org/gnome/shell/extensions/user-theme" = {
-        name = lib.mkForce "Gruvbox-Dark";
-      };
+      # No shell user-theme override: gruvbox-dark-gtk ships no gnome-shell/
+      # subdir, so Stylix's "Stylix" shell theme (same base16 palette) wins.
 
       "org/gnome/desktop/wm/preferences" = {
         # Stylix doesn't theme the WM titlebar font; follow the Stylix sans

--- a/modules/desktop/stylix-theme.nix
+++ b/modules/desktop/stylix-theme.nix
@@ -44,18 +44,18 @@ in
         size = vars.baseTheme.cursor.size;
       };
 
-      # Gruvbox-Material icons — shipped in gruvbox-material-gtk-theme as
-      # share/icons/Gruvbox-Material-Dark. Driving the icon theme THROUGH
-      # Stylix (rather than fighting it) is what stops Stylix clobbering the
-      # icon choice on every rebuild. Only a Dark variant ships; polarity is
-      # dark so `light` reuses it harmlessly.
+      # Gruvbox icons. Driving the icon theme THROUGH Stylix (rather than
+      # fighting it) is what stops Stylix clobbering the icon choice on every
+      # rebuild.
       # Note: use the modern `stylix.icons` namespace; the old
       # `stylix.iconTheme` is deprecated and emits a warning.
+      # Was gruvbox-material-gtk-theme, removed from nixpkgs 2026-07 with
+      # gtk-engine-murrine (GTK2, unmaintained upstream).
       icons = {
         enable = true;
-        package = pkgs.gruvbox-material-gtk-theme;
-        dark = "Gruvbox-Material-Dark";
-        light = "Gruvbox-Material-Dark";
+        package = pkgs.gruvbox-plus-icons;
+        dark = "Gruvbox-Plus-Dark";
+        light = "Gruvbox-Plus-Light";
       };
 
       targets = {


### PR DESCRIPTION
nixpkgs dropped gtk-engine-murrine (GTK2, unmaintained upstream), taking
gruvbox-material-gtk-theme and gruvbox-gtk-theme with it. All three hosts
failed to evaluate.

- stylix.icons: gruvbox-material-gtk-theme -> gruvbox-plus-icons, which
  ships both Gruvbox-Plus-Dark and -Light (the old package was dark-only).
- GNOME: gruvbox-gtk-theme -> gruvbox-dark-gtk; its theme directory is
  named "gruvbox-dark", so the dconf gtk-theme value changes to match.
- Drop the shell user-theme mkForce: gruvbox-dark-gtk ships no gnome-shell
  subdir, so the name would dangle. Stylix's own shell theme uses the same
  base16 palette.

Verified: nix eval of system.build.toplevel succeeds for p620, razer, p510.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn
