### PR TITLE
chore(warp-terminal): bump to v0.2026.08.12.21.54.stable_00

### DIFF
--- a/pkgs/warp-terminal/versions.json
+++ b/pkgs/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "linux_x86_64": {
-    "hash": "sha256-Rj9W2Fbnz3OfzgV4OOmI4ryyB1DOyLBtD6LyZ5FyGmY=",
-    "version": "0.2026.08.05.09.03.stable_01"
+    "hash": "sha256-VzeANeKlRngHZKBAK7Pgpcq89YoW91aaWxWOrwra6sA=",
+    "version": "0.2026.08.12.21.54.stable_00"
   },
   "linux_aarch64": {
-    "hash": "sha256-t6KmreIsDEk/cbt2l2R3cLa3FYOjQZMsxEqlenla4mw=",
-    "version": "0.2026.08.05.09.03.stable_01"
+    "hash": "sha256-VUCK0QxSilp7oqGhBpRbInH4qSgzvDR4mOIJEDraj0M=",
+    "version": "0.2026.08.12.21.54.stable_00"
   }
 }


### PR DESCRIPTION
Bumps `pkgs/warp-terminal/versions.json` from `0.2026.08.05.09.03.stable_01` to `0.2026.08.12.21.54.stable_00` (both arches) via `scripts/update-warp-terminal.sh`.

Verified:
- package builds
- `warp` binary is ELF, no missing shared libs
- `.version` eval matches versions.json
- p620 toplevel composes

Not deployed — build-verify only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc