### PR TITLE
fix(p620): stop mixing dotted and block `modules` — CI could not evaluate

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -489,25 +489,29 @@ in
 
   # Advanced CPU monitoring script for Waybar
 
-  # Consolidated modules configuration
-  modules = {
-    # Docker configuration
-    containers.docker = {
-      enable = true;
-      users = hostUsers; # Use all users for this host
-      rootless = false;
-      # Preserves the path this host has always used — 81 volumes live here.
-      # Unlike p510, /mnt/img_pool here is a plain directory on the root
-      # filesystem, not a separate disk; the value is legacy rather than
-      # deliberate, but repointing it would orphan the existing data-root.
-      dataRoot = "/mnt/img_pool/docker";
-    };
+  # Dotted paths, NOT a `modules = { ... }` block. This file already sets
+  # modules.containers.k3d above, and older Nix rejects mixing the two forms
+  # for the same parent: "attribute 'containers' already defined". Nix 2.34
+  # merges them happily, which is why this evaluated locally while every CI
+  # run failed — CI pins an older Nix via cachix/install-nix-action@v27.
+  # Keeping one style throughout removes the version dependency.
 
-    # Enable secrets management
-    security.secrets = {
-      enable = true;
-      userKeys = [ "/home/${vars.username}/.ssh/id_ed25519" ];
-    };
+  # Docker configuration
+  modules.containers.docker = {
+    enable = true;
+    users = hostUsers; # Use all users for this host
+    rootless = false;
+    # Preserves the path this host has always used — 81 volumes live here.
+    # Unlike p510, /mnt/img_pool here is a plain directory on the root
+    # filesystem, not a separate disk; the value is legacy rather than
+    # deliberate, but repointing it would orphan the existing data-root.
+    dataRoot = "/mnt/img_pool/docker";
+  };
+
+  # Enable secrets management
+  modules.security.secrets = {
+    enable = true;
+    userKeys = [ "/home/${vars.username}/.ssh/id_ed25519" ];
   };
 
   # Create system users for all host users


### PR DESCRIPTION
Every CI run has failed since the k3d migration:

  error: attribute 'containers' already defined at hosts/p620/configuration.nix:495:5
  at hosts/p620/configuration.nix:390:3

The file set `modules.containers.k3d` as a dotted path (added with the k3d
cluster in #1398) while also carrying a `modules = { containers.docker = ...; }`
block further down. Older Nix rejects mixing the two forms for the same parent
attribute; Nix 2.34 merges them silently — which is exactly why this evaluated
on every host here and failed in CI on the same commit. CI pins an older Nix
through cachix/install-nix-action@v27, so `nix build` locally was never going
to reproduce it.

Converted the block to dotted paths so the file uses one style throughout and
no longer depends on which Nix reads it. That block held only two entries, so
this is a formatting change, not a behavioural one.

Verified: the evaluated values are unchanged — containers.docker.enable=true,
dataRoot=/mnt/img_pool/docker, containers.k3d.enable=true,
k3d.storageDir=/mnt/games/k3d/storage, security.secrets.enable=true — and all
three hosts build. p510 and razer already used dotted paths only and were
never affected.

Fixes the lint-check, security-check and check-configurations (p620) jobs,
which all failed on this same evaluation.
