### PR TITLE
fix(razer): give the Intel iGPU a VA-API driver, add smartd + cache prune

### DIFF
--- a/hosts/razer/nixos/laptop.nix
+++ b/hosts/razer/nixos/laptop.nix
@@ -49,8 +49,8 @@
     };
   };
 
-  # Backlight control
-  environment.systemPackages = [ pkgs.brightnessctl ];
+  # Backlight control + SMART tooling (see services.smartd below)
+  environment.systemPackages = [ pkgs.brightnessctl pkgs.smartmontools ];
 
   # Fan control and thermal management for Razer
   boot.extraModprobeConfig = ''
@@ -72,4 +72,16 @@
 
   # Add Razer utilities
   # Razer hardware packages moved to main configuration.nix for consolidation
+
+  # SMART monitoring for the NVMe. p620 gets this from
+  # storage.performanceOptimization and p510 from its resilience module, but
+  # that whole storage module is p620-scoped (sysctls, tmpfs sizing), so wire
+  # up just the disk-health bit here rather than dragging the rest onto a
+  # laptop. A dying laptop SSD should not be a surprise.
+  # (smartmontools is added to the systemPackages list above — this file
+  # already defines that attribute, so it cannot be assigned twice.)
+  services.smartd = {
+    enable = true;
+    autodetect = true;
+  };
 }

--- a/hosts/razer/nixos/nvidia.nix
+++ b/hosts/razer/nixos/nvidia.nix
@@ -37,6 +37,17 @@
         libva-vdpau-driver
         nvidia-vaapi-driver
 
+        # Intel iGPU video decode (Optimus: the Intel chip drives the panel and
+        # should do video, leaving the dGPU idle). Without this there is NO
+        # Intel VA-API driver in the closure at all — /run/opengl-driver/lib/dri
+        # had neither iHD nor i965 — so browsers and players fell back to
+        # software decode and burned battery.
+        #
+        # Deliberately NOT paired with LIBVA_DRIVER_NAME=nvidia: forcing VA-API
+        # at the dGPU on a hybrid laptop defeats exactly this. Leave the driver
+        # unset so libva picks per-device.
+        intel-media-driver
+
         # # CUDA support
         # cudaPackages.cudatoolkit
         # cudaPackages.cudnn
@@ -82,11 +93,22 @@
         echo "nvidia-cdi-generator: skipped (driver mismatch, will retry after reboot)"
     '');
 
-  # Create proper device nodes for NVIDIA
+  # Create proper device nodes for NVIDIA.
+  # Note the 0664 + video group: some configs float around using MODE="0666",
+  # which makes the GPU nodes world-writable. Group ownership is enough.
   services.udev.extraRules = ''
     KERNEL=="nvidia_uvm", GROUP="video", MODE="0664"
     KERNEL=="nvidia*", GROUP="video", MODE="0664"
   '';
+
+  # The NVIDIA shader cache grows without bound and is pure derived data —
+  # prune anything untouched for a week. tmpfiles rather than a bespoke
+  # service+timer: the `e` type is documented to accept shell-style globs and
+  # apply age-based cleanup, which is exactly this job. (`d` does NOT glob —
+  # a common mistake.) Cleanup runs via systemd-tmpfiles-clean.timer.
+  systemd.tmpfiles.rules = [
+    "e /home/*/.cache/nvidia - - - 7d"
+  ];
 
   # Remove global Firefox/Chromium configs to avoid conflicts
   # These will be handled in individual user configurations


### PR DESCRIPTION
## The real gap

razer had **no Intel VA-API driver in its closure at all** —
`/run/opengl-driver/lib/dri` contained neither `iHD` nor `i965`. On a hybrid
Optimus laptop the Intel chip drives the panel and should handle video, so
every browser and player was falling back to **software decode**, burning
battery.

`intel-media-driver` fixes it. Verified on the live host, not just the closure:

```
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 26.2.4
32 VA-API profiles, incl. H.264/HEVC VAEntrypointVLD (decode) + encode
```

Deliberately **not** paired with `LIBVA_DRIVER_NAME=nvidia`: forcing VA-API onto
the dGPU on a hybrid laptop would defeat exactly this fix.

> **Debugging note:** render nodes here are *not* "integrated first".
> `renderD128` is the NVIDIA dGPU (`pci-0000_01_00_0`, matching `nvidiaBusId`);
> `renderD129` is the Intel iGPU. Probing D128 looks like failure.

## Also included

- **`services.smartd`** — p620 gets SMART monitoring from
  `storage.performanceOptimization`, p510 from its resilience module, but that
  storage module is p620-scoped (sysctls, tmpfs sizing). Only the disk-health
  bit is wired up here rather than dragging the rest onto a laptop.
- **tmpfiles prune of `~/.cache/nvidia` older than 7 days.** Uses the `e` type,
  documented to accept globs and apply age-based cleanup. `d` does **not** glob
  — the `d /home/*/.cache/...` form seen in the wild silently does nothing.

## Deliberately rejected (checked, not assumed)

| candidate | why not |
|---|---|
| `irqbalance` | `/proc/interrupts`: CPU0 carries 2–7% on p620/p510 — already balanced |
| zram on p510 | 94 GiB RAM, 9 MB swap in use — it never swaps |
| `RADV_PERFTEST=sam` | zero occurrences in our Mesa 26.2.0 driver; removed upstream once resizable-BAR became automatic |
| `MODE="0666"` udev | ours are `0664` + `video` group; 0666 is world-writable |
| `LIBVA_DRIVER_NAME=nvidia` | breaks iGPU decode on hybrid |
| pinned driver + SHA256 | we use `nvidiaPackages.latest` on purpose |

## Verification

Deployed to razer: **0 failed units**, smartd active, tmpfiles rule live.
Changes are razer-scoped; p620 and p510 untouched and still evaluate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc