### PR TITLE
feat(editors): add Zed with Nix LSP, dev extensions and Claude agent (#1268)

### DIFF
--- a/Users/common/features-impl.nix
+++ b/Users/common/features-impl.nix
@@ -30,6 +30,7 @@ in
         neovim.enable = cfg.editors.neovim;
         vscode.enable = cfg.editors.vscode;
         windsurf.enable = cfg.editors.windsurf;
+        zed.enable = cfg.editors.zed;
       };
     })
 

--- a/Users/common/features.nix
+++ b/Users/common/features.nix
@@ -18,6 +18,7 @@ let inherit (lib) mkEnableOption; in {
       neovim = mkEnableOption "Enable Neovim editor";
       vscode = mkEnableOption "Enable VS Code editor";
       windsurf = mkEnableOption "Enable Windsurf editor";
+      zed = mkEnableOption "Enable Zed editor";
     };
 
     browsers = {

--- a/Users/olafkfreund/p510_home.nix
+++ b/Users/olafkfreund/p510_home.nix
@@ -49,6 +49,7 @@
       neovim = lib.mkForce true; # Primary editor for server development
       vscode = lib.mkForce false; # No GUI editors
       windsurf = lib.mkForce false; # No web-based editors
+      zed = lib.mkForce false; # No GUI editors
     };
 
     # No browsers on headless server

--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -80,6 +80,7 @@ in
       neovim = true;
       vscode = true;
       windsurf = true;
+      zed = true;
     };
 
     browsers = {

--- a/home/development/default.nix
+++ b/home/development/default.nix
@@ -7,6 +7,7 @@ _: {
     ./nvim.nix
     ./cursor-code.nix
     ./windsurf.nix
+    ./zed-editor.nix
 
     # Development utilities
     ./distrobox.nix

--- a/home/development/zed-editor.nix
+++ b/home/development/zed-editor.nix
@@ -1,0 +1,120 @@
+{ config
+, lib
+, pkgs
+, ...
+}:
+# Zed — GPU-accelerated editor, used here as the AI-assisted counterpart to
+# neovim. Configured for this repo's actual stack: Nix first, then the
+# container/k8s/justfile tooling the hosts are built with.
+#
+# LLM integration deliberately carries NO credentials. Zed's Agent Panel can
+# drive Claude through the Agent Client Protocol, and an ACP agent "owns its
+# own authentication" — it reuses the already-authenticated `claude` binary
+# (pkgs.claude-code-native, on p620 and razer). Nothing needs an API key in
+# settings.json, which matters because settings.json lands in the world-
+# readable Nix store. `secrets/api-anthropic.age` exists if you ever want
+# Zed's *built-in* Anthropic provider instead, but that key must be delivered
+# at runtime via the environment — never written into userSettings.
+let
+  inherit (lib) mkIf mkEnableOption;
+  cfg = config.editor.zed;
+in
+{
+  options.editor.zed = {
+    enable = mkEnableOption "Zed editor with Nix + LLM tooling";
+  };
+
+  config = mkIf cfg.enable {
+    programs.zed-editor = {
+      enable = true;
+      package = pkgs.zed-editor;
+
+      # Written to settings.json as `auto_install_extensions`; Zed pulls these
+      # on first launch. Every name verified against the zed-industries/
+      # extensions tree (1358 entries) — a typo here silently no-ops.
+      extensions = [
+        "nix" # the point of the exercise
+        "toml" # flake/cargo/config files
+        "dockerfile"
+        "docker-compose"
+        "helm" # k3d/factory manifests
+        "terraform"
+        "just" # this repo is driven by a justfile
+        "make"
+        "sql"
+        "env"
+        "log" # journal/service logs
+        "lua" # neovim config
+        "git-firefly" # inline blame
+      ];
+
+      # Zed resolves language servers and formatters from its own PATH, so
+      # they must be listed here even though lsp-servers.nix already puts them
+      # in the user profile.
+      extraPackages = with pkgs; [
+        nixd # Nix LSP (evaluates, so it understands this flake)
+        nil # fallback Nix LSP
+        alejandra # Nix formatter
+        bash-language-server
+        shfmt
+        taplo # TOML
+        yaml-language-server
+        marksman # Markdown
+      ];
+
+      userSettings = {
+        # Zed phones home by default.
+        telemetry = {
+          diagnostics = false;
+          metrics = false;
+        };
+
+        # No `theme` here: stylix's own zed target (modules/zed/hm.nix) sets
+        # `theme = "Base16 Gruvbox dark"`, generated from the base16 scheme in
+        # shared-variables.nix. Defining it here is a duplicate-definition
+        # error, and overriding it would fight stylix — the same mistake the
+        # niri and GNOME modules already document.
+
+        format_on_save = "on";
+        ensure_final_newline_on_save = true;
+        remove_trailing_whitespace_on_save = true;
+
+        terminal.shell.program = "${pkgs.zsh}/bin/zsh";
+
+        # nixd over nil: nixd evaluates the flake, so completion and go-to-def
+        # work across our own modules and options rather than just parsing.
+        lsp.nixd.settings = {
+          nixpkgs.expr = "import <nixpkgs> { }";
+          formatting.command = [ "alejandra" ];
+        };
+
+        languages.Nix = {
+          language_servers = [ "nixd" "!nil" ];
+          formatter.external = {
+            command = "${pkgs.alejandra}/bin/alejandra";
+            arguments = [ "--quiet" "--" ];
+          };
+          tab_size = 2;
+        };
+
+        # Agent Panel. No provider credentials here on purpose — add Claude
+        # via the Agent Panel's ACP registry and it will reuse the `claude`
+        # CLI's existing login.
+        agent = {
+          enabled = true;
+          button = true;
+          default_profile = "ask";
+        };
+
+        # Ships a bundled Node purely for extensions; we already have one.
+        node = {
+          path = lib.mkDefault "${pkgs.nodejs}/bin/node";
+          npm_path = lib.mkDefault "${pkgs.nodejs}/bin/npm";
+        };
+
+        vim_mode = false;
+        load_direnv = "shell_hook";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Zed as the AI-assisted counterpart to neovim, behind features.editors.zed
following the existing editor.<name>.enable pattern.

13 extensions, each verified against the full zed-industries/extensions
tree (1358 entries — a wrong name silently no-ops): nix, toml, dockerfile,
docker-compose, helm, terraform, just, make, sql, env, log, lua,
git-firefly.

Language servers go in extraPackages because Zed resolves them from its
own PATH, not the user profile, even though lsp-servers.nix already
installs them: nixd, nil, alejandra, bash-language-server, shfmt, taplo,
yaml-language-server, marksman. nixd is preferred over nil for Nix because
it evaluates, so completion and go-to-def work across our own modules and
options instead of only parsing.

No LLM credentials anywhere. Zed's Agent Panel reaches Claude over ACP and
an ACP agent owns its own auth, reusing the already-authenticated `claude`
binary present on both hosts. settings.json is materialised into the
world-readable store, so a key there would break the repo's
secrets-at-runtime-only rule; secrets/api-anthropic.age remains available
if Zed's built-in Anthropic provider is ever wanted, but only via the
environment. Verified: no api_key string in the generated settings.

No theme set here — stylix's own zed target already sets
"Base16 Gruvbox dark" from shared-variables.nix. Defining it locally is a
duplicate-definition error, and overriding it would fight stylix, the same
mistake niri and GNOME already document.

p620 + razer only; p510 is headless and gets an explicit mkForce false
next to the other "No GUI editors" entries — it already resolved false,
but implicitly, which could drift.

Verified: all three hosts evaluate; generated settings.json carries all 13
auto_install_extensions, the stylix theme, and nixd; activation merges via
jq '$dynamic * $static' so Zed's own edits survive rebuilds.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn
