### PR TITLE
feat(home): install tuios on all three hosts

### DIFF
--- a/home/development/default.nix
+++ b/home/development/default.nix
@@ -1,6 +1,6 @@
 # Enhanced Development Environment
 # Complete development workflow with unified language support and productivity tools
-_: {
+{ pkgs, ... }: {
   imports = [
     # Editor configurations (enhanced)
     ./vscode.nix
@@ -49,4 +49,9 @@ _: {
   # installed catalogues already there.
   programs.claude-code-skills.enable = true;
   programs.claude-code-commands.enable = true;
+
+  # tuios — terminal-based window manager (tmux/zellij-adjacent). Bound here
+  # rather than in Users/olafkfreund/profile.nix so it also reaches p510, which
+  # imports this module via Users/common/imports.nix but not profile.nix.
+  home.packages = [ pkgs.tuios ];
 }


### PR DESCRIPTION
tuios 0.7.0 — terminal-based window manager (github.com/Gaurav-Gosain/tuios),
already in the current nixpkgs pin, so no bump or packaging needed.

Bound in home/development/default.nix rather than Users/olafkfreund/profile.nix
because p510 imports the development module via Users/common/imports.nix but
not profile.nix, which is the p620/razer-only bind site (same reason the
syncthing .stignore lives on the common path).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
