### PR TITLE
fix(p510): keep k3d alive across rebuilds, and give docker a resolver that answers

### DIFF
--- a/hosts/p510/nixos/resilience.nix
+++ b/hosts/p510/nixos/resilience.nix
@@ -50,4 +50,32 @@ _:
     ManagedOOMMemoryPressure = "kill";
     ManagedOOMMemoryPressureLimit = "80%";
   };
+  # ── 4. Keep k3d alive across a nixos-rebuild ────────────────────────────
+  # nixos-upgrade.timer rebuilds nightly (~04:00). When the docker unit changes
+  # — which it does whenever nvidia-container-toolkit-cdi-generator.service, a
+  # hard `Requires=`, is rebuilt — activation restarts docker.service and takes
+  # every k3d container with it.
+  #
+  # The server and serverlb come back on their `unless-stopped` policy. The
+  # agent does not, because its shutdown deadlocks: a pod holding an open file
+  # on the in-cluster NFS export cannot complete __fput -> nfs_file_release ->
+  # nfs4_do_close without an RPC to a server that docker has just stopped. The
+  # kubelet's mounts are `vers=4.1` with no `soft`, so the RPC retries forever,
+  # the container's PID namespace never drains, and docker reports the corpse
+  # as `Up` with zero processes inside — so `restart: unless-stopped` never
+  # fires and the node sits NotReady.
+  #
+  # That is not theoretical: 2026-08-06, agent killed 04:15, node NotReady for
+  # 7h. It stranded argocd-application-controller (every deploy landed nowhere
+  # while ArgoCD still reported Synced), nfs-provisioner (its local-path PV
+  # pins it to that node), and tfactory (FailedMount x218). The wedge was
+  # SIGKILL-proof kernel state, so recovery meant rebuilding the container by
+  # hand. See Factory#582 and factory-gitops#138.
+  #
+  # Not restarting docker on rebuild removes the trigger entirely. The cost is
+  # that daemon.settings changes need a manual `systemctl restart docker` (or a
+  # reboot) to take effect — the same trade already accepted for libvirtd in
+  # modules/virt/virt.nix. Cheap, because that config changes rarely and the
+  # cluster it carries is expensive to rebuild.
+  systemd.services.docker.restartIfChanged = false;
 }

--- a/hosts/p510/nixos/resilience.nix
+++ b/hosts/p510/nixos/resilience.nix
@@ -78,4 +78,31 @@ _:
   # modules/virt/virt.nix. Cheap, because that config changes rarely and the
   # cluster it carries is expensive to rebuild.
   systemd.services.docker.restartIfChanged = false;
+
+  # ── 5. Give docker containers a resolver that actually answers ──────────
+  # Without this, containers get `nameserver 172.18.0.1` — the bridge gateway,
+  # where NOTHING listens: systemd-resolved binds only 127.0.0.53/127.0.0.54,
+  # so every lookup returns `connection refused`. Docker picks the gateway
+  # because the host's /etc/resolv.conf lists only loopback addresses, which it
+  # cannot copy into a container namespace, and it assumes the host proxies on
+  # the bridge. NixOS does not.
+  #
+  # Measured 2026-08-13: generation 512 restarted docker at 04:50, the k3d
+  # nodes came back with the broken resolv.conf, and containerd could not
+  # resolve ghcr.io at all (`lookup ghcr.io: Try again`). Running pods were
+  # fine — their images were already cached — so this surfaced ONLY as new
+  # image tags failing to pull, which is a slow and confusing way to discover
+  # a dead resolver. fides sat on a 13-day-old image because of it (fides#395).
+  #
+  # Public resolvers rather than the host stub: they are reachable from any
+  # container namespace with no bridge-address assumption, so this keeps
+  # working if the k3d network is recreated on a different subnet.
+  #
+  # NOTE: this is `daemon.settings`, so it needs a manual `systemctl restart
+  # docker` to take effect — see the trade recorded in section 4 above. It
+  # applies to containers created AFTER that restart.
+  virtualisation.docker.daemon.settings.dns = [
+    "1.1.1.1"
+    "8.8.8.8"
+  ];
 }


### PR DESCRIPTION
Two related p510 failures, both traced to `docker.service` restarting on `nixos-rebuild`. The first commit has been sitting on this branch since 2026-08-06; the second is what today's outage turned up.

## 1. Don't restart docker on rebuild (already on this branch, 2026-08-06)

`nixos-upgrade.timer` rebuilds nightly, docker's unit changes whenever `nvidia-container-toolkit-cdi-generator.service` rebuilds, and activation takes every k3d container with it. The agent doesn't come back — its shutdown deadlocks on an NFS RPC to a server docker just stopped, so docker reports the corpse as `Up` with nothing inside and `restart: unless-stopped` never fires.

Cost: 7h `NotReady` on 2026-08-06, ArgoCD reporting Synced while every deploy landed nowhere.

## 2. Give docker containers a working resolver (new)

Containers get `nameserver 172.18.0.1` — the bridge gateway, where **nothing listens**. systemd-resolved binds only `127.0.0.53`/`127.0.0.54`, so every lookup in every container returns `connection refused`:

```
$ dig @172.18.0.1 ghcr.io
;; communications error to 172.18.0.1#53: connection refused
```

Docker picks the gateway because the host's `/etc/resolv.conf` lists only loopback addresses, which it can't copy into a container namespace — it assumes the host proxies DNS on the bridge. NixOS doesn't.

**Why this took a while to spot:** generation 512 restarted docker at 04:50 today, the k3d nodes came back with the broken resolv.conf, but already-running pods were fine because their images were cached. The only symptom was *new* image tags failing to pull, which reads like a registry or auth problem:

```
Failed to resolve reference "ghcr.io/olafkfreund/fides-server:d02b1fde...":
dial tcp: lookup ghcr.io: Try again
```

fides sat on a 13-day-old unsigned image because of it ([fides#395](https://github.com/olafkfreund/fides/issues/395)).

Public resolvers rather than the host stub, so it holds with no bridge-address assumption if the k3d network is recreated on another subnet.

## Interaction between the two, worth knowing

`daemon.settings` only takes effect on a **manual** `systemctl restart docker` — which is exactly the trade commit 1 accepts. So merging both means the DNS fix is inert until you deliberately restart docker or reboot. That's the safe ordering: commit 1 stops the nightly rebuild from killing k3d, and the restart that activates commit 2 happens when someone is watching.

## Verification

- `nix-instantiate --parse` → ok
- `nixos-rebuild build --flake .#p510` → exit 0
- evaluated config carries it:
  ```json
  {"data-root":"/mnt/img_pool/docker","dns":["1.1.1.1","8.8.8.8"], ...}
  ```
- runtime workaround already applied to both k3d nodes, so the cluster is pulling images now; this PR is what makes it survive the next restart

**Aside, not changed here:** `live-restore` is `false`. Setting it true would let containers survive a daemon restart outright and is arguably a better fix for problem 1 — but it's a behaviour change deserving its own PR, and it needs a docker restart to take effect too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)