### PR TITLE
fix(docker): restart dockerd when daemon.json changes (#1412)

### DIFF
--- a/modules/containers/docker.nix
+++ b/modules/containers/docker.nix
@@ -91,6 +91,20 @@ in
       // lib.optionalAttrs (cfg.dataRoot != null) { data-root = cfg.dataRoot; };
     };
 
+    # nixpkgs puts daemon.json in *reloadTriggers*, so a settings change only
+    # SIGHUPs dockerd. dockerd's SIGHUP handler re-reads a subset of the file —
+    # log-driver is not in it. That is why setting logDriver = "local" above
+    # (#1412) landed in the closure on 2026-08-21 and still had not taken
+    # effect three days later: the running daemon kept its old journald driver
+    # and the k3d node kept filing ~220k INFO lines at priority err per boot.
+    #
+    # Safe to force a real restart because live-restore keeps containers up
+    # across it (see above). Triggering on the settings rather than on the
+    # generated daemon.json path keeps this off nixpkgs internals.
+    systemd.services.docker.restartTriggers = [
+      (builtins.toJSON config.virtualisation.docker.daemon.settings)
+    ];
+
     # Add specified users to docker group
     users.users = genAttrs cfg.users (_username: {
       extraGroups = [ "docker" ];


### PR DESCRIPTION
## Problem

PR #1412 set `logDriver = "local"` on 2026-08-21 to stop the k3d node filing its whole kubelet INFO stream into p620's journal at priority `err`. It landed in the closure and three days later still had not taken effect.

Evidence from p620 on 2026-08-24:

- Live `dockerd` (PID 974591, started Aug 22 04:34:49) runs `/nix/store/jb35zx19...-daemon.json` -> `"log-driver": "journald"`
- Current generation ships `/nix/store/f6i6r938...-daemon.json` -> `"log-driver": "local"`
- `docker info` reports `journald`
- `journalctl -b -p3` = 222878 lines, 97.7% of them `docker.service`

## Cause

nixpkgs lists `daemon.json` in `reloadTriggers`, not `restartTriggers`, so a settings change only SIGHUPs dockerd. dockerd's SIGHUP handler re-reads a subset of the file and `log-driver` is not in that subset, so the new value was silently ignored.

## Fix

Force a real restart when the settings change. Safe because `live-restore` keeps containers running across it, which this module already sets and documents. The trigger is the serialised settings rather than the generated `daemon.json` path, so it does not depend on a nixpkgs implementation detail.

## Note

This fixes the daemon only. Containers bake `LogConfig` in at creation, so `k3d-factory-server-0` keeps its journald driver until it is recreated; handled separately.