### PR TITLE
fix: clear deprecation warnings, correct stale docs, add missing Wayland keybinds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ imports one plus its own hardware config.
 
 | Host  | Type          | Notes |
 | ----- | ------------- | ----- |
-| p620  | `workstation` | AMD GPU / ROCm. Set `services.ollama.package = pkgs.ollama-rocm`; `services.ollama.acceleration` was removed from nixpkgs (unrelated to this repo's own `acceleration` attribute in `hosts/common/hardware-profiles/`). Serves the binary cache. |
+| p620  | `workstation` | AMD GPU / ROCm. Set `services.ollama.package = pkgs.ollama-rocm`; `services.ollama.acceleration` was removed from nixpkgs (unrelated to this repo's own `acceleration` attribute in `hosts/common/hardware-profiles/`). |
 | razer | `laptop`      | Hybrid Intel/NVIDIA (Optimus). Heavy rebuilds: build on p620 via `just deploy-via-p620 razer`. |
 | p510  | `workstation` | Headless media server (Plex, NZBGet, k3s microvms). **Never build or deploy without asking first.** |
 
@@ -75,6 +75,12 @@ Things the code no longer shows, so they are easy to get wrong:
   nix-community.cachix.org. Tailscale mesh is used for remote SSH access, not caching.
 - **Monitoring was removed** (Prometheus/Grafana/Loki/Alertmanager). Use `journalctl`
   and `systemctl status`.
-- **Hyprland was removed.** The desktop is niri with noctalia/DMS.
+- **Two Wayland sessions, both live: niri and Hyprland**, with DankMaterialShell
+  (DMS) as the shell for each. `modules/desktop/dms-shell.nix` builds "Niri (DMS)"
+  always and "Hyprland (DMS)" when `desktop.hyprland.enable` is set — true on p620
+  and razer, false on p510. Packages come from nixpkgs (`pkgs.niri`, `pkgs.hyprland`);
+  the niri-flake input supplies only the `programs.niri` module, not the binary.
+  **Noctalia was removed** (PR #1410, with labwc and mango); stale `${DESK_SHELL:-noctalia}`
+  comments survive in a few files.
 - DEX5550 is offline; Samsung and HP are decommissioned.
 - MicroVMs are per-host files (`hosts/p510/microvm.nix`), not a shared module.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,9 +70,10 @@ Branch `<type>/<issue>-<description>`. Conventional Commits with the issue numbe
 
 Things the code no longer shows, so they are easy to get wrong:
 
-- **No binary cache.** There is no nix-serve/harmonia anywhere in the repo; nothing
-  listens on p620:5000. `modules/nix/nix.nix` only substitutes from cache.nixos.org and
-  nix-community.cachix.org. Tailscale mesh is used for remote SSH access, not caching.
+- **No binary cache of our own.** There is no nix-serve/harmonia anywhere in the repo;
+  nothing listens on p620:5000. `modules/nix/nix.nix` substitutes from cache.nixos.org and
+  nix-community.cachix.org; `flake.nix` adds cuda-maintainers and devenv as flake-level
+  `extra-substituters`. Tailscale mesh is used for remote SSH access, not caching.
 - **Monitoring was removed** (Prometheus/Grafana/Loki/Alertmanager). Use `journalctl`
   and `systemctl status`.
 - **Two Wayland sessions, both live: niri and Hyprland**, with DankMaterialShell

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
 
     # Development and specific package caches. Only caches with an actual
     # consumer belong here: every extra substituter costs a round-trip per
-    # uncached path. hyprland/cosmic were dropped (#1452) — no hyprland flake
+    # uncached path. hyprland/cosmic were dropped (#1457) — no hyprland flake
     # input (we build pkgs.hyprland), and desktop.cosmic.enable is false on
     # every host.
     extra-substituters = [

--- a/flake.nix
+++ b/flake.nix
@@ -12,18 +12,18 @@
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
     ];
 
-    # Development and specific package caches
+    # Development and specific package caches. Only caches with an actual
+    # consumer belong here: every extra substituter costs a round-trip per
+    # uncached path. hyprland/cosmic were dropped (#1452) — no hyprland flake
+    # input (we build pkgs.hyprland), and desktop.cosmic.enable is false on
+    # every host.
     extra-substituters = [
       "https://cuda-maintainers.cachix.org/"
-      "https://hyprland.cachix.org/"
       "https://devenv.cachix.org/"
-      "https://cosmic.cachix.org/"
     ];
     extra-trusted-public-keys = [
       "cuda-maintainers.cachix.org-1:0dq3bujKpuEPMCX6U4WylrUDZ9JyUG0VpVZa7CNfq5E="
-      "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
       "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
-      "cosmic.cachix.org-1:Dya9IyXD4xdBehWjrkPv6rtxpmMdRel02smYzA85dPE="
     ];
   };
 

--- a/home/desktop/wayland/hyprland.nix
+++ b/home/desktop/wayland/hyprland.nix
@@ -208,6 +208,7 @@ in
       hl.bind(mod .. " + TAB", hl.dsp.exec_cmd("dms ipc call hypr toggleOverview"))
       hl.bind(mod .. " + SHIFT + SLASH", hl.dsp.exec_cmd("dms ipc call hypr toggleBinds"))
       hl.bind(mod .. " + BACKSPACE", hl.dsp.exec_cmd("dms ipc call lock lock"), { locked = true })
+      hl.bind(mod .. " + SHIFT + V", hl.dsp.exec_cmd("dms ipc call clipboard toggle"))
 
       -- Media / brightness (locked so they work on the lock screen)
       hl.bind("XF86AudioRaiseVolume", hl.dsp.exec_cmd("wpctl set-volume -l 1 @DEFAULT_AUDIO_SINK@ 5%+"), { locked = true, repeating = true })
@@ -215,6 +216,16 @@ in
       hl.bind("XF86AudioMute", hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"), { locked = true })
       hl.bind("XF86MonBrightnessUp", hl.dsp.exec_cmd("brightnessctl set 5%+"), { locked = true, repeating = true })
       hl.bind("XF86MonBrightnessDown", hl.dsp.exec_cmd("brightnessctl set 5%-"), { locked = true, repeating = true })
+      hl.bind("XF86AudioMicMute", hl.dsp.exec_cmd("wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"), { locked = true })
+
+      -- Media transport. services.playerctld.enable is true on p620 and razer and
+      -- playerctl ships in modules/system-utils, but nothing was bound to it in
+      -- either session, so these keys did nothing.
+      hl.bind("XF86AudioPlay", hl.dsp.exec_cmd("playerctl play-pause"), { locked = true })
+      hl.bind("XF86AudioPause", hl.dsp.exec_cmd("playerctl play-pause"), { locked = true })
+      hl.bind("XF86AudioNext", hl.dsp.exec_cmd("playerctl next"), { locked = true })
+      hl.bind("XF86AudioPrev", hl.dsp.exec_cmd("playerctl previous"), { locked = true })
+      hl.bind("XF86AudioStop", hl.dsp.exec_cmd("playerctl stop"), { locked = true })
     '';
   };
 }

--- a/home/desktop/wayland/niri.nix
+++ b/home/desktop/wayland/niri.nix
@@ -136,6 +136,13 @@ in
         Mod+3 { focus-workspace 3; }
         Mod+4 { focus-workspace 4; }
         Mod+5 { focus-workspace 5; }
+        // Move the focused column to workspace N. The Hyprland session has had
+        // these since #1367; niri only ever got the Page_Up/Down pair.
+        Mod+Shift+1 { move-column-to-workspace 1; }
+        Mod+Shift+2 { move-column-to-workspace 2; }
+        Mod+Shift+3 { move-column-to-workspace 3; }
+        Mod+Shift+4 { move-column-to-workspace 4; }
+        Mod+Shift+5 { move-column-to-workspace 5; }
         "Mod+Page_Down" { focus-workspace-down; }
         "Mod+Page_Up" { focus-workspace-up; }
         "Mod+Shift+Page_Down" { move-column-to-workspace-down; }
@@ -159,11 +166,24 @@ in
         Mod+Alt+R { spawn "screenrecord" "region"; }
         Mod+Shift+Slash { show-hotkey-overlay; }
         Mod+Shift+E { quit; }
-        XF86AudioRaiseVolume { spawn "wpctl" "set-volume" "@DEFAULT_AUDIO_SINK@" "5%+"; }
-        XF86AudioLowerVolume { spawn "wpctl" "set-volume" "@DEFAULT_AUDIO_SINK@" "5%-"; }
-        XF86AudioMute { spawn "wpctl" "set-mute" "@DEFAULT_AUDIO_SINK@" "toggle"; }
-        XF86MonBrightnessUp { spawn "brightnessctl" "set" "5%+"; }
-        XF86MonBrightnessDown { spawn "brightnessctl" "set" "5%-"; }
+        // allow-when-locked mirrors the Hyprland session, where these carry
+        // locked=true — volume and brightness should work on the lock screen.
+        // -l 1 caps the sink at 100%, matching the Hyprland bind.
+        XF86AudioRaiseVolume allow-when-locked=true { spawn "wpctl" "set-volume" "-l" "1" "@DEFAULT_AUDIO_SINK@" "5%+"; }
+        XF86AudioLowerVolume allow-when-locked=true { spawn "wpctl" "set-volume" "@DEFAULT_AUDIO_SINK@" "5%-"; }
+        XF86AudioMute allow-when-locked=true { spawn "wpctl" "set-mute" "@DEFAULT_AUDIO_SINK@" "toggle"; }
+        XF86AudioMicMute allow-when-locked=true { spawn "wpctl" "set-mute" "@DEFAULT_AUDIO_SOURCE@" "toggle"; }
+        XF86MonBrightnessUp allow-when-locked=true { spawn "brightnessctl" "set" "5%+"; }
+        XF86MonBrightnessDown allow-when-locked=true { spawn "brightnessctl" "set" "5%-"; }
+
+        // Media transport. services.playerctld.enable is true on p620 and razer
+        // and playerctl ships in modules/system-utils, but nothing was bound to
+        // it in either session, so these keys did nothing.
+        XF86AudioPlay allow-when-locked=true { spawn "playerctl" "play-pause"; }
+        XF86AudioPause allow-when-locked=true { spawn "playerctl" "play-pause"; }
+        XF86AudioNext allow-when-locked=true { spawn "playerctl" "next"; }
+        XF86AudioPrev allow-when-locked=true { spawn "playerctl" "previous"; }
+        XF86AudioStop allow-when-locked=true { spawn "playerctl" "stop"; }
 
         // Shell actions — DankMaterialShell (distinct from the Noctalia session,
         // (DMS IPC).
@@ -173,6 +193,7 @@ in
         Mod+N { spawn "dms" "ipc" "call" "notifications" "toggle"; }
         Mod+X { spawn "dms" "ipc" "call" "powermenu" "toggle"; }
         Mod+Backspace { spawn "dms" "ipc" "call" "lock" "lock"; }
+        Mod+Shift+V { spawn "dms" "ipc" "call" "clipboard" "toggle"; }
     }
 
     // Start DMS (prefer the managed service; fall back to a direct spawn), plus

--- a/modules/email/neomutt/default.nix
+++ b/modules/email/neomutt/default.nix
@@ -88,8 +88,8 @@ in
         image/*; ${pkgs.chafa}/bin/chafa --size=80x24 %s; copiousoutput;
 
         # Other document types
-        application/msword; ${pkgs.libreoffice}/bin/libreoffice --writer %s;
-        application/vnd.openxmlformats-officedocument.wordprocessingml.document; ${pkgs.libreoffice}/bin/libreoffice --writer %s;
+        application/msword; ${pkgs.libreoffice-stable}/bin/libreoffice --writer %s;
+        application/vnd.openxmlformats-officedocument.wordprocessingml.document; ${pkgs.libreoffice-stable}/bin/libreoffice --writer %s;
       '';
       mode = "0644";
     };

--- a/modules/office/default.nix
+++ b/modules/office/default.nix
@@ -16,7 +16,7 @@ in
   };
   config = mkIf cfg.enable {
     environment.systemPackages = with pkgs; [
-      libreoffice-fresh
+      libreoffice-stable
     ];
   };
 }

--- a/pkgs/okena/default.nix
+++ b/pkgs/okena/default.nix
@@ -7,7 +7,7 @@
 , libglvnd
 , vulkan-loader
 , wayland
-, xorg
+, libxcb
 , dtach
 }:
 # Okena — native terminal multiplexer (tabs, splits, detachable windows) built
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   # DT_NEEDED entries of both binaries.
   buildInputs = [
     libxkbcommon
-    xorg.libxcb
+    libxcb
     stdenv.cc.cc.lib
   ];
 


### PR DESCRIPTION
Started as a fix for three eval warnings and grew into the adjacent staleness those warnings exposed.

## Deprecation warnings

- `pkgs/okena`: `xorg.libxcb` → `libxcb` (the `xorg` set is deprecated)
- `modules/office`: `libreoffice-fresh` → `libreoffice-stable` — upstream collapsed the fresh/still split on 2026-08-11 and left `-fresh` as a `warnAlias`. All names resolve to the same derivation (`libreoffice-26.2.5.2-wrapped`), so nothing about the installed suite changes.
- `modules/email/neomutt`: use the canonical `libreoffice-stable`

The third warning, `stdenv.isLinux is deprecated`, has **no callsite in this repo** — it comes from a flake input or a nixpkgs-internal package. Left alone.

## Stale documentation

`CLAUDE.md` claimed *"Hyprland was removed. The desktop is niri with noctalia/DMS."* Both halves were backwards:

- Hyprland is **enabled** on p620 and razer (`hyprland-0.56.2`, portal `1.4.1`)
- **Noctalia** was the thing removed, in #1410 alongside labwc and mango

Replaced with the verified state: two live sessions, each with DMS as the shell, built by `modules/desktop/dms-shell.nix`.

Also dropped `"Serves the binary cache."` from the p620 row — it directly contradicted the "No binary cache" note ten lines below. Verified: no `nix-serve`/`harmonia` anywhere, and p620 substitutes only from cache.nixos.org and nix-community.cachix.org.

## Substituters

Dropped two with no consumer:

- `hyprland.cachix.org` — there is no hyprland flake input; the compositor comes from `pkgs.hyprland`, which cache.nixos.org already serves
- `cosmic.cachix.org` — `desktop.cosmic.enable` is `false` on both p620 and razer, so `modules/desktop/cosmic.nix` never builds the applet

Kept `cuda-maintainers` (p510 installs `cudaPackages.{cuda_nvcc,cudatoolkit,cudnn}`) and `devenv` (`pkgs.devenv` via `modules/development/devbox.nix`).

No rebuild impact — `nixConfig` is not part of the system derivation; p620's toplevel drvPath is unchanged.

## Missing keybinds

- **niri had no `Mod+Shift+<N>`** — the only way to move a window to another workspace was `Mod+Shift+Page_Up/Down`. The Hyprland session has had the numbered moves since #1367.
- **Media transport keys were bound in neither session.** `services.playerctld.enable` is true on p620 and razer and `playerctl` ships in `modules/system-utils`, but `XF86AudioPlay/Pause/Next/Prev/Stop` did nothing. Bound in both.
- `XF86AudioMicMute` → `wpctl` (consistent with the other audio binds rather than routing through DMS)
- `Mod+Shift+V` → DMS clipboard history, another live IPC target with no key
- niri's volume/brightness binds lacked `allow-when-locked`, so unlike Hyprland they were dead on the lock screen

## Verification

- `niri validate` → `config is valid`
- p620 `system.build.toplevel` builds
- okena builds
- Cold-cache eval confirms the libxcb and libreoffice warnings are gone

The Hyprland Lua is verified only insofar as the Nix build succeeds — there is no offline validator, so a runtime-only error can't be ruled out until someone logs into that session. `Mod`+scroll-wheel workspace switching (`hyprland.nix:186-187`) is untested and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)