### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1150,11 +1150,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1786785523,
-        "narHash": "sha256-9CG2WC+ZsutktwSSNQG4IAr7oiF12cO0228whaCkZv0=",
+        "lastModified": 1786812997,
+        "narHash": "sha256-MhbbCm54yrK94xQqTLSosAP1Pt+n7Mw3VZM67ewCcFc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ee85fa8a2f763ab6f195b0c8aad12b56fe3cd1a2",
+        "rev": "21e486671e60b2f013fc17265b8a764f8c1ab99a",
         "type": "github"
       },
       "original": {
@@ -1430,11 +1430,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786785865,
-        "narHash": "sha256-7V+bSEC6Z50aqJZbEv+B6Ptj5SALoOmm6buA68oFxV4=",
+        "lastModified": 1786815153,
+        "narHash": "sha256-H1/sTm6m2LXw81zn3DKvT9y5M5Y8L12+ik/CUOlZAIU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a94c96806b93c69e3f27973fcc0427de9ad152aa",
+        "rev": "8e7c9409509380c2bebd6e6136bd101309c1b5ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=p620, scope=all).

Built and verified locally against nixosConfigurations.p620 before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)