### PR TITLE
fix(audit): route nixpkgs issue links through redirect.github.com

### DIFF
--- a/.claude/commands/check-nixos-issues.md
+++ b/.claude/commands/check-nixos-issues.md
@@ -52,7 +52,7 @@ Audited against:
     ```nix
     <minimal diff snippet if applicable>
     ```
-- **Upstream:** https://github.com/NixOS/nixpkgs/issues/<n>
+- **Upstream:** https://redirect.github.com/NixOS/nixpkgs/issues/<n>
 
 … repeat per finding, ranked by severity …
 

--- a/scripts/nixos-issue-audit.sh
+++ b/scripts/nixos-issue-audit.sh
@@ -130,7 +130,7 @@ classify_one() {
   # without char-class tricks (the spell-checker can't parse [bB] etc.)
   local tl="${t,,}"
   labels=$(jq -r '.labels | join(",")' <<<"$row")
-  local url="https://github.com/NixOS/nixpkgs/issues/$n"
+  local url="https://redirect.github.com/NixOS/nixpkgs/issues/$n"
 
   # Severity rules — ORDER MATTERS, first match wins. Defaults catch
   # the case where a top-level branch matches but its inner condition


### PR DESCRIPTION
Use redirect.github.com to prevent cross-reference timeline notifications on upstream NixOS/nixpkgs issues during nightly audit runs.

recommended by https://redirect.github.com/n0099 in comment: https://github.com/olafkfreund/nixos_config/issues/777#issuecomment-5132101658