### PR TITLE
feat(p510): back up the media-stack databases off the failing disk

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -37,6 +37,7 @@ in
       ../../modules/secrets/api-keys.nix
       ../../modules/services/ollama.nix
       ../../modules/services/plex-mcp.nix # Plex MCP server (HTTP transport, tailnet-only)
+      ../../modules/services/sqlite-backup.nix # sqlite snapshots off the failing media disk
       ../../modules/services/backstage.nix # Backstage developer portal (epic #731, disabled by default)
       ../../modules/containers/k3d.nix # k3d (k3s in Docker) cluster — ArgoCD + Tailscale operator (see docs/applications/k3d-cluster.md)
       ../../modules/services/arr-suite-mcp.nix # *arr suite MCP server (SSE bridge, tailnet-only)
@@ -692,6 +693,28 @@ in
   # download dir every 5 min, parses release names with the local qwen2.5:7b,
   # merges multi-file books into chaptered M4B via m4b-tool, and places them
   # under /mnt/media/Media/Audiobooks/<Author>/[<Series>/]<Title>/.
+  # The Plex library database lives on /mnt/media — the 12TB ST12000NM0127
+  # (ZJV2NZE9) with 2896 reallocated and 656 pending sectors, no RAID, and no
+  # other copy. Watch history and curation are the only things here that cannot
+  # be re-downloaded, and they are ~1GB. Snapshot them onto /mnt/img_pool,
+  # which is a different physical disk.
+  features.sqlite-backup = {
+    enable = true;
+    # Plex's two (module default) plus the *arr trio. All of them keep their
+    # state on /mnt/media, and Sonarr/Radarr's own Backups/ directories are on
+    # that same disk — which protects against a bad upgrade, not a dying drive.
+    # ~1.1GB total: library curation, quality profiles, indexer config and
+    # download history that would take days to rebuild by hand.
+    databases = [
+      "${config.services.plex.dataDir}/Plex Media Server/Plug-in Support/Databases/com.plexapp.plugins.library.db"
+      "${config.services.plex.dataDir}/Plex Media Server/Plug-in Support/Databases/com.plexapp.plugins.library.blobs.db"
+      "/mnt/media/sonarr/sonarr.db"
+      "/mnt/media/radarr/radarr.db"
+      "/mnt/media/lidarr/lidarr.db"
+    ];
+    readPaths = [ "/mnt/media" ];
+  };
+
   features.audiobook-import = {
     enable = true;
     # ABB torrents land here; SABnzbd (audiobook-only on p510 — the *arr stack

--- a/modules/services/sqlite-backup.nix
+++ b/modules/services/sqlite-backup.nix
@@ -1,0 +1,167 @@
+{ config, lib, pkgs, ... }:
+# Periodic backup of SQLite databases to durable storage.
+#
+# The library database holds every watch state, rating, collection and piece of
+# curated metadata — the one thing on this host that cannot be re-acquired. It
+# lives under services.plex.dataDir, which on p510 is /mnt/media, i.e. the
+# 12TB ST12000NM0127 (ZJV2NZE9) that has been shedding sectors since August
+# 2026: 2896 reallocated and 656 currently-pending at the time of writing,
+# while SMART still self-assesses as PASSED. There is no RAID and no other
+# copy — a scan on 2026-08-21 found nothing resembling a Plex backup anywhere
+# on the healthy disks.
+#
+# `sqlite3 .backup`, not cp: these databases run in WAL mode (the -wal/-shm
+# files sit right beside them), so copying the .db alone captures a torn state
+# missing everything still in the write-ahead log. The backup API takes a
+# consistent snapshot of a database that is actively being written, so Plex
+# keeps running throughout.
+let
+  inherit (lib) mkEnableOption mkIf mkOption types;
+  cfg = config.features.sqlite-backup;
+
+  plexDbDir = "${config.services.plex.dataDir}/Plex Media Server/Plug-in Support/Databases";
+in
+{
+  options.features.sqlite-backup = {
+    enable = mkEnableOption "Periodic sqlite backup of application databases";
+
+    databases = mkOption {
+      type = types.listOf types.str;
+      default = [
+        "${plexDbDir}/com.plexapp.plugins.library.db"
+        "${plexDbDir}/com.plexapp.plugins.library.blobs.db"
+      ];
+      description = ''
+        Absolute paths of the SQLite databases to snapshot. A missing file is
+        skipped with a warning rather than failing the run, so a service that
+        has not started yet does not break the others.
+      '';
+    };
+
+    readPaths = mkOption {
+      type = types.listOf types.str;
+      default = [ config.services.plex.dataDir ];
+      description = ''
+        Directories the unit may read. ProtectSystem=strict hides everything
+        else, so any path holding a listed database must appear here.
+      '';
+    };
+
+    destination = mkOption {
+      type = types.str;
+      default = "/mnt/img_pool/backups/sqlite";
+      description = ''
+        Where snapshots are written. MUST be a different physical disk from
+        services.plex.dataDir — the entire point is surviving that disk.
+      '';
+    };
+
+    keep = mkOption {
+      type = types.int;
+      default = 7;
+      description = "How many timestamped snapshots to retain.";
+    };
+
+    dates = mkOption {
+      type = types.str;
+      default = "03:30";
+      description = ''
+        systemd OnCalendar expression. Defaults to a quiet hour: the backup
+        reads ~1GB off a disk that is already struggling, so it should not
+        compete with evening playback.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(lib.any (rp: lib.hasPrefix rp cfg.destination) cfg.readPaths);
+        message =
+          "features.sqlite-backup.destination (${cfg.destination}) sits inside one "
+          + "of readPaths. A backup on the same disk as the original protects "
+          + "against nothing — the whole point is surviving that disk.";
+      }
+    ];
+
+    # 0770 root:plex so the DynamicUser can write via SupplementaryGroups.
+    systemd.tmpfiles.rules = [
+      "d ${cfg.destination} 0770 root ${config.services.plex.group} - -"
+    ];
+
+    systemd.services.sqlite-backup = {
+      description = "Back up application SQLite databases to durable storage";
+      after = [ "plex.service" ];
+      path = with pkgs; [ sqlite coreutils ];
+
+      serviceConfig = {
+        Type = "oneshot";
+
+        # DynamicUser can read the databases without help: they are mode 0644
+        # under world-traversable directories. The plex group is only needed to
+        # WRITE into the destination, whose owner cannot be pinned to a UID
+        # that changes on every run.
+        DynamicUser = true;
+        SupplementaryGroups = [ config.services.plex.group ];
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ReadOnlyPaths = cfg.readPaths;
+        ReadWritePaths = [ cfg.destination ];
+      };
+
+      script = ''
+        set -uo pipefail
+        ts=$(date +%Y%m%d-%H%M%S)
+        rc=0
+
+        for src in ${lib.escapeShellArgs cfg.databases}; do
+          db=$(basename "$src")
+          if [ ! -f "$src" ]; then
+            echo "[sqlite-backup] $src not found; skipping" >&2
+            continue
+          fi
+
+          out="${cfg.destination}/''${db%.db}-$ts.db"
+          # No `pragma integrity_check` afterwards: Plex builds its databases
+          # with custom collations, and a stock sqlite3 aborts with "unknown
+          # tokenizer: collating" before it checks anything. That is a property
+          # of the reader, not damage to the file — .backup copies at the page
+          # level, and the snapshot queries fine (verified against
+          # metadata_items on 2026-08-21). A check that always fails would
+          # train you to ignore the one that matters.
+          if sqlite3 "$src" ".backup '$out'"; then
+            echo "[sqlite-backup] $db -> $(basename "$out") ($(stat -c %s "$out") bytes)"
+          else
+            echo "[sqlite-backup] ERROR: backup of $src failed" >&2
+            rm -f "$out"
+            rc=1
+          fi
+        done
+
+        # Prune per database, so one large file cannot evict another's history.
+        for src in ${lib.escapeShellArgs cfg.databases}; do
+          db=$(basename "$src")
+          ls -1t "${cfg.destination}/''${db%.db}"-2*.db 2>/dev/null \
+            | tail -n +${toString (cfg.keep + 1)} \
+            | xargs -r rm -f
+        done
+
+        exit "$rc"
+      '';
+    };
+
+    systemd.timers.sqlite-backup = {
+      description = "Periodic application database backup";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.dates;
+        # Catch up after the host has been down — this box loses power.
+        Persistent = true;
+        RandomizedDelaySec = "5m";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Everything irreplaceable on this host lives on one dying drive. Plex's library
database holds every watch state, rating and collection; Sonarr, Radarr and
Lidarr hold library config, quality profiles, indexer settings and download
history. All of it sits under /mnt/media — the 12TB ST12000NM0127 (ZJV2NZE9)
that has been shedding sectors since August: 2896 reallocated and 656
currently-pending, while SMART still self-assesses as PASSED. There is no RAID.

Sonarr and Radarr do keep their own Backups/ directories — on that same disk.
That protects against a bad upgrade, not a dying drive.

~1.1GB of curation that would take days to rebuild, next to 4.2TB of
re-downloadable media that will not fit on the healthy disks anyway. So back
up the small irreplaceable part daily to /mnt/img_pool (a different physical
disk, 841GB free), keeping 7 snapshots.

`.backup`, not cp: these run in WAL mode (the -wal/-shm files sit beside
them), so copying the .db alone captures a torn state missing everything still
in the log. The online backup API snapshots a database that is actively being
written, so the services keep running during the run.

An assertion refuses a destination inside readPaths — a backup on the disk it
is meant to survive protects against nothing.

DynamicUser reads the databases unaided (mode 0644 under traversable
directories) and joins the plex group only to write the destination, whose
owner cannot be pinned to a UID that changes every run. ProtectSystem=strict
with the source tree read-only. lib.escapeShellArgs keeps the Plex paths
intact — "Plex Media Server/Plug-in Support" contains spaces.

Verified on p510 against the live Plex database: .backup exits 0, produces a
62MB snapshot, and metadata_items reads back 7067 rows. Deliberately no
integrity_check — Plex's custom collations make a stock sqlite3 abort with
"unknown tokenizer: collating" regardless of file health, and a check that
always fails trains you to ignore the one that matters.

This mitigates the symptom. 656 pending sectors is still the fault, and the
replacement drive is still the fix.