### PR TITLE
fix(atuin): retry on transient startup failure

### DIFF
--- a/modules/services/atuin/default.nix
+++ b/modules/services/atuin/default.nix
@@ -3,4 +3,17 @@
     enable = true;
     package = pkgs.atuin;
   };
+
+  # atuin-server connects to postgres over the unix socket with peer auth, which
+  # resolves the client UID through NSS. Under DynamicUser the UID is allocated at
+  # runtime, so if nscd is restarting in the same activation batch the lookup
+  # returns nothing, libpq sends the user as "unknown", and postgres rejects it.
+  # The unit ordering (After/Requires=postgresql.target) doesn't help — postgres
+  # is up; it's the name lookup that isn't. nixpkgs' module sets no Restart=, so
+  # that one-off blip is terminal and `nh os switch` fails the whole deploy on it.
+  # Retrying is enough: the next attempt resolves the user fine.
+  systemd.services.atuin.serviceConfig = {
+    Restart = "on-failure";
+    RestartSec = 2;
+  };
 }


### PR DESCRIPTION
A razer deploy rolled back today on a single failed unit:

```
warning: the following units failed: atuin.service
```

Everything else activated cleanly — Lanzaboote installed, secrets decrypted, every other unit started.

## Cause

```
Error: failed to connect to db: postgresql:///atuin?host=/run/postgresql
Caused by: Peer authentication failed for user "unknown"
```

Peer auth resolves the **client's** UID through NSS. `DynamicUser = true` allocates that UID at runtime, and `nscd.service` was being restarted in the same activation batch — so the lookup returned nothing, libpq sent `"unknown"`, and postgres rejected it.

The existing `After=`/`Requires=postgresql.target` ordering doesn't help: postgres was up. It's the *name lookup* that wasn't ready.

nixpkgs' atuin module sets no `Restart=`, so that one-off blip is terminal — which is why `nh` saw a failed unit and rolled the whole deploy back, and why the service came up fine the moment it was started again (it's been healthy on razer since).

## Fix

`Restart = "on-failure"` + `RestartSec = 2`. Chosen over adding `After=nscd.service` because it covers any transient startup failure rather than only the path we happened to observe, and because an auto-restarting unit reports as `activating`, not `failed`, so it won't trip the deploy.

## Verification
p620, razer, p510 all build; `Restart` evaluates to `on-failure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc