### PR TITLE
fix(p510): stop thermald and the PAL healthcheck failing every deploy

### DIFF
--- a/hosts/p510/nixos/cpu.nix
+++ b/hosts/p510/nixos/cpu.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }: {
+{ lib, pkgs, ... }: {
   # CPU frequency scaling for Xeon workstation
   powerManagement = {
     enable = true;
@@ -24,6 +24,13 @@
     # turbostat # Intel CPU power/frequency statistics
   ];
 
-  # Thermal management for Xeon
-  services.thermald.enable = true;
+  # thermald cannot run on this box. The Xeon E5-2698 v4 (Broadwell-EP,
+  # family 6 model 79) is a server part: thermald wants the Linux PowerCap
+  # sysfs interface, which it does not expose, so every start logs
+  #   Need Linux PowerCap sysfs / Unsupported cpu model or platform
+  # and exits. A permanently-dead unit makes switch-to-configuration report
+  # "units failed" -> exit 4 -> nh rolls the whole deploy back, so this must be
+  # off rather than merely ignored. mkForce beats the Intel-CPU default in
+  # modules/services/system/default.nix, which is true here but not sufficient.
+  services.thermald.enable = lib.mkForce false;
 }

--- a/modules/services/plex-auto-languages/default.nix
+++ b/modules/services/plex-auto-languages/default.nix
@@ -58,15 +58,21 @@ in
           # API, not webhooks-into-PAL — so no port mapping needed.
           "--network=host"
 
-          # The image ships HEALTHCHECK `curl --fail localhost:9880` on a 30s
-          # interval with no start period, and podman runs each probe in its own
-          # transient systemd unit. The first probe fires before PAL is
-          # listening, exits 1, and leaves a failed unit behind — which
-          # `nh os switch` treats as a failed activation and rolls the entire
-          # p510 deploy back. Measured over 3h: 346 healthy, 2 failures, both
-          # the first probe after a container start. Give it a start period so
-          # boot-time failures don't count.
-          "--health-start-period=90s"
+          # No healthcheck at all. The image ships HEALTHCHECK
+          # `curl --fail localhost:9880` on a 30s interval, and podman runs each
+          # probe in its own transient systemd unit. The first probe fires
+          # before PAL is listening and exits 1, leaving a failed unit behind —
+          # which switch-to-configuration reports as "units failed", so nh
+          # exits 4 and rolls the entire p510 deploy back.
+          #
+          # --health-start-period=90s (used here previously) does NOT fix that:
+          # it only stops the early failure flipping the CONTAINER's status to
+          # unhealthy — the journal shows health_status=starting — while
+          # `podman healthcheck run` still exits 1 and systemd still marks its
+          # transient unit failed. Nothing here consumes the health status
+          # (podman only reports it; no restart policy keys off it), so the
+          # probe buys nothing and costs a rolled-back deploy.
+          "--no-healthcheck"
         ];
       };
     };


### PR DESCRIPTION
Both units left p510's activation reporting "units failed", which is exit 4,
which makes nh roll the whole deploy back.

thermald: hosts/p510/nixos/cpu.nix enabled it explicitly "for Xeon", but the
E5-2698 v4 (Broadwell-EP, family 6 model 79) is a server part with no Linux
PowerCap sysfs, so thermald logs "Need Linux PowerCap sysfs / Unsupported cpu
model or platform" and exits on every start. mkForce false — the Intel-CPU
default added in #1362 is true here and is not sufficient, because the useful
predicate is "thermald supports this CPU", not "the CPU is Intel".

plex-auto-languages: --health-start-period=90s does not do what its comment
claimed. It only stops an early probe flipping the CONTAINER status to
unhealthy (the journal shows health_status=starting), while
`podman healthcheck run` still exits 1 and systemd still marks the transient
probe unit failed. Nothing consumes the health status — podman only reports
it, no restart policy keys off it — so the probe is pure cost. Replaced with
--no-healthcheck; it is the only container on the host that has one.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
