### PR TITLE
chore(warp-terminal): bump to v0.2026.08.19.08.15.stable_01

### DIFF
--- a/pkgs/warp-terminal/versions.json
+++ b/pkgs/warp-terminal/versions.json
@@ -1,10 +1,10 @@
 {
   "linux_x86_64": {
-    "hash": "sha256-VzeANeKlRngHZKBAK7Pgpcq89YoW91aaWxWOrwra6sA=",
-    "version": "0.2026.08.12.21.54.stable_00"
+    "hash": "sha256-0QyyOjKuPRciYWk0aOz3/ML0mahkRHEeWVmmINDDhY8=",
+    "version": "0.2026.08.19.08.15.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-VUCK0QxSilp7oqGhBpRbInH4qSgzvDR4mOIJEDraj0M=",
-    "version": "0.2026.08.12.21.54.stable_00"
+    "hash": "sha256-36zuyK4fw81AboaI45oES4r4uQ+DLFy0fB3MafBkkSc=",
+    "version": "0.2026.08.19.08.15.stable_01"
   }
 }


### PR DESCRIPTION
0.2026.08.12.21.54.stable_00 -> 0.2026.08.19.08.15.stable_01, both arches. Versions and SRI hashes
resolved by scripts/update-warp-terminal.sh through the app.warp.dev redirect
chain; we track upstream stable ourselves because nixpkgs' warp-terminal lags
by roughly two weeks (#401).

Verified: the diff touches only version and hash for linux_x86_64 and
linux_aarch64 (4 lines, no other file); the package builds; its version
attribute matches versions.json; the binary is ELF with no unresolved
libraries; and all three host closures compose.

Not deployed.
