### PR TITLE
chore(claude-code): update to 2.1.237 (#1388)

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -31,7 +31,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.235";
+  version = "2.1.237";
 
   # Claude Code reads clipboard images by shelling out to:
   #   xclip -selection clipboard -t TARGETS -o ... || wl-paste -l ...   (detect)
@@ -63,11 +63,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-v88K4tv5SytqEGB0qr85OLmhCInDtnjky1oAwDJ01dU=";
+      hash = "sha256-c5dRZ/AQhpPPb9ZhSZR4FlfruEVuvvXSR0WHNKv7ORY=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-z/lZL6opLbD2rCGHTxUbjD1E4jvwq5/RvMqV7cNGlUk=";
+      hash = "sha256-pwHPtrtHA6vG885HUIyHjKgVjr2+rNXDXH1RDHvHAXc=";
     };
   };
 


### PR DESCRIPTION
2.1.235 -> 2.1.237 from the GCS binary channel (latest; stable is still
2.1.228). Version + both SRI hashes only.

Verified: the built binary reports 2.1.237, it is static so there are no
unresolved libs, p620 and razer both evaluate programs.claude-code.package
at 2.1.237, and all three host closures build.

Closes #1388
Closes #1385

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
