### PR TITLE
fix(razer): cap boot generations at 3 so the ESP cannot fill (#1248)

### DIFF
--- a/hosts/razer/nixos/boot.nix
+++ b/hosts/razer/nixos/boot.nix
@@ -2,7 +2,16 @@
   # Boot optimizations
   boot.loader.systemd-boot = {
     enable = true;
-    configurationLimit = 10; # Keep 10 generations so known-good kernels stay selectable in the boot menu
+    # Was 10 ("keep known-good kernels selectable"), but this ESP cannot hold
+    # them. razer boots via lanzaboote, which honours this option and writes a
+    # SIGNED kernel + initrd per kernel version into a 511 MiB /boot; each
+    # initrd is ~155 MiB. Ten generations spanning three kernel versions needs
+    # ~510 MiB, so on 2026-08-06 a third kernel (7.1.6) filled the partition
+    # and the deploy died mid-install with ENOSPC — taking the rollback with
+    # it, since that must write the bootloader too. Three bounds the worst
+    # case at ~507 MiB and is ~170 MiB when generations share a kernel.
+    # Raising this again requires a bigger ESP, not just a bigger number.
+    configurationLimit = 3;
     editor = false; # Disable bootloader editing for security
   };
   boot.loader.efi.canTouchEfiVariables = true;


### PR DESCRIPTION
razer boots via lanzaboote, which honours
boot.loader.systemd-boot.configurationLimit and writes a signed kernel +
initrd per kernel version into a 511 MiB ESP. Each initrd is ~155 MiB, so
the old limit of 10 needs ~510 MiB once three kernel versions are present.
On 2026-08-06 kernel 7.1.6 was the third and the deploy died mid-install
with ENOSPC — and so did the rollback, which must also write the
bootloader, leaving no clean recovery path.

Store GC does not help: the Nix profile had already been pruned to a
single generation while the ESP still held ten. They are separate
mechanisms.

Three bounds the worst case at ~507 MiB and is ~170 MiB when generations
share a kernel. Raising this again needs a bigger ESP, not a bigger
number — hence the comment.

p620/p510 also set 10 but do not use lanzaboote and have much smaller
initrds, so they are unaffected and left alone.

Recovery on the host (kept bootable throughout; the booted default,
generation 2728, was never touched) took /boot from 100% to 35%.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn
