### PR TITLE
feat(ollama): make qwen3.8:27b the default model

### DIFF
--- a/home/development/claude-code-commands/default.nix
+++ b/home/development/claude-code-commands/default.nix
@@ -138,7 +138,7 @@ let
   #
   # The bundled run_crew.py reads four env knobs:
   #   CREW_ENDPOINT     — chat-completion URL (default p620's LiteLLM)
-  #   CREW_MODEL        — model alias (default qwen3:14b)
+  #   CREW_MODEL        — model alias (default qwen3.8:27b)
   #   CREW_API_KEY_FILE — path to bearer-token file
   #                       (default /run/agenix/api-router-<hostname>)
   #   CREW_REPO_ROOT    — where <file> tag paths land (default cwd)
@@ -195,14 +195,15 @@ in
 
     model = mkOption {
       type = types.str;
-      default = "qwen3:14b";
+      default = "qwen3.8:27b";
       example = "claude-sonnet-4-6";
       description = ''
         Model name as the configured endpoint advertises it. For our
-        LiteLLM router these are the aliases in model_list (qwen3:14b,
+        LiteLLM router these are the aliases in model_list (qwen3.8:27b,
         qwen3, claude-sonnet-4-6, gemma4, …). Pick whichever balance
-        of speed/quality you want — the default qwen3:14b matches the
-        previous bare-ollama behaviour.
+        of speed/quality you want — the default matches the persistent
+        model on p620, so /crew hits an already-loaded model instead of
+        forcing an evict-and-load on every run.
       '';
     };
   };

--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -597,7 +597,15 @@ in
     persistentModels = [ ]; # No persistent models to save VRAM
     # qwen2.5:7b for reliable strict-JSON audiobook metadata extraction +
     # tool-calling (audiobook-import / audiobook-mcp).
-    onDemandModels = [ "gemma4:e4b" "qwen2.5:7b" "gemma4:12b" "qwen2.5-coder:14b" ];
+    #
+    # qwen3.8:27b is on-demand ONLY here, unlike p620 where it is the
+    # persistent default. This host has no single GPU that fits it: a
+    # 3070 Ti (8GB) + a 3060 (12GB) means ollama splits an 18GB dense model
+    # across both cards over PCIe, leaving ~1.5GB of the combined 19.5GB for
+    # everything else. Those GPUs also back Plex, so a resident copy would
+    # squat on the whole box. On-demand keeps it a deliberate choice that
+    # unloads itself after `keepAlive`.
+    onDemandModels = [ "gemma4:e4b" "qwen2.5:7b" "gemma4:12b" "qwen2.5-coder:14b" "qwen3.8:27b" ];
     keepAlive = "5m"; # Evict from VRAM after 5 minutes of idle
   };
 

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -105,8 +105,16 @@ in
     enable = true;
     host = "0.0.0.0";
     modelsDir = "/mnt/data/ollama/models";
-    persistentModels = [ "qwen3:14b" ];
+    # qwen3.8:27b (~18GB Q4) on a 24GB card. Dense, so the whole thing has to
+    # sit in VRAM to be worth running; MAX_LOADED_MODELS=1 (module) evicts it
+    # before loading any on-demand model rather than trying to fit both.
+    persistentModels = [ "qwen3.8:27b" ];
     onDemandModels = [ "qwen2.5-coder:14b" "gemma4:e4b" "gemma4:12b" ];
+    # The model supports 256K but ollama caps every request at 4096 unless
+    # told otherwise. 32K is what the ~6GB left above the weights pays for —
+    # cheap here because qwen3.8 runs full attention on only 16 of 64 layers,
+    # so the KV cache grows far slower with context than a standard 27B.
+    contextLength = 32768;
     # Ollama cloud-models access (Ollama Turbo / hosted). Raw key in agenix;
     # the daemon's preStart composes /run/ollama/cloud-env at unit start.
     cloudApiKeyFile = config.age.secrets."api-ollama".path;

--- a/modules/services/litellm-router.nix
+++ b/modules/services/litellm-router.nix
@@ -6,12 +6,17 @@
 #   Claude Code  →  http(s)://p620.../router (LiteLLM)  →  127.0.0.1:11434 (Ollama)
 #
 # Model aliases:
-#   claude-sonnet-4-6  →  qwen3:14b          (default coding model — primary)
+#   claude-sonnet-4-6  →  qwen3.8:27b        (default coding model — primary)
 #   claude-opus-4-6    →  gemma4:e4b         (light/fast on-demand)
-#   qwen3              →  qwen3:14b          (native name passthrough)
-#   qwen3.6            →  qwen3:14b          (backward compatibility alias)
+#   qwen3              →  qwen3.8:27b        (native name passthrough)
+#   qwen3.8            →  qwen3.8:27b        (native name passthrough)
+#   qwen3.6            →  qwen3.8:27b        (backward compatibility alias)
 #   qwen2.5-coder      →  qwen2.5-coder:14b  (previous default, still pulled)
 #   gemma4             →  gemma4:e4b         (backward compatibility alias)
+#
+# The aliases point at whatever host's Ollama is fronted, so they only
+# resolve to a model that host actually pulled — this file is p620's, where
+# qwen3.8:27b is the persistent model (hosts/p620/configuration.nix).
 #
 # Authentication: a single master bearer key loaded at runtime from agenix
 # (/run/agenix/litellm-master-key). Per-host clients hold the same plaintext
@@ -34,7 +39,7 @@ let
       # Anthropic-compatible aliases that Claude Code recognises by name.
       - model_name: claude-sonnet-4-6
         litellm_params:
-          model: ollama_chat/qwen3:14b
+          model: ollama_chat/qwen3.8:27b
           api_base: http://127.0.0.1:11434
           additional_drop_params: ["thinking", "think", "reasoning_effort"]
 
@@ -47,13 +52,19 @@ let
       # Native names for ai-cli / aichat / direct OpenAI-compat clients.
       - model_name: qwen3
         litellm_params:
-          model: ollama_chat/qwen3:14b
+          model: ollama_chat/qwen3.8:27b
           api_base: http://127.0.0.1:11434
           additional_drop_params: ["thinking", "think", "reasoning_effort"]
 
       - model_name: qwen3.6
         litellm_params:
-          model: ollama_chat/qwen3:14b
+          model: ollama_chat/qwen3.8:27b
+          api_base: http://127.0.0.1:11434
+          additional_drop_params: ["thinking", "think", "reasoning_effort"]
+
+      - model_name: qwen3.8
+        litellm_params:
+          model: ollama_chat/qwen3.8:27b
           api_base: http://127.0.0.1:11434
           additional_drop_params: ["thinking", "think", "reasoning_effort"]
 
@@ -70,6 +81,12 @@ let
           additional_drop_params: ["thinking", "think", "reasoning_effort"]
 
       # Explicit model:tag passthroughs (for clients that send the raw Ollama name).
+      - model_name: qwen3.8:27b
+        litellm_params:
+          model: ollama_chat/qwen3.8:27b
+          api_base: http://127.0.0.1:11434
+          additional_drop_params: ["thinking", "think", "reasoning_effort"]
+
       - model_name: qwen3:14b
         litellm_params:
           model: ollama_chat/qwen3:14b

--- a/modules/services/ollama.nix
+++ b/modules/services/ollama.nix
@@ -1,13 +1,18 @@
 # Ollama coding-model server (services.ollama wrapper).
 #
 # Designed for p620's RX 7900 XTX (gfx1100, 24GB VRAM, ROCm). The single
-# GPU comfortably fits each default model individually (qwen3.6:27b ~17GB,
-# gemma4:26b MoE ~18GB) but NOT both at once (~35GB > 24GB), so
+# GPU comfortably fits each default model individually (qwen3.8:27b ~18GB,
+# gemma4:26b MoE ~18GB) but NOT both at once (~36GB > 24GB), so
 # MAX_LOADED_MODELS=1 forces deterministic evict-then-load on switch.
 #
-# Default model choices (May 2026):
-#   Persistent: qwen3.6:27b — strong agentic tool calling (Qwen RL-trained
-#     on 1M agentic envs), good for Claude Code's tool-use loops.
+# Default model choices (Aug 2026):
+#   Persistent: qwen3.8:27b — 18GB Q4, 256K context. DENSE 27B, so unlike a
+#     MoE nothing here is free: everything that spills out of VRAM is paid
+#     for at full width. It stays affordable because the architecture is
+#     hybrid — only 16 of its 64 layers run full attention, the other 48 use
+#     linear attention with a constant recurrent state, so the KV cache
+#     barely grows with context. That is what makes a large `contextLength`
+#     practical on a 24GB card.
 #   On-demand:  gemma4:26b — MoE with ~3.8B active params, very fast
 #     (~80-100 tok/s) for raw code-gen bursts.
 #
@@ -43,11 +48,14 @@ in
 
     persistentModels = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [ "qwen3.6:27b" ];
+      default = [ "qwen3.8:27b" ];
       description = ''
         Models pulled at activation and used as the default coding model.
-        Listed first in the load priority. Default qwen3.6:27b (~17GB,
-        strong agentic tool calling).
+        Listed first in the load priority. Default qwen3.8:27b (~18GB,
+        256K context, strong agentic tool calling).
+
+        Leave empty on hosts whose GPUs are shared with something else — a
+        persistent model holds its VRAM until `keepAlive` expires.
       '';
     };
 
@@ -81,6 +89,22 @@ in
         keep this low so the GPU is released for desktop work (Blender,
         games, video editing) when not actively coding. Use "-1" for
         always-loaded if Ollama is the only GPU consumer.
+      '';
+    };
+
+    contextLength = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = null;
+      example = 32768;
+      description = ''
+        Value for OLLAMA_CONTEXT_LENGTH — the context window the server uses
+        for requests that do not set `num_ctx` themselves.
+
+        Ollama defaults to 4096 no matter what the model supports, so a
+        256K-context model like qwen3.8:27b is capped at 4096 unless this is
+        raised. Cost is VRAM for the KV cache on top of the weights, so the
+        ceiling is the card, not the model — raise it only as far as the
+        headroom above the resident model allows.
       '';
     };
 
@@ -150,6 +174,9 @@ in
         OLLAMA_MAX_LOADED_MODELS = "1";
         OLLAMA_FLASH_ATTENTION = "1";
         OLLAMA_ORIGINS = cfg.origins;
+      }
+      // lib.optionalAttrs (cfg.contextLength != null) {
+        OLLAMA_CONTEXT_LENGTH = toString cfg.contextLength;
       };
     };
 


### PR DESCRIPTION
qwen3.8:27b (Aug 2026, 18GB Q4, 256K context) replaces qwen3:14b as the
default coding model. Dense 27B, but its hybrid attention runs full
attention on only 16 of 64 layers — the other 48 use linear attention with
a constant recurrent state — so the KV cache barely grows with context and a
large window stays affordable on one card.

"Default" lives in four places; changing only the model list would leave
Claude Code still talking to qwen3:14b, so all four move together:

- hosts/p620/configuration.nix — persistentModels, plus contextLength 32768
- modules/services/litellm-router.nix — claude-sonnet-4-6, qwen3 and the
  qwen3.6 compat alias now resolve to qwen3.8:27b; added a native qwen3.8
  alias and a qwen3.8:27b raw passthrough. The qwen3:14b passthrough still
  maps to qwen3:14b, since that name means the literal model.
- home/development/claude-code-commands — CREW_MODEL, so /crew hits the
  already-resident model instead of forcing an evict-and-load per run
- modules/services/ollama.nix — module default (was qwen3.6:27b, which no
  host used) and the header rationale

New `contextLength` option -> OLLAMA_CONTEXT_LENGTH. Ollama caps every
request at 4096 regardless of what the model supports, so without it the
256K window is unreachable. Null by default, set only on p620.

p510 gets qwen3.8:27b as on-demand ONLY, not persistent: its 3070 Ti (8GB) +
3060 (12GB) cannot hold an 18GB dense model on either card, so ollama splits
it across both over PCIe and leaves ~1.5GB of the combined 19.5GB free.
Those GPUs also back Plex. persistentModels stays empty there.

Verified: rendered litellm YAML parses and every alias resolves as intended;
loadModels evaluates correctly per host; OLLAMA_CONTEXT_LENGTH is set on
p620 and unset on p510; all three hosts build.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
