### PR TITLE
fix(p620): stop the container log flood and the udev sysfs errors

### DIFF
--- a/hosts/p620/nixos/usb-power-fix.nix
+++ b/hosts/p620/nixos/usb-power-fix.nix
@@ -1,20 +1,27 @@
 { pkgs, lib, ... }: {
-  # Fix USB and Bluetooth mouse disconnection issues
+  # Fix USB and Bluetooth mouse disconnection issues.
+  #
+  # ENV{DEVTYPE}=="usb_device" on every rule that sets power/* : udev fires
+  # these for INTERFACES too (1-1:1.0), and an interface has no power/control
+  # or power/autosuspend attribute — only its parent device does. Without the
+  # guard each hotplug logged a pair of "Could not chase sysfs attribute ...
+  # No such file or directory" errors; 176 of them in one boot. The rules
+  # still take effect, because ATTRS{} matches walk up to the parent device.
   services.udev.extraRules = ''
     # Disable autosuspend for TP-Link Bluetooth adapter (causes mouse freezing)
-    ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="2357", ATTRS{idProduct}=="0604", ATTR{power/autosuspend}="-1", ATTR{power/control}="on"
+    ACTION=="add", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="2357", ATTRS{idProduct}=="0604", ATTR{power/autosuspend}="-1", ATTR{power/control}="on"
 
     # Disable autosuspend for all Bluetooth class devices
-    ACTION=="add", SUBSYSTEM=="usb", ATTRS{bDeviceClass}=="e0", ATTR{power/autosuspend}="-1", ATTR{power/control}="on"
+    ACTION=="add", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{bDeviceClass}=="e0", ATTR{power/autosuspend}="-1", ATTR{power/control}="on"
 
     # Disable autosuspend for HID devices (mice, keyboards)
-    ACTION=="add", SUBSYSTEM=="usb", ATTRS{bInterfaceClass}=="03", ATTR{power/autosuspend}="-1", ATTR{power/control}="on"
+    ACTION=="add", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{bInterfaceClass}=="03", ATTR{power/autosuspend}="-1", ATTR{power/control}="on"
 
     # Disable autosuspend for all Razer devices
-    ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1532", ATTR{power/autosuspend}="-1", ATTR{power/control}="on"
+    ACTION=="add", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="1532", ATTR{power/autosuspend}="-1", ATTR{power/control}="on"
 
     # Razer Basilisk X HyperSpeed - prevent power management issues (both USB and Bluetooth)
-    ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0083", ATTR{power/autosuspend}="-1", ATTR{power/control}="on"
+    ACTION=="add", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0083", ATTR{power/autosuspend}="-1", ATTR{power/control}="on"
     ACTION=="add", SUBSYSTEM=="bluetooth", ATTRS{name}=="Basilisk X HyperSpeed*", ATTR{power/control}="on"
     ACTION=="add", SUBSYSTEM=="input", ATTRS{name}=="Basilisk X HyperSpeed*", ATTR{power/control}="on"
 
@@ -25,7 +32,7 @@
     ACTION=="add", KERNEL=="hidraw*", ATTRS{name}=="Basilisk X HyperSpeed*", ATTR{power/control}="on"
 
     # Disable autosuspend for ALL USB hubs to prevent downstream devices from disconnecting
-    ACTION=="add", SUBSYSTEM=="usb", ATTR{bDeviceClass}=="09", ATTR{power/autosuspend}="-1", ATTR{power/control}="on"
+    ACTION=="add", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{bDeviceClass}=="09", ATTR{power/autosuspend}="-1", ATTR{power/control}="on"
   '';
 
   # Completely disable USB autosuspend

--- a/modules/containers/docker.nix
+++ b/modules/containers/docker.nix
@@ -56,6 +56,21 @@ in
     virtualisation.docker = {
       enable = true;
       enableOnBoot = true;
+
+      # Container logs go to files, not the host journal.
+      #
+      # nixpkgs defaults this to "journald", and Docker's journald driver
+      # assigns priority by STREAM, not by content: stdout -> info, stderr ->
+      # err. Every component that logs to stderr therefore lands in the host
+      # journal as an error. On p620 that meant k3s inside k3d filing ~94k
+      # INFO-level lines ("enqueueing job", SQL DDL, kubelet chatter) at
+      # priority 3 in a single boot — 95% of all errors on the host — which
+      # makes `journalctl -p err` useless for triage exactly when it matters.
+      #
+      # "local" keeps `docker logs` and `kubectl logs` working (both read the
+      # runtime's own store, not the journal) and rotates on its own, so this
+      # also stops container output counting against journald's SystemMaxUse.
+      logDriver = "local";
       rootless = {
         enable = cfg.rootless;
         setSocketVariable = cfg.rootless;

--- a/modules/services/rescreenshot-mcp.nix
+++ b/modules/services/rescreenshot-mcp.nix
@@ -94,12 +94,14 @@ in
     # Ensure required runtime dependencies are available
     services.pipewire.enable = mkDefault true;
 
-    xdg.portal = {
-      enable = mkDefault true;
-      extraPortals = with pkgs; [
-        xdg-desktop-portal-gtk
-      ];
-    };
+    # Only assert that a portal stack exists. The gtk backend is NOT added
+    # here: every desktop this runs under already pulls it in (the GNOME module
+    # adds gnome + gtk, Hyprland adds its own), and a second entry does not
+    # deduplicate — xdg.portal.extraPortals is a plain list, so the same
+    # .portal file ends up on the search path twice and dbus logs "Ignoring
+    # duplicate name org.freedesktop.impl.portal.desktop.gtk" on every session
+    # start (78 of them in one boot on p620).
+    xdg.portal.enable = mkDefault true;
 
     # Configure Claude Desktop for the user.
     # systemd.user.services are loaded for EVERY user's systemd-user instance


### PR DESCRIPTION
Two real noise sources, plus one hygiene change that is NOT a noise fix.

**Docker's journald log driver.** nixpkgs defaults virtualisation.docker to
logDriver = "journald", and that driver assigns priority by STREAM, not by
content: stdout -> info, stderr -> err. Every component logging to stderr is
therefore filed as a host-level error. On p620 that meant k3s inside k3d
writing ~94k INFO lines ("enqueueing job", SQL DDL, kubelet chatter) at
priority 3 in a single boot — 95% of every error on the host, which makes
`journalctl -p err` useless for triage exactly when it matters. Switching to
"local" moves container output to the runtime's own rotating store; both
`docker logs` and `kubectl logs` read from there, not the journal, so nothing
is lost and container output stops counting against journald's SystemMaxUse.

**udev rules firing on USB interfaces.** The mouse-freeze workaround sets
power/autosuspend and power/control, but udev also runs those rules for
INTERFACES (1-1:1.0), which have no power/* attributes — only the parent
device does. Each hotplug logged a pair of "Could not chase sysfs attribute
... No such file or directory", 176 in one boot. ENV{DEVTYPE}=="usb_device"
restricts them to device nodes; behaviour is unchanged because ATTRS{}
matches still walk up to the parent.

**A redundant portal declaration.** rescreenshot-mcp added
xdg-desktop-portal-gtk, which every desktop it runs under already provides.
This is hygiene, not a log fix: an earlier version of this message claimed it
would stop the ~78 "Ignoring duplicate name ...desktop.gtk" dbus warnings per
boot. It will not. buildEnv deduplicates identical store paths, so the extra
list entry never reached the built system — verified: the portals directory
contains gnome, gnome-keyring, gtk and hyprland exactly once each, the gtk
service file exists only in the system path, and XDG_DATA_DIRS has no
duplicate entries. Those warnings come from xdg-desktop-portal's own scanning
and are not caused by this repo.

Verified: logDriver evaluates to "local", 7 udev rules carry the DEVTYPE
guard, all three hosts build and just validate passes.