### PR TITLE
chore(p510): remove the k3d cluster — migrated to p620

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -18,6 +18,15 @@ extend-ignore-re = [
 ]
 
   [default.extend-words]
+  # `evidance-vault_*` is the literal name of a set of Docker volumes on p620.
+  # The misspelling is baked into the volume names themselves, so documenting
+  # them accurately means writing it exactly as it appears on disk.
+  evidance = "evidance"
+
+  # rsync's archive flags: -aHAX = archive, Hardlinks, ACLs, Xattrs. "HAX" is
+  # the flag cluster, not a misspelling of HEX.
+  HAX = "HAX"
+
   # NixOS-specific terms
   nixos = "nixos"
   nixpkgs = "nixpkgs"


### PR DESCRIPTION
The Factory suite now runs on p620 and serves all 10 factory hostnames from
the in-cluster tunnel there; p510's cluster has been stopped since yesterday
with its data retained. Dropping the module import and config so a deploy
cannot recreate it.

It moved because this host cannot power its own GPUs: a 490W PSU against a
135W Xeon plus a 290W-limit 3070 Ti and a 170W-limit 3060, which produced
three hard power cuts on 19/20 Aug 2026. A GitOps control plane should not sit
on a box that loses power under load.

The media stack stays: Plex, the *arr suite, NZBGet, Overseerr,
Audiobookshelf, and their own host-level cloudflared tunnel (p510-home), which
is entirely separate from the factory one and was never affected.

Also unblocks the typos pre-push hook, which was failing every push on the
migration plan doc:
- `evidance` is the literal name of the evidance-vault_* Docker volumes on
  p620 — the misspelling is in the volume names, so documenting them
  accurately requires writing it as it appears on disk.
- `HAX` is rsync's -aHAX flag cluster (archive, Hardlinks, ACLs, Xattrs), not
  a misspelling of HEX.

Verified: no k3d references remain in p510's config, the option no longer
evaluates, all three hosts build, and typos --config .typos.toml exits 0.
