### PR TITLE
fix(scripts): escalate ESP cleanup to one generation when two will not fit

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1149,11 +1149,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1786964780,
-        "narHash": "sha256-dUSzK18wR9X0Pbiu4llRLprYbvlpB+jUQCa3KxiZFO4=",
+        "lastModified": 1786965681,
+        "narHash": "sha256-t8iGgRsHy0w2V0pLo7IR+duOrGuk86zEOGrGOK+8Nzg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6aac65065239d4747508a7a41f64fefb507443fe",
+        "rev": "1b3da43a920453e7a3b19d3e4a791142804d1ac1",
         "type": "github"
       },
       "original": {
@@ -1412,11 +1412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786964265,
-        "narHash": "sha256-dlvVro/cZbZopl1t9+Ln5Oq/9D1zjdPfJj7w5h3hOts=",
+        "lastModified": 1786965391,
+        "narHash": "sha256-ysZ/yGXjofUxBNbe4BMWqYJQnLx3Tg6OLlNdk7Yx8FE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d13eaccec030904bd971deebade6f9ca12a3b765",
+        "rev": "b4190b78ec6f92661c56e1be15299ee47c668fb5",
         "type": "github"
       },
       "original": {

--- a/scripts/check-boot-space.sh
+++ b/scripts/check-boot-space.sh
@@ -64,12 +64,37 @@ run 'sudo find /boot -name "*.tmp" -type f -print -delete 2>/dev/null || true'
 #    /boot by hand is how people brick a laptop: the installer knows which
 #    kernel/initrd the remaining generations still reference, so let it decide.
 #    +2 keeps the current generation and one fallback.
-run 'sudo nix-env -p /nix/var/nix/profiles/system --delete-generations +2 2>/dev/null || true'
-run 'sudo /run/current-system/bin/switch-to-configuration boot 2>&1 | tail -3'
+prune_to() {
+  run "sudo nix-env -p /nix/var/nix/profiles/system --delete-generations +$1 2>/dev/null || true"
+  run 'sudo /run/current-system/bin/switch-to-configuration boot 2>&1 | tail -3'
+}
+
+prune_to 2
 
 FREE="$(free_mib)"
 if [ "$FREE" -ge "$MIN_FREE_MIB" ]; then
   echo "✅ ${LABEL}: ${FREE}MiB free after cleanup"
+  exit 0
+fi
+
+# Escalate to a single generation.
+#
+# Keeping 2 generations is not always reachable: on razer the initrds are
+# ~150MiB, so 2 generations occupy 312MiB of a 511MiB ESP and leave 198MiB —
+# permanently 2MiB under MIN_FREE_MIB. `--delete-generations +2` therefore
+# "succeeded" while still failing the check, every single deploy.
+#
+# Dropping to 1 frees a full initrd. The fallback is not lost for long: the
+# deploy that follows writes a second generation immediately, so the end state
+# is still current + fallback. The window without a fallback lasts only until
+# that switch completes, which beats refusing to deploy at all.
+echo "🧹 ${LABEL}: ${FREE}MiB still short — escalating to a single generation"
+prune_to 1
+
+FREE="$(free_mib)"
+if [ "$FREE" -ge "$MIN_FREE_MIB" ]; then
+  echo "✅ ${LABEL}: ${FREE}MiB free after pruning to one generation"
+  echo "   (the upcoming switch restores a second, so you keep a fallback)"
   exit 0
 fi
 


### PR DESCRIPTION
`check-boot-space.sh --clean` could never satisfy its own threshold on razer.

## The contradiction

- cleanup prunes with `--delete-generations +2` → keeps **2** generations
- razer's initrds are ~149 MiB, so 2 generations + the shared 14 MiB kernel = 312 MiB of a 511 MiB ESP → **198 MiB free**
- the guard requires **200 MiB**

So the cleanup did exactly what it was told, reported success, and the guard aborted anyway — blocking *every* razer deploy, not just untidy ones. Observed today:

```
🔎 razer: /boot has 198MiB free (62% used), need ≥200MiB
🧹 razer: reclaiming space…
❌ razer: still only 198MiB free after cleanup.
```

## Fix

Escalate to a single generation when two won't fit. Frees a full initrd, and the switch that follows immediately writes a second generation — so the end state is still current + fallback. The window without a fallback lasts only until that switch completes, which beats refusing to deploy.

`MIN_FREE_MIB` is deliberately unchanged: 200 MiB is a correct reservation for one 149 MiB initrd plus slack, and the 2026-08-12 mid-install ENOSPC (which left razer running a generation `/boot` couldn't boot) is precisely what it exists to prevent.

## Verified on razer

```
🧹 razer: 198MiB still short — escalating to a single generation
✅ razer: 347MiB free after pruning to one generation
```

ESP now holds one initrd + one kernel (165 MiB used / 347 MiB free); generation 2771 intact and bootable.

## Context, not fixed here

The underlying cause is the 149 MiB initrd — NVIDIA GSP firmware pulled in by `boot.initrd.kernelModules` in `hosts/razer/nixos/nvidia.nix`. Measured: dropping it gives a **46 MiB** initrd. Left alone deliberately, since razer runs `prime.sync.enable = true` and a dark panel on a laptop is worse than a tight ESP. Growing the ESP isn't remotely possible either — it's followed immediately by the root ext4 with only 6.6 MiB free anywhere on the disk, so that needs offline maintenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
