### PR TITLE
chore(claude-desktop): update to 1.28929.0 (#1294)

### DIFF
--- a/pkgs/claude-desktop-beta/default.nix
+++ b/pkgs/claude-desktop-beta/default.nix
@@ -64,7 +64,7 @@
 # then update `version` + `sha256` below (hex sha256 from the index is accepted
 # by fetchurl as-is).
 let
-  version = "1.24012.11";
+  version = "1.28929.0";
 
   # dlopen'd at runtime (not in DT_NEEDED) — appended to RUNPATH.
   runtimeLibs = [
@@ -81,7 +81,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_${version}_amd64.deb";
-    sha256 = "99c4bcf5e3f7d0ec44a49fbf24d7d659f2ea46e29c7ec61c77c7298522f57e76";
+    sha256 = "3ceb391268bde9a7fec32520d349b704043166204cdd571c62d1e950701f48fc";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Bumps `pkgs/claude-desktop-beta` 1.24012.11 → 1.28929.0 (Anthropic official signed apt repo, stable channel).

## Verification
- `nix build .#nixosConfigurations.p620.pkgs.claude-desktop-linux` → `claude-desktop-1.28929.0`, `bin/claude-desktop` present
- `ldd` on packaged `.so` → 0 missing libs
- host matrix builds clean: p620, razer, p510

## Deploy note
Large middle-component jump (24012 → 28929). If the app fails to launch with "VM service not running", clear the stale bundle: `rm -rf ~/.config/Claude/vm_bundles/` and relaunch.

Closes #1294

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc