### PR TITLE
fix(obs): unbreak source-switcher against OBS 32 + flake bump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -980,11 +980,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787360063,
-        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
         "type": "github"
       },
       "original": {
@@ -1120,11 +1120,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1787360063,
-        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
         "type": "github"
       },
       "original": {
@@ -1257,11 +1257,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1787360063,
-        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
         "type": "github"
       },
       "original": {
@@ -1295,11 +1295,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787553713,
-        "narHash": "sha256-p8MtyfrVMhzQcsCj/kk5TP2n2+a6ISPJ8OX+7Jrp/ok=",
+        "lastModified": 1787569960,
+        "narHash": "sha256-uPcXaKMKkauUPZD91k4WX3DMiqMarGPI/QQXaoSO/Dc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6567b432377e55de563efe1e0deb5fed978735e0",
+        "rev": "e3fad17b7e2c35998439de8c5e433864ed4bb011",
         "type": "github"
       },
       "original": {

--- a/home/desktop/obs/default.nix
+++ b/home/desktop/obs/default.nix
@@ -26,7 +26,12 @@ in
         looking-glass-obs # Low-latency VM window capture
         obs-vintage-filter # Vintage video effects
         obs-command-source # Run shell commands from OBS
-        obs-source-switcher # Automatic source switching
+        # OBS 32 deprecated obs_properties_add_button; the plugin builds with
+        # -Werror so the deprecation is fatal. Append -Wno-error to un-fatal it
+        # until upstream migrates the API.
+        (obs-source-switcher.overrideAttrs (prev: {
+          env.NIX_CFLAGS_COMPILE = ((prev.env or { }).NIX_CFLAGS_COMPILE or "") + " -Wno-error=deprecated-declarations";
+        })) # Automatic source switching
         obs-move-transition # Smooth transitions between scenes
         obs-vkcapture # Vulkan/OpenGL game capture
         obs-gstreamer # GStreamer integration


### PR DESCRIPTION
## Problem
Flake bump (nixpkgs `2c423e0` → `56c02bc`) pulls **OBS 32.2.1**, which deprecates `obs_properties_add_button`. `obs-source-switcher` builds with `-Werror`, so the deprecation is a hard failure (3 call sites in `source-switcher.c`) — razer rebuild aborts in `buildPhase`.

## Fix
Override the plugin in `home/desktop/obs/default.nix` to append `-Wno-error=deprecated-declarations`. Later flag wins over the project's `-Werror`; plugin stays functional.

## Verified
Built the overridden derivation standalone against the flake's nixpkgs → succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)