### PR TITLE
chore(flake): un-pin herdr, noctalia and ollama-cuda

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -733,17 +733,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1784942815,
-        "narHash": "sha256-sSzijwp8RjM048EaWgRH1dP6oLLPz7jd3rNKaMbzVdk=",
+        "lastModified": 1786831869,
+        "narHash": "sha256-ALhahxbdgnN8rMvlKmgB5py0etICwyYY75Uz0jLIpM4=",
         "owner": "ogulcancelik",
         "repo": "herdr",
-        "rev": "d4e0dd3d903c50d2edb8c3cec71952a83989b310",
+        "rev": "51b7064ef0a02642393bab1d2eea0f4dbd8414d2",
         "type": "github"
       },
       "original": {
         "owner": "ogulcancelik",
         "repo": "herdr",
-        "rev": "d4e0dd3d903c50d2edb8c3cec71952a83989b310",
         "type": "github"
       }
     },
@@ -1164,22 +1163,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-ollama": {
-      "locked": {
-        "lastModified": 1783915482,
-        "narHash": "sha256-FmieJB8/OUvNxbkboi7+IGfIuSXY3nF/hZQm8kD0r50=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee",
-        "type": "github"
-      }
-    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1782847189,
@@ -1388,17 +1371,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1783495226,
-        "narHash": "sha256-+Qg4wlqjEf4CRxkLtQ4tvsk5U2CAbWDZfCdXuyLBoo8=",
+        "lastModified": 1786865707,
+        "narHash": "sha256-JjW75NMnVw6/igd3agY+zWZfgY5A0bU4g/R0KkmtBRg=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "b9b4bc3408a906f392a8d277d172ef440debc5cc",
+        "rev": "257a03d374184f6f906100d2aee8c261c69a182e",
         "type": "github"
       },
       "original": {
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "b9b4bc3408a906f392a8d277d172ef440debc5cc",
         "type": "github"
       }
     },
@@ -1534,7 +1516,6 @@
         "nixpkgs": "nixpkgs_8",
         "nixpkgs-f2k": "nixpkgs-f2k",
         "nixpkgs-master": "nixpkgs-master",
-        "nixpkgs-ollama": "nixpkgs-ollama",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "noctalia": "noctalia",
         "noctalia-greeter": "noctalia-greeter",

--- a/flake.nix
+++ b/flake.nix
@@ -35,11 +35,6 @@
     # hasn't reached the nixos-unstable channel yet. Grafted in via overlay
     # (overlays/default.nix). Remove this input + the graft once unstable catches up.
     nixpkgs-master.url = "github:nixos/nixpkgs/master";
-    # Pinned solely for ollama 0.31.2 (last version whose CUDA build works in
-    # nixpkgs — 0.32.1's llama.cpp CUDA ExternalProject can't find nvcc, an active
-    # upstream bug). Grafted as pkgs.ollama-cuda for p510 via overlays/default.nix.
-    # Remove this input + the graft once nixpkgs 0.32.x CUDA builds again.
-    nixpkgs-ollama.url = "github:nixos/nixpkgs/6cdc7fc76e8bf7fde9fa43a849fcaaa70e230dee";
 
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
     flake-utils.url = "github:numtide/flake-utils";
@@ -62,12 +57,8 @@
     # provides programs.noctalia. Follows nixpkgs: the package is a light QML
     # wrapper over pkgs.quickshell (already cached in nixpkgs), so this avoids
     # duplicating the Qt closure and needs no extra cachix.
-    # Pinned to a known-good rev: noctalia HEAD (b87c8acf) fails to compile — its
-    # mango workspace backend has a type error (mango_workspace_backend.cpp:162,
-    # `TagInfo` vs `uint32_t`). Unpin (back to a bare branch url) once upstream
-    # noctalia fixes the mango backend build.
     noctalia = {
-      url = "github:noctalia-dev/noctalia/b9b4bc3408a906f392a8d277d172ef440debc5cc";
+      url = "github:noctalia-dev/noctalia";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -228,18 +219,8 @@
     # offline in-repo), exposed as packages.default. Consumed via overlay
     # as pkgs.herdr on the interactive-host developer profile (p620 + razer).
     # Bump with `nix flake update herdr`.
-    # ponytail: temporarily pinned to d4e0dd3d (2026-07-25), the last rev whose
-    # own flake builds. Upstream cb2e17a4 ("feat: print bundled agent skill")
-    # added `include_str!("../SKILL.md")` to src/main.rs but did NOT add
-    # ../SKILL.md to the lib.fileset.unions allowlist in nix/package.nix, so the
-    # file never reaches the sandbox:
-    #     error: couldn't read `src/../SKILL.md`: No such file or directory
-    # That breaks any consumer of their packages.default, us included, and it is
-    # upstream's bug — not a packaging problem on our side.
-    # UN-PIN (drop the rev, back to plain `github:ogulcancelik/herdr`) once the
-    # fileset includes SKILL.md; verify with `nix build github:ogulcancelik/herdr`.
     herdr = {
-      url = "github:ogulcancelik/herdr/d4e0dd3d903c50d2edb8c3cec71952a83989b310";
+      url = "github:ogulcancelik/herdr";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.rust-overlay.follows = "rust-overlay";
     };

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -16,19 +16,6 @@
     dms-shell = inputs.nixpkgs-master.legacyPackages.${prev.stdenv.hostPlatform.system}.dms-shell;
   })
 
-  # ponytail: temporary graft. ollama-cuda 0.32.1's CUDA build is broken in
-  # current nixpkgs (llama.cpp ExternalProject can't find nvcc — active upstream
-  # bug, nixpkgs #303046/#432731). Pin ollama-cuda to 0.31.2 (last working CUDA
-  # build; what p510 already runs) from the nixpkgs-ollama input. allowUnfree is
-  # required because the CUDA closure is unfree. Drop this + the input once
-  # nixpkgs 0.32.x CUDA builds again.
-  (final: _prev: {
-    ollama-cuda = (import inputs.nixpkgs-ollama {
-      inherit (final.stdenv.hostPlatform) system;
-      config.allowUnfree = true;
-    }).ollama-cuda;
-  })
-
   (_final: prev: {
     gogmail = inputs.gogmail.packages.${prev.stdenv.hostPlatform.system}.gogmail;
   })


### PR DESCRIPTION
Three temporary pins are no longer needed — each upstream blocker was verified fixed by an actual build, not just by reading upstream.

| Pin | Blocker | Now |
|---|---|---|
| `herdr` @ d4e0dd3d | `include_str!("../SKILL.md")` missing from the crate fileset | upstream moved it to `skills/herdr/SKILL.md` and added it in `nix/package.nix` → builds `herdr-0.8.0` |
| `noctalia` @ b9b4bc34 | `mango_workspace_backend.cpp:162` `TagInfo` vs `uint32_t` type error | backend rewritten under `src/compositors/mango/` → builds `noctalia-5.0.0` |
| `nixpkgs-ollama` @ 6cdc7fc7 | ollama CUDA build couldn't find nvcc | nixpkgs builds `ollama-0.32.7` with CUDA → input **and** the `overlays/default.nix` graft removed |

Net effect: `-59 / +8` lines, three pins and their now-obsolete comment blocks gone.

**p510 changes**: `services.ollama.package` moves 0.31.2 → 0.32.7.

Verified: toplevel builds green on p620, razer and p510. `nixpkgs` itself untouched (we're already at channel tip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc