### PR TITLE
fix(boot): bound ESP usage by peak, not steady state, and guard deploys

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -284,6 +284,21 @@ test-host HOST:
     @echo "🧪 Testing {{HOST}} configuration..."
     nix build .#nixosConfigurations.{{HOST}}.config.system.build.toplevel --show-trace
 
+# Check a host's EFI System Partition has room for another generation.
+# The bootloader writes the new kernel+initrd BEFORE pruning the old ones, so
+# "not full" is not the same as "can deploy". Read-only by default.
+boot-space HOST="$(hostname)":
+    ./scripts/check-boot-space.sh {{HOST}}
+
+# Same check, but reclaim space when it is short (prunes old generations and
+# lets the bootloader installer garbage-collect the ESP entries).
+boot-space-clean HOST="$(hostname)":
+    ./scripts/check-boot-space.sh {{HOST}} --clean
+
+# ESP headroom across every host, at a glance.
+boot-space-all:
+    @for h in p620 razer p510; do ./scripts/check-boot-space.sh "$h" || true; done
+
 # Validate flake syntax and inputs
 check:
     @echo "🔍 Validating flake configuration..."

--- a/hosts/p510/nixos/boot.nix
+++ b/hosts/p510/nixos/boot.nix
@@ -1,7 +1,16 @@
 { pkgs, lib, ... }: {
   # Bootloader.
   boot.loader.systemd-boot.enable = true;
-  boot.loader.systemd-boot.configurationLimit = 10; # Limit boot entries to prevent /boot from filling up
+  # Bound by the ESP, not by taste. The installer writes the new kernel+initrd
+  # BEFORE pruning old ones, so the partition must hold limit + 1 generations:
+  #
+  #   487 MiB ESP, ~50 MiB per initrd, ~26 MiB kernels
+  #   peak = (limit + 1) x 50 + 26;  limit = 6 -> ~376 MiB, fits
+  #   limit = 10 would peak at ~576 MiB and fail mid-install
+  #
+  # razer hit exactly that failure twice (see hosts/razer/nixos/boot.nix).
+  # Raising this needs a bigger ESP, not a bigger number.
+  boot.loader.systemd-boot.configurationLimit = 6;
   boot.loader.efi.canTouchEfiVariables = true;
   boot.kernelPackages = pkgs.linuxPackages_6_18; # Use kernel 6.18 for NVIDIA driver compatibility
   boot.plymouth.enable = true;

--- a/hosts/p620/nixos/boot.nix
+++ b/hosts/p620/nixos/boot.nix
@@ -1,7 +1,16 @@
 { pkgs, ... }: {
   # Bootloader.
   boot.loader.systemd-boot.enable = true;
-  boot.loader.systemd-boot.configurationLimit = 10; # Limit boot entries to prevent /boot from filling up
+  # Bound by the ESP, not by taste. The installer writes the new kernel+initrd
+  # BEFORE pruning old ones, so the partition must hold limit + 1 generations:
+  #
+  #   511 MiB ESP, ~69 MiB per initrd, ~28 MiB kernels
+  #   peak = (limit + 1) x 69 + 28;  limit = 5 -> ~442 MiB, fits
+  #   limit = 10 would peak at ~787 MiB and fail mid-install
+  #
+  # razer hit exactly that failure twice (see hosts/razer/nixos/boot.nix).
+  # Raising this needs a bigger ESP, not a bigger number.
+  boot.loader.systemd-boot.configurationLimit = 5;
   boot.loader.efi.canTouchEfiVariables = true;
   boot.kernelPackages = pkgs.linuxPackages_latest; # Use the beta kernel for better hardware support
   boot.plymouth.enable = true;

--- a/hosts/razer/nixos/boot.nix
+++ b/hosts/razer/nixos/boot.nix
@@ -2,16 +2,25 @@
   # Boot optimizations
   boot.loader.systemd-boot = {
     enable = true;
-    # Was 10 ("keep known-good kernels selectable"), but this ESP cannot hold
-    # them. razer boots via lanzaboote, which honours this option and writes a
-    # SIGNED kernel + initrd per kernel version into a 511 MiB /boot; each
-    # initrd is ~155 MiB. Ten generations spanning three kernel versions needs
-    # ~510 MiB, so on 2026-08-06 a third kernel (7.1.6) filled the partition
-    # and the deploy died mid-install with ENOSPC — taking the rollback with
-    # it, since that must write the bootloader too. Three bounds the worst
-    # case at ~507 MiB and is ~170 MiB when generations share a kernel.
-    # Raising this again requires a bigger ESP, not just a bigger number.
-    configurationLimit = 3;
+    # razer boots via lanzaboote, which writes a SIGNED kernel + initrd into a
+    # 511 MiB /boot. Each initrd is ~150 MiB (NVIDIA firmware), and in practice
+    # every nixpkgs bump produces a distinct one even on the same kernel
+    # version — so budget one initrd PER GENERATION, not per kernel.
+    #
+    # The number that matters is limit + 1, not limit: the installer copies the
+    # new kernel+initrd in BEFORE garbage-collecting old ones. This was set to
+    # 3 after the same ENOSPC failure on 2026-08-06, with the note that 3
+    # "bounds the worst case at ~507 MiB" — but that is the steady state, and
+    # the peak is 4 x 150 = 600 MiB. It duly failed again on 2026-08-12,
+    # mid-install, leaving razer running a generation /boot could not boot.
+    #
+    #   peak = (limit + 1) x 150 MiB initrd + ~28 MiB kernels + ~2 MiB stubs
+    #   limit = 2  ->  3 x 150 + 30 = ~480 MiB, fits 511 MiB with ~30 MiB spare
+    #
+    # Two keeps the current generation plus one fallback. Raising it needs a
+    # BIGGER ESP or a smaller initrd, not a bigger number — that lesson has now
+    # cost two failed deploys.
+    configurationLimit = 2;
     editor = false; # Disable bootloader editing for security
   };
   boot.loader.efi.canTouchEfiVariables = true;

--- a/scripts/check-boot-space.sh
+++ b/scripts/check-boot-space.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Pre-deploy guard for the EFI System Partition.
+#
+# Why this exists: on 2026-08-12 a razer deploy died half-way with
+# "No space left on device" while Lanzaboote copied the initrd into /boot.
+# The system had already been activated, so razer was RUNNING one generation
+# while /boot could only boot an older one — a reboot away from a surprise.
+#
+# The trap is that the bootloader installs the NEW kernel+initrd *before* it
+# garbage-collects the old ones, so the ESP must briefly hold
+# configurationLimit + 1 generations. razer's initrds are ~150M (NVIDIA
+# firmware) on a 511M ESP, so limit=3 needed 600M at peak and never fit.
+#
+# Usage:
+#   check-boot-space.sh <host>            # host = local hostname or ssh target
+#   check-boot-space.sh <host> --clean    # also reclaim space when low
+#
+# Exit 0 = enough room to deploy. Exit 1 = still short, deploy should abort.
+set -euo pipefail
+
+HOST="${1:?usage: check-boot-space.sh <host> [--clean]}"
+CLEAN="${2:-}"
+
+# Reserve room for one full generation plus slack. The bootloader needs to
+# write a new kernel + initrd before pruning anything, and an ESP that is
+# merely "not full" is not enough.
+MIN_FREE_MIB=200
+
+if [ "$HOST" = "$(hostname)" ] || [ "$HOST" = "local" ] || [ "$HOST" = "localhost" ]; then
+  run() { bash -c "$1"; }
+  LABEL="$(hostname) (local)"
+else
+  run() { ssh -o ConnectTimeout=10 -o BatchMode=yes "$HOST" "$1"; }
+  LABEL="$HOST"
+fi
+
+# shellcheck disable=SC2016  # single quotes are deliberate: `run` evaluates
+# these remotely, so $4/$5 must reach the far side unexpanded.
+free_mib() { run 'df -PBM /boot | awk "NR==2{gsub(/M/,\"\",\$4); print \$4}"'; }
+# shellcheck disable=SC2016
+used_pct() { run 'df -P /boot | awk "NR==2{gsub(/%/,\"\",\$5); print \$5}"'; }
+
+FREE="$(free_mib)"
+echo "🔎 ${LABEL}: /boot has ${FREE}MiB free ($(used_pct)% used), need ≥${MIN_FREE_MIB}MiB"
+
+if [ "$FREE" -ge "$MIN_FREE_MIB" ]; then
+  echo "✅ ${LABEL}: enough room on the ESP"
+  exit 0
+fi
+
+if [ "$CLEAN" != "--clean" ]; then
+  echo "❌ ${LABEL}: only ${FREE}MiB free — re-run with --clean, or the deploy will"
+  echo "   fail half-way and leave the host running a generation it cannot boot."
+  exit 1
+fi
+
+echo "🧹 ${LABEL}: reclaiming space…"
+
+# 1. Partial copies left by a previous ENOSPC. Always orphans, never booted.
+run 'sudo find /boot -name "*.tmp" -type f -print -delete 2>/dev/null || true'
+
+# 2. Drop old system generations, then let the bootloader installer prune the
+#    ESP entries that no longer belong to a generation. Deleting files out of
+#    /boot by hand is how people brick a laptop: the installer knows which
+#    kernel/initrd the remaining generations still reference, so let it decide.
+#    +2 keeps the current generation and one fallback.
+run 'sudo nix-env -p /nix/var/nix/profiles/system --delete-generations +2 2>/dev/null || true'
+run 'sudo /run/current-system/bin/switch-to-configuration boot 2>&1 | tail -3'
+
+FREE="$(free_mib)"
+if [ "$FREE" -ge "$MIN_FREE_MIB" ]; then
+  echo "✅ ${LABEL}: ${FREE}MiB free after cleanup"
+  exit 0
+fi
+
+echo "❌ ${LABEL}: still only ${FREE}MiB free after cleanup."
+echo "   The ESP is too small for this host's initrd size, not just untidy."
+echo "   Lower boot.loader.systemd-boot.configurationLimit for ${LABEL}, or"
+echo "   grow the partition. Current ESP contents:"
+run 'sudo ls -1sh /boot/EFI/nixos/ 2>/dev/null | head -20 || true'
+exit 1

--- a/scripts/update-commit-deploy.sh
+++ b/scripts/update-commit-deploy.sh
@@ -546,6 +546,19 @@ rollback_and_close_pr() {
   err "deploy aborted; ${HOST} rolled back. Re-run after upstream regression clears."
 }
 
+# --- 10b2. ESP space guard --------------------------------------------------
+# The bootloader writes the new kernel+initrd BEFORE pruning old generations,
+# so the ESP must briefly hold configurationLimit + 1 of them. When it doesn't
+# fit, activation has already happened by the time the copy fails: the host
+# ends up RUNNING a generation that /boot cannot boot. That happened to razer
+# on 2026-08-12. Check (and reclaim) before switching, not after.
+log "checking ESP space on ${HOST} before switch"
+if ! "${REPO_ROOT:-.}/scripts/check-boot-space.sh" "$HOST" --clean; then
+  err "ESP on ${HOST} is too small to deploy safely — aborting BEFORE activation.
+   Nothing was changed on the host. Lower boot.loader.systemd-boot.configurationLimit
+   for ${HOST} (it must fit limit+1 generations) or grow the partition."
+fi
+
 # --- 10c. Switch -----------------------------------------------------------
 case "$MODE" in
   local)


### PR DESCRIPTION
razer's deploy died mid-install with `No space left on device` writing the
initrd into `/boot`. Not an upstream regression — the ESP was 100% full.

## The mechanism that was missed twice

The bootloader writes the new kernel+initrd **before** garbage-collecting the
old ones, so the ESP must briefly hold `configurationLimit + 1` generations.

This exact failure happened on **2026-08-06**. The fix then set
`configurationLimit = 3`, with the note that it "bounds the worst case at ~507
MiB" on a 511 MiB partition. But that is the **steady state** — the peak is
`4 x 150 = 600 MiB`. It was always going to recur, and on **2026-08-12** it did.

There is a nastier consequence than a failed deploy: activation succeeds
before the bootloader step, so razer ended up **running generation 2755 while
`/boot` could only boot 2754** — one reboot from silently reverting.

## Limits recomputed from measured sizes

| host | ESP | initrd | was | now | new peak |
|---|---|---|---|---|---|
| razer | 511 MiB | 150 MiB | 3 | **2** | ~480 MiB |
| p620 | 511 MiB | 69 MiB | 10 | **5** | ~442 MiB |
| p510 | 487 MiB | 50 MiB | 10 | **6** | ~376 MiB |

p620 and p510 were on the same trajectory (`limit = 10` peaks at ~787 and ~576
MiB). p510 measured **exactly 200 MiB free** — right on the threshold.

The peak arithmetic is written into each `boot.nix` so the steady-state
mistake isn't repeated a third time.

## The guard

`scripts/check-boot-space.sh`, wired into `update-commit-deploy.sh` **before
the switch**, so a short ESP aborts while the host is still untouched instead
of half-deployed.

Cleanup deletes ENOSPC leftovers (`*.tmp` — always orphans), prunes old
generations, then runs `switch-to-configuration boot` and lets the bootloader
installer decide which ESP files are safe to drop. It deliberately does **not**
`rm` files out of `/boot` by hand — only the installer knows which
kernel/initrd the remaining generations still reference.

Standalone: `just boot-space HOST`, `boot-space-clean HOST`, `boot-space-all`.

## Verification

razer recovered by hand first (stale `.tmp` removed, two oldest entries dropped
while keeping a known-good fallback, then the bootloader installed for 2755).
Now running = bootable = 2755, 0 failed units, 347 MiB free.

p620 builds clean; shellcheck clean; the guard was exercised against all three
hosts (local and ssh paths).

**p510 is config-only** — not deployed, per the never-deploy-without-asking
rule. Its new limit takes effect on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc