### PR TITLE
chore(claude-desktop): update to 1.37937.0 (#1458)

### DIFF
--- a/pkgs/claude-desktop-beta/default.nix
+++ b/pkgs/claude-desktop-beta/default.nix
@@ -64,7 +64,7 @@
 # then update `version` + `sha256` below (hex sha256 from the index is accepted
 # by fetchurl as-is).
 let
-  version = "1.28929.0";
+  version = "1.37937.0";
 
   # dlopen'd at runtime (not in DT_NEEDED) — appended to RUNPATH.
   runtimeLibs = [
@@ -81,7 +81,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_${version}_amd64.deb";
-    sha256 = "3ceb391268bde9a7fec32520d349b704043166204cdd571c62d1e950701f48fc";
+    sha256 = "99ceb88204aab49b1388d6773fe60255bcb8402cc964e1a2d767d81e42f02790";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Bumps `pkgs/claude-desktop-beta` from **1.28929.0** to **1.37937.0**, read from Anthropic's signed apt index.

## Changes

Two lines in `pkgs/claude-desktop-beta/default.nix`: `version` and `sha256`. The hex hash from the index is used as-is (`fetchurl` accepts it; no SRI conversion), and `url` is templated on `${version}` so it needs no edit.

## Verification

- Builds as `claude-desktop-1.37937.0`, `bin/claude-desktop` present
- `ldd` → 0 missing libs
- Host matrix: p620, razer, p510 all build

## Notes for whoever deploys

**This is a ~9000 jump in the middle component** (28929 → 37937). Per the runbook that magnitude is normal for this package and not a red flag by itself, but it is worth watching after deploy. In particular `~/.config/Claude/vm_bundles/` is version-sensitive — if the app fails to launch with "VM service not running", the first remedy is `rm -rf ~/.config/Claude/vm_bundles/` and relaunch.

**claude-desktop is currently running on p620** (pid 53266). After `nixos-rebuild switch` the live Electron process keeps executing from the old store path until it is quit and relaunched, so installed≠running is expected, not a failed deploy. Do not `pkill` it to force the upgrade — that loses in-flight conversation state.

Deploy order should be the host *not* running the app first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)