### PR TITLE
fix(razer): stop external-monitor flicker with nvidia-drm.fbdev=1

### DIFF
--- a/hosts/razer/nixos/nvidia.nix
+++ b/hosts/razer/nixos/nvidia.nix
@@ -75,6 +75,9 @@
   boot = {
     kernelParams = [
       "nvidia-drm.modeset=1" # Required for Wayland
+      "nvidia-drm.fbdev=1" # Fixes external-monitor flicker on niri: without a DRM
+      # fbdev the NVIDIA driver drops the surface in the vblank callback on the
+      # second dGPU-driven CRTC ("missing surface in vblank callback").
       "nvidia.NVreg_PreserveVideoMemoryAllocations=1" # Helps with suspend/resume
       "nvidia.NVreg_TemporaryFilePath=/tmp" # Fix for temp file issues
     ];


### PR DESCRIPTION
## Problem
Two external monitors flicker on razer. Journal shows the niri/NVIDIA signature repeatedly this boot:

\`\`\`
ERROR niri::backend::tty: missing surface in vblank callback for crtc ...
\`\`\`

External outputs (HDMI-A-1, DP-1) hang off the NVIDIA dGPU (card1) under PRIME sync. Without a DRM fbdev, the driver drops the surface in the vblank callback on the second CRTC → flicker. `nvidia-drm.fbdev=1` was absent from the kernel command line.

## Fix
Add `nvidia-drm.fbdev=1` to `hosts/razer/nixos/nvidia.nix` kernel params.

## Verify (after rebuild + reboot)
\`\`\`
grep -o 'nvidia-drm.fbdev=1' /proc/cmdline
journalctl -b 0 | grep -c "missing surface in vblank callback"   # want 0
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)