### PR TITLE
feat(desktop): add Hyprland 0.56 (Lua config) as a DMS session (#1366)

### DIFF
--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -6,6 +6,7 @@
   imports = [
     ./profile.nix
     ../../home/desktop/noctalia # Noctalia shell for niri/labwc sessions
+    ../../home/desktop/hyprland # Hyprland session config (Lua)
     ../../home/desktop/dank-calendar # dcal daemon backing the DMS calendar card
   ];
 

--- a/Users/olafkfreund/razer_home.nix
+++ b/Users/olafkfreund/razer_home.nix
@@ -7,6 +7,7 @@
   imports = [
     ./profile.nix
     ../../home/desktop/noctalia # Noctalia shell for niri/labwc sessions
+    ../../home/desktop/hyprland # Hyprland session config (Lua)
   ];
 
   desktop.gnome.profile = "laptop";

--- a/home/desktop/hyprland/default.nix
+++ b/home/desktop/hyprland/default.nix
@@ -1,0 +1,177 @@
+{ config, lib, osConfig, ... }:
+# Hyprland session config — the DMS/Noctalia counterpart to home/desktop/noctalia.
+#
+# Hyprland 0.55+ replaced hyprlang with an embedded Lua runtime, so home-manager
+# writes ~/.config/hypr/hyprland.lua (configType = "lua"): `settings.<name>`
+# renders as `hl.<name>(...)`, `extraConfig` is appended verbatim as Lua.
+#
+# Which shell starts is decided by the login session, exactly as for labwc/mango:
+# the stock "Hyprland" session leaves DESK_SHELL unset -> Noctalia, the
+# "Hyprland (DankMaterialShell)" session sets DESK_SHELL="dms run" -> DMS
+# (modules/desktop/dms-shell.nix).
+#
+# Phase 1 (#1366): session, colours, essential binds. The full 146-bind niri
+# parity port, screen recorder and window rules are #1367.
+let
+  inherit (lib.generators) mkLuaInline;
+
+  # Same wallpaper Stylix uses; swaybg paints it, as on niri/labwc/mango.
+  wallpaper = (import ../../../hosts/common/shared-variables.nix).baseTheme.wallpaper;
+
+  # Only laptops auto-suspend on idle; the workstation stays up (RDP / AI host).
+  isLaptop = (osConfig.host.class or "") == "laptop";
+
+  # Fixed UK coordinates (London), matching the niri session's gammastep.
+  geo = "51.5:-0.13";
+
+  c = n: "rgb(${config.lib.stylix.colors.${n}})";
+in
+{
+  # Stylix's hyprland target writes hyprlang-shaped keys ("col.active_border")
+  # even in lua mode, where the API nests them (general.col.active_border), and
+  # its hyprpaper sub-target would start a second wallpaper daemon next to
+  # swaybg. We set the same base16 colours by hand below instead.
+  stylix.targets.hyprland.enable = false;
+
+  wayland.windowManager.hyprland = {
+    enable = true;
+    configType = "lua";
+
+    # The compositor and its portal come from the NixOS module
+    # (modules/desktop/hyprland.nix); home-manager only writes the config.
+    package = null;
+    portalPackage = null;
+
+    # greetd launches the session directly, like niri/labwc/mango — no
+    # hyprland-session.target wiring.
+    systemd.enable = false;
+
+    settings = {
+      # `hl.env(...)`. greetd does not source environment.sessionVariables, so
+      # the Electron apps need these exported from the compositor itself.
+      env = [
+        { _args = [ "NIXOS_OZONE_WL" "1" ]; }
+        { _args = [ "ELECTRON_OZONE_PLATFORM_HINT" "auto" ]; }
+      ];
+
+      # `hl.config{...}`. Colours mirror the niri layout block in
+      # home/desktop/noctalia: 1px borders, active base0B, inactive base03,
+      # 12px outer gaps, base0B-tinted shadow.
+      config = {
+        general = {
+          gaps_in = 6;
+          gaps_out = 12;
+          border_size = 1;
+          col = {
+            active_border = c "base0B";
+            inactive_border = c "base03";
+          };
+          layout = "dwindle";
+        };
+
+        decoration = {
+          rounding = 8;
+          shadow = {
+            enabled = true;
+            range = 14;
+            render_power = 2;
+            color = "rgba(${config.lib.stylix.colors.base0B}33)";
+          };
+        };
+
+        dwindle.preserve_split = true;
+
+        input = {
+          # Matches programs.niri.settings.input.keyboard.xkb.layout.
+          kb_layout = "gb";
+          follow_mouse = 1;
+        };
+
+        misc = {
+          force_default_wallpaper = 0;
+          disable_hyprland_logo = true;
+        };
+      };
+
+      # `hl.on("hyprland.start", function() ... end)`. swaybg/gammastep/swayidle
+      # are the same helpers the niri and labwc sessions start.
+      on = {
+        _args = [
+          "hyprland.start"
+          (mkLuaInline ''
+            function()
+              hl.exec_cmd("sh -c 'exec ''${DESK_SHELL:-noctalia}'")
+              hl.exec_cmd("swaybg -m fill -i ${wallpaper}")
+              hl.exec_cmd("gammastep -l ${geo}")
+              hl.exec_cmd("swayidle -w timeout 300 'dms ipc call lock lock' timeout 600 'hyprctl dispatch dpms off' resume 'hyprctl dispatch dpms on' ${lib.optionalString isLaptop "timeout 1800 'systemctl suspend' "}before-sleep 'dms ipc call lock lock'")
+            end
+          '')
+        ];
+      };
+    };
+
+    # Binds as plain Lua: 30 hl.bind() calls read better here than 30 nested
+    # _args/mkLuaInline attrsets, and this is the form the DMS docs use.
+    #
+    # DMS writes ~/.config/hypr/dms/{colors,layout,outputs}.lua at runtime.
+    # Only outputs is required: colours and layout are ours (same reasoning as
+    # the excluded dms/colors.kdl + dms/layout.kdl on niri). hyprland.lua is a
+    # read-only store symlink, so the require must tolerate a missing file.
+    extraConfig = ''
+      package.path = (os.getenv("XDG_CONFIG_HOME") or (os.getenv("HOME") .. "/.config"))
+        .. "/hypr/?.lua;" .. package.path
+      pcall(require, "dms.outputs")
+
+      local mod = "SUPER"
+
+      -- Launchers / window management
+      hl.bind(mod .. " + RETURN", hl.dsp.exec_cmd("ghostty"))
+      hl.bind(mod .. " + T", hl.dsp.exec_cmd("ghostty"))
+      hl.bind(mod .. " + E", hl.dsp.exec_cmd("nautilus"))
+      hl.bind(mod .. " + Q", hl.dsp.window.close())
+      hl.bind(mod .. " + V", hl.dsp.window.float({ action = "toggle" }))
+      hl.bind(mod .. " + F", hl.dsp.window.fullscreen({ mode = "maximized", action = "toggle" }))
+      hl.bind(mod .. " + SHIFT + F", hl.dsp.window.fullscreen({ mode = "fullscreen", action = "toggle" }))
+      hl.bind(mod .. " + R", hl.dsp.layout("togglesplit"))
+      hl.bind(mod .. " + SHIFT + E", hl.dsp.exit())
+
+      -- Focus / move. HJKL and the arrows both move focus; niri's arrow-based
+      -- workspace switching lives on Page_Up/Down here (see #1367).
+      for key, dir in pairs({ H = "left", L = "right", J = "down", K = "up" }) do
+        hl.bind(mod .. " + " .. key, hl.dsp.focus({ direction = dir }))
+        hl.bind(mod .. " + SHIFT + " .. key, hl.dsp.window.move({ direction = dir }))
+      end
+      for key, dir in pairs({ left = "left", right = "right", down = "down", up = "up" }) do
+        hl.bind(mod .. " + " .. key, hl.dsp.focus({ direction = dir }))
+        hl.bind(mod .. " + SHIFT + " .. key, hl.dsp.window.move({ direction = dir }))
+      end
+
+      -- Workspaces
+      for i = 1, 5 do
+        hl.bind(mod .. " + " .. i, hl.dsp.focus({ workspace = tostring(i) }))
+        hl.bind(mod .. " + SHIFT + " .. i, hl.dsp.window.move({ workspace = tostring(i) }))
+      end
+      hl.bind(mod .. " + Page_Down", hl.dsp.focus({ workspace = "e+1" }))
+      hl.bind(mod .. " + Page_Up", hl.dsp.focus({ workspace = "e-1" }))
+      hl.bind(mod .. " + mouse_down", hl.dsp.focus({ workspace = "e+1" }))
+      hl.bind(mod .. " + mouse_up", hl.dsp.focus({ workspace = "e-1" }))
+
+      -- Shell actions — DankMaterialShell
+      hl.bind(mod .. " + D", hl.dsp.exec_cmd("dms ipc call spotlight toggle"))
+      hl.bind(mod .. " + SPACE", hl.dsp.exec_cmd("dms ipc call spotlight toggle"))
+      hl.bind(mod .. " + C", hl.dsp.exec_cmd("dms ipc call control-center toggle"))
+      hl.bind(mod .. " + N", hl.dsp.exec_cmd("dms ipc call notifications toggle"))
+      hl.bind(mod .. " + X", hl.dsp.exec_cmd("dms ipc call powermenu toggle"))
+      hl.bind(mod .. " + O", hl.dsp.exec_cmd("dms ipc call overview toggle"))
+      hl.bind(mod .. " + TAB", hl.dsp.exec_cmd("dms ipc call overview toggle"))
+      hl.bind(mod .. " + BACKSPACE", hl.dsp.exec_cmd("dms ipc call lock lock"), { locked = true })
+
+      -- Media / brightness (locked so they work on the lock screen)
+      hl.bind("XF86AudioRaiseVolume", hl.dsp.exec_cmd("wpctl set-volume -l 1 @DEFAULT_AUDIO_SINK@ 5%+"), { locked = true, repeating = true })
+      hl.bind("XF86AudioLowerVolume", hl.dsp.exec_cmd("wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-"), { locked = true, repeating = true })
+      hl.bind("XF86AudioMute", hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"), { locked = true })
+      hl.bind("XF86MonBrightnessUp", hl.dsp.exec_cmd("brightnessctl set 5%+"), { locked = true, repeating = true })
+      hl.bind("XF86MonBrightnessDown", hl.dsp.exec_cmd("brightnessctl set 5%-"), { locked = true, repeating = true })
+    '';
+  };
+}

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -367,6 +367,7 @@ in
   desktop.niri.enable = true;
   desktop.labwc.enable = true;
   desktop.mangowm.enable = true;
+  desktop.hyprland.enable = true;
 
   # Adds "(DankMaterialShell)" login sessions for niri/labwc/mango next to the
   # stock (Noctalia) ones — pick per login in the greeter.

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -332,6 +332,7 @@ in
   desktop.niri.enable = true;
   desktop.labwc.enable = true;
   desktop.mangowm.enable = true;
+  desktop.hyprland.enable = true;
 
   # Adds "(DankMaterialShell)" login sessions for niri/labwc/mango next to the
   # stock (Noctalia) ones — pick per login in the greeter.

--- a/modules/desktop/default.nix
+++ b/modules/desktop/default.nix
@@ -6,6 +6,7 @@
     ./niri.nix
     ./labwc.nix
     ./mangowm.nix
+    ./hyprland.nix
     ./dms-shell.nix
     ./ddcutil.nix
   ];

--- a/modules/desktop/dms-shell.nix
+++ b/modules/desktop/dms-shell.nix
@@ -34,10 +34,17 @@ let
     export DESK_SHELL="dms run"
     exec mango
   '';
+  # Hyprland has no NIRI_CONFIG equivalent — one hyprland.lua serves both
+  # sessions and the ${DESK_SHELL:-noctalia} switch in its hyprland.start hook
+  # (home/desktop/hyprland) picks the shell, same as labwc/mango.
+  hyprlandLauncher = pkgs.writeShellScript "hyprland-dms-session" ''
+    export DESK_SHELL="dms run"
+    exec ${config.programs.hyprland.package}/bin/start-hyprland
+  '';
 
   # services.displayManager.sessionPackages requires passthru.providedSessions to
   # match the .desktop basename.
-  mkSession = { name, label, comment, exec }:
+  mkSession = { name, label, comment, exec, desktopNames ? name }:
     (pkgs.writeTextFile {
       name = "${name}-wayland-session";
       destination = "/share/wayland-sessions/${name}.desktop";
@@ -47,13 +54,17 @@ let
         Comment=${comment}
         Exec=${exec}
         Type=Application
-        DesktopNames=${name}
+        DesktopNames=${desktopNames}
       '';
     }).overrideAttrs (_: { passthru.providedSessions = [ name ]; });
 
   niriDmsSession = mkSession { name = "niri-dms"; label = "Niri (DankMaterialShell)"; comment = "Niri with the DankMaterialShell desktop shell"; exec = "${niriDmsLauncher}"; };
   labwcDmsSession = mkSession { name = "labwc-dms"; label = "labwc (DankMaterialShell)"; comment = "labwc with the DankMaterialShell desktop shell"; exec = "${labwcLauncher}"; };
   mangoDmsSession = mkSession { name = "mango-dms"; label = "mango (DankMaterialShell)"; comment = "mango with the DankMaterialShell desktop shell"; exec = "${mangoLauncher}"; };
+  # DesktopNames stays "Hyprland" (not the session name): xdg-desktop-portal-hyprland
+  # declares UseIn=wlroots;Hyprland;... and would not bind for "hyprland-dms",
+  # breaking ScreenCast/Screenshot in this session.
+  hyprlandDmsSession = mkSession { name = "hyprland-dms"; label = "Hyprland (DankMaterialShell)"; comment = "Hyprland with the DankMaterialShell desktop shell"; exec = "${hyprlandLauncher}"; desktopNames = "Hyprland"; };
 
   # Shadow niri-flake's stock niri.desktop (which runs niri-session against the
   # default config.kdl — now the DMS config) so the plain "Niri" session stays
@@ -64,7 +75,8 @@ let
   dmsSessions =
     [ niriDmsSession ]
     ++ optional config.desktop.labwc.enable labwcDmsSession
-    ++ optional config.desktop.mangowm.enable mangoDmsSession;
+    ++ optional config.desktop.mangowm.enable mangoDmsSession
+    ++ optional config.desktop.hyprland.enable hyprlandDmsSession;
 in
 {
   options.desktop.dmsShell.enable =

--- a/modules/desktop/hyprland.nix
+++ b/modules/desktop/hyprland.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+# Hyprland — dynamic-tiling Wayland compositor, exposed as a selectable login
+# session alongside niri/labwc/mango. Hyprland 0.55+ dropped hyprlang in favour
+# of an embedded Lua runtime, so the config is ~/.config/hypr/hyprland.lua,
+# written by home-manager (see home/desktop/hyprland).
+#
+# programs.hyprland ships its own share/wayland-sessions/hyprland.desktop, so
+# unlike labwc/mango no session file is generated here; the DMS variant lives in
+# dms-shell.nix.
+let
+  inherit (lib) mkEnableOption mkIf;
+  cfg = config.desktop.hyprland;
+in
+{
+  options.desktop.hyprland.enable =
+    mkEnableOption "Hyprland dynamic-tiling Wayland compositor (selectable login session)";
+
+  config = mkIf cfg.enable {
+    programs.hyprland = {
+      enable = true;
+      package = pkgs.hyprland;
+      xwayland.enable = true;
+      # Explicit rather than relying on the default: portal routing is the usual
+      # failure mode when adding a compositor here (stale XDG_CURRENT_DESKTOP
+      # sends ScreenCast to the wrong backend).
+      portalPackage = pkgs.xdg-desktop-portal-hyprland;
+    };
+  };
+}


### PR DESCRIPTION
Hyprland 0.55+ replaced hyprlang with an embedded Lua runtime, so the config
is ~/.config/hypr/hyprland.lua, written by home-manager with
configType = "lua" (settings.<name> -> hl.<name>(...), extraConfig appended
verbatim). nixpkgs already ships 0.56.2 and dms-shell 1.5.3 has Hyprland Lua
support, so no new flake input is needed.

- modules/desktop/hyprland.nix: desktop.hyprland.enable -> programs.hyprland
  with an explicit xdg-desktop-portal-hyprland.
- modules/desktop/dms-shell.nix: "Hyprland (DankMaterialShell)" session using
  the same ${DESK_SHELL:-noctalia} switch as labwc/mango. mkSession gains an
  optional desktopNames, because the portal declares UseIn=...;Hyprland;... and
  would not bind for a "hyprland-dms" desktop name.
- home/desktop/hyprland: colours mirroring the niri layout block (1px borders,
  base0B active / base03 inactive, 12px gaps, base0B-tinted shadow), gb keymap,
  the swaybg/gammastep/swayidle startup hook and 30 binds. Stylix's hyprland
  target is disabled: it emits hyprlang-shaped keys ("col.active_border") even
  in lua mode, and its hyprpaper sub-target would race swaybg.

Enabled on p620 + razer only. The generated hyprland.lua passes luac -p, and
the niri config is byte-identical before and after.

Full 146-bind niri parity port is #1367.

Closes #1366

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
