### PR TITLE
fix(plex-auto-languages): give the health check a start period

### DIFF
--- a/modules/services/plex-auto-languages/default.nix
+++ b/modules/services/plex-auto-languages/default.nix
@@ -57,6 +57,16 @@ in
           # no inbound surface — Plex notifies it via its own websocket
           # API, not webhooks-into-PAL — so no port mapping needed.
           "--network=host"
+
+          # The image ships HEALTHCHECK `curl --fail localhost:9880` on a 30s
+          # interval with no start period, and podman runs each probe in its own
+          # transient systemd unit. The first probe fires before PAL is
+          # listening, exits 1, and leaves a failed unit behind — which
+          # `nh os switch` treats as a failed activation and rolls the entire
+          # p510 deploy back. Measured over 3h: 346 healthy, 2 failures, both
+          # the first probe after a container start. Give it a start period so
+          # boot-time failures don't count.
+          "--health-start-period=90s"
         ];
       };
     };


### PR DESCRIPTION
A p510 deploy rolled back on one transient unit:

```
ed20373...-5510ee53f15d2be3.service: Main process exited, code=exited, status=1/FAILURE
health_status=starting, health_failing_streak=1
```

## Cause

The image ships `HEALTHCHECK curl --silent --fail http://localhost:9880/` on a 30s interval with **no start period**, and podman runs every probe in its own transient systemd unit. The first probe fires before PAL is listening, exits 1, and leaves a failed unit — which `nh os switch` treats as a failed activation and rolls the entire deploy back.

Measured on p510 over 3 hours:

| health_status | count |
|---|---|
| `healthy` | 346 |
| `starting` (streak=1) | 2 |

Both failures are the first probe after a container start — i.e. the two deploy attempts. The container was `Up 14 minutes (healthy)` when checked afterwards. A healthy service killed twice by its own startup probe.

Same shape as #1319 (atuin on razer): a transient startup failure promoted into a rolled-back deploy.

## Fix

`--health-start-period=90s`, so boot-time failures aren't counted. Chosen over `--no-healthcheck` to keep liveness visible in `podman ps` — though that remains the fallback if a probe still trips the transient unit on the next deploy.

## Verification
p510 builds; `--health-start-period=90s` confirmed present in the generated `podman run` script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc