### PR TITLE
fix(p510): a failed GPU spec generator must not stop docker

### DIFF
--- a/hosts/p510/nixos/resilience.nix
+++ b/hosts/p510/nixos/resilience.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 # Resilience hardening for p510 (headless media / k3d-factory server).
 #
 # Added after a 2026-07-08 hard freeze: the Odin metrics pod hammered sshd in a
@@ -78,6 +78,53 @@
   # modules/virt/virt.nix. Cheap, because that config changes rarely and the
   # cluster it carries is expensive to rebuild.
   systemd.services.docker.restartIfChanged = false;
+
+  # ...and that was only half the trigger. On 2026-08-12 the k3d SERVER wedged
+  # the same way despite the line above, and the cluster sat dead ~6h. The
+  # nightly upgrade never restarted docker for its own definition — it stopped
+  # docker as a DEPENDENCY:
+  #
+  #   $ systemctl show docker.service -p Requires
+  #   Requires=... nvidia-container-toolkit-cdi-generator.service ...
+  #   $ systemctl show nvidia-container-toolkit-cdi-generator.service -p ActiveState
+  #   ActiveState=failed
+  #
+  # nixpkgs' nvidia-container-toolkit module sets
+  # `requiredBy = mkIf virtualisation.docker.enable [ "docker.service" ]`
+  # (services/hardware/nvidia-container-toolkit/default.nix). A `Requires=` on a
+  # unit that FAILS stops docker, and `restartIfChanged` has no bearing on that
+  # — it governs restart-on-changed-definition only. The knob was applied, and
+  # inert, which is why it looked fixed for six days.
+  #
+  # The generator fails after every driver update until the box reboots:
+  #   "failed to initialize NVML: Driver/library version mismatch"
+  # — new nvidia-x11 in the store, old kernel module still loaded. So the
+  # trigger is not rare, it is EVERY nvidia bump, on a nightly timer.
+  #
+  # A GPU spec generator must not be able to take the cluster down. `wantedBy`
+  # still runs it with docker and `before` orders it properly (upstream has
+  # requiredBy with NO ordering, so docker could already start before the spec
+  # existed — fatal, and not even reliably first). Failing now degrades GPU
+  # containers instead of stopping the container runtime.
+  #
+  # This removes the TRIGGER. The reason a stopped docker is catastrophic here
+  # is the NFS __fput deadlock described above, which is unchanged: any docker
+  # stop can still strand a container holding a file on the in-cluster export.
+  # See Factory#687.
+  # podman is enabled here too and upstream gives it the same fatal `requiredBy`,
+  # so both are re-wired. Dropping podman's without replacing it would quietly
+  # cost it the CDI spec it does want, just not at the price of the runtime.
+  systemd.services.nvidia-container-toolkit-cdi-generator = {
+    requiredBy = lib.mkForce [ ];
+    wantedBy = [
+      "docker.service"
+      "podman.service"
+    ];
+    before = [
+      "docker.service"
+      "podman.service"
+    ];
+  };
 
   # ── 5. Disk health monitoring ───────────────────────────────────────────
   # p510 had NO way to see disk health: smartctl was not installed, so the


### PR DESCRIPTION
The k3d cluster on p510 went down at 03:41Z on 2026-08-12 and stayed down about six hours. Full incident write-up in Factory#687; this is the trigger half of the fix.

## `restartIfChanged = false` was applied, and inert

`f3d731d` added it so k3d would survive the nightly upgrade. It did not, because the upgrade never restarted docker for **its own definition** — it stopped docker as a **dependency**:

```
$ systemctl show docker.service -p Requires
Requires=... nvidia-container-toolkit-cdi-generator.service ...

$ systemctl show nvidia-container-toolkit-cdi-generator.service -p ActiveState
ActiveState=failed
```

The dependency does not come from our config. `nixos/modules/services/hardware/nvidia-container-toolkit/default.nix:323`:

```nix
requiredBy = lib.mkMerge [
  (lib.mkIf config.virtualisation.docker.enable [ "docker.service" ])
  (lib.mkIf config.virtualisation.podman.enable [ "podman.service" ])
];
```

It materialises as a symlink in `/etc/systemd/system/docker.service.requires/`, which is why `systemctl cat docker.service` shows only `Requires=docker.socket` and the real constraint is invisible unless you use `systemctl show`.

`restartIfChanged` governs restart-on-changed-definition. It has nothing to say about a hard `Requires=` on a unit that fails. The option looked like the fix, and did nothing for six days.

## The trigger recurs nightly

```
failed to initialize NVML: Driver/library version mismatch
```

New `nvidia-x11` in the store, old kernel module still loaded — the generator fails after **every** driver bump until the host reboots. Combined with `nixos-upgrade.timer` at 04:00, this is a nightly opportunity to stop docker.

## The change

```nix
systemd.services.nvidia-container-toolkit-cdi-generator = {
  requiredBy = lib.mkForce [ ];
  wantedBy = [ "docker.service" "podman.service" ];
  before = [ "docker.service" "podman.service" ];
};
```

A GPU spec generator should not be able to take the container runtime down. `wantedBy` still runs it with both runtimes; failing now degrades GPU containers instead of stopping docker.

`before` is an improvement on upstream, not just a replacement: `requiredBy` carries **no ordering**, so docker could already start before the CDI spec existed — fatal, and not even reliably first.

podman is enabled on this host and gets the same treatment. Dropping its `requiredBy` without replacing it would quietly cost it the spec it does want.

## Verified by evaluating the config, not by reading it

```
before  requiredBy=["docker.service","podman.service"]  wantedBy=["multi-user.target"]                      before=[]
after   requiredBy=[]                                   wantedBy=[…,"docker.service","podman.service"]      before=["docker.service","podman.service"]
```

`docker.requires` is `["docker.socket"]` in both — confirming the constraint only ever arrived via `requiredBy`. `nixpkgs-fmt --check`: clean.

## Scope

This removes the **trigger** only. A stopped docker is catastrophic on this host because of the NFS `__fput` deadlock documented directly above this block, which is unchanged — any docker stop can still strand a container holding a file on the in-cluster export. That is tracked in Factory#687.

Takes effect on the next rebuild; the cluster itself needs a reboot to clear the current kernel-level wedge (and the reboot also clears the driver mismatch).