### PR TITLE
fix(k3d): survive docker restarts and never create over a live cluster (#1291)

### DIFF
--- a/modules/containers/docker.nix
+++ b/modules/containers/docker.nix
@@ -63,6 +63,15 @@ in
       # Explicitly disable Docker Swarm
       daemon.settings = {
         swarm-default-advertise-addr = "";
+        # Keep containers alive across a docker.service restart. Every
+        # `nixos-rebuild switch` that touches the docker unit restarts it,
+        # and without this that tears down every container. On 2026-08-11
+        # it killed the k3d server node while it held mounts from an NFS
+        # export served by a pod *inside that same cluster*: the unmount
+        # blocked forever, docker never got an exit event, and the node was
+        # left as a phantom container ("Up 4 days", no network endpoint,
+        # unkillable) that only a reboot could clear. Requires swarm off.
+        live-restore = true;
       }
       // lib.optionalAttrs (cfg.dataRoot != null) { data-root = cfg.dataRoot; };
     };

--- a/modules/containers/k3d.nix
+++ b/modules/containers/k3d.nix
@@ -122,8 +122,24 @@ let
           ;;
       esac
 
-      # 1. Create cluster if missing
-      if ! k3d cluster list -o json | jq -e --arg n "$CLUSTER" '.[] | select(.name==$n)' >/dev/null; then
+      # 1. Create cluster if missing.
+      #
+      # `k3d cluster list` FAILING is not the same as the cluster being
+      # ABSENT, and conflating the two is how 2026-08-11 happened: a node
+      # container had lost its docker network endpoint, so k3d died in
+      # ParseAddr("") on the empty IP, the `if !` read that as "no cluster",
+      # and the script drove `k3d cluster create` at a live cluster. It was
+      # saved only by the container-name conflict — had the name been free,
+      # every PVC would have been re-created against the current storageDir
+      # and the existing pvc-* directories orphaned (cf. 2026-06-25).
+      # Enumerate first, and refuse to guess when k3d cannot answer.
+      if ! cluster_json=$(k3d cluster list -o json 2>/dev/null); then
+        echo "[k3d-bootstrap] ERROR: k3d cannot enumerate clusters — refusing to create," \
+             "since existing cluster state may be live. Inspect with:" \
+             "docker ps -a --filter label=k3d.cluster=$CLUSTER" >&2
+        exit 1
+      fi
+      if ! jq -e --arg n "$CLUSTER" '.[] | select(.name==$n)' >/dev/null <<<"$cluster_json"; then
         echo "[k3d-bootstrap] Creating cluster $CLUSTER (api ${cfg.apiHostBind}:$API_PORT, storage $STORAGE_DIR)"
         k3d cluster create "$CLUSTER" \
           --image "${cfg.k3sImage}" \
@@ -530,6 +546,16 @@ in
         # Re-run on transient failure (e.g. docker daemon not ready yet)
         Restart = "on-failure";
         RestartSec = "10s";
+      };
+
+      # Give up after 5 tries rather than retrying forever. On 2026-08-11
+      # this unit logged 34 restarts against a cluster it could not fix,
+      # re-running `k3d cluster create` (and its rollback, which issues
+      # `Deleting cluster`) every 10s over live etcd. A permanent failure
+      # should stay failed and visible, not hammer.
+      unitConfig = {
+        StartLimitIntervalSec = 600;
+        StartLimitBurst = 5;
       };
 
       environment = {


### PR DESCRIPTION
Fixes #1291

See #1291 for the full incident chain. Verified: `nix build .#nixosConfigurations.p510.config.system.build.toplevel` succeeds (shellcheck passes on the rewritten bootstrap logic) and `live-restore: true` is present in p510's evaluated daemon.json.

Not addressed here (tracked in #1291): the failing /dev/sdb media disk, the self-referential in-cluster NFS provisioner, and the storageDir drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc