### PR TITLE
chore(antigravity): bump cli 1.1.19, sdk 0.1.14

### DIFF
--- a/pkgs/antigravity-cli/default.nix
+++ b/pkgs/antigravity-cli/default.nix
@@ -24,11 +24,11 @@
 # Closed-source proprietary Google binary, license is unfree.
 stdenv.mkDerivation {
   pname = "antigravity-cli";
-  version = "1.1.17-5084709148033024";
+  version = "1.1.19-4894004681244672";
 
   src = fetchurl {
-    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.17-5084709148033024/linux-x64/cli_linux_x64.tar.gz";
-    hash = "sha256-FUQ5ZklM1ik4MgkArP0W35Bs9NpWJ55N2PSEbAn4Sd8=";
+    url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.1.19-4894004681244672/linux-x64/cli_linux_x64.tar.gz";
+    hash = "sha256-oCEyp8bGR+8K1IPsvnZ2Ga32tmClWJy6XJN7DIOQm5c=";
   };
 
   # Tarball contains a single file `antigravity` at the root.

--- a/pkgs/google-antigravity-py/default.nix
+++ b/pkgs/google-antigravity-py/default.nix
@@ -25,15 +25,15 @@
 # Upstream: https://github.com/google-antigravity/antigravity-sdk-python
 buildPythonPackage rec {
   pname = "google-antigravity";
-  version = "0.1.13";
+  version = "0.1.14";
   format = "wheel";
 
   # fetchPypi gets the URL wrong for this package (constructs
   # google-antigravity- instead of google_antigravity-), so use fetchurl
   # with the canonical PyPI download URL.
   src = fetchurl {
-    url = "https://files.pythonhosted.org/packages/35/ac/698e469568e8fced1534b8a0f1576cb76c986ce6bad3098dce26d99f226d/google_antigravity-0.1.13-py3-none-manylinux_2_17_x86_64.whl";
-    hash = "sha256-85hmSzYigAN/jtbfXNYbmW89Ar4RUf9mXG0JyHzGqZI=";
+    url = "https://files.pythonhosted.org/packages/f5/0b/c80d37ce6482b8933eab306ebedeb7086588201c69ac4b434cd0817f0c7d/google_antigravity-0.1.14-py3-none-manylinux_2_17_x86_64.musllinux_1_1_x86_64.whl";
+    hash = "sha256-H8oJiYJHACtfFLuHyb651kBLGxhAvlWQImLXnkqMOl4=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
cli 1.1.17-5084709148033024 -> 1.1.19-4894004681244672
sdk 0.1.13 -> 0.1.14 (wheel is now manylinux+musllinux)

ide 2.5.5 and hub 2.9.1 already current.
Verified: agy --version reports 1.1.19, SDK imports OK,
p620 and razer closures build clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
