### PR TITLE
fix(p620): point /mnt/media NFS at p510's LAN IP (#1224)

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -630,7 +630,10 @@ in
   # Read-mostly media share, so `soft` is acceptable here - data
   # corruption from a half-finished write is not in scope.
   fileSystems."/mnt/media" = {
-    device = "p510.lan:/mnt/media";
+    # LAN IP, not p510.lan: the router change dropped the .lan search domain,
+    # so the name no longer resolves and the automount hangs. Keep a DHCP
+    # reservation for 192.168.1.75 on the router to stop this drifting again.
+    device = "192.168.1.75:/mnt/media";
     fsType = "nfs";
     options = [
       "noauto"


### PR DESCRIPTION
The new router does not serve the .lan search domain, so p510.lan no
longer resolves and mnt-media.mount hangs in "activating (mounting)".

Use 192.168.1.75 directly rather than the Tailscale name: MagicDNS would
resolve reliably but route NFS over tailscale0, costing throughput on a
media share. Needs a DHCP reservation on the router to stay stable.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn
