### PR TITLE
feat(ci): nightly auto-update for claude-code, claude-desktop, warp, antigravity (#1467)

### DIFF
--- a/.github/workflows/package-autoupdate.yml
+++ b/.github/workflows/package-autoupdate.yml
@@ -1,0 +1,134 @@
+# Nightly upstream bumps for the packages we track ourselves rather than
+# taking from nixpkgs. For each one: resolve the latest upstream version,
+# rewrite version + hash in place, build it, and merge if it builds.
+#
+# Why this verifies inline instead of gating on ci.yml: pull requests opened
+# with GITHUB_TOKEN do not trigger other workflows, so `gh pr merge --auto`
+# would wait forever on checks that never run. The job that merges is
+# therefore the job that built it.
+#
+# The per-package logic lives in scripts/, not here, so the same bump can be
+# run by hand — `./scripts/update-warp-terminal.sh` etc. Each script is
+# idempotent and writes nothing when already current, which is what the
+# "did anything change" check below relies on.
+#
+# The hourly claude-code-watch / claude-desktop-watch workflows still file
+# their tracking issues; this does not replace them.
+
+name: package autoupdate
+
+on:
+  schedule:
+    # 03:43 UTC — after the nixos issue audit (02:00) and before the flake
+    # update (06:00), so a package bump and a flake bump never race for main.
+    - cron: "43 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# One run at a time. Four packages merging to main concurrently would leave
+# the later ones rebasing against a moved base for no benefit.
+concurrency:
+  group: package-autoupdate
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # Serial: each job merges to main, so a parallel matrix would race.
+      max-parallel: 1
+      matrix:
+        include:
+          - pkg: claude-code
+            script: ./scripts/update-claude-code-native.sh --write latest
+            paths: pkgs/claude-code-native
+            verify: .#claude-code-native
+          - pkg: claude-desktop
+            script: ./scripts/update-claude-desktop.sh
+            paths: pkgs/claude-desktop-beta
+            verify: .#nixosConfigurations.p620.pkgs.claude-desktop-linux
+          - pkg: warp-terminal
+            script: ./scripts/update-warp-terminal.sh
+            paths: pkgs/warp-terminal
+            verify: .#nixosConfigurations.p620.pkgs.warp-terminal
+          # antigravity-hub is bumped by the script but is not in the overlay,
+          # so `verify` builds the cli instead. See issue #1468.
+          - pkg: antigravity
+            script: ./scripts/update-antigravity.sh
+            paths: pkgs/antigravity-cli pkgs/antigravity-ide pkgs/antigravity-hub pkgs/google-antigravity-py
+            verify: .#nixosConfigurations.p620.pkgs.antigravity-cli
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31.11.1
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Setup Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v7
+
+      - name: Run update script
+        run: ${{ matrix.script }}
+
+      - name: Did anything change?
+        id: changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- ${{ matrix.paths }}; then
+            echo "changed=false" >>"$GITHUB_OUTPUT"
+            echo "${{ matrix.pkg }} already current — nothing to do"
+          else
+            echo "changed=true" >>"$GITHUB_OUTPUT"
+            # First bumped version line is enough to title the commit. For
+            # antigravity, which can bump several components at once, this
+            # names the first and the PR body carries the full diff.
+            v=$(git diff -U0 -- ${{ matrix.paths }} \
+              | sed -nE 's/^\+[[:space:]]*version = "([^"]+)";.*/\1/p' | head -1)
+            echo "version=${v:-unknown}" >>"$GITHUB_OUTPUT"
+            git --no-pager diff --stat -- ${{ matrix.paths }}
+          fi
+
+      - name: Build the bumped package
+        if: steps.changed.outputs.changed == 'true'
+        run: nix build --no-link --print-out-paths '${{ matrix.verify }}'
+
+      - name: Open PR
+        if: steps.changed.outputs.changed == 'true'
+        id: pr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/autoupdate-${{ matrix.pkg }}
+          delete-branch: true
+          commit-message: "chore(${{ matrix.pkg }}): auto-update to ${{ steps.changed.outputs.version }}"
+          title: "chore(${{ matrix.pkg }}): auto-update to ${{ steps.changed.outputs.version }}"
+          labels: |
+            dependencies
+            automated
+          body: |
+            Automated nightly bump of **${{ matrix.pkg }}** to `${{ steps.changed.outputs.version }}`.
+
+            Produced by `${{ matrix.script }}` and verified with:
+
+            ```
+            nix build ${{ matrix.verify }}
+            ```
+
+            The build passed before this PR was opened, which is the gate for the
+            auto-merge below — `ci.yml` does not run on GITHUB_TOKEN pull requests.
+
+            Nothing is deployed. Pick it up with `just quick-deploy HOST`.
+
+      - name: Merge
+        if: steps.changed.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge ${{ steps.pr.outputs.pull-request-number }} --squash --delete-branch

--- a/scripts/update-claude-code-native.sh
+++ b/scripts/update-claude-code-native.sh
@@ -5,9 +5,11 @@
 #   ./scripts/update-claude-code-native.sh <version>  # prints Nix snippet for that version
 #   ./scripts/update-claude-code-native.sh latest     # resolves and uses the /latest channel
 #   ./scripts/update-claude-code-native.sh stable     # resolves and uses the /stable channel
+#   ./scripts/update-claude-code-native.sh --write latest   # edit default.nix in place
 #
-# Read-only: prints version + hashes. Does NOT edit default.nix — paste the
-# output yourself or pipe through sed.
+# Without --write this is read-only: it prints version + hashes for you to
+# paste. With --write it rewrites version and both platform hashes in
+# default.nix, which is what package-autoupdate.yml runs nightly.
 
 set -u
 # NB: intentionally no `set -e` — curl on a miss should not abort the whole
@@ -43,6 +45,33 @@ prefetch_hash() {
     }
 }
 
+# Rewrite version + both platform hashes in default.nix. Anchored on the
+# platform key so the two hashes cannot be swapped, which a positional
+# sed would happily do.
+rewrite_pkg() {
+  python3 - "$@" <<'PY'
+import re, sys
+f, ver, x64, arm64 = sys.argv[1:5]
+s = open(f).read()
+subs = [
+    (r'(\n  version = ")[^"]*(";)', ver),
+    (r'(x86_64-linux = \{\s*url = "[^"]*";\s*hash = ")[^"]*(";)', x64),
+    (r'(aarch64-linux = \{\s*url = "[^"]*";\s*hash = ")[^"]*(";)', arm64),
+]
+for pat, val in subs:
+    s, n = re.subn(pat, lambda m: m.group(1) + val + m.group(2), s, count=1)
+    if n != 1:
+        sys.exit(f"rewrite failed for {f}: pattern {pat!r} matched {n} times")
+open(f, 'w').write(s)
+PY
+}
+
+WRITE=0
+if [ "${1-}" = "--write" ]; then
+  WRITE=1
+  shift
+fi
+
 # Banner + channel summary (always, for context).
 echo "Channels:"
 echo "  stable  = $(resolve_channel stable)"
@@ -68,6 +97,17 @@ arm64_hash=$(prefetch_hash "$GCS/$version/linux-arm64/claude" aarch64-linux) \
   || die "could not hash linux-arm64 binary for $version"
 
 current=$(sed -nE 's/^[[:space:]]*version = "([^"]+)";.*$/\1/p' "$PKG_FILE" | head -1)
+
+if [ "$WRITE" -eq 1 ]; then
+  if [ "$current" = "$version" ]; then
+    echo "up-to-date at $version; no changes written"
+    exit 0
+  fi
+  rewrite_pkg "$PKG_FILE" "$version" "$x64_hash" "$arm64_hash" \
+    || die "could not rewrite $PKG_FILE"
+  echo "wrote $PKG_FILE: $current -> $version"
+  exit 0
+fi
 
 cat <<EOF
 Current pinned: $current

--- a/scripts/update-claude-desktop.sh
+++ b/scripts/update-claude-desktop.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Bump pkgs/claude-desktop-beta to the latest Anthropic Linux release.
+#
+# Modes:
+#   ./scripts/update-claude-desktop.sh           # resolve latest, edit default.nix in place
+#   ./scripts/update-claude-desktop.sh --check   # exit 0 if current, 1 if a bump is available
+#
+# Source of truth is Anthropic's signed apt repository. The Packages index
+# carries Version and SHA256 in the same stanza, so no separate prefetch is
+# needed — fetchurl takes the hex sha256 from the index as-is.
+#
+# THE INDEX IS NOT SORTED. It holds every historical release in arbitrary
+# order, so a top-down read picks whatever happens to be first: on
+# 2026-08-26 that was 1.17180.0, over 11,000 versions BEHIND the pinned
+# 1.28929.0. The build would have succeeded and silently downgraded the
+# package by more than a year. `sort -V` is mandatory, not stylistic.
+#
+# Wired into .github/workflows/package-autoupdate.yml for the nightly run.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_FILE="$(cd "${SCRIPT_DIR}/.." && pwd)/pkgs/claude-desktop-beta/default.nix"
+INDEX="https://downloads.claude.ai/claude-desktop/apt/stable/dists/stable/main/binary-amd64/Packages"
+
+CHECK_ONLY=0
+case "${1:-}" in
+  --check) CHECK_ONLY=1 ;;
+  "") ;;
+  *)
+    echo "usage: $0 [--check]" >&2
+    exit 2
+    ;;
+esac
+
+[ -f "${PKG_FILE}" ] || {
+  echo "error: ${PKG_FILE} not found" >&2
+  exit 1
+}
+
+for cmd in curl awk python3; do
+  command -v "$cmd" >/dev/null || {
+    echo "error: '$cmd' is required" >&2
+    exit 1
+  }
+done
+
+# Pair each Version with the SHA256 from the same stanza, then take the
+# highest by version sort. See the header on why sort -V is load-bearing.
+latest=$(curl -fsSL --max-time 30 "${INDEX}" \
+  | awk '/^Version:/{v=$2} /^SHA256:/{if (v != "") print v, $2; v=""}' \
+  | sort -V | tail -1)
+
+[ -n "${latest}" ] || {
+  echo "error: could not parse any version from ${INDEX}" >&2
+  exit 1
+}
+
+latest_version="${latest%% *}"
+latest_sha="${latest##* }"
+
+# The version lives in a `let` block; the sha256 in the fetchurl src.
+current_version=$(grep -m1 -oE 'version = "[^"]*"' "${PKG_FILE}" \
+  | sed -E 's/version = "([^"]*)"/\1/')
+
+printf '  claude-desktop  current=%s latest=%s\n' "${current_version}" "${latest_version}"
+
+if [ "${current_version}" = "${latest_version}" ]; then
+  [ "${CHECK_ONLY}" -eq 1 ] && echo "up-to-date" || echo "up-to-date; no changes written"
+  exit 0
+fi
+
+if [ "${CHECK_ONLY}" -eq 1 ]; then
+  echo "outdated: a newer claude-desktop release is available"
+  exit 1
+fi
+
+python3 - "${PKG_FILE}" "${latest_version}" "${latest_sha}" <<'PY'
+import re, sys
+f, ver, sha = sys.argv[1:4]
+s = open(f).read()
+for pat, val in ((r'(\n  version = ")[^"]*(";)', ver),
+                 (r'(sha256 = ")[^"]*(";)', sha)):
+    s, n = re.subn(pat, lambda m: m.group(1) + val + m.group(2), s, count=1)
+    if n != 1:
+        sys.exit(f"rewrite failed for {f}: pattern {pat!r} matched {n} times")
+open(f, 'w').write(s)
+PY
+
+echo "wrote ${PKG_FILE}: ${current_version} -> ${latest_version}"


### PR DESCRIPTION
Closes #1467

Nightly workflow that bumps the four packages we track ourselves, builds each one, and merges if it builds.

## What existed already

Two of the four were closer than expected:

| Package | Script | Wrote in place? |
| --- | --- | --- |
| warp-terminal | `update-warp-terminal.sh` | yes, with `--check` |
| antigravity | `update-antigravity.sh` | yes, with `--check` |
| claude-code | `update-claude-code-native.sh` | no -- printed a snippet to paste |
| claude-desktop | none | -- |

`update-flake.yml` already proved Nix + build + PR works on a hosted runner. So this is mostly wiring, plus closing the two gaps.

## Changes

**`update-claude-code-native.sh` gains `--write`.** The rewrite anchors on the platform key rather than position, so the x86_64 and aarch64 hashes cannot be swapped -- a positional `sed` would do that silently and it would only surface as a hash mismatch on the other architecture.

**`update-claude-desktop.sh` is new.** The apt Packages index carries `Version` and `SHA256` in the same stanza, so no prefetch is needed. The index is **not sorted** -- it holds every historical release in arbitrary order. On 2026-08-26 a top-down read returned `1.17180.0`, over 11,000 versions behind the then-pinned `1.28929.0`. That build would have succeeded and silently downgraded the package by more than a year, so `sort -V` is load-bearing and the header says so.

**`package-autoupdate.yml`** runs all four from a matrix at 03:43 UTC.

## Design notes

**Verification runs inline, then the job merges.** PRs opened with `GITHUB_TOKEN` do not trigger other workflows, so `gh pr merge --auto` would wait forever on checks that never run. The job that merges is the job that built it.

**`max-parallel: 1`** -- four packages merging to main concurrently would leave the later ones rebasing against a moved base for no benefit.

**03:43 UTC** sits between the issue audit (02:00) and the flake update (06:00), so a package bump and a flake bump never race for main.

**Build targets:** only `claude-code-native` is in `packages.x86_64-linux`; the rest are overlay-only and verify through `.#nixosConfigurations.p620.pkgs.<name>`.

The hourly `claude-code-watch` / `claude-desktop-watch` workflows are unchanged and still file their tracking issues.

## Verification

- [x] `--write` exercised for real: claude-code `2.1.246 -> 2.1.231` and back. Exactly 3 lines changed, correct hash per platform, no cross-assignment.
- [x] claude-desktop script exercised for real: found `1.37937.1` (released today, after this morning's bump to `.0`), wrote it, reverted. `--check` returns exit 1 when outdated.
- [x] All four `verify` targets resolve via `nix eval`.
- [x] `actionlint` clean.
- [x] No-op path confirmed: script writes nothing and exits 0 when already current, which is what the change-detection step relies on.

## Known gap

`antigravity-hub` is bumped by its script but is not in the overlay, so it cannot be build-verified -- the matrix verifies `antigravity-cli` instead. Tracked in #1468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
