### PR TITLE
chore(antigravity): bump cli 1.1.17, hub 2.9.1, sdk 0.1.13

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.1.15-5350383476932608";
+  version = "1.1.17-5084709148033024";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.15-5350383476932608/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-0LHW82eKBhkVyuvEMZMOJAuGO/QFk2nAjG/86yTma18=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.17-5084709148033024/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-FUQ5ZklM1ik4MgkArP0W35Bs9NpWJ55N2PSEbAn4Sd8=";
   };
 
   # Tarball contains a single file `antigravity` at the root.

--- a/pkgs/antigravity-hub/default.nix
+++ b/pkgs/antigravity-hub/default.nix
@@ -98,11 +98,11 @@ let
 in
 stdenv.mkDerivation {
   pname = "antigravity-hub";
-  version = "2.8.1-6512087774658560";
+  version = "2.9.1-4871453687021568";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.8.1-6512087774658560/linux-x64/Antigravity.tar.gz";
-    hash = "sha256-I/bDv+8rMyb4t0fNnhW6NAHHAigENuTgO5qGPGZ47/M=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.9.1-4871453687021568/linux-x64/Antigravity.tar.gz";
+    hash = "sha256-AW2/akLFpJqsT6QD16iSBKPHyTN5nJXsuRrCwW+jTe0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/google-antigravity-py/default.nix
+++ b/pkgs/google-antigravity-py/default.nix
@@ -25,15 +25,15 @@
 # Upstream: https://github.com/google-antigravity/antigravity-sdk-python
 buildPythonPackage rec {
   pname = "google-antigravity";
-  version = "0.1.12";
+  version = "0.1.13";
   format = "wheel";
 
   # fetchPypi gets the URL wrong for this package (constructs
   # google-antigravity- instead of google_antigravity-), so use fetchurl
   # with the canonical PyPI download URL.
   src = fetchurl {
-    url = "https://files.pythonhosted.org/packages/90/cd/a206d89eda0d944ddef6a0557a430d94a38c2e770335023754981fa67126/google_antigravity-0.1.12-py3-none-manylinux_2_17_x86_64.whl";
-    hash = "sha256-JJwQLKyDHikKSmKRii4MAUgmlrZTOyoC6CFYkAgNY0o=";
+    url = "https://files.pythonhosted.org/packages/35/ac/698e469568e8fced1534b8a0f1576cb76c986ce6bad3098dce26d99f226d/google_antigravity-0.1.13-py3-none-manylinux_2_17_x86_64.whl";
+    hash = "sha256-85hmSzYigAN/jtbfXNYbmW89Ar4RUf9mXG0JyHzGqZI=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Versions and hashes from the Hy4ri/antigravity-flake tracker, which mirrors
Google's auto-updater manifests — Antigravity ships outside nixpkgs via CDNs
with unguessable build-id suffixes, so the tracker is the practical source.

  cli  1.1.15-5350383476932608 -> 1.1.17-5084709148033024
  hub  2.8.1-6512087774658560  -> 2.9.1-4871453687021568
  sdk  0.1.12                  -> 0.1.13
  ide  2.5.5-4923483625488384  (already current, untouched)

Verified: the diff moves only version/url/hash across the three files (18
changed lines, 0 outside those fields); all four packages build; agy reports
1.1.17; `import google.antigravity` succeeds; the hub binary is present; and
both Antigravity hosts' closures compose. p510 is not built — it does not
ship Antigravity.

Not deployed.
