### PR TITLE
chore(claude-code): update to 2.1.235 (#1361)

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -31,7 +31,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.233";
+  version = "2.1.235";
 
   # Claude Code reads clipboard images by shelling out to:
   #   xclip -selection clipboard -t TARGETS -o ... || wl-paste -l ...   (detect)
@@ -63,11 +63,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-VdKBCW9X1BHrvdlNv16f86zLfAVxPjc0jCwR1Lg7+dk=";
+      hash = "sha256-v88K4tv5SytqEGB0qr85OLmhCInDtnjky1oAwDJ01dU=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-Qt8YQfdOmyrBPywaKoIO9rmsWy77hka7JcmpK4vWkZQ=";
+      hash = "sha256-z/lZL6opLbD2rCGHTxUbjD1E4jvwq5/RvMqV7cNGlUk=";
     };
   };
 


### PR DESCRIPTION
Bumps `pkgs/claude-code-native` 2.1.233 → 2.1.235 (Anthropic GCS `latest` channel), with refreshed x86_64 + aarch64 SRI hashes.

## Verification
- `nix build .#claude-code-native` → `claude --version` = `2.1.235 (Claude Code)`
- `ldd` on the binary: no missing libs
- `nixosConfigurations.{p620,razer,p510}.config.system.build.toplevel` all build (exit 0)

Closes #1361
Closes #1352 (superseded — 2.1.234 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc