### PR TITLE
chore(claude-code): update to 2.1.246 (#1453)

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -31,7 +31,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.241";
+  version = "2.1.246";
 
   # Claude Code reads clipboard images by shelling out to:
   #   xclip -selection clipboard -t TARGETS -o ... || wl-paste -l ...   (detect)
@@ -63,11 +63,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-B3G9hmz/grdlgfwEmfZSnho2hFB48UT4yB3Ms7xwN7g=";
+      hash = "sha256-GgpmLcG7k46uw4VFq86aSmkRPX1/fF4aVT6idmF7kGo=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-LbDLiT6+2O+K7kZlbaRbxoAfolhik9rmSr+jreiUov4=";
+      hash = "sha256-+YKW5uYcUHWJ0alzsmKXa3NHAOxOBVy2Sv2/bZozfbc=";
     };
   };
 


### PR DESCRIPTION
Bumps `pkgs/claude-code-native` from **2.1.241** to **2.1.246**, tracking Anthropic's GCS `latest` channel.

Supersedes both open watcher issues — #1453 (2.1.245) and #1452 (2.1.243).

Note the `stable` channel is currently **2.1.231**, which is *older* than the version already pinned, so `latest` was the only forward move.

## Changes

Three lines in `pkgs/claude-code-native/default.nix`: `version`, and the x86_64/aarch64 source hashes.

## Verification

- `result/bin/claude --version` → `2.1.246 (Claude Code)`
- `ldd` on the binary → no missing libs
- Host matrix: p620, razer, p510 all build

p510 does not ship the CLI but evaluates it in its closure, so it was built as a gate only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)