### PR TITLE
fix(overlays): give litellm the `expression` module its proxy needs

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -35,6 +35,54 @@
     seance = inputs.seance.packages.${prev.stdenv.hostPlatform.system}.default;
   })
 
+  # litellm: add the `expression` module its proxy needs.
+  #
+  # `litellm --config ...` dies at import with
+  #   ModuleNotFoundError: Missing dependency No module named 'expression'.
+  #   Run `pip install 'litellm[proxy]'`
+  # because nixpkgs' litellm 1.97.0 omits it. dbrattli/Expression is a runtime
+  # dependency of the proxy's server code, and nixpkgs has no
+  # python3Packages.expression at all, so it is defined here too.
+  #
+  # The failure is intermittent-looking: systemd restarts the unit, the retry
+  # fails the same way, and the service reports active while every request 502s
+  # — so a deploy exits 4 without an obviously-dead unit. Not a flake.
+  (final: prev: {
+    pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
+      (pyFinal: _pyPrev: {
+        expression = pyFinal.buildPythonPackage rec {
+          pname = "expression";
+          version = "5.7.0";
+          pyproject = true;
+
+          src = prev.fetchPypi {
+            pname = "expression";
+            inherit version;
+            hash = "sha256-TF6kJH+HG4ckrVgJEa1zwVUPxlO7Zp2vLUnktkXMR3A=";
+          };
+
+          build-system = [ pyFinal.hatchling ];
+          dependencies = [ pyFinal.typing-extensions ];
+
+          # The test suite pulls hypothesis + pytest-asyncio for a dependency we
+          # only need importable; upstream CI covers it.
+          doCheck = false;
+          pythonImportsCheck = [ "expression" ];
+
+          meta = {
+            description = "Practical functional programming for Python";
+            homepage = "https://github.com/dbrattli/Expression";
+            license = prev.lib.licenses.mit;
+          };
+        };
+      })
+    ];
+
+    litellm = prev.litellm.overridePythonAttrs (old: {
+      dependencies = (old.dependencies or [ ]) ++ [ final.python3Packages.expression ];
+    });
+  })
+
   # Rust toolchain overlay — exposes `rust-bin.*` on `final` so packages
   # that need a newer rustc than nixpkgs ships (e.g. splashboard) can
   # build with `makeRustPlatform`. Doesn't replace the default `rustc`.


### PR DESCRIPTION
`litellm --config ...` died at import with

  ModuleNotFoundError: Missing dependency No module named 'expression'.
  Run `pip install 'litellm[proxy]'`

nixpkgs' litellm 1.97.0 omits dbrattli/Expression, a runtime dependency of the
proxy server code, and nixpkgs has no python3Packages.expression at all — so
this adds the package (pure Python, hatchling, typing-extensions) via
pythonPackagesExtensions and appends it to litellm's dependencies.

The failure read as intermittent: systemd restarts the unit, the retry fails
identically, and the service ends up reporting active while every request
502s — so p620 deploys exited 4 with no obviously-dead unit to point at. It
had been mis-filed as a transient flake twice today.

Verified: the built litellm starts against the real
/nix/store/...-litellm-config.yaml with zero import errors and answers
HTTP 200 on /health/liveliness; all three hosts build; just validate passes.
