### PR TITLE
fix(gnome): give each GNOME app a single owning layer

### DIFF
--- a/home/desktop/gnome/default.nix
+++ b/home/desktop/gnome/default.nix
@@ -93,6 +93,7 @@ in
 
       # File management
       nautilus
+      nautilus-open-any-terminal # extension: must share nautilus's profile
       file-roller
 
       # Media

--- a/home/media/music.nix
+++ b/home/media/music.nix
@@ -12,7 +12,6 @@
     pkgs.parabolic
     pkgs.musicpod
     pkgs.pear-desktop # YouTube Music desktop client (formerly th-ch/youtube-music)
-    pkgs.playerctl
     (pkgs.callPackage ../../pkgs/mpris-album-art { })
   ];
 

--- a/modules/services/gnome/gnome-services.nix
+++ b/modules/services/gnome/gnome-services.nix
@@ -15,8 +15,9 @@
   };
 
   # Trim GNOME defaults that survive `core-apps.enable = false` via transitive
-  # deps. The packages we *do* want (gnome-calendar, gnome-contacts, etc.) are
-  # listed in environment.systemPackages below.
+  # deps. The user-facing apps (nautilus, gnome-calendar, gnome-contacts,
+  # gnome-weather, gnome-tweaks) are owned by home/desktop/gnome/, not here —
+  # see the note on environment.systemPackages below.
   environment.gnome.excludePackages = with pkgs; [
     gnome-tour
     epiphany
@@ -27,19 +28,22 @@
     cheese
   ];
 
+  # System-level only: themes, schemas, settings, and apps with no per-user
+  # config. GNOME *applications* belong to home/desktop/gnome/, which reaches
+  # p620 and razer via Users/olafkfreund/profile.nix.
+  #
+  # Declaring an app in both layers puts its .service file in both
+  # /run/current-system/sw and /etc/profiles/per-user/$USER, and dbus-broker
+  # logs "Ignoring duplicate name" at priority err for each one on every
+  # session start — ~5000 lines a boot on p620 before this was split. It also
+  # dragged nautilus, gnome-boxes, gimp and darktable into headless p510's
+  # closure, since this module is imported unconditionally via modules/core.nix.
   environment.systemPackages = with pkgs; [
     gnome-themes-extra
-    nautilus
-    nautilus-open-any-terminal
     libadwaita
     adwaita-icon-theme
     gsettings-desktop-schemas
-    gnome-extension-manager
-    gnome-calendar
-    gnome-contacts
-    gnome-weather
     gnome-online-accounts
-    gnome-tweaks
     gnome-control-center
     gnome-boxes
     gnomeExtensions.user-themes


### PR DESCRIPTION
## Problem

Six packages were declared in **both** the system module and home-manager, so each shipped a D-Bus `.service` file into `/run/current-system/sw` *and* `/etc/profiles/per-user/olafkfreund`. dbus-broker logs `Ignoring duplicate name` at priority **err** for every one on each session start — roughly **5000 lines a boot** on p620, the largest remaining noise source once the k3d log flood was fixed.

Nine duplicate names, from: `nautilus`, `gnome-calendar`, `gnome-contacts`, `gnome-tweaks`, `gnome-weather`, `playerctl`.

## Which layer should own what

Decided from the import graph rather than preference:

| Layer | Reached via | Hosts |
|---|---|---|
| `modules/services/gnome/gnome-services.nix` | `modules/core.nix` (unconditional) | **all**, incl. headless p510 |
| `home/desktop/gnome/` | `Users/olafkfreund/profile.nix` | p620 + razer only |

So: **system owns services and base utilities, home-manager owns user applications.**

## Changes

- `nautilus`, `gnome-calendar`, `gnome-contacts`, `gnome-weather`, `gnome-tweaks`, `gnome-extension-manager` leave the system module. All six were already declared in `home/desktop/gnome/`, and `desktop.gnome.apps.enable` is `true` on both p620 and razer — verified by eval, nothing is lost on either desktop.
- `nautilus-open-any-terminal` **moves with** nautilus. It is a nautilus extension and must sit in the same profile to be found at all.
- `playerctl` goes the other way: `services.playerctld.enable` on p620/razer already puts it (and its `playerctld` D-Bus name) in the system profile, so the copy in `home/media/music.nix` was the duplicate half.

## Verification

On the **built** p620 system:

```
overlap between the two dbus service dirs: 0    (was 9)
system dbus dir: 71 -> 63 files
hm dbus dir:     47 -> 46 files
```

All six apps confirmed still present in the HM profile on p620 **and** razer. `deadnix` / `statix` clean.

## Side effect worth having

Headless **p510 no longer drags nautilus and the GNOME apps into its closure**. It still gets `gimp`, `krita`, `darktable`, `gnome-boxes` and `gnome-control-center` from this module — a separate question about whether the module wants a feature flag.