### PR TITLE
fix(p510): normalise /mnt/img_pool ownership so sqlite-backup can run (#1464)

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -709,6 +709,16 @@ in
   # other copy. Watch history and curation are the only things here that cannot
   # be re-downloaded, and they are ~1GB. Snapshot them onto /mnt/img_pool,
   # which is a different physical disk.
+  # systemd-tmpfiles refuses to descend from a user-owned directory into a
+  # root-owned one — a symlink-swap guard — so it created backups/ and stopped,
+  # and the destination below never existed. ReadWritePaths cannot bind-mount a
+  # missing path, so the unit died at namespace setup (226/NAMESPACE) before
+  # ExecStart ever ran. The mountpoint is the only olafkfreund-owned path in
+  # this tree; every child is root or a service uid.
+  systemd.tmpfiles.rules = [
+    "d /mnt/img_pool 0755 root root - -"
+  ];
+
   features.sqlite-backup = {
     enable = true;
     # Plex's two (module default) plus the *arr trio. All of them keep their


### PR DESCRIPTION
Closes #1464

## Problem

`sqlite-backup.service` on p510 has failed every run since 2026-08-22 with `226/NAMESPACE`. It is the only off-disk copy of the Plex and *arr databases living on the failing ST12000NM0127 (ZJV2NZE9, now 2896 reallocated / 664 pending sectors), and it has never produced a single snapshot.

## Root cause

Not the disk. `systemd-tmpfiles` refuses to descend from an unprivileged-user-owned directory into a root-owned one -- a symlink-swap guard -- and logs at every boot:

```
Detected unsafe path transition /mnt/img_pool (owned by olafkfreund)
  -> /mnt/img_pool/backups (owned by root) during canonicalization
```

It created `backups/` and stopped, so the module's `d /mnt/img_pool/backups/sqlite` rule never ran. `ReadWritePaths` then cannot bind-mount a path that does not exist, so the unit dies at namespace setup *before* `ExecStart` -- the script's own logic never gets a chance to create the directory.

This also explains why `systemd-tmpfiles-setup.service` exits 73 every boot while still logging "Finished", making the failure read as green.

## Change

One tmpfiles rule normalising the mountpoint to root.

Blast radius verified on the live host -- `find /mnt/img_pool -maxdepth 1 -user olafkfreund` returns only the mountpoint itself. Every child is root or a service uid (`backups` root, `docker.RETIRED` root, `ollama` 61547), and `k3d/` does not exist yet. Permissions stay 0755, so only the top-level write bit for `olafkfreund` changes, and nothing writes there as that user.

## Verification

- [x] `nix build .#nixosConfigurations.p510.config.system.build.toplevel` succeeds
- [x] both tmpfiles rules present in the built `etc/tmpfiles.d/00-nixos.conf`
- [ ] post-deploy: `systemctl start sqlite-backup` exits 0 and snapshots appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
