### PR TITLE
fix(dns): claim stray resolved drop-in on p620, drop dead p510 nameserver (#1251)

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -69,8 +69,11 @@ in
     # Note: Tailscale is enabled via services.tailscale (built-in NixOS module)
     # Custom networking.tailscale module was removed during anti-pattern cleanup
 
-    # DNS configuration - using 192.168.1.1 (router DNS server)
-    nameservers = [ "192.168.1.1" "1.1.1.1" ];
+    # DNS: no static nameservers. NetworkManager + systemd-resolved (nixos/network.nix)
+    # already pick up the router's DHCP-advertised DNS (192.168.1.254, verified working),
+    # and resolved's built-in fallback list covers 1.1.1.1/8.8.8.8/9.9.9.9 if that ever
+    # fails. A hardcoded router IP is exactly what went stale and dead (192.168.1.1) when
+    # the router changed — DHCP tracks that automatically, a static entry does not.
   };
 
   # Tailscale VPN using built-in NixOS service with subnet routing

--- a/hosts/p620/nixos/dns-fallback.nix
+++ b/hosts/p620/nixos/dns-fallback.nix
@@ -25,4 +25,16 @@
     "ipv4.ignore-auto-dns" = true;
     "ipv4.dns" = "9.9.9.9;1.1.1.1;";
   };
+
+  # Root cause of the mitigation above not taking effect: a stray, non-Nix-managed
+  # file /etc/systemd/resolved.conf.d/performance.conf (dated Oct 2025, no module
+  # in this repo produces it) sets global `DNS=192.168.1.222 1.1.1.1` directly.
+  # systemd-resolved reads conf.d drop-ins *after* the main /etc/systemd/resolved.conf
+  # (which this file manages via services.resolved.settings and leaves DNS unset), so
+  # that leftover drop-in's DNS= wins and re-injects p620's own dead IP as the global
+  # primary resolver — independent of the NetworkManager settings above. Claiming the
+  # same path here makes activation replace it with an empty, Nix-managed drop-in.
+  environment.etc."systemd/resolved.conf.d/performance.conf".text = ''
+    [Resolve]
+  '';
 }


### PR DESCRIPTION
p620: /etc/systemd/resolved.conf.d/performance.conf is a plain,
non-Nix-managed file from Oct 2025 setting DNS=192.168.1.222 (p620's own
IP, nothing on :53). resolved reads conf.d AFTER resolved.conf and the
later DNS= wins, so it silently overrode the managed config — and
nixos-rebuild never removes stray files at unclaimed paths. The existing
NetworkManager ignore-auto-dns mitigation could not have worked: it
governs per-link DHCP DNS, a different mechanism. Claim the path via
environment.etc so activation replaces it with an empty drop-in.

This is what killed a deploy earlier with "Could not resolve hostname
github.com" during git push.

p510: nameservers pointed at 192.168.1.1, the old router, now dead. Drop
the static list entirely instead of swapping in 192.168.1.254 — DHCP
already supplies a self-correcting resolver and resolved has a fallback
list, whereas a hardcoded router IP just recreates the same trap. This
dead entry made plex-auto-languages fail its one-shot init on plex.tv,
leaving it permanently unhealthy and the host "degraded" — which with
#1245 rolled back two deploys.

Verified: p620, razer and p510 all evaluate; p510 now reports
system: running with 0 failed units.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn
