### PR TITLE
fix(logging): cap coredump storage at 1G

### DIFF
--- a/modules/system/logging.nix
+++ b/modules/system/logging.nix
@@ -35,6 +35,18 @@ in
       MaxFileSec=1day
     '';
 
+    # Cap coredump storage the same way. systemd's default MaxUse is 10% of
+    # the filesystem, which on p620's 916G root is ~90G of crash dumps before
+    # anything is evicted. It had accumulated 2.1G by 2026-08-24, most of it a
+    # single 968M Chrome core, and nothing was ever going to reclaim it.
+    #
+    # 1G keeps enough history to actually debug a repeat crash while staying
+    # small enough that a browser core cannot quietly eat the disk.
+    systemd.coredump.settings.Coredump = {
+      MaxUse = "1G";
+      KeepFree = "10G";
+    };
+
     # Docker's log driver is deliberately NOT set here.
     #
     # This block used to pin daemon.settings.log-driver = "journald", which


### PR DESCRIPTION
Found during the p620 log review.

## Problem

`/var/lib/systemd/coredump` had reached **2.1G**, most of it a single **968M Chrome core**. systemd's default `MaxUse` is 10% of the filesystem — on p620's 916G root that is ~90G of crash dumps before anything is evicted, so nothing was ever going to reclaim it.

Largest cores present: 3x `chrome`, 2x `quickshell-wrapped`, plus musicpod and gnome-control-center SIGSEGVs.

## Fix

```nix
systemd.coredump.settings.Coredump = {
  MaxUse = "1G";
  KeepFree = "10G";
};
```

1G keeps enough history to debug a repeat crash while staying small enough that a browser core cannot quietly eat the disk.

Placed next to the journald storage caps in `modules/system/logging.nix`, which bound on-disk diagnostic data the same way.

## Note

`systemd.coredump.extraConfig` has been **removed** from nixpkgs (`error: ... can no longer be used`); this uses `systemd.coredump.settings.Coredump`.

## Verification

- `deadnix` / `statix` clean
- `nix eval ...systemd.coredump.settings.Coredump` -> `{"KeepFree":"10G","MaxUse":"1G"}`