### PR TITLE
fix(p510): drop qwen3.8:27b — the PSU cannot power both GPUs

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -598,14 +598,14 @@ in
     # qwen2.5:7b for reliable strict-JSON audiobook metadata extraction +
     # tool-calling (audiobook-import / audiobook-mcp).
     #
-    # qwen3.8:27b is on-demand ONLY here, unlike p620 where it is the
-    # persistent default. This host has no single GPU that fits it: a
-    # 3070 Ti (8GB) + a 3060 (12GB) means ollama splits an 18GB dense model
-    # across both cards over PCIe, leaving ~1.5GB of the combined 19.5GB for
-    # everything else. Those GPUs also back Plex, so a resident copy would
-    # squat on the whole box. On-demand keeps it a deliberate choice that
-    # unloads itself after `keepAlive`.
-    onDemandModels = [ "gemma4:e4b" "qwen2.5:7b" "gemma4:12b" "qwen2.5-coder:14b" "qwen3.8:27b" ];
+    # qwen3.8:27b is deliberately ABSENT here (it is p620's persistent
+    # default). This host's PSU is rated 490W and already cannot cover a 135W
+    # Xeon plus a 290W-limit 3070 Ti and a 170W-limit 3060 — three hard power
+    # cuts on 19/20 Aug 2026, one of them six seconds into an ollama model
+    # load. An 18GB dense model does not fit either card alone, so ollama
+    # would have to spin up BOTH GPUs to hold it: precisely the transient
+    # that kills the box. See docs/plans/2026-08-20-k3d-p510-to-p620-migration.md.
+    onDemandModels = [ "gemma4:e4b" "qwen2.5:7b" "gemma4:12b" "qwen2.5-coder:14b" ];
     keepAlive = "5m"; # Evict from VRAM after 5 minutes of idle
   };
 


### PR DESCRIPTION
p510 hard-power-cut three times on 19/20 Aug 2026. dmidecode -t 39 reports a
490W supply against a 135W Xeon E5-2698 v4, a 290W-limit RTX 3070 Ti and a
170W-limit RTX 3060 — ~695W if both cards ramp together. No MCE, panic, OOM
or thermal event in any of the three; the journal just stops mid-write, and
p620 stayed up throughout, so it is not mains.

All three crashes coincide with GPU load, two of them with an ollama model
load specifically: 08:53:01 was six seconds after llama-server began loading,
and 09:30:59 followed tensor loading that started at 09:28:43.

qwen3.8:27b is 18GB dense and fits neither card alone, so ollama must spin up
BOTH GPUs to hold it — exactly the transient that kills the box. It stays
p620's persistent default (24GB single card) and is simply absent here.

This removes the worst new offender; it does not fix the host. Capping both
cards with nvidia-smi -pl, or moving ollama off p510 entirely, is still
needed — see docs/plans/2026-08-20-k3d-p510-to-p620-migration.md.

Verified: p510 loadModels no longer lists it, host closure builds.
