### PR TITLE
fix(p510): drop power-limit line for the removed second GPU

### DIFF
--- a/hosts/p510/nixos/nvidia.nix
+++ b/hosts/p510/nixos/nvidia.nix
@@ -55,9 +55,19 @@
   # ollama model load, once mid-Plex-NVENC-transcode. No MCE, panic, OOM or
   # thermal event in any of them: the journal just stops mid-write.
   #
-  # 130W + 110W brings the worst case to ~475W, under the rating. Both cards
-  # floor at 100W (power.min_limit), so these are valid. Transcoding draws
-  # nowhere near the cap, so the practical cost is nil.
+  # 130W + 110W brought the worst case to ~475W, under the rating. Transcoding
+  # draws nowhere near the cap, so the practical cost is nil.
+  #
+  # The second card was physically removed on 2026-08-24, so only GPU 0 (the
+  # RTX 3070 Ti at 03:00.0) is left. Its `-i 1` line stayed behind and failed
+  # every boot with "No devices found", exiting 2 and leaving the unit failed
+  # — which matters beyond tidiness, because one permanently-failed unit makes
+  # every subsequent switch return exit 4 and can roll the deploy back.
+  #
+  # 130W is deliberately left as-is. The card's stock limit is 290W and the
+  # PSU now has ~110W more headroom, but the freezes above are why this cap
+  # exists at all, so raising it is a separate decision backed by its own
+  # testing rather than a side effect of pulling a card.
   #
   # This runs as root on purpose — setting a power limit needs CAP_SYS_ADMIN
   # and /dev/nvidiactl, so the usual DynamicUser/ProtectHome hardening cannot
@@ -74,7 +84,6 @@
       # sticky across a driver reload, hence re-applying at every boot.
       ExecStart = [
         "${config.hardware.nvidia.package.bin}/bin/nvidia-smi -i 0 -pl 130"
-        "${config.hardware.nvidia.package.bin}/bin/nvidia-smi -i 1 -pl 110"
       ];
       ProtectSystem = "strict";
       ProtectHome = true;


### PR DESCRIPTION
## Problem

The second GPU was physically pulled from p510 on 2026-08-24, leaving only GPU 0 — the RTX 3070 Ti at `03:00.0`. `nvidia-power-limit.service` still ran a second `nvidia-smi` against index 1:

```
nvidia-smi[2121]: Power limit for GPU 00000000:03:00.0 was set to 130.00 W from 290.00 W.
nvidia-smi[2278]: No devices found.
systemd[1]: nvidia-power-limit.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
systemd[1]: nvidia-power-limit.service: Failed with result 'exit-code'.
```

So p510 boots with a permanently failed unit.

**This is not cosmetic.** One dead unit makes every later `nixos-rebuild switch` return exit 4 and can roll the deploy back — a trap this repo has hit before.

## Change

Remove the `-i 1 -pl 110` ExecStart line. Comment updated to record why the second line existed and why it's gone.

## What is deliberately NOT changed

The 130W cap on GPU 0 stays. Its stock limit is 290W and the PSU now has ~110W more headroom, but the unexplained mid-write freezes documented above this unit are the entire reason the cap exists. Raising it deserves its own testing, not a ride-along with a card removal.

## Verification

```
$ nix eval ...systemd.services.nvidia-power-limit.serviceConfig.ExecStart
["/nix/store/...-nvidia-x11-595.91.07-bin/bin/nvidia-smi -i 0 -pl 130"]
```

Confirmed on the live host that GPU 0 is present and GPU 1 is not:

```
$ nvidia-smi -L
GPU 0: NVIDIA GeForce RTX 3070 Ti (UUID: GPU-4f16c92e-...)
$ ls /proc/driver/nvidia/gpus/
0000:03:00.0
```

`deadnix` clean. The one `statix` W20 in this file pre-exists on main.

## Not deployed

p510 is never switched without asking first.