### PR TITLE
fix(health-checks): make p510 accept a degraded system (#1245)

### DIFF
--- a/scripts/health-checks/p510.sh
+++ b/scripts/health-checks/p510.sh
@@ -8,7 +8,15 @@
 # Exit 0 = healthy, non-zero = scripts/update-commit-deploy.sh rolls back.
 set -uo pipefail
 
-state=$(systemctl is-system-running 2>/dev/null || echo unknown)
+# `systemctl is-system-running` PRINTS the state and simultaneously exits
+# non-zero for every state except "running" — degraded exits 1. The old
+# `$(... || echo unknown)` therefore appended "unknown" to a perfectly good
+# answer, yielding the two-line value "degraded\nunknown", which matches
+# neither arm of the case below. That made the "degraded" arm unreachable and
+# rolled back every deploy to a host with even one failed unit. Capture the
+# output and ignore the exit status; only an empty result is genuinely unknown.
+state=$(systemctl is-system-running 2>/dev/null) || true
+[ -n "$state" ] || state=unknown
 case "$state" in
   running | degraded) ;;
   *)


### PR DESCRIPTION
`systemctl is-system-running` prints the state AND exits non-zero for
every state except "running". The `$(... || echo unknown)` capture
therefore appended "unknown" to a correct answer, producing the two-line
value "degraded\nunknown" — matching neither arm of the case, so the
check always failed.

That made the "degraded" arm unreachable, including its own
"OK: system degraded but Plex + sshd ... active" message, which shows
accepting degraded was the intent. Consequence: any host with a single
failed unit had every deploy rolled back. p510 is degraded only because
of one stray failed transient podman healthcheck unit; sshd, plex and
podman-backstage are all active.

Capture the output and ignore the exit status; only an empty result is
genuinely unknown.

Verified on the same degraded host: exit 0, and it now prints
"OK: system degraded but Plex + sshd + (Backstage if enabled) active".
p620.sh and razer.sh don't call is-system-running, so this is p510-only.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn
