### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -855,11 +855,11 @@
         "scenefx": "scenefx"
       },
       "locked": {
-        "lastModified": 1786880552,
-        "narHash": "sha256-kOH8g7pOD9tx+q6qPMAH6BFiCiuRUC6R4m4+4UCXRhM=",
+        "lastModified": 1786958759,
+        "narHash": "sha256-qekO+S6m6vfOcSoZwCMpnqVawBtclw7f2qUHLFLUpHo=",
         "owner": "mangowm",
         "repo": "mango",
-        "rev": "c5dd50494a22bde6cd59f583b1aed8daa5cbde7e",
+        "rev": "7b0b39fabb3bca04b90f75b444eafb8825454179",
         "type": "github"
       },
       "original": {
@@ -1149,11 +1149,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1786953970,
-        "narHash": "sha256-WtJHylmsmKwKvTF+hE7KQ49WXMrXJDqLUbeZocMhdcA=",
+        "lastModified": 1786964780,
+        "narHash": "sha256-dUSzK18wR9X0Pbiu4llRLprYbvlpB+jUQCa3KxiZFO4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3f07edb9437d7ec38fb71c1ee58b5e8c26e66515",
+        "rev": "6aac65065239d4747508a7a41f64fefb507443fe",
         "type": "github"
       },
       "original": {
@@ -1412,11 +1412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786953994,
-        "narHash": "sha256-lN4r/k2eg1M99VHAhDtC+Why1DfWxOGkFpPU9ghNiFY=",
+        "lastModified": 1786964265,
+        "narHash": "sha256-dlvVro/cZbZopl1t9+Ln5Oq/9D1zjdPfJj7w5h3hOts=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8a7e13b610645e57a6e8341105f63505b685a424",
+        "rev": "d13eaccec030904bd971deebade6f9ca12a3b765",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=p620, scope=all).

Built and verified locally against nixosConfigurations.p620 before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)