### PR TITLE
fix(scripts): key lock-bump branch name on lock content, not nixpkgs rev

### DIFF
--- a/scripts/update-commit-deploy.sh
+++ b/scripts/update-commit-deploy.sh
@@ -330,7 +330,10 @@ built. Nothing was committed or deployed; re-run from a clean tree."
     msg_subject="chore(flake): bump ${SCOPE} (nixpkgs unchanged)"
   fi
 
-  branch_name="chore/lock-bump-${SCOPE//\//-}-${new_rev:0:8}"
+  # Suffix from the new lock content, not the nixpkgs rev: a "nixpkgs unchanged"
+  # bump would otherwise reuse the same branch name on every run and collide.
+  lock_id=$(git hash-object flake.lock | cut -c1-8)
+  branch_name="chore/lock-bump-${SCOPE//\//-}-${lock_id}"
   log "creating branch ${branch_name}"
   if git show-ref --quiet "refs/heads/${branch_name}"; then
     err "branch ${branch_name} already exists locally. Delete it (\`git branch -D ${branch_name}\`) and retry."


### PR DESCRIPTION
`update-commit-deploy.sh` built the branch name from the **new nixpkgs rev**:

```sh
branch_name="chore/lock-bump-${SCOPE//\//-}-${new_rev:0:8}"
```

When a bump leaves nixpkgs unchanged (the `chore(flake): bump all (nixpkgs unchanged)` case), consecutive runs generate the *same* branch name, and the run aborts:

```
!! branch chore/lock-bump-all-0ae2bc14 already exists locally.
error: recipe `update-commit-deploy` failed on line 43 with exit code 1
```

Keying the suffix on `git hash-object flake.lock` makes it unique per distinct lock. The existing collision guard is kept and now only fires when the lock is genuinely unchanged — i.e. there is nothing to bump, which is exactly when aborting is right.

Verified: `bash -n` clean; next run resolves to `chore/lock-bump-all-4b9722e8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc