### PR TITLE
chore(claude-desktop): update to 1.24012.11 (#1222)

### DIFF
--- a/pkgs/claude-desktop-beta/default.nix
+++ b/pkgs/claude-desktop-beta/default.nix
@@ -64,7 +64,7 @@
 # then update `version` + `sha256` below (hex sha256 from the index is accepted
 # by fetchurl as-is).
 let
-  version = "1.24012.9";
+  version = "1.24012.11";
 
   # dlopen'd at runtime (not in DT_NEEDED) — appended to RUNPATH.
   runtimeLibs = [
@@ -81,7 +81,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_${version}_amd64.deb";
-    sha256 = "302e6d208dd8c8e9e52067daa28ef3b1171a1613586fd0e10bedc642225b6ee1";
+    sha256 = "99c4bcf5e3f7d0ec44a49fbf24d7d659f2ea46e29c7ec61c77c7298522f57e76";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Bumps the locally-packaged official .deb from 1.24012.9 to 1.24012.11,
picked from the apt index with `sort -V` (the index lists every historical
release unsorted, so reading it top-down downgrades the pin).

Verified:
  bin/          -> claude-desktop
  missing libs  -> 0
  toplevel      -> evaluates on p620, razer, p510

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn
