### PR TITLE
chore(antigravity): bump cli/ide/hub/sdk to latest

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.1.12-5877618327814144";
+  version = "1.1.13-6057583128215552";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.12-5877618327814144/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-x3iuT9EeXcLb3f1xCO4ZdK5g/VMa+yRr5BxuS7Scgco=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.13-6057583128215552/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-7cfDK1q0/C5NoDOB/ug+1WbeprVrVvkynNE813lHodk=";
   };
 
   # Tarball contains a single file `antigravity` at the root.

--- a/pkgs/antigravity-hub/default.nix
+++ b/pkgs/antigravity-hub/default.nix
@@ -98,11 +98,11 @@ let
 in
 stdenv.mkDerivation {
   pname = "antigravity-hub";
-  version = "2.7.1-5840911524036608";
+  version = "2.8.1-6512087774658560";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.7.1-5840911524036608/linux-x64/Antigravity.tar.gz";
-    hash = "sha256-JQSQshc/Rw0ZsuLz7UdQaxN6ifj5XiqHKgXTyhJ8M98=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.8.1-6512087774658560/linux-x64/Antigravity.tar.gz";
+    hash = "sha256-I/bDv+8rMyb4t0fNnhW6NAHHAigENuTgO5qGPGZ47/M=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/antigravity-ide/package.nix
+++ b/pkgs/antigravity-ide/package.nix
@@ -103,11 +103,11 @@ let
 in
 stdenv.mkDerivation {
   pname = "antigravity-ide";
-  version = "2.1.1-6123990880747520";
+  version = "2.5.5-4923483625488384";
 
   src = fetchurl {
-    url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.1.1-6123990880747520/linux-x64/Antigravity%20IDE.tar.gz";
-    hash = "sha256-Wyzr99M6aNAD/Y8fqYjRYAkFrOIlBKCF5ThCFCkIeL0=";
+    url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.5.5-4923483625488384/linux-x64/Antigravity%20IDE.tar.gz";
+    hash = "sha256-DFIzspfSs667Ya9J+JRAEsKVPTYaXrsWl4SQY2kX+DE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/google-antigravity-py/default.nix
+++ b/pkgs/google-antigravity-py/default.nix
@@ -25,15 +25,15 @@
 # Upstream: https://github.com/google-antigravity/antigravity-sdk-python
 buildPythonPackage rec {
   pname = "google-antigravity";
-  version = "0.1.10";
+  version = "0.1.12";
   format = "wheel";
 
   # fetchPypi gets the URL wrong for this package (constructs
   # google-antigravity- instead of google_antigravity-), so use fetchurl
   # with the canonical PyPI download URL.
   src = fetchurl {
-    url = "https://files.pythonhosted.org/packages/46/9b/58237a8448386fc3c724ae4006964894b28448c3840b7af555166bed8f29/google_antigravity-0.1.10-py3-none-manylinux_2_17_x86_64.whl";
-    hash = "sha256-3hxmzgoKxtpFFP7dKusGeqaMC0fys4D0dzZDzNaFDio=";
+    url = "https://files.pythonhosted.org/packages/90/cd/a206d89eda0d944ddef6a0557a430d94a38c2e770335023754981fa67126/google_antigravity-0.1.12-py3-none-manylinux_2_17_x86_64.whl";
+    hash = "sha256-JJwQLKyDHikKSmKRii4MAUgmlrZTOyoC6CFYkAgNY0o=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Bumps all four locally-packaged Antigravity components via `scripts/update-antigravity.sh` (tracker: Hy4ri/antigravity-flake).

| Component | From | To |
|---|---|---|
| cli | 1.1.12 | 1.1.13 |
| ide | 2.1.1 | 2.5.5 |
| hub | 2.7.1 | 2.8.1 |
| sdk | 0.1.10 | 0.1.12 |

Verified:
- all four derivations build (IDE 2.5.5 passes autoPatchelfHook, no new runtime libs)
- `agy --version` → 1.1.13
- `import google.antigravity` OK
- p620 + razer toplevels build (p510 doesn't ship Antigravity)

Not deployed — build-verify only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc