### PR TITLE
fix(services): enable thermald only on Intel CPUs (#1362)

### DIFF
--- a/hosts/p620/nixos/power.nix
+++ b/hosts/p620/nixos/power.nix
@@ -1,6 +1,5 @@
 { pkgs, ... }: {
   services = {
-    thermald.enable = true;
     upower.enable = true;
     power-profiles-daemon.enable = true;
     auto-cpufreq = {

--- a/modules/services/system/default.nix
+++ b/modules/services/system/default.nix
@@ -1,4 +1,4 @@
-_: {
+{ config, ... }: {
   # Override udevil to use GCC 14 for compatibility (GCC 15 fails on old C code)
   nixpkgs.config.packageOverrides = prev: {
     udevil = prev.udevil.override {
@@ -10,7 +10,8 @@ _: {
     gvfs.enable = true;
     udisks2.enable = true;
     devmon.enable = true; # Now works with GCC 14 override
-    thermald.enable = true;
+    # thermald is Intel-only; it exits with "Unsupported cpu model" on AMD
+    thermald.enable = config.hardware.cpu.intel.updateMicrocode;
   };
   services.hardware.bolt = {
     enable = true;


### PR DESCRIPTION
thermald is Intel-only. On p620 (AMD) it exits with "Unsupported cpu model
or platform", so every switch reported a failed unit and nh exited 4,
which the deploy wrapper treated as a failure and rolled back.

Gate it on hardware.cpu.intel.updateMicrocode in the shared services
module and drop the duplicate enable in p620's power.nix.

Closes #1362

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
