### PR TITLE
fix(nhs): surface nix eval errors in the freshness check (#1242)

### DIFF
--- a/scripts/update-commit-deploy.sh
+++ b/scripts/update-commit-deploy.sh
@@ -210,9 +210,22 @@ LOCK_SHA_AT_UPDATE=$(sha256sum flake.lock | cut -d' ' -f1)
 # cheap probe that tells us if the target is stale. We only do the expensive
 # full build if we actually need to deploy.
 log "freshness check: evaluating expected closure for ${HOST}"
+# Capture nix's stderr instead of discarding it. A failure here is almost never
+# a missing nixosConfigurations entry — it is a real eval error (a removed
+# nixpkgs attribute, a broken module) — and the old message sent people hunting
+# the wrong thing. Route it to a file rather than 2>&1 so that nix warnings can
+# never end up inside $expected, which is compared against /run/current-system.
+eval_err=$(mktemp)
 expected=$(nix eval --raw \
-  ".#nixosConfigurations.${HOST}.config.system.build.toplevel.outPath" 2>/dev/null) \
-  || err "could not eval target closure outPath. Is ${HOST} listed in nixosConfigurations?"
+  ".#nixosConfigurations.${HOST}.config.system.build.toplevel.outPath" 2>"$eval_err") \
+  || {
+    printf '\n--- nix eval error ---\n' >&2
+    cat "$eval_err" >&2
+    printf -- '----------------------\n' >&2
+    rm -f "$eval_err"
+    err "could not eval the ${HOST} closure (see the nix error above)"
+  }
+rm -f "$eval_err"
 
 case "$MODE" in
   local) current=$(readlink /run/current-system 2>/dev/null || echo "") ;;


### PR DESCRIPTION
The eval ran with 2>/dev/null and then guessed at the cause, printing
"Is HOST listed in nixosConfigurations?" — which was never actually the
problem. In one session it masked both the gtk-engine-murrine theme
removal (#1211) and the libdisplay-info_0_2 removal (#1238), each
costing a round of re-running the eval by hand to see the real error.

Capture stderr to a temp file and dump it on failure. Deliberately not
2>&1: `nix eval --raw` can emit warnings on stderr, and folding them
into $expected would corrupt the comparison against /run/current-system
that decides whether the host is stale.

Verified: missing host, bad attribute, and both healthy hosts — failures
now print the real nix error, and the success path still yields a bare
store path.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn
