### PR TITLE
feat(home): writable npm/npx global prefix

### DIFF
--- a/home/development/default.nix
+++ b/home/development/default.nix
@@ -26,6 +26,7 @@ _: {
 
     # Core language support and tooling
     ./languages.nix
+    ./npm-prefix.nix # writable npm/npx global prefix (nodejs-slim has no lib/)
 
     # LSP servers for Claude Code and other editors
     ./lsp-servers.nix

--- a/home/development/npm-prefix.nix
+++ b/home/development/npm-prefix.nix
@@ -1,0 +1,46 @@
+# npm/npx global prefix on NixOS.
+#
+# nixpkgs splits npm out of node: the `npm` on PATH is `npm-cli.js` from
+# `nodejs-slim-<ver>-npm`, and its shebang points at `nodejs-slim`, not at the
+# full `nodejs` derivation. npm derives its global prefix from `process.execPath`,
+# so it lands on the nodejs-slim store path — which ships bin/, include/ and
+# share/ but no lib/. Every `npm install -g` and every `npx <pkg>` that has to
+# fetch then dies with:
+#
+#   npm error enoent ENOENT: no such file or directory,
+#   lstat '/nix/store/...-nodejs-slim-20.20.2/lib'
+#
+# The store path is also read-only, so even a present lib/ would not help.
+# Point the prefix at a writable directory in $HOME instead. That is the right
+# answer regardless of the shebang bug: global npm packages are mutable state
+# and have no business inside the store.
+{ config, lib, ... }:
+let
+  prefix = "${config.home.homeDirectory}/.npm-global";
+in
+{
+  home.sessionVariables.NPM_CONFIG_PREFIX = prefix;
+
+  # npx invoked via an absolute path (${pkgs.nodejs}/bin/npx, as the MCP server
+  # configs do) never sources the shell profile, so the session variable alone
+  # is not enough — npm reads ~/.npmrc unconditionally.
+  # force: razer already carries a hand-rolled ~/.npmrc with the same two
+  # settings. backupFileExtension is not set repo-wide, so without force the
+  # activation aborts with "Existing file ... is in the way" on any host that
+  # has one — and p620 has none, so it would pass locally and break remotely.
+  home.file.".npmrc" = {
+    force = true;
+    text = ''
+      registry=https://registry.npmjs.org/
+      prefix=${prefix}
+    '';
+  };
+
+  home.sessionPath = [ "${prefix}/bin" ];
+
+  # npm requires <prefix>/lib to already exist; it will not create it, and
+  # fails with the same ENOENT if it is missing.
+  home.activation.npmGlobalPrefix = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    run mkdir -p ${lib.escapeShellArg "${prefix}/lib"} ${lib.escapeShellArg "${prefix}/bin"}
+  '';
+}


### PR DESCRIPTION
## Problem

nixpkgs splits npm out of node. The `npm` on PATH is `npm-cli.js` from `nodejs-slim-<ver>-npm`, and its shebang points at `nodejs-slim`, not the full `nodejs` derivation. npm derives its global prefix from `process.execPath`, so it lands on the nodejs-slim store path — which ships `bin/`, `include/` and `share/` but no `lib/`:

```
npm error enoent ENOENT: no such file or directory,
  lstat '/nix/store/...-nodejs-slim-20.20.2/lib'
```

Every `npm install -g` and any `npx <pkg>` that has to fetch dies there. The store path is read-only anyway, so a present `lib/` wouldn't help.

## Fix

Point the prefix at `~/.npm-global`. Global npm packages are mutable state and have no business inside the store.

- `NPM_CONFIG_PREFIX` **plus** a managed `~/.npmrc` — `npx` invoked by absolute path (as the MCP server configs do) never sources the shell profile, while npm reads `~/.npmrc` unconditionally
- `~/.npm-global/bin` on `sessionPath`
- activation hook creates `<prefix>/lib` and `/bin`, which npm requires to exist and won't create itself

## `force = true` on `~/.npmrc`

razer already carries a hand-rolled `~/.npmrc` with the same two settings, and `backupFileExtension` isn't set repo-wide, so without `force` activation aborts with "Existing file … is in the way". p620 has no `~/.npmrc` — so this would have passed locally and failed only on the remote deploy. Same pattern as the existing `home.file."…claude".force = true` (#936).

## Verified

- toplevel builds green on p620, razer and p510
- `home.file.".npmrc".force` evaluates `true` on p620 and razer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
