### PR TITLE
fix(ci): replace dead magic-nix-cache with our own Cachix, clear Node 20 warnings (#1470)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31.11.1
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31.11.1
@@ -161,7 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check documentation completeness
         run: |
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31.11.1
@@ -241,7 +241,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31.11.1

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-code-watch.yml
+++ b/.github/workflows/claude-code-watch.yml
@@ -28,7 +28,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve upstream + pinned versions
         id: v

--- a/.github/workflows/claude-desktop-watch.yml
+++ b/.github/workflows/claude-desktop-watch.yml
@@ -35,7 +35,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve latest apt version + pinned version
         id: v
@@ -58,9 +58,11 @@ jobs:
             exit 1
           fi
 
-          echo "latest_ver=$latest_ver" >>"$GITHUB_OUTPUT"
-          echo "latest_sha=$latest_sha" >>"$GITHUB_OUTPUT"
-          echo "pinned_ver=$pinned_ver" >>"$GITHUB_OUTPUT"
+          {
+            echo "latest_ver=$latest_ver"
+            echo "latest_sha=$latest_sha"
+            echo "pinned_ver=$pinned_ver"
+          } >>"$GITHUB_OUTPUT"
           echo "latest=$latest_ver pinned=$pinned_ver"
 
       - name: Exit if no drift

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31.11.1

--- a/.github/workflows/nixos-issue-audit.yml
+++ b/.github/workflows/nixos-issue-audit.yml
@@ -38,7 +38,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31.11.1

--- a/.github/workflows/package-autoupdate.yml
+++ b/.github/workflows/package-autoupdate.yml
@@ -63,7 +63,7 @@ jobs:
             verify: .#nixosConfigurations.p620.pkgs.antigravity-cli
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31.11.1
@@ -72,8 +72,15 @@ jobs:
             experimental-features = nix-command flakes
             accept-flake-config = true
 
-      - name: Setup Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v7
+      # Our own binary cache. magic-nix-cache was retired by Determinate
+      # Systems and now fails the job outright with "Cache service responded
+      # with 400" / "Our services aren't available right now".
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v17
+        with:
+          name: olafkfreund
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          extraPullNames: nix-community
 
       - name: Run update script
         run: ${{ matrix.script }}
@@ -103,7 +110,7 @@ jobs:
       - name: Open PR
         if: steps.changed.outputs.changed == 'true'
         id: pr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/autoupdate-${{ matrix.pkg }}

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -25,14 +25,15 @@ jobs:
             experimental-features = nix-command flakes
             accept-flake-config = true
 
-      - name: Setup Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v7
-
+      # Our own binary cache. magic-nix-cache was retired by Determinate
+      # Systems and now fails the job outright with "Cache service responded
+      # with 400" / "Our services aren't available right now".
       - name: Setup Cachix
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@v17
         with:
-          name: nix-community
+          name: olafkfreund
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          extraPullNames: nix-community
 
       - name: Update flake inputs
         id: update
@@ -47,10 +48,10 @@ jobs:
 
           # Check if anything changed
           if diff -q flake.lock flake.lock.old > /dev/null; then
-            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No updates available"
           else
-            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "Updates found"
 
             # Show what changed
@@ -90,13 +91,15 @@ jobs:
           ' | head -20)
 
           # Save to output
-          echo "summary<<EOF" >> $GITHUB_OUTPUT
-          echo "$summary" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "summary<<EOF"
+            echo "$summary"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         if: steps.update.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore(deps): update flake inputs - daily automatic update'


### PR DESCRIPTION
Closes #1470

## The failure

The first `package-autoupdate` run failed its cache steps outright:

```
Failed to save: <h2>Our services aren't available right now</h2>
Failed to restore: Cache service responded with 400
```

Determinate Systems retired `magic-nix-cache`. It is dead everywhere it appears, not just in the new workflow -- `update-flake.yml` has the same step.

## What the investigation turned up

**`CACHIX_AUTH_TOKEN` never existed.** `update-flake.yml` has referenced `secrets.CACHIX_AUTH_TOKEN` since it was written, but `gh secret list` returned only `CLAUDE_CODE_OAUTH_TOKEN`. That step has been a silent no-op the entire time.

It also pointed at cache `nix-community`, which we cannot push to.

So **neither** Nix workflow has ever had a working binary cache. Every CI run has been rebuilding from source.

## Changes

- `CACHIX_AUTH_TOKEN` set on the repo (via stdin, never through a commit or terminal output)
- Both Nix workflows now use `cachix/cachix-action@v17` against our own `olafkfreund` cache, with `nix-community` as `extraPullNames`
- `actions/checkout@v4` -> `v5`, all 13 uses across 9 workflows
- `peter-evans/create-pull-request@v6` -> `v8`
- `install-nix-action` left at `v31.11.1` -- already current

Touching `update-flake.yml` and `claude-desktop-watch.yml` pulled their pre-existing shellcheck findings under the `actionlint` pre-commit hook. Fixed rather than skipped with `--no-verify`, since bypassing would leave the repo's own gate red for whoever edits those files next: quote `GITHUB_OUTPUT`, group the multi-line output writes.

## Verification

- [x] Cache `olafkfreund` exists -- `nix-cache-info` returns `StoreDir` / `Priority: 41`
- [x] Token authenticates for **write** -- `cachix push` returns "Nothing to push - all store paths are already on Cachix", which is a successful authenticated round-trip
- [x] `actionlint` clean across **all** workflows, not just the changed ones
- [x] `gh secret list` shows `CACHIX_AUTH_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
