### PR TITLE
fix(logging): stop forcing Docker's log driver back to journald

### DIFF
--- a/modules/system/logging.nix
+++ b/modules/system/logging.nix
@@ -59,13 +59,19 @@ in
       };
     };
 
-    # Configure Docker daemon for better logging
-    virtualisation.docker.daemon.settings = {
-      log-driver = "journald";
-      log-opts = {
-        "labels" = "service";
-      };
-    };
+    # Docker's log driver is deliberately NOT set here.
+    #
+    # This block used to pin daemon.settings.log-driver = "journald", which
+    # silently beat virtualisation.docker.logDriver: daemon.settings IS the
+    # rendered daemon.json, so a raw entry here wins over the typed option no
+    # matter what a host sets. #1412 switched logDriver to "local" to stop k3s
+    # inside k3d filing ~94k INFO lines a boot as host-level errors, and this
+    # line quietly reverted it — the built daemon.json still read "journald"
+    # after that deploy.
+    #
+    # A module whose purpose is noise reduction should not be the thing forcing
+    # every container's stderr into the journal. The driver now comes from
+    # modules/containers/docker.nix, which owns Docker's configuration.
 
     # Environment variables for better log control
     environment.variables = {


### PR DESCRIPTION
#1412 set virtualisation.docker.logDriver = "local" so k3s inside k3d would
stop filing ~94k INFO lines a boot as host-level errors. After deploying it,
p620's daemon.json still read "journald" and container logs still flooded the
journal.

modules/system/logging.nix pinned daemon.settings.log-driver = "journald"
directly. daemon.settings IS the rendered daemon.json, so a raw entry there
beats the typed logDriver option no matter what a host sets — the fix was
reverted before it ever reached the daemon, silently, with no evaluation
conflict to warn about it.

Removed, so the driver comes from modules/containers/docker.nix, which owns
Docker's configuration. A module whose purpose is noise reduction should not
be the thing forcing every container's stderr into the journal.

Verified: the evaluated daemon.settings now carries "log-driver":"local"; all
three hosts build and just validate passes.

Note for deploy: existing containers keep the driver they were created with,
so the k3d nodes need recreating (or a reboot) before the journal actually
goes quiet.
