### PR TITLE
feat(pkgs): add okena and seance terminal multiplexers

### DIFF
--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -182,6 +182,19 @@ in
     # herdr — TUI "agent multiplexer": run multiple AI coding agents in one
     # terminal workspace (tmux/zellij-style). From github:ogulcancelik/herdr.
     pkgs.herdr
+    # seance — GTK/ghostty terminal multiplexer that tracks AI coding agents.
+    # Upstream flake input (see flake.nix), exposed by overlays/default.nix.
+    #
+    # lowPrio: seance vendors a patched ghostty and installs its resources
+    # (share/ghostty/themes, terminfo, shell-integration, icons) under the same
+    # paths as the real pkgs.ghostty we use as the terminal, so buildEnv fails
+    # with "two given paths contain a conflicting subpath". Deprioritising
+    # seance keeps the stock ghostty's copies and only drops its duplicates —
+    # seance reads its own resources from its store path, not from $HOME.
+    (lib.lowPrio pkgs.seance)
+    # okena — GPUI (Zed's UI framework) terminal multiplexer: tabs, splits,
+    # detachable windows, workspace restore. Local pkg from the release tarball.
+    pkgs.customPkgs.okena
     pkgs.wayfarer
     # FlyCrys — GTK4-native Claude Code GUI. Wraps the local `claude`
     # binary (installed via programs.claude-code.enable in home/default.nix).

--- a/flake.lock
+++ b/flake.lock
@@ -347,6 +347,22 @@
         "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
       }
     },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -572,7 +588,7 @@
     },
     "flake-utils_8": {
       "inputs": {
-        "systems": "systems_10"
+        "systems": "systems_11"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -590,7 +606,7 @@
     },
     "flake-utils_9": {
       "inputs": {
-        "systems": "systems_11"
+        "systems": "systems_12"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -1504,6 +1520,7 @@
         "noctalia-greeter": "noctalia-greeter",
         "nur": "nur",
         "rust-overlay": "rust-overlay_4",
+        "seance": "seance",
         "sops-nix": "sops-nix",
         "spicetify-nix": "spicetify-nix",
         "stylix": "stylix",
@@ -1655,6 +1672,30 @@
         "type": "github"
       }
     },
+    "seance": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "zig": "zig"
+      },
+      "locked": {
+        "lastModified": 1777632093,
+        "narHash": "sha256-t3bAQBgiULkKDKnTxQlVnNMvqn9+rCEEb/HmmCbGQdk=",
+        "ref": "refs/tags/v0.1.4",
+        "rev": "83013a4b7ce2d2b970f670266049e89090c732b8",
+        "revCount": 44,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/no1msd/seance"
+      },
+      "original": {
+        "ref": "refs/tags/v0.1.4",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/no1msd/seance"
+      }
+    },
     "sops-nix": {
       "inputs": {
         "nixpkgs": [
@@ -1694,7 +1735,7 @@
     "spicetify-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_10",
-        "systems": "systems_8"
+        "systems": "systems_9"
       },
       "locked": {
         "lastModified": 1786855359,
@@ -1723,7 +1764,7 @@
           "nixpkgs"
         ],
         "nur": "nur_2",
-        "systems": "systems_9",
+        "systems": "systems_10",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
@@ -1760,6 +1801,22 @@
     },
     "systems_10": {
       "locked": {
+        "lastModified": 1774449309,
+        "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "c29398b59d2048c4ab79345812849c9bd15e9150",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "ref": "future-26.11",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_11": {
+      "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
@@ -1773,7 +1830,7 @@
         "type": "github"
       }
     },
-    "systems_11": {
+    "systems_12": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1879,6 +1936,7 @@
       }
     },
     "systems_8": {
+      "flake": false,
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1895,16 +1953,15 @@
     },
     "systems_9": {
       "locked": {
-        "lastModified": 1774449309,
-        "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
         "repo": "default",
-        "rev": "c29398b59d2048c4ab79345812849c9bd15e9150",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "ref": "future-26.11",
         "repo": "default",
         "type": "github"
       }
@@ -2024,6 +2081,29 @@
       "original": {
         "owner": "Benexl",
         "repo": "yt-x",
+        "type": "github"
+      }
+    },
+    "zig": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "nixpkgs": [
+          "seance",
+          "nixpkgs"
+        ],
+        "systems": "systems_8"
+      },
+      "locked": {
+        "lastModified": 1775609538,
+        "narHash": "sha256-m6vHEtrU5pZ0qJhEMJRJwqL51DRTHLQrd8/11CYnWWg=",
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "rev": "f15617a4bfee9c159fc87db3c578ff5b30ec37fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -221,6 +221,21 @@
       inputs.rust-overlay.follows = "rust-overlay";
     };
 
+    # seance — Zig terminal multiplexer that tracks AI coding agents. Upstream
+    # ships a working flake (pkg/nix/package.nix), so there is nothing to
+    # package locally; it is consumed via overlay as pkgs.seance.
+    #
+    # The URL must be git+https with submodules=1: seance vendors a patched
+    # ghostty as a git SUBMODULE and its package.nix reads
+    # ghostty/nix/build-support/*. The `github:` fetcher does not fetch
+    # submodules, so `github:no1msd/seance` fails at eval with
+    # "path .../ghostty/nix/build-support/gi-typelib-path.nix does not exist".
+    # Bump by moving the ref= tag.
+    seance = {
+      url = "git+https://github.com/no1msd/seance?submodules=1&ref=refs/tags/v0.1.4";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
   };
 
   outputs =

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -30,6 +30,11 @@
     herdr = inputs.herdr.packages.${prev.stdenv.hostPlatform.system}.default;
   })
 
+  # seance — Zig terminal multiplexer that tracks AI coding agents (flake input).
+  (_final: prev: {
+    seance = inputs.seance.packages.${prev.stdenv.hostPlatform.system}.default;
+  })
+
   # Rust toolchain overlay — exposes `rust-bin.*` on `final` so packages
   # that need a newer rustc than nixpkgs ships (e.g. splashboard) can
   # build with `makeRustPlatform`. Doesn't replace the default `rustc`.

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -80,6 +80,9 @@
   # github/app release tag (see header comment in the derivation).
   github-copilot-app = pkgs.callPackage ./github-copilot-app { };
 
+  # okena — GPUI-based native terminal multiplexer (contember/okena).
+  okena = pkgs.callPackage ./okena { };
+
   # FlyCrys — GTK4-native GUI for Claude Code (Rust). Not in nixpkgs yet;
   # custom buildRustPackage derivation. Wraps the local `claude` binary.
   flycrys = pkgs.callPackage ./flycrys { };

--- a/pkgs/okena/default.nix
+++ b/pkgs/okena/default.nix
@@ -1,0 +1,88 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, makeWrapper
+, libxkbcommon
+, libglvnd
+, vulkan-loader
+, wayland
+, xorg
+, dtach
+}:
+# Okena — native terminal multiplexer (tabs, splits, detachable windows) built
+# in Rust on GPUI, the UI framework behind the Zed editor.
+#
+# Built from the upstream x86_64 release tarball rather than from source: the
+# workspace pulls gpui and gpui_platform straight from the zed-industries/zed
+# git repo, so a source build means vendoring Zed's tree and compiling all of
+# GPUI. Same trade-off as pkgs/github-copilot-app and pkgs/claude-desktop-beta.
+#
+# Bump: `gh release view --repo contember/okena` for the tag, then re-prefetch
+# okena-linux-x64.tar.gz and update version + hash.
+let
+  # GPUI resolves its GPU/Wayland stack with dlopen, so these never appear in
+  # DT_NEEDED and autoPatchelf cannot see them — they go in LD_LIBRARY_PATH.
+  runtimeLibs = [
+    vulkan-loader # libvulkan.so.1 — GPUI's renderer
+    libglvnd # libEGL.so.1
+    wayland # libwayland-client.so.0, libwayland-egl.so.1
+    libxkbcommon
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "okena";
+  version = "0.28.0";
+
+  src = fetchurl {
+    url = "https://github.com/contember/okena/releases/download/v${finalAttrs.version}/okena-linux-x64.tar.gz";
+    hash = "sha256-MImvbDLJ7Gbc1rwfNPqcTzNqutCLTdlmBXjCsWJlv7g=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+
+  # DT_NEEDED entries of both binaries.
+  buildInputs = [
+    libxkbcommon
+    xorg.libxcb
+    stdenv.cc.cc.lib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 okena "$out/bin/okena"
+    install -Dm755 okena-daemon "$out/bin/okena-daemon"
+    install -Dm444 okena.desktop "$out/share/applications/okena.desktop"
+
+    for icon in icons/app-icon-*.png; do
+      size=''${icon##*app-icon-}
+      size=''${size%.png}
+      install -Dm444 "$icon" \
+        "$out/share/icons/hicolor/''${size}x''${size}/apps/okena.png"
+    done
+
+    runHook postInstall
+  '';
+
+  # dtach is okena's preferred session-persistence backend (it auto-detects
+  # dtach > tmux > screen); without it on PATH every terminal dies with the app.
+  postFixup = ''
+    for bin in okena okena-daemon; do
+      wrapProgram "$out/bin/$bin" \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeLibs}" \
+        --prefix PATH : "${lib.makeBinPath [ dtach ]}"
+    done
+  '';
+
+  meta = {
+    description = "Fast, native terminal multiplexer built in Rust with GPUI";
+    homepage = "https://github.com/contember/okena";
+    license = lib.licenses.mit;
+    mainProgram = "okena";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Two AI-agent-oriented terminal multiplexers, both on p620 + razer (both are
GUI apps, so p510 gets neither).

okena (contember/okena, MIT) — pkgs/okena, built from the upstream x86_64
release tarball with autoPatchelfHook. Not built from source: the workspace
pulls gpui and gpui_platform straight from the zed-industries/zed git repo, so
a source build means vendoring Zed's tree and compiling all of GPUI. Same
trade-off as pkgs/github-copilot-app and pkgs/claude-desktop-beta.
- GPUI dlopens its GPU/Wayland stack (libvulkan, libEGL, libwayland-*), so
  those are absent from DT_NEEDED and autoPatchelf cannot see them; they go on
  LD_LIBRARY_PATH.
- dtach is on the wrapper PATH: it is okena's preferred session-persistence
  backend (auto-detects dtach > tmux > screen) and without it every terminal
  dies with the app.

seance (no1msd/seance, MIT) — no local derivation, upstream ships a working
flake, consumed as a flake input + overlay like herdr. The input must be
git+https with submodules=1: seance vendors a patched ghostty as a git
SUBMODULE and its package.nix reads ghostty/nix/build-support/*, so the
`github:` fetcher (which does not fetch submodules) fails at eval.

seance is installed lowPrio because it ships that vendored ghostty's resources
(share/ghostty/themes, terminfo, shell-integration, icons) under the same paths
as the real pkgs.ghostty we use as the terminal, which otherwise fails the
buildEnv with "two given paths contain a conflicting subpath". Verified after:
ghostty still resolves to ghostty-1.3.1 with all 463 themes.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
