### PR TITLE
fix(p510): disable unattended autoUpgrade, add stale-session cleanup

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -411,7 +411,46 @@ p620:
 
 # Deploy to p510 workstation (Intel Xeon/NVIDIA) - OPTIMIZED
 p510:
+    just p510-clear-sessions
     nixos-rebuild switch --flake .#p510 --target-host p510 --build-host p510 --sudo --no-reexec --keep-going --accept-flake-config
+
+# p510 runs GNOME for gnome-remote-desktop, so a leftover session keeps a
+# systemd --user manager alive with ~47 GUI units that can't start without a
+# display. switch-to-configuration then tries to start them, reloads the user
+# dbus-broker mid-flight, loses its own bus connection and returns exit 4.
+# Clearing idle sessions first removes most of that noise. It does NOT
+# guarantee exit 0 — verify the end state, not the exit code:
+#   readlink -f /run/current-system && systemctl --failed
+# Drop stale olafkfreund sessions on p510 before a switch
+p510-clear-sessions:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    echo "🧹 Clearing stale olafkfreund sessions on p510..."
+    ssh p510 'bash -s' <<'REMOTE'
+    set -uo pipefail
+    # Columns: SESSION UID USER SEAT LEADER CLASS TTY IDLE ...
+    # Only idle, TTY-less user sessions are stale. Never touch a session with a
+    # TTY (a live login / tmux) and never our own ssh session.
+    self="${XDG_SESSION_ID:-none}"
+    killed=0
+    while read -r id uid _user _seat _leader class tty _rest; do
+      [ "$uid" = "1000" ] || continue
+      [ "$class" = "user" ] || continue
+      [ "$tty" = "-" ] || continue
+      [ "$id" = "$self" ] && continue
+      loginctl terminate-session "$id" 2>/dev/null
+      # A session whose leader already died sits in State=closing forever and
+      # terminate-session is a no-op on it — its scope keeps running abandoned
+      # (seen: a wedged `docker run … | head` from an old debug session held one
+      # open for 3 days). Stop the scope directly in that case.
+      if loginctl show-session "$id" -p Id >/dev/null 2>&1; then
+        sudo systemctl stop "session-$id.scope" 2>/dev/null || true
+      fi
+      loginctl show-session "$id" -p Id >/dev/null 2>&1 || killed=$((killed+1))
+    done < <(loginctl list-sessions --no-legend)
+    systemctl --user reset-failed 2>/dev/null || true
+    echo "  terminated $killed stale session(s); user manager: $(systemctl --user is-system-running 2>&1)"
+    REMOTE
 
 
 # =============================================================================

--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -561,6 +561,17 @@ in
   };
   system.stateVersion = "25.11";
 
+  # p510 is a headless media server (Plex, NZBGet, k3s microvms) and is only
+  # ever deployed on explicit request — never unattended. The global
+  # system.autoUpgrade in modules/nix/nix.nix pulled and switched this host
+  # nightly at ~04:00, which is exactly what we don't want here: an unreviewed
+  # switch can restart media services, and its user-activation step fails every
+  # run anyway (switch-to-configuration reloads the user dbus-broker and then
+  # talks over the dead connection, so nixos-upgrade.service reported failure
+  # each morning while having actually applied the upgrade).
+  # Deploy with `just p510` instead.
+  system.autoUpgrade.enable = lib.mkForce false;
+
   # Local Ollama model server on NVIDIA GPU (CUDA).
   # Bound to 0.0.0.0:11434 with OLLAMA_ORIGINS=* so tailnet/LAN clients
   # and browser UIs can hit it directly. p510's firewall is disabled —


### PR DESCRIPTION
p510 is a headless media server that must only be deployed on explicit request, but the global `system.autoUpgrade` in `modules/nix/nix.nix` was pulling and switching it nightly at ~04:00.

## Why it failed every morning

Not the build. `switch-to-configuration-ng` reloads the user's `dbus-broker.service` during user activation, then keeps issuing job requests over that now-dead connection:

```
reloading the following user units: dbus-broker.service
starting the following user units: …47 GNOME units…
Error: Failed to process dbus messages while waiting for jobs
Caused by: disconnected from D-Bus?
warning: user activation for olafkfreund failed
```

It exits 4 while the system half has already applied cleanly. p510 runs GNOME on purpose (gnome-remote-desktop), so those GUI units log `cannot open display:` outside an RDP session.

The user manager it activated into was kept alive by a wedged `docker run … | head` left over from an oauth2-proxy debug session on 2026-08-13 — an abandoned scope holding 26 tasks whose leader had already died, so `loginctl terminate-session` was a no-op on it.

## Changes

- `hosts/p510/configuration.nix`: `system.autoUpgrade.enable = mkForce false` (p620 and razer keep it)
- `Justfile`: `just p510` now runs `p510-clear-sessions` first — drops idle TTY-less sessions and stops abandoned scopes, never touching a live login or its own ssh session

## Verified

- toplevel builds green on p620, razer, p510
- deployed to p510: `nixos-upgrade.timer` is now `not-found`, zero failed units, plex/nzbget/ollama active, ollama 0.32.7
- deployed closure is byte-identical to the one built from this branch

Exit 4 on a manual `just p510` is still expected — it is a switch-to-configuration bug we cannot reach from config. Verify with `readlink -f /run/current-system` and `systemctl --failed`, not the exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
