### PR TITLE
fix(obs): downgrade deprecated-declarations for all plugins on OBS 32

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1295,11 +1295,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787569960,
-        "narHash": "sha256-uPcXaKMKkauUPZD91k4WX3DMiqMarGPI/QQXaoSO/Dc=",
+        "lastModified": 1787577036,
+        "narHash": "sha256-+QS89dTRwqw0VhlgQ2vjP0yFEj2EaA42ANUI2LnQLUc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e3fad17b7e2c35998439de8c5e433864ed4bb011",
+        "rev": "c7cc57c31091e1538d9ea77c706f80da4ba91988",
         "type": "github"
       },
       "original": {

--- a/home/desktop/obs/default.nix
+++ b/home/desktop/obs/default.nix
@@ -6,6 +6,14 @@
 let
   inherit (lib) mkIf mkEnableOption;
   cfg = config.programs.obs;
+
+  # OBS 32 deprecated obs_properties_add_button; the C plugins build with
+  # -Werror, so the deprecation is fatal. Downgrade that one warning class for
+  # every plugin until upstream migrates the API. Applied list-wide rather than
+  # per-plugin — the same break hits any plugin using the old properties API.
+  unWerror = p: p.overrideAttrs (prev: {
+    env.NIX_CFLAGS_COMPILE = ((prev.env or { }).NIX_CFLAGS_COMPILE or "") + " -Wno-error=deprecated-declarations";
+  });
 in
 {
   options.programs.obs = {
@@ -15,7 +23,7 @@ in
   config = mkIf cfg.enable {
     programs.obs-studio = {
       enable = true;
-      plugins = with pkgs.obs-studio-plugins; [
+      plugins = map unWerror (with pkgs.obs-studio-plugins; [
         wlrobs # Wayland window capture
         obs-backgroundremoval # Virtual background effects
         obs-pipewire-audio-capture # Audio capture for Pipewire
@@ -26,19 +34,14 @@ in
         looking-glass-obs # Low-latency VM window capture
         obs-vintage-filter # Vintage video effects
         obs-command-source # Run shell commands from OBS
-        # OBS 32 deprecated obs_properties_add_button; the plugin builds with
-        # -Werror so the deprecation is fatal. Append -Wno-error to un-fatal it
-        # until upstream migrates the API.
-        (obs-source-switcher.overrideAttrs (prev: {
-          env.NIX_CFLAGS_COMPILE = ((prev.env or { }).NIX_CFLAGS_COMPILE or "") + " -Wno-error=deprecated-declarations";
-        })) # Automatic source switching
+        obs-source-switcher # Automatic source switching
         obs-move-transition # Smooth transitions between scenes
         obs-vkcapture # Vulkan/OpenGL game capture
         obs-gstreamer # GStreamer integration
         obs-vaapi # Hardware acceleration support
         obs-shaderfilter # Custom shader effects
         obs-gradient-source # Gradient backgrounds
-      ];
+      ]);
     };
   };
 }


### PR DESCRIPTION
## Problem
The previous per-plugin fix (#1443) only patched `obs-source-switcher`. OBS 32's `obs_properties_add_button` deprecation + `-Werror` breaks **every** C plugin using the old properties API — `obs-move-transition` failed next, and others would follow.

## Fix
Apply `-Wno-error=deprecated-declarations` list-wide via `map unWerror` over the plugin list in `home/desktop/obs/default.nix`, instead of overriding plugins one at a time.

## Verified
Built both previously-failing plugins (`obs-source-switcher`, `obs-move-transition`) with the fix → succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)