### PR TITLE
chore(antigravity): bump cli to 1.1.12 and hub to 2.7.1

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.1.11-4956531888881664";
+  version = "1.1.12-5877618327814144";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.11-4956531888881664/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-yu8d1MmcV97h0d7CtsZ3Jt9TXqSexx6rrdNtr/giPRk=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.12-5877618327814144/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-x3iuT9EeXcLb3f1xCO4ZdK5g/VMa+yRr5BxuS7Scgco=";
   };
 
   # Tarball contains a single file `antigravity` at the root.

--- a/pkgs/antigravity-hub/default.nix
+++ b/pkgs/antigravity-hub/default.nix
@@ -98,11 +98,11 @@ let
 in
 stdenv.mkDerivation {
   pname = "antigravity-hub";
-  version = "2.6.0-4603467860410368";
+  version = "2.7.1-5840911524036608";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.6.0-4603467860410368/linux-x64/Antigravity.tar.gz";
-    hash = "sha256-y5iv8A261OcYt/stlf71MbfdMPmFUx5shEtCqvZ99DE=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.7.1-5840911524036608/linux-x64/Antigravity.tar.gz";
+    hash = "sha256-JQSQshc/Rw0ZsuLz7UdQaxN6ifj5XiqHKgXTyhJ8M98=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Bumps two of the four locally-packaged Antigravity components from the
`Hy4ri/antigravity-flake` tracker:

| Component | From | To |
|---|---|---|
| cli (`agy`) | 1.1.11-4956531888881664 | 1.1.12-5877618327814144 |
| hub | 2.6.0-4603467860410368 | 2.7.1-5840911524036608 |
| ide | 2.1.1-6123990880747520 | *(current)* |
| sdk | 0.1.10 | *(current)* |

Verified:
- all four `customPkgs.antigravity-*` / `google-antigravity-py` build
- p620 `system.build.toplevel` composes
- `agy --version` → `1.1.12`
- `import google.antigravity` OK

Build-verified only, not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc