### PR TITLE
fix(overlays): drop the nixpkgs-master dms-shell graft

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1147,22 +1147,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-master": {
-      "locked": {
-        "lastModified": 1786965681,
-        "narHash": "sha256-t8iGgRsHy0w2V0pLo7IR+duOrGuk86zEOGrGOK+8Nzg=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "1b3da43a920453e7a3b19d3e4a791142804d1ac1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "master",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1782847189,
@@ -1371,11 +1355,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786951251,
-        "narHash": "sha256-QQfBDYvPPaD1uVHlyM71qridwXoFyhGLcR5ZWaYcdy0=",
+        "lastModified": 1786967249,
+        "narHash": "sha256-JOrKQpfSG7/VkgtVTBEKkJuhiZya3utxXUEXGAQ94P8=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "ced2221ee68d33aa8862fdf0cd45a899a3cb0b31",
+        "rev": "b10dd5529ba1e386826f377ff39a7f0339e8de54",
         "type": "github"
       },
       "original": {
@@ -1412,11 +1396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786965391,
-        "narHash": "sha256-ysZ/yGXjofUxBNbe4BMWqYJQnLx3Tg6OLlNdk7Yx8FE=",
+        "lastModified": 1786967687,
+        "narHash": "sha256-vcEqm5xontMUcBbjxg9bZc3BV98vs5IGtK/PXc9hQ5o=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b4190b78ec6f92661c56e1be15299ee47c668fb5",
+        "rev": "c6cbd8f9b5bb32f72fbf27f5c4821d8f16cec571",
         "type": "github"
       },
       "original": {
@@ -1515,7 +1499,6 @@
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_8",
         "nixpkgs-f2k": "nixpkgs-f2k",
-        "nixpkgs-master": "nixpkgs-master",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "noctalia": "noctalia",
         "noctalia-greeter": "noctalia-greeter",

--- a/flake.nix
+++ b/flake.nix
@@ -31,10 +31,6 @@
     # Core
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
-    # Temporary: dms-shell 1.5.0 landed on master (PR #539682, 2026-07-09) but
-    # hasn't reached the nixos-unstable channel yet. Grafted in via overlay
-    # (overlays/default.nix). Remove this input + the graft once unstable catches up.
-    nixpkgs-master.url = "github:nixos/nixpkgs/master";
 
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
     flake-utils.url = "github:numtide/flake-utils";
@@ -82,8 +78,8 @@
     # here needs fetchSubmodules.
     #
     # Pinned to a release tag: this is a fast-moving 0.x (v0.2.7, 2026-07-24).
-    # Requires DMS >= 1.5 for the dankcal backend to exist at all — do not drop
-    # the nixpkgs-master DMS graft above until unstable carries 1.5+.
+    # Requires DMS >= 1.5 for the dankcal backend to exist at all; nixos-unstable
+    # ships dms-shell 1.5.3, so plain pkgs.dms-shell satisfies that.
     dankcalendar = {
       url = "github:AvengeMedia/dankcalendar/v0.2.7";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -8,14 +8,6 @@
     zjstatus = inputs.zjstatus.packages.${prev.stdenv.hostPlatform.system}.default;
   })
 
-  # ponytail: temporary graft. dms-shell 1.5.0 is on nixpkgs master but not yet
-  # in the nixos-unstable channel. Pull the whole derivation from master (correct
-  # inputs, no hash maintenance). Drop this + the nixpkgs-master input once unstable
-  # ships 1.5.0 — check with: nix eval nixpkgs#dms-shell.version
-  (_final: prev: {
-    dms-shell = inputs.nixpkgs-master.legacyPackages.${prev.stdenv.hostPlatform.system}.dms-shell;
-  })
-
   (_final: prev: {
     gogmail = inputs.gogmail.packages.${prev.stdenv.hostPlatform.system}.gogmail;
   })


### PR DESCRIPTION
p620 builds were dying after 30 minutes in ffmpeg-9.0's FATE suite:

```
--- ./tests/ref/fate/fifo-muxer-tst
+++ tests/data/fate/fifo-muxer-tst
-overflow with packet dropping: ok
+overflow with packet dropping: fail
make: *** [tests/Makefile:326: fate-fifo-muxer-tst] Error 190
```

## Why ffmpeg was built locally at all

The dependency chain from the failure graph: `dms-shell-1.5.3` → `qtmultimedia-6.11.1` → `ffmpeg-9.0`. `dms-shell` was grafted from **`nixpkgs-master`**, which Hydra doesn't build — so the whole Qt/ffmpeg stack compiled from source and tripped a flaky test `cache.nixos.org` would never have exposed us to.

Disabling the test would have treated the symptom. The graft itself is the problem.

## The graft is obsolete

nixos-unstable now ships the same version master has:

| rev | dms-shell |
|---|---|
| channel `e5bdc4a4` | 1.5.3 |
| master `a9b6bf56` | 1.5.3 |

So plain `pkgs.dms-shell` is correct *and* cached. Removed:

- the overlay in `overlays/default.nix`
- the `nixpkgs-master` input — the graft was its only consumer
- the stale "do not drop the graft" note on `dankcalendar`, whose DMS ≥ 1.5 requirement the channel now meets on its own

## Verified

- `dms-shell-1.5.3` substitutes from `cache.nixos.org`
- p620's dry-run goes from a 30-minute ffmpeg build to **4 trivial derivations** (`system-units`, `etc`, `activate`, `toplevel`)
- toplevel builds green on p620, razer and p510 with no local compilation

Bonus: this removes a master-tracking input, which was a standing cache-poisoning risk for every package above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
