### PR TITLE
style(k3d): nixpkgs-fmt modules/containers/k3d.nix

### DIFF
--- a/modules/containers/k3d.nix
+++ b/modules/containers/k3d.nix
@@ -913,27 +913,28 @@ in
             };
           };
         in
-        builtins.listToAttrs (map mkSecret [
-          "cloudflared-factory"
-          "factory-secrets"
-          "factory-cli-creds"
-          "ghcr-pull"
-          "skillai-db"
-          "skillai-app"
-          "factory-db-aifactory"
-          "factory-db-pfactory"
-          "factory-db-tfactory"
-          "minio-creds"
-          "minio-kms"
-          "oauth2-proxy-cfactory"
-          "oauth2-proxy-observe"
-          "oauth2-proxy-odin"
-          "observe-root"
-          "otel-otlp-auth"
-          "cfactory-api-keys"
-          "odin-ssh-key"
-          "odin-api-keys"
-        ])
+        builtins.listToAttrs
+          (map mkSecret [
+            "cloudflared-factory"
+            "factory-secrets"
+            "factory-cli-creds"
+            "ghcr-pull"
+            "skillai-db"
+            "skillai-app"
+            "factory-db-aifactory"
+            "factory-db-pfactory"
+            "factory-db-tfactory"
+            "minio-creds"
+            "minio-kms"
+            "oauth2-proxy-cfactory"
+            "oauth2-proxy-observe"
+            "oauth2-proxy-odin"
+            "observe-root"
+            "otel-otlp-auth"
+            "cfactory-api-keys"
+            "odin-ssh-key"
+            "odin-api-keys"
+          ])
         // {
           # Non-factory namespaces (see the 4b loop in the bootstrap script).
           k3d-secret-fides-secrets = {


### PR DESCRIPTION
The lint-check job fails on `nixpkgs-fmt --check` (1 of 494 files). The
agenix secret list in this module lost its expected indentation when
odin-api-keys and the non-factory `// { ... }` block were added in #1399 —
a whitespace-only drift that nothing local caught.

Whitespace only: p620's toplevel derivation hashes to 3g3rlc33... both before
and after, and the agenix secret count is unchanged at 42. `nixpkgs-fmt
--check .` now reports 0 of 494 needing reformatting.

Worth noting `just validate` does NOT run nixpkgs-fmt, which is why this
passed locally through several PRs while CI rejected it.
