### PR TITLE
chore(warp-terminal): bump to v0.2026.08.05.09.03.stable_01

### DIFF
--- a/pkgs/warp-terminal/versions.json
+++ b/pkgs/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "linux_x86_64": {
-    "hash": "sha256-yjgUjX38PeCCz7GbboUpOILu1VvOadTZPyB9UgAKuzM=",
-    "version": "0.2026.07.29.09.05.stable_02"
+    "hash": "sha256-Rj9W2Fbnz3OfzgV4OOmI4ryyB1DOyLBtD6LyZ5FyGmY=",
+    "version": "0.2026.08.05.09.03.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-8a13daXZHrgPCQMz0psEl7TjCYvkwBV7ri0y9FgmqzQ=",
-    "version": "0.2026.07.29.09.05.stable_02"
+    "hash": "sha256-t6KmreIsDEk/cbt2l2R3cLa3FYOjQZMsxEqlenla4mw=",
+    "version": "0.2026.08.05.09.03.stable_01"
   }
 }


### PR DESCRIPTION
0.2026.07.29.09.05.stable_02 -> 0.2026.08.05.09.03.stable_01, both arches.

Verified:
  binary          -> ELF, 0 missing libs
  derivation vers -> 0.2026.08.05.09.03.stable_01 (matches versions.json)
  package build   -> ok
  toplevel closure-> composes on p620

Only version + hash changed in versions.json; no flake.lock drift.

Branched rather than committed to main as the command suggests: CLAUDE.md
says never commit to main, and two unpushed main commits already had to be
rescued this session.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrE282DmHNYwfjhvJDaZPn
