### PR TITLE
fix(ci): verify antigravity through customPkgs, not the flake input (#1468)

### DIFF
--- a/.github/workflows/package-autoupdate.yml
+++ b/.github/workflows/package-autoupdate.yml
@@ -55,12 +55,21 @@ jobs:
             script: ./scripts/update-warp-terminal.sh
             paths: pkgs/warp-terminal
             verify: .#nixosConfigurations.p620.pkgs.warp-terminal
-          # antigravity-hub is bumped by the script but is not in the overlay,
-          # so `verify` builds the cli instead. See issue #1468.
+          # Every component must be verified through customPkgs. Bare
+          # `pkgs.antigravity-cli` is the antigravity-nix FLAKE INPUT's
+          # package, not ours — a different derivation at a different version
+          # — so building it proved nothing about the files this script
+          # rewrites. The hosts install pkgs.customPkgs.antigravity-cli
+          # (modules/ai/antigravity-cli.nix) and Users/olafkfreund/profile.nix
+          # installs the other three. See #1468.
           - pkg: antigravity
             script: ./scripts/update-antigravity.sh
             paths: pkgs/antigravity-cli pkgs/antigravity-ide pkgs/antigravity-hub pkgs/google-antigravity-py
-            verify: .#nixosConfigurations.p620.pkgs.antigravity-cli
+            verify: >-
+              .#nixosConfigurations.p620.pkgs.customPkgs.antigravity-cli
+              .#nixosConfigurations.p620.pkgs.customPkgs.antigravity-ide
+              .#nixosConfigurations.p620.pkgs.customPkgs.antigravity-hub
+              .#nixosConfigurations.p620.pkgs.customPkgs.google-antigravity-py
 
     steps:
       - uses: actions/checkout@v5
@@ -105,7 +114,13 @@ jobs:
 
       - name: Build the bumped package
         if: steps.changed.outputs.changed == 'true'
-        run: nix build --no-link --print-out-paths '${{ matrix.verify }}'
+        env:
+          VERIFY: ${{ matrix.verify }}
+        run: |
+          # VERIFY is a deliberate space-separated list of installables, so it
+          # must word-split — antigravity verifies four components at once.
+          # shellcheck disable=SC2086
+          nix build --no-link --print-out-paths $VERIFY
 
       - name: Open PR
         if: steps.changed.outputs.changed == 'true'


### PR DESCRIPTION
Closes #1468

## The bug is not what the issue said

#1468 claimed `antigravity-hub` was missing from the overlay. It isn't. The probe that produced that claim used `pkgs.antigravity-hub` instead of `pkgs.customPkgs.antigravity-hub` -- and the *same mistake* was baked into the workflow, where it matters far more.

## What was actually wrong

The antigravity job verified `.#nixosConfigurations.p620.pkgs.antigravity-cli`. That is **not** the package the update script rewrites:

| Attribute | Source | Version |
| --- | --- | --- |
| `pkgs.antigravity-cli` | the `antigravity-nix` **flake input** | `1.1.19` |
| `pkgs.customPkgs.antigravity-cli` | **our** `pkgs/antigravity-cli/` | `1.1.19-4894004681244672` |

Different derivations, different versions. The build gate passed without touching a single file the script had changed.

PR #1473 bumped cli to `1.1.21` and hub to `2.10.0` and auto-merged on the strength of a build of something else entirely.

## Nothing here is dead code

Every component the script touches is live:

- `modules/ai/antigravity-cli.nix:26` -- `default = pkgs.customPkgs.antigravity-cli`
- `Users/olafkfreund/profile.nix:167,169,206` -- installs `antigravity-ide`, `antigravity-hub`, `google-antigravity-py`

So the fix is to verify all four, not to drop any.

## Change

`verify` becomes a space-separated list of all four `customPkgs` attributes. The build step passes it through an env var and word-splits deliberately, with the `shellcheck disable` annotated rather than silent.

## Verification

Built the exact versions #1473 merged **unverified**:

```
antigravity-cli-1.1.21-6424454201475072
antigravity-ide-2.5.5-4923483625488384
antigravity-hub-2.10.0-4996573600546816
python3-3.14.7-env
```

All four build. Those hashes were right by luck, not by check -- from now on they're gated.

The other three matrix entries were cross-checked and are correct: `claude-code-native`, `claude-desktop-linux` and `warp-terminal` all resolve to derivations built from our own `pkgs/` files.

`actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWYY1ddmohh6aTQThmYHSc
