### PR TITLE
docs(plans): p510 crash post-mortem + k3d migration to p620

### DIFF
--- a/docs/plans/2026-08-20-k3d-p510-to-p620-migration.md
+++ b/docs/plans/2026-08-20-k3d-p510-to-p620-migration.md
@@ -143,6 +143,41 @@ Two PVs have no local directory and need separate handling:
 | kine `state.db` | inside `k3d-factory-server-0` | 776 MB | **No — derived state** |
 | Secrets | agenix + `factorySecrets.enable` | — | No — re-seeded by bootstrap |
 
+#### Everything is ArgoCD-managed — including fides
+
+All **37** ArgoCD applications report Synced/Healthy, spanning namespaces
+`factory`, `fides`, `fides-reporter`, `argocd`, `keda`, `kyverno`,
+`kube-system` and `tailscale`. Nothing was applied by hand, so the entire
+cluster is reconstructed from git and only PV *data* has to be carried over.
+
+**fides is in scope** (in-use service, not a demo): the `fides` app targets
+namespace `fides` and `fides-reporter` its own namespace. Its two PVs
+(`fides-db-pvc` 103 MB, `fides-evidence-pvc` <5 MB) migrate with the rest.
+
+#### Databases need dumps, not file copies
+
+Three PostgreSQL instances run at **three different major versions**:
+
+| Workload | Image | PV |
+| --- | --- | --- |
+| `factory/postgres` | postgres:16.4 | data-postgres-0 (88 MB) |
+| `factory/skillai-db` | pgvector/pgvector:**pg17** | data-skillai-db-0 (121 MB) |
+| `fides/fides-db` | postgres:**15**-alpine | fides-db-pvc (103 MB) |
+
+A PGDATA directory is tied to its major version and will refuse to start
+under a different one. The images are digest-pinned in git, so a raw copy
+*can* work — but it also carries any unclean-shutdown state, and these
+volumes are small. **Prefer `pg_dump` per database, restore into the fresh
+cluster, and keep the file copy only as a fallback.** That also sidesteps the
+risk that a pod restarts mid-rsync.
+
+Redis (`factory/redis`, `argocd/argocd-redis`) is cache-shaped — let it
+rebuild rather than copying `redis-data`.
+
+MinIO (`minio-data`, 1.6 GB — the largest real payload after
+`aifactory-data`) is a plain object store on disk; a quiesced file copy is
+fine, or `mc mirror` if you prefer a live transfer.
+
 ### Approach: rebuild from GitOps, copy only PVs
 
 Do **not** lift-and-shift the kine database or Docker state. The cluster is
@@ -225,8 +260,9 @@ a reference snapshot. Note `KUBECONFIG=/etc/k3d/kubeconfig` on p510 —
 `~/.kube/config` does not exist, and forcing that path yields a confusing
 Cloudflare "API Key Required" error rather than a Kubernetes one.
 
-Remember the **fides** namespace: it is not part of the factory app-of-apps,
-so confirm how it is reconciled before assuming ArgoCD recreates it.
+Resolved: **fides IS ArgoCD-managed** (app `fides` -> ns `fides`, plus
+`fides-reporter`), so it reconciles from git like everything else. It is an
+in-use service and migrates with the cluster.
 
 **Phase 2 — stand up on p620**
 Enable `modules.containers.k3d` in `hosts/p620/configuration.nix` with
@@ -236,10 +272,15 @@ Enable `modules.containers.k3d` in `hosts/p620/configuration.nix` with
 the precedent). p510 keeps running untouched at this point.
 
 **Phase 3 — data copy**
-Quiesce the p510 cluster (scale stateful workloads to 0 so the PV contents are
-consistent), `rsync -aHAX --numeric-ids` the live PV directories to p620's
-`storageDir`, preserving the `pvc-<uid>_<ns>_<name>` directory names the local
-provisioner keys on.
+Databases first, while the cluster is still up: `pg_dump` each of the three
+PostgreSQL instances (`factory/postgres`, `factory/skillai-db`,
+`fides/fides-db`) to files outside the cluster.
+
+Then quiesce (scale stateful workloads to 0 so the PV contents are
+consistent) and `rsync -aHAX --numeric-ids` the **14 live** PV directories
+from **`/mnt/img_pool/k3d/storage`** — not the configured path — to p620's
+`storageDir`, preserving the `pvc-<uid>_<ns>_<name>` directory names the
+local provisioner keys on. Skip the 26 orphans and `redis-data`.
 
 **Phase 4 — bootstrap + reattach**
 Let the module create the cluster and ArgoCD sync from git. PVCs must bind to

--- a/docs/plans/2026-08-20-k3d-p510-to-p620-migration.md
+++ b/docs/plans/2026-08-20-k3d-p510-to-p620-migration.md
@@ -23,13 +23,15 @@ P510, 30B5S0L000). The parts fitted:
 
 ### Evidence
 
-Two crashes, both with a GPU transient and nothing else:
+Three crashes, all with a GPU transient and nothing else:
 
 - **2026-08-19 19:27:12** — Plex was mid **video transcode** (NVENC) and kine
   was doing slow SQL inserts. Log ends mid-line.
 - **2026-08-20 08:53:01** — ollama began loading a model at 08:52:54,
   llama-server started loading at 08:52:55, **machine died 6 seconds later**.
   No Plex transcode was running (last activity 08:23, a photo thumbnail).
+- **2026-08-20 09:30:59** — a third cut, 17 minutes after the reboot. ollama
+  was loading model tensors from 09:28:43. Same signature.
 
 Ruled out:
 
@@ -62,8 +64,8 @@ CUDA0 and CUDA1 in the crash log) on the same supply as Plex NVENC.
    (a systemd oneshot) rather than left as a shell command.
 2. **Reconsider ollama on p510 entirely.** It is the trigger for today's crash
    and the host has no headroom for it.
-3. **Revert `qwen3.8:27b` from p510's `onDemandModels`** (merged in #1391, not
-   yet deployed). It is an 18GB dense model on 8GB + 12GB cards, so ollama
+3. **Revert `qwen3.8:27b` from p510's `onDemandModels`** (merged in #1391;
+   removed again in #1395). It is an 18GB dense model on 8GB + 12GB cards, so ollama
    *must* split it across both — the exact condition that trips the supply.
    p620's entry is unaffected and should stay.
 
@@ -133,9 +135,13 @@ of the media stack stay on p510 — they are not part of this migration.
    | Images | 42.6 GB | 30.4 GB (71%) |
    | Local volumes | 5.6 GB | 5.6 GB — **do not blind-prune, see below** |
 
-   Reclaiming the build cache alone roughly doubles free space on / and
-   removes this blocker outright. Still point `storageDir` at `/mnt/data`
-   (196 GB free, separate disk) to keep PV IOPS off the root NVMe.
+   **Resolved 2026-08-20:** `docker builder prune -a` reclaimed **143 GB**;
+   / went from 84% used (142 GB free) to **70% used (265 GB free)**.
+
+   `storageDir` should point at **`/mnt/games`** — `/dev/sdb1`, ext4, 938 GB
+   with **638 GB free**, a separate spindle from both / (nvme0n1) and
+   /mnt/data (sda1). It has the most headroom of any filesystem on the host
+   and keeps PV IOPS off the root NVMe entirely.
 
    **Do NOT run `docker volume prune`.** With no containers running, all 117
    volumes report as unused, including `evidance-vault_postgres_data`,

--- a/docs/plans/2026-08-20-k3d-p510-to-p620-migration.md
+++ b/docs/plans/2026-08-20-k3d-p510-to-p620-migration.md
@@ -1,7 +1,40 @@
 # p510 crash post-mortem + k3d migration to p620
 
 Date: 2026-08-20
-Status: proposed — no changes made
+Status: **DONE** — executed 2026-08-20, factory services live on p620
+
+## Outcome
+
+Cutover completed the same day. All 10 factory hostnames serve from p620 and
+p510's cluster is stopped (data retained pending cleanup). The media stack was
+never touched: it runs on a separate host-level tunnel (`p510-home`,
+`features.cloudflared` in hosts/p510), not in the cluster.
+
+What the plan got right: rebuilding from GitOps and copying only PV data. All
+37 ArgoCD apps reconstructed from git; 9.3 GB of PVs moved.
+
+What it missed, found during execution:
+
+- **The configured storageDir was not the one in use.** p510's containers bound
+  the module default, not `/home/k3d/storage`. Copying the configured path
+  would have migrated a 24-day-stale snapshot. Verified by mtime, not by name.
+- **Three Secrets existed only as live objects** (`fides-secrets`,
+  `odin-api-keys`, `fides-reporter-token`) plus a drifted key
+  (`CFACTORY_READ_KEY`). All are now in agenix — the last of these would also
+  have been wiped on p510's own next bootstrap.
+- **Keycloak's backup had been silently stale for 24 days**, reading the H2
+  from `cfg.storageDir` rather than the live bind mount (fixed, #1400).
+- **ganesha exports are keyed on PVC UIDs.** p620 minted new ones, so the NFS
+  mount failed with "No such file or directory" despite the data being present
+  — tfactory stayed down until `vfs.conf` gained a matching EXPORT block.
+- **Disabling self-heal on the root app is not enough**; all 37 child
+  Applications carry their own, and workloads restart within seconds.
+- **`du -sm` is not a verification.** It compares disk blocks, differs across
+  filesystems, and passed directories that were genuinely broken. File-list
+  comparison found 6 of them.
+
+`rolehunter` was retired during this work (#1402, factory-gitops#240): it had
+already been removed from GitOps and only survived as a 502-ing tunnel route.
 
 ## Part 1 — Why p510 keeps going down
 

--- a/docs/plans/2026-08-20-k3d-p510-to-p620-migration.md
+++ b/docs/plans/2026-08-20-k3d-p510-to-p620-migration.md
@@ -101,28 +101,53 @@ Carrying `state.db` across would import the exact bloat that caused the
 17-minute cold starts (it needed a manual `VACUUM` on 2026-08-19), plus node
 identity and CNI state that will not match the new host.
 
+### Scope
+
+**Factory services only.** Plex, the *arr stack, NZBGet, Overseerr and the rest
+of the media stack stay on p510 — they are not part of this migration.
+
 ### Why p620 can host it
 
 - 251 GB RAM, 128 threads — the cluster's requests are noise at that scale.
-- Docker already running, and it **already hosts two k3d clusters**
-  (`hecate-dev`, `hecate-remote`, plus `hecate-registry`), so the pattern is proven.
+- Docker already running, and the k3d pattern was already proven here by the
+  `hecate-dev` / `hecate-remote` demo clusters (**deleted 2026-08-20** — they
+  were demo-only, so there is no longer any cluster-name or port contention;
+  6443 is free and nothing else runs in Docker on this host).
 - No CUDA dependency to lose: the gitops repo has **0** `nvidia.com/gpu`
   requests, and `p510` appears only in docs/READMEs — no manifest pins the host.
 
 ### Blockers to settle first
 
-1. **Disk.** p620's Docker data-root is `/mnt/img_pool/docker`, which is a
-   plain directory on the **root filesystem** — 916 GB, **85% used, 138 GB
-   free**. Adding this cluster (~49 GB images + PVs) lands / around 93%.
-   Options: point `storageDir` at `/mnt/data` (196 GB free, separate disk),
-   prune first, or move the data-root. **`/mnt/data` for `storageDir` is the
-   recommendation** — it also keeps PV IOPS off the root NVMe.
-2. **Ports.** The hecate clusters bind ephemeral host ports (40187, 35941);
-   6443 is free. Set `apiPort` explicitly and `apiHostBind` to p620's tailnet
-   IP, exactly as p510 does — the module's comment about k3d 5.x not honouring
-   `0.0.0.0` still applies.
-3. **Cluster name.** `clusterName` must not collide with `hecate-*`. Keeping
-   `factory` is fine.
+1. **Disk — and it is not where `dataRoot` says it is.** `hosts/p620`
+   sets `dataRoot = "/mnt/img_pool/docker"`, but that path holds only 10 GB.
+   Docker here runs the **containerd snapshotter**, so the real storage is
+   **`/var/lib/containerd` — 168 GB, on the root filesystem**, which is
+   916 GB at **84% used, 142 GB free**. This is the same bloat pattern that
+   filled p510's /home (651 GB reclaimed by hand on 2026-08-13).
+
+   `docker system df` after deleting the demo clusters:
+
+   | Type | Size | Reclaimable |
+   | --- | --- | --- |
+   | Build cache | 143 GB | **125 GB** |
+   | Images | 42.6 GB | 30.4 GB (71%) |
+   | Local volumes | 5.6 GB | 5.6 GB — **do not blind-prune, see below** |
+
+   Reclaiming the build cache alone roughly doubles free space on / and
+   removes this blocker outright. Still point `storageDir` at `/mnt/data`
+   (196 GB free, separate disk) to keep PV IOPS off the root NVMe.
+
+   **Do NOT run `docker volume prune`.** With no containers running, all 117
+   volumes report as unused, including `evidance-vault_postgres_data`,
+   `evidance-vault_minio_data` and `rolehunter_pgdata` — real project data,
+   not demo leftovers. Remove volumes by name or not at all.
+
+   Whatever `imageGc` does for the cluster, the host also needs a build-cache
+   policy, or / refills the same way.
+2. **Ports.** 6443 is free now that the demo clusters are gone. Set `apiPort`
+   explicitly and `apiHostBind` to p620's tailnet IP, exactly as p510 does —
+   the module's comment about k3d 5.x not honouring `0.0.0.0` still applies.
+3. **Cluster name.** `factory` is unused on p620; no collision remains.
 4. **Tailnet identity.** The kubeconfig server URL changes from p510's tailnet
    IP to p620's, and every sidecar tailnet node re-registers under the new
    host. Stale p510 nodes need removing from the tailnet admin.
@@ -177,4 +202,6 @@ there and the old cluster returns.
   interactive workstation and AI host? A dedicated node would avoid the
   workstation coupling entirely.
 - How long should p510 keep the fallback copy?
-- Should Plex/ollama stay on p510 at all once its power budget is understood?
+- p510 keeps the media stack (decided). That leaves ollama as the remaining
+  discretionary GPU load on a supply that cannot carry it — drop it, or cap
+  it and accept the risk?

--- a/docs/plans/2026-08-20-k3d-p510-to-p620-migration.md
+++ b/docs/plans/2026-08-20-k3d-p510-to-p620-migration.md
@@ -77,22 +77,71 @@ real fixes are a bigger PSU, one GPU, or moving the GPU workloads off.
 ### What exists today
 
 Cluster `factory` on p510, from `modules/containers/k3d.nix` (849 lines),
-ArgoCD app-of-apps watching `github.com/olafkfreund/factory-gitops`.
+ArgoCD app-of-apps watching `github.com/olafkfreund/factory-gitops`. Two
+nodes (`k3d-factory-server-0`, `k3d-agent-0-0`), both Ready, k3s v1.31.5.
+16 PVs across two namespaces: **factory** (14) and **fides** (2).
+
+#### The storage directory is NOT the one in the host config
+
+`hosts/p510/configuration.nix` sets `storageDir = "/home/k3d/storage"`, but
+**both running containers bind-mount `/mnt/img_pool/k3d/storage`** — the
+module *default*. The containers predate the config change and k3d does not
+re-bind an existing container, so the setting never took effect. This is the
+"bind mounts don't follow config" gotcha this cluster has hit before.
+
+Verified by modification time, not by guessing:
+
+| Directory | Size | Files modified in last 3h |
+| --- | --- | --- |
+| `/mnt/img_pool/k3d/storage` | 19.6 GB | **3,813 — this is live** |
+| `/home/k3d/storage` | 16.5 GB | **0 — dead data** |
+
+**Copying `/home/k3d/storage` would migrate a stale snapshot and silently
+lose every write since the config changed.** Migrate `/mnt/img_pool/k3d/storage`.
+
+Two consequences for the migration:
+
+- The SMR-vs-/home reasoning in the p510 config comment is moot — the PVs
+  have been on the SMR pool the whole time regardless of what it says.
+- On p620, confirm the created containers actually bind the intended
+  `storageDir` (`docker inspect ... --format '{{range .Mounts}}'`) before
+  copying anything into it.
+
+#### What actually needs to move
+
+Of 40 directories on disk, only **14 back live PVs — 9.3 GB total**. The
+other 26 are orphans from previous cluster recreations.
+
+| PVC | Namespace | Size |
+| --- | --- | --- |
+| aifactory-data | factory | 3,974 MB |
+| observe-data | factory | 2,947 MB |
+| minio-data | factory | 1,573 MB |
+| tfactory-data | factory | 294 MB |
+| nfs-provisioner-backing | factory | 159 MB |
+| data-skillai-db-0 | factory | 121 MB |
+| fides-db-pvc | **fides** | 103 MB |
+| data-postgres-0 | factory | 88 MB |
+| cfactory-data | factory | 11 MB |
+| pfactory-data, keycloak-data, redis-data, skillai-uploads, fides-evidence-pvc | | <5 MB each |
+| **Total** | | **9.3 GB** |
+
+Two PVs have no local directory and need separate handling:
+
+- `tfactory-data-rwx` (20Gi, storageClass **nfs**, server 10.43.222.179) —
+  served by the in-cluster NFS provisioner, whose own backing store *is* the
+  `nfs-provisioner-backing` PV above. It follows that PV; do not copy it
+  separately.
+- `nfs-rwx-test` (1Gi) — **Released**, a leftover test claim. Do not migrate.
 
 | Thing | Where | Size | Migrate? |
 | --- | --- | --- | --- |
-| PV data | `/home/k3d/storage` | **17 GB** | **Yes — this is the only real data** |
+| **Live PV data** | `/mnt/img_pool/k3d/storage` (14 dirs) | **9.3 GB** | **Yes — this is the only real data** |
+| Orphaned PV dirs | same, 26 dirs | ~10 GB | No |
+| Stale storage dir | `/home/k3d/storage` | 16.5 GB | **No — dead, see above** |
 | Docker images + container state | `/home/docker` | 49 GB | No — re-pulled/rebuilt |
 | kine `state.db` | inside `k3d-factory-server-0` | 776 MB | **No — derived state** |
 | Secrets | agenix + `factorySecrets.enable` | — | No — re-seeded by bootstrap |
-
-PV breakdown (largest first): `aifactory-data` 6.2G + 3.7G, `minio-data`
-1.6G + 1.5G, two `*-nix-store` 692M each, `observe-data` 653M + 338M,
-`tfactory-data` 294M, `nfs-provisioner-backing` 151M, `data-skillai-db-0`
-121M, `data-postgres-0` 94M.
-
-Note the **duplicate PVC pairs** — those are orphans from earlier cluster
-recreations. Identifying the live set first will cut the copy well below 17 GB.
 
 ### Approach: rebuild from GitOps, copy only PVs
 
@@ -166,10 +215,18 @@ of the media stack stay on p510 — they are not part of this migration.
 GPU power limits + drop `qwen3.8:27b` from p510. Buys a stable window to
 migrate from rather than racing the next crash.
 
-**Phase 1 — pre-flight**
-Identify live vs orphaned PVCs (`kubectl get pv` against the live cluster,
-match by `pvc-<uid>`); confirm the real copy size; decide `storageDir`; pick
-`apiPort`. Take a `kubectl get all -A -o yaml` dump as a reference snapshot.
+**Phase 1 — pre-flight — DONE 2026-08-20**
+Live vs orphaned PVCs identified (14 live of 40 dirs), real copy size
+measured (**9.3 GB**, not the 17 GB first estimated), live storage directory
+identified as `/mnt/img_pool/k3d/storage` (**not** the configured
+`/home/k3d/storage`), `storageDir` target chosen (`/mnt/games` on p620).
+Still to do: pick `apiPort`, and take a `kubectl get all -A -o yaml` dump as
+a reference snapshot. Note `KUBECONFIG=/etc/k3d/kubeconfig` on p510 —
+`~/.kube/config` does not exist, and forcing that path yields a confusing
+Cloudflare "API Key Required" error rather than a Kubernetes one.
+
+Remember the **fides** namespace: it is not part of the factory app-of-apps,
+so confirm how it is reconciled before assuming ArgoCD recreates it.
 
 **Phase 2 — stand up on p620**
 Enable `modules.containers.k3d` in `hosts/p620/configuration.nix` with

--- a/docs/plans/2026-08-20-k3d-p510-to-p620-migration.md
+++ b/docs/plans/2026-08-20-k3d-p510-to-p620-migration.md
@@ -1,0 +1,180 @@
+# p510 crash post-mortem + k3d migration to p620
+
+Date: 2026-08-20
+Status: proposed — no changes made
+
+## Part 1 — Why p510 keeps going down
+
+### Conclusion
+
+The PSU is undersized for the two GPUs. Both recent crashes happened while a
+GPU was ramping from idle to load, and the machine lost power instantly.
+
+`dmidecode -t 39` reports **Max Power Capacity: 490 W** (Lenovo ThinkStation
+P510, 30B5S0L000). The parts fitted:
+
+| Component | Draw |
+| --- | --- |
+| Xeon E5-2698 v4 | 135 W TDP |
+| RTX 3070 Ti | 290 W (`power.limit`) |
+| RTX 3060 | 170 W (`power.limit`) |
+| Board, 94GB RAM, 5 disks, fans | ~100 W |
+| **Total if both GPUs load together** | **~695 W on a 490 W supply** |
+
+### Evidence
+
+Two crashes, both with a GPU transient and nothing else:
+
+- **2026-08-19 19:27:12** — Plex was mid **video transcode** (NVENC) and kine
+  was doing slow SQL inserts. Log ends mid-line.
+- **2026-08-20 08:53:01** — ollama began loading a model at 08:52:54,
+  llama-server started loading at 08:52:55, **machine died 6 seconds later**.
+  No Plex transcode was running (last activity 08:23, a photo thumbnail).
+
+Ruled out:
+
+- **No kernel cause.** `journalctl -b -1 -k` ends at 08:50:36 with routine CNI
+  veth churn. No MCE, no panic, no `oom-kill`, no thermal event.
+- **Not thermal.** Idle temps now: CPU package 59 °C (crit 105 °C), GPUs 36/42 °C.
+  A thermal trip would also have logged.
+- **Not a mains outage.** p620 stayed up through both events.
+- **Not a clean shutdown.** No shutdown sequence in either boot; the journal
+  simply stops mid-write, which is what a hard power cut looks like.
+
+### Why it started on 19 Aug
+
+Uptime history: 13 Aug → 19 Aug was stable for 6 days, then two crashes in
+under 14 hours. What changed is *coincident GPU demand* — the box now serves
+ollama (multi-GPU model fitting, see `common_params_fit_impl` probing both
+CUDA0 and CUDA1 in the crash log) on the same supply as Plex NVENC.
+
+### Immediate mitigation — do this regardless of the migration
+
+1. **Cap the GPUs.** The 3070 Ti at 290 W is the single biggest transient:
+
+   ```
+   sudo nvidia-smi -i 0 -pl 150
+   sudo nvidia-smi -i 1 -pl 120
+   ```
+
+   That brings the worst case to ~135 + 150 + 120 + 100 = **505 W** — still at
+   the edge, so go lower if crashes continue. Needs to be made declarative
+   (a systemd oneshot) rather than left as a shell command.
+2. **Reconsider ollama on p510 entirely.** It is the trigger for today's crash
+   and the host has no headroom for it.
+3. **Revert `qwen3.8:27b` from p510's `onDemandModels`** (merged in #1391, not
+   yet deployed). It is an 18GB dense model on 8GB + 12GB cards, so ollama
+   *must* split it across both — the exact condition that trips the supply.
+   p620's entry is unaffected and should stay.
+
+A 490 W supply cannot run these two cards. Power limits are a workaround; the
+real fixes are a bigger PSU, one GPU, or moving the GPU workloads off.
+
+## Part 2 — Migrating the k3d cluster to p620
+
+### What exists today
+
+Cluster `factory` on p510, from `modules/containers/k3d.nix` (849 lines),
+ArgoCD app-of-apps watching `github.com/olafkfreund/factory-gitops`.
+
+| Thing | Where | Size | Migrate? |
+| --- | --- | --- | --- |
+| PV data | `/home/k3d/storage` | **17 GB** | **Yes — this is the only real data** |
+| Docker images + container state | `/home/docker` | 49 GB | No — re-pulled/rebuilt |
+| kine `state.db` | inside `k3d-factory-server-0` | 776 MB | **No — derived state** |
+| Secrets | agenix + `factorySecrets.enable` | — | No — re-seeded by bootstrap |
+
+PV breakdown (largest first): `aifactory-data` 6.2G + 3.7G, `minio-data`
+1.6G + 1.5G, two `*-nix-store` 692M each, `observe-data` 653M + 338M,
+`tfactory-data` 294M, `nfs-provisioner-backing` 151M, `data-skillai-db-0`
+121M, `data-postgres-0` 94M.
+
+Note the **duplicate PVC pairs** — those are orphans from earlier cluster
+recreations. Identifying the live set first will cut the copy well below 17 GB.
+
+### Approach: rebuild from GitOps, copy only PVs
+
+Do **not** lift-and-shift the kine database or Docker state. The cluster is
+already declarative: ArgoCD reconstructs every workload from git, and the
+module re-seeds the Tailscale and factory Secrets from agenix at bootstrap.
+Carrying `state.db` across would import the exact bloat that caused the
+17-minute cold starts (it needed a manual `VACUUM` on 2026-08-19), plus node
+identity and CNI state that will not match the new host.
+
+### Why p620 can host it
+
+- 251 GB RAM, 128 threads — the cluster's requests are noise at that scale.
+- Docker already running, and it **already hosts two k3d clusters**
+  (`hecate-dev`, `hecate-remote`, plus `hecate-registry`), so the pattern is proven.
+- No CUDA dependency to lose: the gitops repo has **0** `nvidia.com/gpu`
+  requests, and `p510` appears only in docs/READMEs — no manifest pins the host.
+
+### Blockers to settle first
+
+1. **Disk.** p620's Docker data-root is `/mnt/img_pool/docker`, which is a
+   plain directory on the **root filesystem** — 916 GB, **85% used, 138 GB
+   free**. Adding this cluster (~49 GB images + PVs) lands / around 93%.
+   Options: point `storageDir` at `/mnt/data` (196 GB free, separate disk),
+   prune first, or move the data-root. **`/mnt/data` for `storageDir` is the
+   recommendation** — it also keeps PV IOPS off the root NVMe.
+2. **Ports.** The hecate clusters bind ephemeral host ports (40187, 35941);
+   6443 is free. Set `apiPort` explicitly and `apiHostBind` to p620's tailnet
+   IP, exactly as p510 does — the module's comment about k3d 5.x not honouring
+   `0.0.0.0` still applies.
+3. **Cluster name.** `clusterName` must not collide with `hecate-*`. Keeping
+   `factory` is fine.
+4. **Tailnet identity.** The kubeconfig server URL changes from p510's tailnet
+   IP to p620's, and every sidecar tailnet node re-registers under the new
+   host. Stale p510 nodes need removing from the tailnet admin.
+5. **Cross-host dependencies.** Confirm nothing in the factory namespace calls
+   Plex/*arr/NZBGet on p510 by localhost — those become cross-host calls.
+
+### Phases
+
+**Phase 0 — stabilise p510** (independent, do first)
+GPU power limits + drop `qwen3.8:27b` from p510. Buys a stable window to
+migrate from rather than racing the next crash.
+
+**Phase 1 — pre-flight**
+Identify live vs orphaned PVCs (`kubectl get pv` against the live cluster,
+match by `pvc-<uid>`); confirm the real copy size; decide `storageDir`; pick
+`apiPort`. Take a `kubectl get all -A -o yaml` dump as a reference snapshot.
+
+**Phase 2 — stand up on p620**
+Enable `modules.containers.k3d` in `hosts/p620/configuration.nix` with
+`clusterName = "factory"`, the chosen `storageDir` and `apiPort`,
+`argocd.enable`, `tailscaleAuthKey.enable`, `factorySecrets.enable`, and
+`imageGc` (p620's / has less slack than p510's /home — the 651 GB incident is
+the precedent). p510 keeps running untouched at this point.
+
+**Phase 3 — data copy**
+Quiesce the p510 cluster (scale stateful workloads to 0 so the PV contents are
+consistent), `rsync -aHAX --numeric-ids` the live PV directories to p620's
+`storageDir`, preserving the `pvc-<uid>_<ns>_<name>` directory names the local
+provisioner keys on.
+
+**Phase 4 — bootstrap + reattach**
+Let the module create the cluster and ArgoCD sync from git. PVCs must bind to
+the copied directories — if the new PVC UIDs differ, the directories need
+renaming to match, or the PVs pre-created with explicit `hostPath`. **This is
+the step most likely to need iteration.**
+
+**Phase 5 — verify, then cut over**
+ArgoCD all-synced/healthy; databases (postgres, skillai-db) come up without
+recovery errors; minio objects present; tailnet endpoints answer. Then update
+kubeconfigs and any DNS/tailnet references.
+
+**Phase 6 — decommission on p510**
+Disable the module, remove the containers, reclaim `/home/docker` (49 GB) and
+`/home/k3d/storage` (17 GB). Keep the PV copy until you are confident.
+
+**Rollback:** until Phase 6, p510's data is untouched — re-enable the module
+there and the old cluster returns.
+
+### Open questions
+
+- Do you want the cluster on p620 at all long-term, given it is your
+  interactive workstation and AI host? A dedicated node would avoid the
+  workstation coupling entirely.
+- How long should p510 keep the fallback copy?
+- Should Plex/ollama stay on p510 at all once its power budget is understood?


### PR DESCRIPTION
Post-mortem: p510's 490W PSU (dmidecode -t 39) cannot cover a 135W Xeon plus
a 290W-limit 3070 Ti and a 170W-limit 3060. Both recent crashes happened on a
GPU power transient — 19 Aug during a Plex NVENC transcode, 20 Aug six seconds
into an ollama model load — with no MCE, panic, OOM or thermal event, and the
journal stopping mid-write. p620 stayed up through both, so it was not mains.

Migration plan: rebuild on p620 from GitOps rather than lift-and-shift. Only
the 17GB of PVs is real data; the 49GB of images and the 776MB kine state.db
are derived, and carrying state.db over would import the bloat behind the
17-minute cold starts. p620 already runs two k3d clusters, has no CUDA
dependency to lose (0 nvidia.com/gpu requests in factory-gitops), but its
root filesystem is 85% full — storageDir should land on /mnt/data.
