### PR TITLE
fix(security): drop security.unprivilegedUsernsClone, removed upstream

### DIFF
--- a/modules/security/default.nix
+++ b/modules/security/default.nix
@@ -8,8 +8,18 @@ _: {
       # Fix for "no new privileges" flag error
       execWheelOnly = true;
     };
-    # This ensures sudo doesn't get the "no new privs" flag
-    unprivilegedUsernsClone = true;
+    # security.unprivilegedUsernsClone was removed from nixpkgs (2c423e03bb,
+    # 2026-08-22) and its assertion now fails the build. Nothing replaces it
+    # here because it was already inert: it wrote kernel.unprivileged_userns_clone,
+    # a Debian/Arch patch that mainline never carried, and /proc/sys/kernel/
+    # unprivileged_userns_clone does not exist on this kernel. Unprivileged user
+    # namespaces are governed by user.max_user_namespaces, which sits at its
+    # default of 1029777 — i.e. already enabled, and not set anywhere in this
+    # repo. Removing the line changes no behaviour.
+    #
+    # The comment it carried ("ensures sudo doesn't get the no-new-privs flag")
+    # was wrong on its own terms: user namespaces have nothing to do with
+    # sudo's NoNewPrivileges. execWheelOnly above is the sudo-related setting.
 
     polkit = {
       enable = true;


### PR DESCRIPTION
nixpkgs 2c423e03bb (2026-08-22) removed the option and replaced it with a hard
assertion, so every host failed to evaluate and nhs died at its freshness
check:

  The option definition `security.unprivilegedUsernsClone' ... no longer has
  any effect; please remove it.

Nothing replaces it, because it was already inert here. The option wrote
kernel.unprivileged_userns_clone, a Debian/Arch kernel patch mainline never
carried — /proc/sys/kernel/unprivileged_userns_clone does not exist on this
kernel. Unprivileged user namespaces are governed by user.max_user_namespaces,
which sits at its default of 1029777 (enabled) and is not set anywhere in this
repo. Verified on p620 before removing rather than assumed.

The comment it carried — "This ensures sudo doesn't get the no new privs
flag" — was wrong on its own terms. User namespaces have nothing to do with
sudo's NoNewPrivileges; execWheelOnly directly above is the sudo setting.

Verified: p620, razer and p510 all evaluate system.build.toplevel again.

flake.lock is deliberately not in this commit — the nhs run that surfaced this
had already bumped it, and that script owns the file.
