### PR TITLE
fix(containers): stop podman filing container output as host errors

### DIFF
--- a/modules/services/backstage.nix
+++ b/modules/services/backstage.nix
@@ -272,6 +272,14 @@ in
       backend = lib.mkDefault "podman";
 
       containers."backstage-postgres" = {
+        # k8s-file, not the NixOS default of journald. Podman's journald driver
+        # files container stdout AND stderr as host-level errors regardless of
+        # content, so ordinary output shows up under `journalctl -p err`:
+        # kometa's ASCII progress tables and postgres's "checkpoint starting"
+        # LOG lines alone accounted for ~2000 "errors" in one boot on p510.
+        # k8s-file keeps `podman logs` working and leaves the journal for
+        # things that are actually wrong.
+        log-driver = "k8s-file";
         image = cfg.postgresImage;
         # No host port mapping — Postgres is only consumed by the sibling
         # backstage container via the shared backstage-net network. Keeps
@@ -283,6 +291,7 @@ in
       };
 
       containers."backstage" = {
+        log-driver = "k8s-file";
         image = cfg.image;
         ports = [ "127.0.0.1:${toString cfg.port}:7007" ];
         environmentFiles = [ "${envDir}/env-backstage" ];

--- a/modules/services/kometa/default.nix
+++ b/modules/services/kometa/default.nix
@@ -49,6 +49,14 @@ in
       backend = "podman";
 
       containers."kometa" = {
+        # k8s-file, not the NixOS default of journald. Podman's journald driver
+        # files container stdout AND stderr as host-level errors regardless of
+        # content, so ordinary output shows up under `journalctl -p err`:
+        # kometa's ASCII progress tables and postgres's "checkpoint starting"
+        # LOG lines alone accounted for ~2000 "errors" in one boot on p510.
+        # k8s-file keeps `podman logs` working and leaves the journal for
+        # things that are actually wrong.
+        log-driver = "k8s-file";
         # Pinned to a specific digest for reproducibility + supply-chain
         # safety. Bump by running on p510 and grabbing the new digest:
         #   sudo podman pull kometateam/kometa:latest

--- a/modules/services/plex-auto-languages/default.nix
+++ b/modules/services/plex-auto-languages/default.nix
@@ -40,6 +40,14 @@ in
       backend = "podman";
 
       containers."plex-auto-languages" = {
+        # k8s-file, not the NixOS default of journald. Podman's journald driver
+        # files container stdout AND stderr as host-level errors regardless of
+        # content, so ordinary output shows up under `journalctl -p err`:
+        # kometa's ASCII progress tables and postgres's "checkpoint starting"
+        # LOG lines alone accounted for ~2000 "errors" in one boot on p510.
+        # k8s-file keeps `podman logs` working and leaves the journal for
+        # things that are actually wrong.
+        log-driver = "k8s-file";
         # Pinned to a specific digest for reproducibility + supply-chain
         # safety. Bump by running on p510 and grabbing the new digest:
         #   sudo podman pull remirigal/plex-auto-languages:latest


### PR DESCRIPTION
Podman's journald log driver — the NixOS default for oci-containers — assigns
priority by stream, not content, so ordinary container output lands under
`journalctl -p err`. On p510 that meant kometa's ASCII progress tables (the
box-drawing borders and "No Item Edits" rows) and backstage-postgres's
"LOG: checkpoint starting" lines accounting for ~2000 of the host's error
entries in a single boot, with 54 still arriving every two hours.

Same class of bug as the Docker one in #1412/#1415, and the same consequence:
`journalctl -p err` stops being a usable triage signal on a host whose actual
faults — a disk with 656 unreadable sectors, a corrupt audiobook breaking a
Plex scan — are buried under thousands of routine lines.

All four containers (backstage, backstage-postgres, kometa,
plex-auto-languages) now use k8s-file, podman's native file logger.
`podman logs` is unaffected; it reads that store, not the journal.

Verified: all four evaluate to log-driver "k8s-file", all three hosts build,
just validate passes.

Note for deploy: existing containers keep the driver they were created with,
so they need recreating before the journal goes quiet.
