### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1150,11 +1150,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1786009417,
-        "narHash": "sha256-rAPqgCN8CqD87gqPkGAKXfTqmdIfNeLH9cdl4erS1oE=",
+        "lastModified": 1786011504,
+        "narHash": "sha256-kotbDdQFLnXW4PlQhlpCNzYi0N5y92JY+xW8WQqYv9s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4030ffb91d3a37b255bf16bcd6f39fc2d8ab77b7",
+        "rev": "13bbb58a4d920b48eb808937b89962738d7fdbe2",
         "type": "github"
       },
       "original": {
@@ -1430,11 +1430,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786009899,
-        "narHash": "sha256-xsgXWxpfQloHXcEg7fWJpbvK/FlyrNLA9xktR2ea2aA=",
+        "lastModified": 1786013385,
+        "narHash": "sha256-8V1smCuHqv5dj1zBaQbLn1/zu129ZCOTWHjogzVs4q0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f6d5f98137fe1c35f30db9821763438e32bccfa8",
+        "rev": "4c120933b930c494a03dccb979812bd41a7a52e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=p510, scope=all).

Built and verified locally against nixosConfigurations.p510 before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)