### PR TITLE
chore(antigravity): bump CLI to 1.1.15

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.1.13-6057583128215552";
+  version = "1.1.15-5350383476932608";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.13-6057583128215552/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-7cfDK1q0/C5NoDOB/ug+1WbeprVrVvkynNE813lHodk=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.15-5350383476932608/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-0LHW82eKBhkVyuvEMZMOJAuGO/QFk2nAjG/86yTma18=";
   };
 
   # Tarball contains a single file `antigravity` at the root.


### PR DESCRIPTION
Bumps `pkgs/antigravity-cli` `1.1.13-6057583128215552` → `1.1.15-5350383476932608` (version + url + hash only), per the `Hy4ri/antigravity-flake` tracker.

IDE (2.5.5), hub (2.8.1) and the Python SDK (0.1.12) were already current — untouched.

## Verification
- All four `customPkgs.antigravity-*` / `google-antigravity-py` build
- `agy --version` → `1.1.15`
- `import google.antigravity` → OK
- `nixosConfigurations.{p620,razer}.config.system.build.toplevel` build (exit 0); p510 doesn't ship Antigravity

Not deployed — build-verify only, per `/update-antigravity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc