### PR TITLE
feat(checks): make `just validate` check formatting, like CI does

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -33,6 +33,30 @@ in
       touch $out
     '';
 
+  # Formatting — mirrors the CI lint-check job.
+  #
+  # `just validate` runs `nix flake check`, which had deadnix and statix but
+  # not the formatter. CI's lint-check DOES run `nixpkgs-fmt --check`, so a
+  # whitespace drift in modules/containers/k3d.nix sailed through several
+  # local validations and failed twelve consecutive CI runs before anyone
+  # traced it. Local validation that does not cover what CI gates on is worse
+  # than none: it teaches you to trust a green run that proves less than you
+  # think.
+  nix-format-check =
+    pkgs.runCommand "nix-format-validation"
+      {
+        src = cleanSource ../.;
+      } ''
+      echo "Running nixpkgs-fmt formatting check..."
+      cd $src
+      ${pkgs.nixpkgs-fmt}/bin/nixpkgs-fmt --check . || {
+        echo "FAIL: some Nix files need formatting"
+        echo "Run: nixpkgs-fmt ."
+        exit 1
+      }
+      touch $out
+    '';
+
   # Nix file syntax validation
   nix-syntax-check =
     pkgs.runCommand "nix-syntax-validation"


### PR DESCRIPTION
`just validate` runs `nix flake check`, which covered deadnix, statix, syntax,
module structure, package duplication and secrets — but not the formatter. CI's
lint-check job DOES run `nixpkgs-fmt --check`, so the two disagreed about what
"valid" means.

The cost was concrete: a whitespace drift in modules/containers/k3d.nix,
introduced in #1399, passed local validation across several PRs while failing
twelve consecutive CI runs. It was only found by reading CI logs directly, and
it hid behind an unrelated evaluation error that failed the same job.

Local validation that does not cover what CI gates on is worse than none — it
teaches you to trust a green run that proves less than you think.

Verified both directions rather than assuming: the check passes on the current
tree, and deliberately mangling the whitespace in modules/desktop/hyprland.nix
makes it fail with "error: fail on changes". `just validate` now lists
nix-format-check among its derivations and still reports all checks passed.
