### PR TITLE
fix(tmux-ccm): no-op hooks cleanly when tmux is not running (#1230)

### DIFF
--- a/pkgs/tmux-ccm/default.nix
+++ b/pkgs/tmux-ccm/default.nix
@@ -40,6 +40,21 @@ stdenvNoCC.mkDerivation rec {
   dontBuild = true;
   dontConfigure = true;
 
+  # Outside tmux every ccm code path is a no-op, but the hooks run under
+  # `set -euo pipefail` and ccm_write_signal does
+  #   win_info=$(tmux list-windows -a ... | awk ...)
+  # With no tmux server that pipeline fails, stderr is already swallowed by
+  # 2>/dev/null, and the assignment aborts the script — so Claude Code reports
+  # "Failed with non-blocking status code: No stderr output" on every single
+  # tool call. Guard the shared init instead of each call site: all seven hook
+  # scripts start with `ccm_hook_init || exit 0`, so returning 1 makes them
+  # exit cleanly. No effect when tmux is running.
+  postPatch = ''
+    substituteInPlace hooks/lib.sh \
+      --replace-fail 'ccm_hook_init() {' 'ccm_hook_init() {
+    tmux has-session 2>/dev/null || return 1'
+  '';
+
   installPhase = ''
     runHook preInstall
 


### PR DESCRIPTION
ccm_write_signal does `win_info=$(tmux list-windows -a ... | awk ...)`.
With no tmux server that pipeline fails, stderr is already swallowed by
2>/dev/null, and under `set -euo pipefail` the assignment aborts the hook.
Claude Code then reported "Failed with non-blocking status code: No stderr
output" on every single tool call, since the managed-settings hooks are
registered without a matcher on seven events.

Guard ccm_hook_init rather than each call site: all seven hook scripts
start with `ccm_hook_init || exit 0`, so returning 1 makes them exit
cleanly. No behaviour change when tmux is running.

Verified: on-pre-tool-use.sh exits 1 unpatched, 0 patched; same for
on-stop.sh, on-prompt-submit.sh, on-session-end.sh. All three hosts eval.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn
