### PR TITLE
fix(p510): give docker containers a resolver that answers

### DIFF
--- a/hosts/p510/nixos/resilience.nix
+++ b/hosts/p510/nixos/resilience.nix
@@ -155,4 +155,34 @@
     # the 04:00 nixos-upgrade window rather than during it).
     defaults.monitored = "-a -o on -S on -s (S/../.././02|L/../../6/03)";
   };
+
+  # ── Give docker containers a resolver that actually answers ─────────────
+  # Without this, containers get `nameserver 172.18.0.1` — the bridge gateway,
+  # where NOTHING listens: systemd-resolved binds only 127.0.0.53/127.0.0.54,
+  # so every lookup in every container returns `connection refused`. Docker
+  # picks the gateway because the host's /etc/resolv.conf lists only loopback
+  # addresses, which it cannot copy into a container namespace, so it assumes
+  # the host proxies DNS on the bridge. NixOS does not.
+  #
+  # Found the slow way, 2026-08-13. Generation 512 restarted docker at 04:50,
+  # the k3d nodes came back with the broken resolv.conf, and containerd could
+  # not resolve ghcr.io at all (`lookup ghcr.io: Try again`). Already-running
+  # pods were fine — their images were cached — so the ONLY symptom was new
+  # image tags failing to pull, which reads like a registry or auth fault
+  # rather than a dead resolver. fides sat on a 13-day-old unsigned image
+  # because of it (fides#395).
+  #
+  # Public resolvers rather than the host stub: reachable from any container
+  # namespace with no bridge-address assumption, so this keeps working if the
+  # k3d network is recreated on a different subnet.
+  #
+  # Merges with the daemon.settings block in modules/system/logging.nix.
+  #
+  # NOTE: `daemon.settings` needs a manual `systemctl restart docker` to take
+  # effect — the same trade the restartIfChanged block above accepts, and it
+  # applies only to containers created after that restart.
+  virtualisation.docker.daemon.settings.dns = [
+    "1.1.1.1"
+    "8.8.8.8"
+  ];
 }


### PR DESCRIPTION
k3d node containers on p510 have had **no working DNS since 04:50 today**. Runtime workaround already applied so the cluster is pulling images again; this is the durable fix.

## The fault

Containers get `nameserver 172.18.0.1` — the bridge gateway, where **nothing listens**:

```
$ dig @172.18.0.1 ghcr.io
;; communications error to 172.18.0.1#53: connection refused

$ sudo ss -lunp | grep :53
127.0.0.54:53      systemd-resolve
127.0.0.53%lo:53   systemd-resolve
```

Docker picks the gateway because the host's `/etc/resolv.conf` lists only loopback addresses, which it can't copy into a container namespace — so it assumes the host proxies DNS on the bridge. NixOS doesn't.

## Why it took hours to find

Generation 512 restarted docker at 04:50, the k3d nodes came back with the broken resolv.conf — but **already-running pods were completely fine**, because their images were cached and nothing re-resolves. The only symptom was *new* image tags failing to pull:

```
Failed to resolve reference "ghcr.io/olafkfreund/fides-server:d02b1fde...":
dial tcp: lookup ghcr.io: Try again
```

which reads like a registry or auth problem, not a dead resolver. fides sat on a 13-day-old unsigned image because of it ([fides#395](https://github.com/olafkfreund/fides/issues/395)).

## The fix

Public resolvers rather than the host stub — reachable from any container namespace with no bridge-address assumption, so it keeps working if the k3d network is recreated on a different subnet. Merges with the existing `daemon.settings` block in `modules/system/logging.nix`.

## Activation

`daemon.settings` needs a manual `systemctl restart docker`, and applies to containers created after it — the same trade `restartIfChanged = false` already accepts. Since `live-restore` is now `true`, that restart no longer takes the running containers with it, so it's a much smaller event than the 2026-08-06 one.

## Verification

- `nix-instantiate --parse` → ok
- `nixos-rebuild build --flake .#p510` → exit 0
- evaluated config carries it:
  ```json
  {"data-root":"/home/docker","dns":["1.1.1.1","8.8.8.8"],"live-restore":true, ...}
  ```

Supersedes #1316, which was based on 2026-08-06 and conflicted with content already upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)