### PR TITLE
fix(p510): do not restart docker on nixos-rebuild, so k3d survives the nightly upgrade

### DIFF
--- a/hosts/p510/nixos/resilience.nix
+++ b/hosts/p510/nixos/resilience.nix
@@ -50,4 +50,32 @@ _:
     ManagedOOMMemoryPressure = "kill";
     ManagedOOMMemoryPressureLimit = "80%";
   };
+  # ── 4. Keep k3d alive across a nixos-rebuild ────────────────────────────
+  # nixos-upgrade.timer rebuilds nightly (~04:00). When the docker unit changes
+  # — which it does whenever nvidia-container-toolkit-cdi-generator.service, a
+  # hard `Requires=`, is rebuilt — activation restarts docker.service and takes
+  # every k3d container with it.
+  #
+  # The server and serverlb come back on their `unless-stopped` policy. The
+  # agent does not, because its shutdown deadlocks: a pod holding an open file
+  # on the in-cluster NFS export cannot complete __fput -> nfs_file_release ->
+  # nfs4_do_close without an RPC to a server that docker has just stopped. The
+  # kubelet's mounts are `vers=4.1` with no `soft`, so the RPC retries forever,
+  # the container's PID namespace never drains, and docker reports the corpse
+  # as `Up` with zero processes inside — so `restart: unless-stopped` never
+  # fires and the node sits NotReady.
+  #
+  # That is not theoretical: 2026-08-06, agent killed 04:15, node NotReady for
+  # 7h. It stranded argocd-application-controller (every deploy landed nowhere
+  # while ArgoCD still reported Synced), nfs-provisioner (its local-path PV
+  # pins it to that node), and tfactory (FailedMount x218). The wedge was
+  # SIGKILL-proof kernel state, so recovery meant rebuilding the container by
+  # hand. See Factory#582 and factory-gitops#138.
+  #
+  # Not restarting docker on rebuild removes the trigger entirely. The cost is
+  # that daemon.settings changes need a manual `systemctl restart docker` (or a
+  # reboot) to take effect — the same trade already accepted for libvirtd in
+  # modules/virt/virt.nix. Cheap, because that config changes rarely and the
+  # cluster it carries is expensive to rebuild.
+  systemd.services.docker.restartIfChanged = false;
 }


### PR DESCRIPTION
## What broke

`nixos-upgrade.timer` rebuilds nightly around 04:00. When the docker unit changes -- which it does whenever `nvidia-container-toolkit-cdi-generator.service`, a hard `Requires=`, is rebuilt -- activation restarts `docker.service` and takes every k3d container with it.

`k3d-factory-server-0` and `k3d-factory-serverlb` come back on their `unless-stopped` policy. `k3d-agent-0-0` does not.

## Why the agent specifically

Its shutdown deadlocks in the kernel. Traced on the live host:

```
docker-init(12504)      zap_pid_ns_processes        waiting for
  python(1820825)       zap_pid_ns_processes        waiting for
    AnyIO worker(1821225)
      rpc_wait_bit_killable <- nfs4_do_close <- nfs_file_release <- __fput <- do_exit
```

A pod holding an open file on the in-cluster NFS export cannot finish `__fput` without an RPC to a server docker has just stopped. The kubelet's mounts are `vers=4.1` with no `soft`, so the RPC retries forever.

Two consequences that made this hard to see:

- The container's PID namespace never drains, so **docker reports the corpse as `Up` with zero processes inside** (`docker top` returns nothing). `restart: unless-stopped` never fires, because docker never observes an exit.
- `SIGKILL` is ineffective. It is delivered and the task enters `do_exit`, but the block is in the kernel's final `__fput`. `docker restart` fails with `tried to kill container, but did not receive an exit event`.

## Measured impact, 2026-08-06

Agent killed 04:15, node `NotReady` for 7 hours. Because `docker ps` looked healthy and `kubectl get application` reported `Synced`, nothing surfaced it:

- **`argocd-application-controller` stranded** -- every deploy landed nowhere while ArgoCD reported `Synced/Healthy` off a six-hour-stale `reconciledAt`. Two merged PRs sat in git and never reached the cluster.
- **`nfs-provisioner` unschedulable** -- its backing PVC is `local-path`, pinning it to that node. Circular: the NFS server could not return because the node was stuck, and the node was stuck because the NFS server was gone.
- **`tfactory` down** -- `Init:0/1`, `FailedMount` x218 over 7h13m.

Recovery required rebuilding the container by hand (rename the wedged one aside, recreate with the same hostname and bind mount so the three pinned PVs still resolve). Tracked as Factory#582 and factory-gitops#138.

## The fix

Do not restart docker on rebuild. That removes the trigger entirely rather than trying to survive it.

Placed as layer 4 in `hosts/p510/nixos/resilience.nix`, which is already organised as independent defence layers (hardware watchdog, sshd throttling, systemd-oomd).

**Cost:** `virtualisation.docker.daemon.settings` changes now need a manual `systemctl restart docker` or a reboot to take effect. That is the same trade already accepted for `libvirtd` in `modules/virt/virt.nix` and `greetd` on p620. Cheap here, because that config changes rarely and the cluster it carries is expensive to rebuild.

## Verification

Evaluated both directions, so the change is demonstrably load-bearing rather than assumed:

```
$ git checkout main && nix eval .#nixosConfigurations.p510.config.systemd.services.docker.restartIfChanged
true      <- docker DOES restart on rebuild (the bug)

$ git checkout fix/p510-k3d-survives-nixos-rebuild && nix eval ...
false     <- fixed
```

Config evaluates cleanly. `nixpkgs-fmt` applied. Pre-commit hooks pass.

Incidental: `.git/hooks/pre-commit` had a stale shebang pointing at a garbage-collected `bash-5.3p3` store path, so every commit in this repo was failing with `cannot exec`. Regenerated with `pre-commit install` rather than bypassed -- worth knowing it will recur after a GC.

## What this does not fix

The underlying fragility is that a `hard` NFS mount to a dying in-cluster server makes container shutdown unkillable. Docker restarting is only the most frequent trigger; a reboot or a manual `systemctl restart docker` reproduces it. Adding `soft` or a bounded `retrans`/`timeo` to the `nfs` StorageClass mount options would contain that, but it changes write semantics on timeout and belongs in a separate, deliberate change on the factory-gitops side.

Also unrelated and still open: #1232, the Docker 29 resolver regression that leaves k3d pods without external DNS. That is what took CoreDNS down when it rescheduled during the same outage.

Refs Factory#582, factory-gitops#138, #1232

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sKH56LqHmqYfeJ9JujEHz
