### PR TITLE
chore(antigravity): bump hub to 2.6.0

### DIFF
--- a/pkgs/antigravity-hub/default.nix
+++ b/pkgs/antigravity-hub/default.nix
@@ -98,11 +98,11 @@ let
 in
 stdenv.mkDerivation {
   pname = "antigravity-hub";
-  version = "2.5.0-5471848641724416";
+  version = "2.6.0-4603467860410368";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.5.0-5471848641724416/linux-x64/Antigravity.tar.gz";
-    hash = "sha256-/4mTOa5KgBGndwrkcAK1VUJjWhwi1Wl5MmmkcLW1gNg=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.6.0-4603467860410368/linux-x64/Antigravity.tar.gz";
+    hash = "sha256-y5iv8A261OcYt/stlf71MbfdMPmFUx5shEtCqvZ99DE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
From the Hy4ri/antigravity-flake tracker:

  hub  2.5.0-5471848641724416 -> 2.6.0-4603467860410368
  cli  1.1.11-4956531888881664  unchanged (already current)
  ide  2.1.1-6123990880747520   unchanged (already current)
  sdk  0.1.10                   unchanged (already current)

Only version/url/hash changed, and only in the hub — the other three
were already at the tracker's latest.

Verified:
  agy --version              -> 1.1.11
  import google.antigravity  -> OK
  antigravity-hub            -> 2.6.0 binary present, 0 missing libs
  toplevel closure           -> builds on p620 and razer

The hub source fetched and unpacked cleanly, so the tracker hash matched
what the CDN served. p510 not built: it does not ship Antigravity.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn
