### PR TITLE
feat(desktop): port the full niri bind set to the Hyprland session (#1367)

### DIFF
--- a/home/desktop/hyprland/default.nix
+++ b/home/desktop/hyprland/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, osConfig, ... }:
+{ config, lib, pkgs, osConfig, ... }:
 # Hyprland session config — the DMS/Noctalia counterpart to home/desktop/noctalia.
 #
 # Hyprland 0.55+ replaced hyprlang with an embedded Lua runtime, so home-manager
@@ -10,8 +10,8 @@
 # "Hyprland (DankMaterialShell)" session sets DESK_SHELL="dms run" -> DMS
 # (modules/desktop/dms-shell.nix).
 #
-# Phase 1 (#1366): session, colours, essential binds. The full 146-bind niri
-# parity port, screen recorder and window rules are #1367.
+# Binds mirror the niri session (home/desktop/noctalia) wherever Hyprland has
+# an equivalent action; the divergences are commented at the bind (#1367).
 let
   inherit (lib.generators) mkLuaInline;
 
@@ -32,6 +32,13 @@ in
   # its hyprpaper sub-target would start a second wallpaper daemon next to
   # swaybg. We set the same base16 colours by hand below instead.
   stylix.targets.hyprland.enable = false;
+
+  # grimblast: Hyprland-aware grim/slurp/wl-copy wrapper behind the screenshot
+  # binds (niri has a native screenshot UI, Hyprland does not). Everything else
+  # the binds and the startup hook call — swaybg, gammastep, swayidle, slurp,
+  # wl-screenrec, the shared `screenrecord` script — comes from
+  # home/desktop/noctalia, which every session here shares.
+  home.packages = [ pkgs.grimblast ];
 
   wayland.windowManager.hyprland = {
     enable = true;
@@ -110,8 +117,13 @@ in
       };
     };
 
-    # Binds as plain Lua: 30 hl.bind() calls read better here than 30 nested
+    # Binds as plain Lua: hl.bind() calls read better here than nested
     # _args/mkLuaInline attrsets, and this is the form the DMS docs use.
+    #
+    # Ported 1:1 from the niri binds block in home/desktop/noctalia where the
+    # action exists in Hyprland. niri is scrollable-tiling and Hyprland is
+    # dwindle, so the column actions have no direct equivalent — the mapping is
+    # recorded per bind below (#1367).
     #
     # DMS writes ~/.config/hypr/dms/{colors,layout,outputs}.lua at runtime.
     # Only outputs is required: colours and layout are ours (same reasoning as
@@ -130,21 +142,43 @@ in
       hl.bind(mod .. " + E", hl.dsp.exec_cmd("nautilus"))
       hl.bind(mod .. " + Q", hl.dsp.window.close())
       hl.bind(mod .. " + V", hl.dsp.window.float({ action = "toggle" }))
-      hl.bind(mod .. " + F", hl.dsp.window.fullscreen({ mode = "maximized", action = "toggle" }))
-      hl.bind(mod .. " + SHIFT + F", hl.dsp.window.fullscreen({ mode = "fullscreen", action = "toggle" }))
-      hl.bind(mod .. " + R", hl.dsp.layout("togglesplit"))
       hl.bind(mod .. " + SHIFT + E", hl.dsp.exit())
 
-      -- Focus / move. HJKL and the arrows both move focus; niri's arrow-based
-      -- workspace switching lives on Page_Up/Down here (see #1367).
+      -- niri maximize-column / fullscreen-window / windowed-fullscreen.
+      hl.bind(mod .. " + F", hl.dsp.window.fullscreen({ mode = "maximized", action = "toggle" }))
+      hl.bind(mod .. " + SHIFT + F", hl.dsp.window.fullscreen({ mode = "fullscreen", action = "toggle" }))
+      hl.bind(mod .. " + CTRL + SHIFT + F", hl.dsp.window.fullscreen_state({ internal = 2, client = 0, action = "toggle" }))
+
+      -- niri switch-preset-column-width has no dwindle equivalent; togglesplit
+      -- is the nearest "change how this window is laid out" action.
+      hl.bind(mod .. " + R", hl.dsp.layout("togglesplit"))
+
+      -- niri set-column-width +-10%. Hyprland resizes in pixels.
+      hl.bind(mod .. " + EQUAL", hl.dsp.window.resize({ x = 100, y = 0, relative = true }))
+      hl.bind(mod .. " + MINUS", hl.dsp.window.resize({ x = -100, y = 0, relative = true }))
+
+      -- niri consume-window-into-column / expel-window-from-column. Groups are
+      -- the closest concept: toggle creates or dissolves one, next cycles
+      -- through its members.
+      hl.bind(mod .. " + COMMA", hl.dsp.group.toggle())
+      hl.bind(mod .. " + PERIOD", hl.dsp.group.next())
+
+      -- Focus / move. HJKL is pure directional focus, as on niri.
       for key, dir in pairs({ H = "left", L = "right", J = "down", K = "up" }) do
         hl.bind(mod .. " + " .. key, hl.dsp.focus({ direction = dir }))
         hl.bind(mod .. " + SHIFT + " .. key, hl.dsp.window.move({ direction = dir }))
       end
-      for key, dir in pairs({ left = "left", right = "right", down = "down", up = "up" }) do
-        hl.bind(mod .. " + " .. key, hl.dsp.focus({ direction = dir }))
-        hl.bind(mod .. " + SHIFT + " .. key, hl.dsp.window.move({ direction = dir }))
-      end
+
+      -- Arrows keep niri's split: left/right move focus, up/down change
+      -- workspace (niri stacks workspaces vertically and columns horizontally).
+      hl.bind(mod .. " + left", hl.dsp.focus({ direction = "left" }))
+      hl.bind(mod .. " + right", hl.dsp.focus({ direction = "right" }))
+      hl.bind(mod .. " + SHIFT + left", hl.dsp.window.move({ direction = "left" }))
+      hl.bind(mod .. " + SHIFT + right", hl.dsp.window.move({ direction = "right" }))
+      hl.bind(mod .. " + down", hl.dsp.focus({ workspace = "e+1" }))
+      hl.bind(mod .. " + up", hl.dsp.focus({ workspace = "e-1" }))
+      hl.bind(mod .. " + SHIFT + down", hl.dsp.window.move({ workspace = "e+1" }))
+      hl.bind(mod .. " + SHIFT + up", hl.dsp.window.move({ workspace = "e-1" }))
 
       -- Workspaces
       for i = 1, 5 do
@@ -153,17 +187,34 @@ in
       end
       hl.bind(mod .. " + Page_Down", hl.dsp.focus({ workspace = "e+1" }))
       hl.bind(mod .. " + Page_Up", hl.dsp.focus({ workspace = "e-1" }))
+      hl.bind(mod .. " + SHIFT + Page_Down", hl.dsp.window.move({ workspace = "e+1" }))
+      hl.bind(mod .. " + SHIFT + Page_Up", hl.dsp.window.move({ workspace = "e-1" }))
+      -- niri throttles wheel workspace switching with cooldown-ms=150; Hyprland
+      -- has no equivalent knob.
       hl.bind(mod .. " + mouse_down", hl.dsp.focus({ workspace = "e+1" }))
       hl.bind(mod .. " + mouse_up", hl.dsp.focus({ workspace = "e-1" }))
 
-      -- Shell actions — DankMaterialShell
+      -- Screenshots. niri has a native screenshot UI; grimblast is the
+      -- Hyprland-aware grim/slurp wrapper. copysave = clipboard + ~/Pictures.
+      hl.bind(mod .. " + S", hl.dsp.exec_cmd("grimblast copysave area"))
+      hl.bind(mod .. " + CTRL + S", hl.dsp.exec_cmd("grimblast copysave output"))
+      hl.bind(mod .. " + SHIFT + S", hl.dsp.exec_cmd("grimblast copysave active"))
+
+      -- Screen recording (shared script, see home/desktop/noctalia)
+      hl.bind(mod .. " + SHIFT + R", hl.dsp.exec_cmd("screenrecord"))
+      hl.bind(mod .. " + ALT + R", hl.dsp.exec_cmd("screenrecord region"))
+
+      -- Shell actions — DankMaterialShell. The overview and the keybind
+      -- cheatsheet go through DMS's Hyprland-specific `hypr` IPC target
+      -- (`dms ipc call hypr ...`), not the niri one.
       hl.bind(mod .. " + D", hl.dsp.exec_cmd("dms ipc call spotlight toggle"))
       hl.bind(mod .. " + SPACE", hl.dsp.exec_cmd("dms ipc call spotlight toggle"))
       hl.bind(mod .. " + C", hl.dsp.exec_cmd("dms ipc call control-center toggle"))
       hl.bind(mod .. " + N", hl.dsp.exec_cmd("dms ipc call notifications toggle"))
       hl.bind(mod .. " + X", hl.dsp.exec_cmd("dms ipc call powermenu toggle"))
-      hl.bind(mod .. " + O", hl.dsp.exec_cmd("dms ipc call overview toggle"))
-      hl.bind(mod .. " + TAB", hl.dsp.exec_cmd("dms ipc call overview toggle"))
+      hl.bind(mod .. " + O", hl.dsp.exec_cmd("dms ipc call hypr toggleOverview"))
+      hl.bind(mod .. " + TAB", hl.dsp.exec_cmd("dms ipc call hypr toggleOverview"))
+      hl.bind(mod .. " + SHIFT + SLASH", hl.dsp.exec_cmd("dms ipc call hypr toggleBinds"))
       hl.bind(mod .. " + BACKSPACE", hl.dsp.exec_cmd("dms ipc call lock lock"), { locked = true })
 
       -- Media / brightness (locked so they work on the lock screen)

--- a/home/desktop/noctalia/default.nix
+++ b/home/desktop/noctalia/default.nix
@@ -37,7 +37,7 @@ let
 in
 {
   # wl-mirror: mirror an output to a window (niri has no native mirroring).
-  # jq: parse `niri msg --json`. wl-screenrec/slurp: HW-encoded screen recording.
+  # jq: parse the compositor's JSON IPC. wl-screenrec/slurp: HW-encoded recording.
   home.packages = with pkgs; [
     wl-mirror
     jq
@@ -57,7 +57,7 @@ in
     #         output config natively in config.kdl, so this is mainly for labwc)
     # Screen-recording toggle bound to Mod+Shift+R / Mod+Alt+R. Records the
     # focused output (or a slurp-selected region) to ~/Videos; re-run to stop.
-    (writeShellScriptBin "niri-screenrecord" ''
+    (writeShellScriptBin "screenrecord" ''
       set -euo pipefail
       out="$HOME/Videos"; mkdir -p "$out"
       if ${procps}/bin/pgrep -x wl-screenrec >/dev/null 2>&1; then
@@ -69,7 +69,13 @@ in
           geom="$(${slurp}/bin/slurp)" || exit 0
           ${wl-screenrec}/bin/wl-screenrec -g "$geom" -f "$f" &
         else
-          name="$(${niri}/bin/niri msg --json focused-output | ${jq}/bin/jq -r .name)"
+          # Focused-output lookup is the only compositor-specific bit; labwc and
+          # mango have no such IPC, which is why they bind the region variant.
+          if [ -n "''${NIRI_SOCKET:-}" ]; then
+            name="$(${niri}/bin/niri msg --json focused-output | ${jq}/bin/jq -r .name)"
+          else
+            name="$(${hyprland}/bin/hyprctl -j activeworkspace | ${jq}/bin/jq -r .monitor)"
+          fi
           ${wl-screenrec}/bin/wl-screenrec -o "$name" -f "$f" &
         fi
         ${libnotify}/bin/notify-send "Screen recording" "Recording… Mod+Shift+R to stop"
@@ -498,8 +504,8 @@ in
         Mod+S { spawn "niri" "msg" "action" "screenshot"; }
         Mod+Ctrl+S { spawn "niri" "msg" "action" "screenshot-screen"; }
         Mod+Shift+S { spawn "niri" "msg" "action" "screenshot-window"; }
-        Mod+Shift+R { spawn "niri-screenrecord"; }
-        Mod+Alt+R { spawn "niri-screenrecord" "region"; }
+        Mod+Shift+R { spawn "screenrecord"; }
+        Mod+Alt+R { spawn "screenrecord" "region"; }
         Mod+Shift+Slash { show-hotkey-overlay; }
         Mod+Shift+E { quit; }
         XF86AudioRaiseVolume { spawn "wpctl" "set-volume" "@DEFAULT_AUDIO_SINK@" "5%+"; }
@@ -597,8 +603,8 @@ in
 
     # Screen recording (wl-screenrec, hardware-encoded) → ~/Videos. Re-press to
     # stop. Mod+Shift+R = focused output; Mod+Alt+R = slurp-selected region.
-    "Mod+Shift+R".action = spawn "niri-screenrecord";
-    "Mod+Alt+R".action = spawn "niri-screenrecord" "region";
+    "Mod+Shift+R".action = spawn "screenrecord";
+    "Mod+Alt+R".action = spawn "screenrecord" "region";
 
     # Screen mirroring (wl-mirror): mirror the focused output into a window.
     # Move that window to the target output and Mod+Shift+F it to fullscreen.
@@ -721,10 +727,10 @@ in
         <keybind key="W-C-s"><action name="Execute" command="noctalia msg screenshot-fullscreen"/></keybind>
         <keybind key="Print"><action name="Execute" command="noctalia msg screenshot-region"/></keybind>
         <!-- Screen recording (region; re-press to stop). Mod+Alt+R matches niri's
-             region key; Mod+Shift+R kept as an alias. niri-screenrecord's region
+             region key; Mod+Shift+R kept as an alias. screenrecord's region
              branch is compositor-agnostic (slurp + wl-screenrec). -->
-        <keybind key="W-A-r"><action name="Execute" command="niri-screenrecord region"/></keybind>
-        <keybind key="W-S-r"><action name="Execute" command="niri-screenrecord region"/></keybind>
+        <keybind key="W-A-r"><action name="Execute" command="screenrecord region"/></keybind>
+        <keybind key="W-S-r"><action name="Execute" command="screenrecord region"/></keybind>
         <!-- Media / brightness (identical to niri) -->
         <keybind key="XF86_AudioRaiseVolume"><action name="Execute" command="wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+"/></keybind>
         <keybind key="XF86_AudioLowerVolume"><action name="Execute" command="wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-"/></keybind>
@@ -844,8 +850,8 @@ in
         bind=none,Print,spawn,noctalia msg screenshot-region
         # Region recording (re-press to stop). Mod+Alt+R matches niri's region key;
         # Mod+Shift+R kept as alias (niri's Mod+Shift+R focused-output is niri-only).
-        bind=SUPER+ALT,r,spawn,niri-screenrecord region
-        bind=SUPER+SHIFT,r,spawn,niri-screenrecord region
+        bind=SUPER+ALT,r,spawn,screenrecord region
+        bind=SUPER+SHIFT,r,spawn,screenrecord region
 
         # Media / brightness
         bind=none,XF86AudioRaiseVolume,spawn,wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+


### PR DESCRIPTION
Brings the Hyprland session up to parity with niri: 47 binds, screenshots,
screen recording, grouping, resize and the keybind cheatsheet.

Arrow keys keep niri's split (left/right move focus, up/down change
workspace) rather than mirroring HJKL, so the muscle memory carries over.

Divergences, each commented at the bind, because niri is scrollable-tiling
and Hyprland is dwindle:
- consume/expel-window-from-column -> group toggle / cycle
- switch-preset-column-width -> togglesplit
- set-column-width +-10% -> resize by +-100px
- wheel workspace switching loses niri's cooldown-ms=150

Also fixes a phase-1 bug: the overview was bound to `dms ipc call overview
toggle`, but DMS has no `overview` target — the Hyprland overview and the
keybind cheatsheet live under its `hypr` target (toggleOverview/toggleBinds).

Screenshots use grimblast (Hyprland-aware grim/slurp wrapper) since Hyprland
has no native screenshot UI. The recorder is now the shared, compositor-
agnostic `screenrecord`: only the focused-output lookup differed, so it picks
niri msg or hyprctl by NIRI_SOCKET instead of being duplicated. It was
already spawned by the labwc and mango sessions, so the niri- prefix was
misleading; the rename touches those binds and nothing else (verified: the
generated niri config.kdl differs only in those two lines).

Closes #1367

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
