### PR TITLE
chore(flake): bump nixpkgs, drop stale FFmpeg 8 overrides

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -774,11 +774,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786826571,
-        "narHash": "sha256-nNqmXIFmESRnU91KARtiekSox0+o+E3AS0d1TuUQ/9o=",
+        "lastModified": 1786887553,
+        "narHash": "sha256-0J8EwNSJ/2OeyuvXgfG+k5uBT1gkg0ww7VEo+14xl50=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c8058ecc1329a71a3c99c4d0353dba4009a66152",
+        "rev": "5bd505963717a894b02a57cdbcc00db28d9b029f",
         "type": "github"
       },
       "original": {
@@ -855,11 +855,11 @@
         "scenefx": "scenefx"
       },
       "locked": {
-        "lastModified": 1786852427,
-        "narHash": "sha256-0mX95LpyZuMMkEKS1qTiVrpDLeuCzO5hVJdmdpr7SY0=",
+        "lastModified": 1786880552,
+        "narHash": "sha256-kOH8g7pOD9tx+q6qPMAH6BFiCiuRUC6R4m4+4UCXRhM=",
         "owner": "mangowm",
         "repo": "mango",
-        "rev": "3cb7cb2d5b0daf09d7245d61ba36f50ea42734ad",
+        "rev": "c5dd50494a22bde6cd59f583b1aed8daa5cbde7e",
         "type": "github"
       },
       "original": {
@@ -1010,11 +1010,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1786717298,
-        "narHash": "sha256-asdPlqtM0AweQ5YNLad6eY4tSYW55YNr1uyayf7mOMQ=",
+        "lastModified": 1786867632,
+        "narHash": "sha256-ez+ubZlA1RtdjCB18a6zJ9M4u8qoPDy08EcnsW5M3Xw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2dda192987ab6815e44df0130f03d6c907b79134",
+        "rev": "ff17823245ab9ff7bcae6acf950bd89cba82c38c",
         "type": "github"
       },
       "original": {
@@ -1026,11 +1026,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1786862985,
+        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
         "type": "github"
       },
       "original": {
@@ -1149,11 +1149,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1786865669,
-        "narHash": "sha256-REIZtns0mp+W2qEPvOfeUffO40gNFiExxAk6D5Jt1v0=",
+        "lastModified": 1786917617,
+        "narHash": "sha256-sOEJVx1ft+JLxZE1FdNbkDfcXT0dj9pojveCLEQZ5Uw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5410a3cecbb866edc56f8cb209ae27bde033ac2f",
+        "rev": "9d9965e70dd40b95fc936aa0595433aa597a6d98",
         "type": "github"
       },
       "original": {
@@ -1197,11 +1197,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1786862985,
+        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
         "type": "github"
       },
       "original": {
@@ -1334,11 +1334,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1786862985,
+        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
         "type": "github"
       },
       "original": {
@@ -1371,11 +1371,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786865707,
-        "narHash": "sha256-JjW75NMnVw6/igd3agY+zWZfgY5A0bU4g/R0KkmtBRg=",
+        "lastModified": 1786905003,
+        "narHash": "sha256-9cqskxPJZ+I5+As8keeu4Vd/UZFhfHdO+FXHENfbq4Y=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "257a03d374184f6f906100d2aee8c261c69a182e",
+        "rev": "ed64dbc392f2f90d12712d6aadca32fcafd17bb4",
         "type": "github"
       },
       "original": {
@@ -1391,11 +1391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786840762,
-        "narHash": "sha256-GxWHKW/k4BxiwxWFjHvrbXiHX9FskjDIfPNXXeJfczM=",
+        "lastModified": 1786882377,
+        "narHash": "sha256-NfnY22tYDrXfIuyexYyqB+jkO6IK23AqmhcNixkU7pw=",
         "owner": "noctalia-dev",
         "repo": "noctalia-greeter",
-        "rev": "f21c5e8253e14c0821e8e0948ced5ea07d8348f8",
+        "rev": "10d2c9074d3a9219e03b55b2c97f1cc743447af5",
         "type": "github"
       },
       "original": {
@@ -1412,11 +1412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786866111,
-        "narHash": "sha256-FzsF9KjLPM31udj2dmGVAD39D3azeDy/JOdEg3JD9ik=",
+        "lastModified": 1786917077,
+        "narHash": "sha256-eY++ui13OfS95Gzp0bJ+METAgZathqe1VpR+vF/i9GQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "90d375cedb96d2dbd4dc90e8ca13c575e4092f8d",
+        "rev": "711a450ee1c11a615f671e46f42b2dce36881333",
         "type": "github"
       },
       "original": {
@@ -2031,11 +2031,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786625014,
-        "narHash": "sha256-RgKJN8748rMCmoLzqMaLtPG+R+GYRhMqp934M3ef2xU=",
+        "lastModified": 1786915905,
+        "narHash": "sha256-p8rjpCgTWcNfmVRaAh6VUDSePOtOWfjCTfH3COLR7j8=",
         "owner": "Benexl",
         "repo": "yt-x",
-        "rev": "65a9d6ef5d8e33797992ac6006b5785becfe21c8",
+        "rev": "6daf417f45732318516038d5520306e29ea803b5",
         "type": "github"
       },
       "original": {

--- a/overlays/upstream-fixes.nix
+++ b/overlays/upstream-fixes.nix
@@ -1,22 +1,4 @@
 _final: prev: {
-  # waypipe 0.11.0's optional video path reads AVVulkanDeviceContext fields
-  # (queue_family_*_index, nb_*_queues) that FFmpeg 8 replaced with the qf[]
-  # array — 10x E0609, build dies at exit 101. with_video defaults to "auto" and
-  # latches on because ffmpeg is in buildInputs, so pin it off. Costs only
-  # waypipe's `--video` lossy-stream option; compression and DMABUF remoting are
-  # unaffected. Drop once waypipe supports the FFmpeg 8 vulkan API.
-  waypipe = prev.waypipe.overrideAttrs (old: {
-    mesonFlags = (old.mesonFlags or [ ]) ++ [ "-Dwith_video=disabled" ];
-  });
-
-  # Same FFmpeg 8 break, one package over: moonlight-qt 6.1.0 reads the removed
-  # AVVulkanDeviceContext queue fields *and* AVCodec.pix_fmts (now behind
-  # avcodec_get_supported_config). Both are load-bearing here — the pix_fmts use
-  # is in the core decoder path, so there's no feature to switch off. Build it
-  # against ffmpeg_7 instead, which keeps hardware decode intact. Drop once
-  # moonlight-qt ships FFmpeg 8 support.
-  moonlight-qt = prev.moonlight-qt.override { ffmpeg = prev.ffmpeg_7; };
-
   # azure-cli 2.81.0 expects azure-mgmt-web v2024_11_01 which isn't packaged yet;
   # disable installCheck until nixpkgs catches up.
   azure-cli = prev.azure-cli.overrideAttrs (_old: {


### PR DESCRIPTION
`nixpkgs` `0e251e2` → `e5bdc4a4` — the `nixos-unstable` channel finally advanced. Also home-manager, mango, nixos-hardware, noctalia, noctalia-greeter and nur.

## What broke

The bump renamed `moonlight-qt`'s `ffmpeg` argument to `ffmpeg_8`, so our override matched no argument:

```
error: function 'anonymous lambda' called with unexpected argument 'ffmpeg'
       at …/pkgs/by-name/mo/moonlight-qt/package.nix:1:1
       Did you mean ffmpeg_8?
```

## Why the fix is deletion, not a rename

Renaming to `ffmpeg_8 = prev.ffmpeg_7` would have silenced the error while keeping a pointless local rebuild. Both FFmpeg 8 workarounds turned out to be obsolete — stock builds come straight from `cache.nixos.org`:

| Package | Stock build |
|---|---|
| `moonlight-qt` 6.1.0 | cached, builds against FFmpeg 8, no patch needed |
| `waypipe` 0.11.0 | cached, builds with video enabled |

Keeping them would have poisoned cache hits for everything downstream for no benefit. Dropping the waypipe flag also restores its `--video` lossy-stream option.

## Verified

- toplevel builds green on p620, razer and p510

## Note

`openssh` is still `10.4p1` after the bump, so the <10.5 exposure tracked in nixpkgs #552175 / #552142 remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
