### PR TITLE
feat(k3d): weekly GC for unreferenced images and orphaned volumes

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -483,6 +483,13 @@ in
     argocd.enable = true;
     tailscaleAuthKey.enable = true;
     factorySecrets.enable = true; # #807: durably seed all factory ns Secrets from agenix
+    # Without this /home fills with per-commit factory images: 651GB reclaimed
+    # by hand on 2026-08-13 (83% -> 8%). Sunday 04:00 keeps the churn off the
+    # media server's evening peak.
+    imageGc = {
+      enable = true;
+      dates = "Sun 04:00";
+    };
     # Bind kube API to p510's tailnet IP so kubectl from any tailnet
     # device can drive the cluster directly (`kubectl get nodes` against
     # https://100.118.96.32:6443). k3d 5.x's port-publishing logic

--- a/modules/containers/k3d.nix
+++ b/modules/containers/k3d.nix
@@ -501,6 +501,25 @@ in
     factorySecrets = {
       enable = mkEnableOption "Apply all factory-namespace agenix-encrypted Secret manifests during cluster bootstrap";
     };
+
+    # A GitOps cluster fed by CI accumulates container images without bound:
+    # every commit pushes a fresh `sha-<commit>` tag, ArgoCD pulls it, and
+    # containerd keeps every previous one. On p510 that reached 349 images /
+    # 465GB inside the server node by 2026-08-13, plus 176GB of anonymous
+    # Docker volumes orphaned by past `k3d cluster delete`s — 83% of a 916GB
+    # disk. kubelet's own image GC never fires because it triggers on the
+    # *host* filesystem crossing its high threshold, which the media server
+    # reaches long after the cluster has starved.
+    imageGc = {
+      enable = mkEnableOption "Periodically drop unreferenced container images and orphaned Docker volumes";
+
+      dates = mkOption {
+        type = types.str;
+        default = "weekly";
+        example = "Sun 04:00";
+        description = "systemd OnCalendar expression for the image GC timer.";
+      };
+    };
   };
 
   config = mkIf cfg.enable {
@@ -661,6 +680,57 @@ in
         OnCalendar = "daily";
         Persistent = true;
         RandomizedDelaySec = "30m";
+      };
+    };
+
+    systemd.services.k3d-image-gc = mkIf cfg.imageGc.enable {
+      description = "Drop unreferenced k3d container images and orphaned Docker volumes";
+      after = [ "docker.service" "k3d-cluster-bootstrap.service" ];
+      requires = [ "docker.service" ];
+      path = with pkgs; [ docker-client coreutils ];
+      serviceConfig = {
+        Type = "oneshot";
+        # Needs the Docker socket and `docker exec` into the k3d nodes, so it
+        # runs as root rather than DynamicUser — same reasoning as the
+        # bootstrap unit above.
+        User = "root";
+        ExecStart = pkgs.writeShellScript "k3d-image-gc" ''
+          set -uo pipefail
+
+          # `crictl rmi --prune` only removes images no pod references, so it is
+          # safe against a live cluster: ArgoCD re-pulls on the next rollout.
+          for node in $(docker ps --filter "label=k3d.cluster=${cfg.clusterName}" --format '{{.Names}}'); do
+            # The serverlb is an nginx container with no containerd. Probe on
+            # exit status, not on output: `docker exec` reports a missing
+            # binary on STDOUT, so counting lines would score it as 1 image.
+            docker exec "$node" crictl version >/dev/null 2>&1 || continue
+            before=$(docker exec "$node" crictl images -q 2>/dev/null | wc -l)
+            docker exec "$node" crictl rmi --prune >/dev/null 2>&1 || true
+            after=$(docker exec "$node" crictl images -q 2>/dev/null | wc -l)
+            echo "[k3d-image-gc] $node: $before -> $after images"
+          done
+
+          # Deliberately NOT `docker system prune` (and hence not
+          # virtualisation.docker.autoPrune): that also removes STOPPED
+          # containers, and this host has a history of k3d nodes wedging
+          # mid-reboot. Deleting such a node would take its state volume with
+          # it. These three only ever touch things no container references.
+          docker volume prune -f | tail -1
+          docker builder prune -f | tail -1
+          docker image prune -f | tail -1
+
+          docker system df
+        '';
+      };
+    };
+
+    systemd.timers.k3d-image-gc = mkIf cfg.imageGc.enable {
+      description = "Periodic k3d image and volume GC";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.imageGc.dates;
+        Persistent = true;
+        RandomizedDelaySec = "1h";
       };
     };
 


### PR DESCRIPTION
Makes last week's 651 GB manual cleanup on p510 recurring.

## Why

Every CI commit pushes a fresh `sha-<commit>` image, ArgoCD pulls it, and
containerd keeps every previous one. p510 reached **349 images / 465 GB**
inside the k3d server node, plus **176 GB** of anonymous Docker volumes
orphaned by past `k3d cluster delete`s — 83% of a 916 GB disk.

kubelet's own image GC never fires: it triggers on the *host* filesystem
crossing its high threshold, which the media server reaches long after the
cluster has already starved.

## What

New `modules.containers.k3d.imageGc = { enable; dates; }` — a oneshot unit
plus timer that:

1. runs `crictl rmi --prune` on each k3d node that actually has containerd
   (only removes images no pod references, so it is safe against a live
   cluster — ArgoCD re-pulls on the next rollout)
2. drops unreferenced Docker volumes, build cache and dangling images

Enabled on p510 at `Sun 04:00`, off everywhere else.

**Not** `virtualisation.docker.autoPrune`: `docker system prune` also removes
STOPPED containers, and this host has a history of k3d nodes wedging
mid-reboot — deleting such a node would take its state volume with it. The
three commands used here only ever touch things no container references.

## Verification

- `nix build` p510 + p620 toplevels clean
- generated `.service`/`.timer` inspected in the built closure
- node-selection logic exercised against the live cluster:
  ```
  k3d-agent-0-0:         PRUNE (24 images)
  k3d-factory-serverlb:  skip (no containerd)
  k3d-factory-server-0:  PRUNE (16 images)
  ```
  (the serverlb probe gates on exit status, not output — `docker exec`
  reports a missing binary on stdout, so counting lines scores it as 1 image)
- the same command sequence run by hand reclaimed 651 GB (83% → 8%) with
  2 nodes Ready / 78 pods throughout

Not deployed — p510 needs explicit approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc