### PR TITLE
chore(logging): drop dead code from the noise-reduction module

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -461,18 +461,7 @@ in
   # Consolidated system configuration
   system = {
     # Enable logging configuration for noise reduction
-    logging = {
-      enableFiltering = true;
-      filterRules = [
-        "router dispatching GET /health"
-        "router jsonParser  : /health"
-        "body-parser:json skip empty body"
-        "GET /health"
-        "health check"
-        "connection established"
-        "connection closed"
-      ];
-    };
+    logging.enableFiltering = true;
 
     # Performance Optimization Configuration - REMOVED
     # The system.resourceManager module was removed during anti-pattern cleanup

--- a/modules/system/logging.nix
+++ b/modules/system/logging.nix
@@ -1,22 +1,15 @@
 # Logging configuration for reduced noise
 { config
 , lib
-, pkgs
 , ...
 }:
 let
-  inherit (lib) mkOption mkIf mkEnableOption types;
+  inherit (lib) mkIf mkEnableOption;
   cfg = config.system.logging;
 in
 {
   options.system.logging = {
     enableFiltering = mkEnableOption "Enable log filtering for noise reduction";
-
-    filterRules = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      description = "List of log filtering rules";
-    };
   };
 
   config = mkIf cfg.enableFiltering {
@@ -42,23 +35,6 @@ in
       MaxFileSec=1day
     '';
 
-    # Configure systemd-journald to filter container logs
-    systemd.services.journal-filter = {
-      description = "Journal Log Filter for Container Noise";
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
-        ExecStart = pkgs.writeShellScript "setup-journal-filter" ''
-          # Create custom journal namespace for filtered logs
-          mkdir -p /var/log/journal-filtered
-
-          # Set up log filtering via systemd-journald
-          systemctl restart systemd-journald
-        '';
-      };
-    };
-
     # Docker's log driver is deliberately NOT set here.
     #
     # This block used to pin daemon.settings.log-driver = "journald", which
@@ -72,15 +48,5 @@ in
     # A module whose purpose is noise reduction should not be the thing forcing
     # every container's stderr into the journal. The driver now comes from
     # modules/containers/docker.nix, which owns Docker's configuration.
-
-    # Environment variables for better log control
-    environment.variables = {
-      # Reduce Docker log verbosity
-      DOCKER_LOG_LEVEL = "warn";
-
-      # Node.js applications log level
-      NODE_ENV = "production";
-      LOG_LEVEL = "info";
-    };
   };
 }


### PR DESCRIPTION
Found while triaging the p620 journal flood. Three things in `system.logging` did nothing, or did something unintended.

## `journal-filter.service`

Its entire `ExecStart`:

```sh
mkdir -p /var/log/journal-filtered
systemctl restart systemd-journald
```

Nothing reads that directory and no journal namespace is configured to write to it. The unit restarted journald on every boot to no effect.

## `filterRules`

Declared as an option and never referenced again anywhere in the module. p620 supplied seven health-check patterns to it (`configuration.nix:466`), none of which could ever have filtered anything. Removed from both sides.

## `environment.variables`

- `DOCKER_LOG_LEVEL` — read by nothing; dockerd takes `log-level` from `daemon.json`.
- `NODE_ENV = "production"` — worse than inert. It is exported system-wide from `/etc/set-environment`, so **every `npm install` on this host silently skipped devDependencies**. A module for reducing log noise has no business setting that.
- `LOG_LEVEL` — generic, unused.

## What remains

The journald tuning that actually works, plus the comment explaining why the docker log driver is deliberately not set here.

## Verification

- `deadnix` and `statix` clean (also dropped the now-unused `pkgs` and `mkOption`/`types`)
- p620 eval no longer carries `NODE_ENV`, `LOG_LEVEL`, or `DOCKER_LOG_LEVEL`