### PR TITLE
chore(ci): align CI's Nix with local — install-nix-action v27/v30 -> v31.11.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31.11.1
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31.11.1
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
@@ -193,7 +193,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31.11.1
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
@@ -244,7 +244,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31.11.1
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31.11.1
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |

--- a/.github/workflows/nixos-issue-audit.yml
+++ b/.github/workflows/nixos-issue-audit.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
+        uses: cachix/install-nix-action@v31.11.1
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31.11.1
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes


### PR DESCRIPTION
CI ran Nix 2.22.1 (pinned by install-nix-action@v27) while these hosts run
2.34.8. The two disagree about valid syntax, and that gap cost a day: p620
mixed `modules.containers.k3d` with a `modules = { containers.docker ...; }`
block, which 2.34 merges silently and 2.22 rejects as "attribute 'containers'
already defined". Every host built clean locally while twelve consecutive CI
runs failed, and no local command could reproduce it.

v31.11.1 installs Nix 2.35.2 — one minor ahead of local instead of twelve
behind, so `nix build` here is once again evidence about CI.

All seven references move together (ci.yml x4, docs.yml, update-flake.yml, and
nixos-issue-audit.yml which was on v30); a split would just relocate the
problem. Diff is action refs only — verified 0 other changed lines, and all
four workflow files still parse.

The bump direction is the safe one for the fault we hit: 2.22 was the stricter
reader, so aligning forward removes that class of failure rather than adding
to it. A newer Nix could still surface its own deprecations, which is exactly
why this goes through CI as its own change rather than riding along with
something else.
