### PR TITLE
fix(overlays): unbreak waypipe and 3 python suites after nixpkgs bump (#1308)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -265,11 +265,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1786502414,
-        "narHash": "sha256-JZzOwyna+H1hLyo261MNKHx/5P7XqOLR++uiTwYasNA=",
+        "lastModified": 1786588916,
+        "narHash": "sha256-VuFNAgh00WlzqnC26ofW0LnjTSyDlyRGIzvsKhInVvc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ca9403a06c3dc3b1af19f4f0715451d777722544",
+        "rev": "9dcd89c975c75ad502af7c69dc5018731718ea77",
         "type": "github"
       },
       "original": {
@@ -775,11 +775,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786538400,
-        "narHash": "sha256-PH8B1YKxedcWKNw2xsk6cKPVk/rJoLgdlWd5d+Icies=",
+        "lastModified": 1786603258,
+        "narHash": "sha256-j1lYPT7YxOQc/G7NcJKqdpQ5/A5yX2aZdhVKkJR6cM4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e13ba5e5abbd9b912fa8c6979bd119e87ca7fdd9",
+        "rev": "0668fdbc15bd602e463cab37ff64346021193652",
         "type": "github"
       },
       "original": {
@@ -856,11 +856,11 @@
         "scenefx": "scenefx"
       },
       "locked": {
-        "lastModified": 1786516317,
-        "narHash": "sha256-ERtlCk10ortjvBcyovnFVUwwPifSw/rORgVtCbmUsFU=",
+        "lastModified": 1786599915,
+        "narHash": "sha256-GVwXr6d2Dtnb2RxR6t58vN+MRo1Uw2cHl/QrCJ2iuak=",
         "owner": "mangowm",
         "repo": "mango",
-        "rev": "7bb3f7e38564e7dcae0d0a7bc01695e6ffcde2c0",
+        "rev": "9072b9bfbe356199f57c186acfd847e43b369cf1",
         "type": "github"
       },
       "original": {
@@ -1027,11 +1027,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786384358,
-        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
+        "lastModified": 1786514691,
+        "narHash": "sha256-9dkt1i5JNbEfPb+EjLcSDNs8zqEHQ/1JlSaKgj0SBAg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
+        "rev": "867dcbc30bafe3c862ef88620f2e7a109d7d3be5",
         "type": "github"
       },
       "original": {
@@ -1052,11 +1052,11 @@
         "parts": "parts"
       },
       "locked": {
-        "lastModified": 1786507863,
-        "narHash": "sha256-LxFwWlpVvi0GlGuWmHOJmGL94BS47XAgGMD+xpFktG0=",
+        "lastModified": 1786594527,
+        "narHash": "sha256-YpMagrnSkEv7BFt5ysQKADlungiLpA8BAvvHMTPxKXI=",
         "owner": "moni-dz",
         "repo": "nixpkgs-f2k",
-        "rev": "44f77b362b4b5a9261c3f547a54423150f503aa7",
+        "rev": "249e496f1892da9316d804686fe4c515fd4f6eef",
         "type": "github"
       },
       "original": {
@@ -1150,11 +1150,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1786572246,
-        "narHash": "sha256-ENNrkAE4gBJeULIkan8zOMAUvbHt4RqMNHQe+kTTCms=",
+        "lastModified": 1786605226,
+        "narHash": "sha256-hXqL68QMalvY6MFrCel8MQ/Tx3ThnTY0AfZHb4Y4kpw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a4b4cd54843d4e3af7ea2eacadcc78549dfe0cff",
+        "rev": "f2c55b87e0e3f57768f2edec3bf37aafa419e011",
         "type": "github"
       },
       "original": {
@@ -1198,11 +1198,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1786313170,
-        "narHash": "sha256-9BG7OgUWdu0ONDO5X2q6+K4bsuBITkX/3W4nNJu1Ito=",
+        "lastModified": 1786535285,
+        "narHash": "sha256-rG5HKMAgAhMgydvKGtco6rqTxRq4EDZQCx9USLvVqYw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d",
+        "rev": "9f78f44a87948854445dae0b6bf82b2e87e4efb5",
         "type": "github"
       },
       "original": {
@@ -1214,11 +1214,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1786384358,
-        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
+        "lastModified": 1786514691,
+        "narHash": "sha256-9dkt1i5JNbEfPb+EjLcSDNs8zqEHQ/1JlSaKgj0SBAg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
+        "rev": "867dcbc30bafe3c862ef88620f2e7a109d7d3be5",
         "type": "github"
       },
       "original": {
@@ -1351,11 +1351,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1786384358,
-        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
+        "lastModified": 1786514691,
+        "narHash": "sha256-9dkt1i5JNbEfPb+EjLcSDNs8zqEHQ/1JlSaKgj0SBAg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
+        "rev": "867dcbc30bafe3c862ef88620f2e7a109d7d3be5",
         "type": "github"
       },
       "original": {
@@ -1430,11 +1430,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786569889,
-        "narHash": "sha256-PYyfrIQAkgm7Di+HNq4Au4lVq2jhmDrUsv+fKpGUG34=",
+        "lastModified": 1786606185,
+        "narHash": "sha256-rrx2ZrxjnWWAYOiFHt5NljTpB2LXMelUjznPptm72wI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ea985d353a42025768ced55abbc8d9ededf97399",
+        "rev": "a4b4351d7fd41395b4e0cbc0748e5c4e43476e25",
         "type": "github"
       },
       "original": {
@@ -1634,11 +1634,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786507911,
-        "narHash": "sha256-w5aZRLbiu7H6TqsYXVMdRKg0S4DRaJpxyqxx86AwxVk=",
+        "lastModified": 1786594607,
+        "narHash": "sha256-5f9qi0HFGX07xuLG4X7MVsXb6imb1pEhEhlYB+ts4Xk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "39db48099ad16834af7e27485a4babf9c28b3897",
+        "rev": "cb8f92ed710cb8402805a509d4083418b5435edb",
         "type": "github"
       },
       "original": {

--- a/overlays/python-compat.nix
+++ b/overlays/python-compat.nix
@@ -32,6 +32,30 @@ _final: prev: {
           pyPrev.typing-extensions
         ];
       });
+      # azure-core 1.38.0: tests/conftest.py starts a Flask server and gives it
+      # 5 seconds to bind the port. On a busy builder it doesn't make it, so all
+      # 271 collected tests error at fixture setup with "Didn't start!". Nothing
+      # to do with the library. Blocks azure-identity/-mgmt-core/-keyvault-*.
+      azure-core = pyPrev.azure-core.overridePythonAttrs (_old: {
+        doCheck = false;
+      });
+      # sse-starlette 3.2.0: 69/70 pass; the odd one out asserts an exact
+      # keepalive-ping count (assert 3 == 2) and picks up a stray ping when the
+      # host is loaded. The python312Packages override below already skips this,
+      # but mcp resolves its deps through python312.pkgs, which never sees it —
+      # hence the same skip here.
+      sse-starlette = pyPrev.sse-starlette.overridePythonAttrs (_old: {
+        doCheck = false;
+      });
+      # httplib2 0.32.0: all 76 tests pass, then pytest-timeout 2.4.0 fires its
+      # 17s SIGALRM inside terminalwriter.flush() during pytest_runtest_logstart
+      # and pytest 9.1.1 aborts with INTERNALERROR (exit 3). Load-dependent — it
+      # only trips when the host is building several derivations at once. Skip
+      # the check; it blocks google-api-python-client -> google-generativeai ->
+      # meet-process. Drop once pytest-timeout/pytest stop racing there.
+      httplib2 = pyPrev.httplib2.overridePythonAttrs (_old: {
+        doCheck = false;
+      });
       # inline-snapshot 0.32.5 has 3 failing tests (of 1428) on this nixpkgs;
       # it's a test-only dep pulled in via fastapi -> mcp. Skip its checks.
       inline-snapshot = pyPrev.inline-snapshot.overridePythonAttrs (_old: {

--- a/overlays/upstream-fixes.nix
+++ b/overlays/upstream-fixes.nix
@@ -1,4 +1,14 @@
 _final: prev: {
+  # waypipe 0.11.0's optional video path reads AVVulkanDeviceContext fields
+  # (queue_family_*_index, nb_*_queues) that FFmpeg 8 replaced with the qf[]
+  # array — 10x E0609, build dies at exit 101. with_video defaults to "auto" and
+  # latches on because ffmpeg is in buildInputs, so pin it off. Costs only
+  # waypipe's `--video` lossy-stream option; compression and DMABUF remoting are
+  # unaffected. Drop once waypipe supports the FFmpeg 8 vulkan API.
+  waypipe = prev.waypipe.overrideAttrs (old: {
+    mesonFlags = (old.mesonFlags or [ ]) ++ [ "-Dwith_video=disabled" ];
+  });
+
   # azure-cli 2.81.0 expects azure-mgmt-web v2024_11_01 which isn't packaged yet;
   # disable installCheck until nixpkgs catches up.
   azure-cli = prev.azure-cli.overrideAttrs (_old: {


### PR DESCRIPTION
Unblocks the 2026-08-12 flake bump, which failed p620 on four independent blockers. Carries the pending `flake.lock` alongside the fixes it requires.

| Package | Failure | Fix |
|---|---|---|
| `waypipe` 0.11.0 | 10x `E0609` — reads `AVVulkanDeviceContext.{queue_family_*_index,nb_*_queues}`, replaced by `qf[]` in FFmpeg 8. **Real upstream API break.** | `-Dwith_video=disabled` (loses only the `--video` lossy-stream option) |
| `python3.12-httplib2` 0.32.0 | 76/76 pass, then pytest-timeout's 17s SIGALRM fires inside `terminalwriter.flush()` → INTERNALERROR | `doCheck = false` |
| `python3.12-sse-starlette` 3.2.0 | 69/70 pass; `assert 3 == 2` on an exact keepalive-ping count | `doCheck = false` on the `python312.pkgs` scope — the existing `python312Packages` skip never reached `mcp` |
| `python3.12-azure-core` 1.38.0 | conftest gives a Flask server 5s to bind; misses → 271 fixture errors | `doCheck = false` |

Three of the four are load-sensitive, not defects — they only fail when the builder is saturated.

## Verification
- `waypipe` builds, ships `bin/waypipe`
- `python312Packages.google-generativeai` builds (httplib2 → google-auth-httplib2 → google-api-python-client chain)
- p620 toplevel run with `--max-jobs 2` cleared all four; heavy tail (`cef-binary`, `gnome-shell`, `ollama`) still compiling at merge time

## Follow-up
`overlays/python-compat.nix` overriding the `python312`/`python314` sets means the whole Python set misses cache.nixos.org and compiles locally — which is why Hydra-green suites keep failing here. Worth revisiting whether those overrides can be narrowed.

Refs #1308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc