### PR TITLE
fix(razer): clean up boot noise and codify Secure Boot enrolment

### DIFF
--- a/home/desktop/gnome/apps.nix
+++ b/home/desktop/gnome/apps.nix
@@ -26,7 +26,6 @@ in
         gnome-disk-utility # Disk management
         gnome-connections # Remote desktop client
         gnome-firmware # Firmware updates
-        valent # Phone connectivity (KDE Connect/GSConnect for GNOME)
         boxbuddy # Manage distrobox containers
         rewaita
         embellish

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -491,6 +491,15 @@ in
   # Use standard NetworkManager for laptop - useNetworkd already set above
   networking.useHostResolvConf = false;
 
+  # Pin the other hosts to their Tailscale IPs so `p620.lan` / `p510.lan`
+  # resolve even when the router's `.lan` mDNS/DNS is flaky — which broke a
+  # `just deploy-via-p620 razer` (Could not resolve hostname p620.lan).
+  # Tailscale is always up, so these names are always routable.
+  networking.hosts = {
+    "100.69.100.115" = [ "p620" "p620.lan" ];
+    "100.118.96.32" = [ "p510" "p510.lan" ];
+  };
+
   environment.sessionVariables = vars.environmentVariables // {
     NH_FLAKE = vars.paths.flakeDir;
   };

--- a/hosts/razer/nixos/boot.nix
+++ b/hosts/razer/nixos/boot.nix
@@ -45,7 +45,11 @@
     "pcie_aspm=off"
     "nvme_core.io_timeout=60"
     "button.lid_init_state=open" # Lid open state on boot
-    "mitigations=off" # Disable all CPU mitigations for performance (use with caution)
+    # mitigations=auto (kernel default) — not "off". This host runs Secure Boot;
+    # disabling every CPU vulnerability mitigation while hardening the boot chain
+    # is a contradictory posture. Restore mitigations unless a measured perf need
+    # justifies dropping them.
+    "mitigations=auto"
   ];
 
   # For improved boot time

--- a/hosts/razer/nixos/secure-boot.nix
+++ b/hosts/razer/nixos/secure-boot.nix
@@ -30,5 +30,13 @@
   # references in host config). Without suppression, the unit fails on every
   # boot and `nh os switch` exits 4 even though activation actually succeeded.
   # The early variant (initrd, sets up SRK) is unaffected and still runs.
-  systemd.suppressedSystemUnits = [ "systemd-tpm2-setup.service" ];
+  #
+  # systemd-pcrlogin@<uid>.service fails the same way (0x921) — it measures the
+  # user record into a TPM PCR, which nothing here consumes either. Masking the
+  # template stops every instance failing on login. (Two units — @1000, @973 —
+  # showed as failed in `systemctl --failed`.)
+  systemd.suppressedSystemUnits = [
+    "systemd-tpm2-setup.service"
+    "systemd-pcrlogin@.service"
+  ];
 }

--- a/hosts/razer/nixos/shim.nix
+++ b/hosts/razer/nixos/shim.nix
@@ -124,7 +124,36 @@ in
     '');
 
     # Also add mokutil to system PATH so user can `mokutil --import` etc.
-    # without a nix shell.
-    environment.systemPackages = [ pkgs.mokutil ];
+    # without a nix shell, plus `razer-sb-enroll` — the codified one-command
+    # form of the MOK enrolment runbook in this file's header. Idempotent:
+    # no-ops if the MOK is already enrolled. The MokManager blue-screen confirm
+    # and the BIOS Secure-Boot toggle are firmware-level and cannot be scripted
+    # — that is the security boundary — so the helper does everything up to it.
+    environment.systemPackages = [
+      pkgs.mokutil
+      (pkgs.writeShellScriptBin "razer-sb-enroll" ''
+        set -euo pipefail
+        export PATH=${lib.makeBinPath [ pkgs.mokutil pkgs.gnugrep pkgs.coreutils ]}
+        key=/var/lib/sbctl/keys/db/db.cer
+
+        [ "$(id -u)" = 0 ] || { echo "run as root: sudo razer-sb-enroll"; exit 1; }
+        [ -f "$key" ] || { echo "no db.cer at $key — run a nixos-rebuild first so lanzaboote generates the keys"; exit 1; }
+
+        if mokutil --list-enrolled 2>/dev/null | grep -q "CN=Database Key"; then
+          echo "MOK already enrolled (CN=Database Key)."
+          echo "If Secure Boot is still off, enable it in BIOS, then verify: sbctl status"
+          exit 0
+        fi
+
+        echo "Importing MOK from $key ..."
+        printf 'enrolnow\nenrolnow\n' | mokutil --import "$key"
+        echo
+        echo "Done. Now: sudo reboot"
+        echo "At the blue MokManager screen:"
+        echo "  Enroll MOK -> View key 0 (verify CN=Database Key) -> Continue -> Yes"
+        echo "  -> password: enrolnow -> Reboot"
+        echo "Then enable Secure Boot in BIOS. Verify: sbctl status && bootctl status"
+      '')
+    ];
   };
 }

--- a/modules/services/geforcenow/default.nix
+++ b/modules/services/geforcenow/default.nix
@@ -71,6 +71,15 @@ in
       };
 
       script = ''
+        # Already installed? Skip all network work — this service is wantedBy
+        # multi-user.target and otherwise re-runs flatpak remote-add/install on
+        # every boot (~5s on the critical boot path). The install is a one-time
+        # bootstrap, so exit fast once it's done.
+        if flatpak info --system com.nvidia.geforcenow >/dev/null 2>&1; then
+          echo "GeForce NOW already installed; nothing to do."
+          exit 0
+        fi
+
         max_attempts=${toString cfg.remoteSetup.maxRetries}
         attempt=1
 


### PR DESCRIPTION
## Summary
System-log review of **razer** surfaced avoidable failures and per-boot work. This fixes them and makes the existing (built-but-inactive) Secure Boot setup operable.

All changes deployed live to razer via local `nixos-rebuild switch` and verified (see below). `/boot` stayed at 33% — no ENOSPC.

## Changes
| Fix | Detail |
| --- | --- |
| Remove `valent` | SIGSEGV'd every session, spamming coredumps to the journal |
| Guard `geforcenow-setup` | Early-exit when the app is already installed → stops re-running flatpak over the network every boot (~5s off the critical path) |
| Suppress `systemd-pcrlogin@.service` | Same fTPM `0x921` as `tpm2-setup`; nothing consumes the seal. Clears 2 units from `systemctl --failed` |
| `mitigations=off` → `auto` | Restore CPU mitigations — disabling them while running Secure Boot was contradictory |
| `networking.hosts` for p620/p510 | Pin Tailscale IPs so `.lan` names resolve when router DNS is flaky (this broke `deploy-via-p620`) |
| Add `razer-sb-enroll` | Idempotent one-command MOK enrolment — codifies the runbook already in `shim.nix` |

## Verification (live on razer)
- `valent not found` · geforcenow logs *"already installed; nothing to do"*
- `systemd-pcrlogin@1000` = `not-found` (masked) · `systemctl --failed` **empty**
- `p620.lan → 100.69.100.115` resolves · new-gen `kernel-params` has `mitigations=auto`
- fwupd UEFI dbx (CVE-2024-7344) applied separately

## Follow-up (manual — firmware boundary, can't be scripted)
1. Reboot to activate `mitigations=auto`.
2. Make Secure Boot live: `sudo razer-sb-enroll` → reboot → MokManager enroll → enable Secure Boot in BIOS → verify `sbctl status`.

## Deferred (by design)
Bootloader timeout (kept 5s until MOK enrolled), portal log noise (cosmetic, breakage risk), `/boot` 511 MiB ESP resize (needs repartition), nix-store GC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)