### PR TITLE
fix(niri): pin programs.niri.package unconditionally (#1238)

### DIFF
--- a/modules/desktop/niri.nix
+++ b/modules/desktop/niri.nix
@@ -11,22 +11,31 @@ in
   options.desktop.niri.enable =
     mkEnableOption "niri scrollable-tiling Wayland compositor (selectable login session)";
 
-  config = mkIf cfg.enable {
-    # Use the nixpkgs niri package and skip niri-flake's binary cache, so we
-    # don't add an extra trusted substituter or need the cache-then-enable
-    # rebuild dance documented upstream.
-    niri-flake.cache.enable = false;
+  config = lib.mkMerge [
+    # Pin the package unconditionally, NOT inside `mkIf cfg.enable`. Hosts that
+    # never enable the session still evaluate programs.niri.package, because the
+    # home-manager profile generates xdg.configFile."niri-config" and validates
+    # it against the package. Left unpinned, those hosts fall back to
+    # niri-flake's default niri-stable, which is a year old and still references
+    # the removed `libdisplay-info_0_2` — so p510 failed to evaluate at all once
+    # nixpkgs dropped it, while p620/razer were fine only because they enable
+    # niri and so hit the pin below.
+    { programs.niri.package = pkgs.niri; }
 
-    programs.niri = {
-      enable = true;
-      package = pkgs.niri;
-    };
+    (mkIf cfg.enable {
+      # Use the nixpkgs niri package and skip niri-flake's binary cache, so we
+      # don't add an extra trusted substituter or need the cache-then-enable
+      # rebuild dance documented upstream.
+      niri-flake.cache.enable = false;
 
-    # programs.niri installs share/wayland-sessions/niri.desktop automatically,
-    # so greetd/GDM list "niri" at login. Minimal runtime deps for a usable
-    # bare session before the Noctalia shell phase.
-    environment.systemPackages = with pkgs; [
-      xwayland-satellite # rootless Xwayland for niri
-    ];
-  };
+      programs.niri.enable = true;
+
+      # programs.niri installs share/wayland-sessions/niri.desktop automatically,
+      # so greetd/GDM list "niri" at login. Minimal runtime deps for a usable
+      # bare session before the Noctalia shell phase.
+      environment.systemPackages = with pkgs; [
+        xwayland-satellite # rootless Xwayland for niri
+      ];
+    })
+  ];
 }


### PR DESCRIPTION
The pin lived inside `mkIf cfg.enable`, so hosts that never enable the
niri session never got it. p510 (desktop.niri.enable = false) therefore
fell back to niri-flake's default niri-stable — rev 01be0e65f from
2025-08-30, which still references `libdisplay-info_0_2`. Once nixpkgs
b7c2ada94f removed that package, p510 stopped evaluating entirely and
`nhs p510` aborted with the misleading "Is p510 listed in
nixosConfigurations?" from the freshness check.

The option is evaluated even when the session is off: p510 imports the
developer home-manager profile, which generates xdg.configFile
"niri-config" and validates it against the package. p620/razer were fine
only because they enable niri and so reached the pin.

Move it out of the mkIf via mkMerge. Verified: p510, p620 and razer all
evaluate, and p510/p620 both resolve to niri-26.04.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn
