### PR TITLE
fix(razer): disable touchpad while typing

### DIFF
--- a/hosts/razer/nixos/laptop.nix
+++ b/hosts/razer/nixos/laptop.nix
@@ -11,7 +11,7 @@
         tapping = true;
         naturalScrolling = true;
         scrollMethod = "twofinger";
-        disableWhileTyping = false;
+        disableWhileTyping = true;
         clickMethod = "clickfinger";
       };
     };


### PR DESCRIPTION
razer has been running `disableWhileTyping = true` as an **uncommitted local edit**
to its working tree. It survived deploys only because `git pull` autostashed and
reapplied it — spotted during today's Antigravity deploy:

```
Created autostash: 374ecfeac
...
Applied autostash.
```

That left razer quietly diverged from main: `nhs razer` refuses a dirty tree, and
any deploy that didn't autostash cleanly would have silently reverted the setting
out from under the user.

This commits the setting that is actually in use.

## Verification

Building razer's toplevel with this change yields
`lijii0ck0n6656asgw7ycvg5xs5g3flq` — **the exact store path razer is already
running**. So this is a no-op for the running system and needs no redeploy; it
only makes the declared config match reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc