### PR TITLE
fix(sqlite-backup): read *arr databases and tolerate the dying blobs.db

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -717,6 +717,15 @@ in
   # this tree; every child is root or a service uid.
   systemd.tmpfiles.rules = [
     "d /mnt/img_pool 0755 root root - -"
+    # The *arr data directories are 0700 olafkfreund:<service>, so the backup's
+    # DynamicUser cannot traverse them and the script reports databases that
+    # plainly exist as "not found". 0750 admits group members without exposing
+    # config.xml — and the API key in it — to every local user. Nothing
+    # re-enforces 0700: the units carry no ExecStartPre chmod and no
+    # StateDirectory, only UMask=0022, so this sticks.
+    "z /mnt/media/sonarr 0750 - - - -"
+    "z /mnt/media/radarr 0750 - - - -"
+    "z /mnt/media/lidarr 0750 - - - -"
   ];
 
   features.sqlite-backup = {
@@ -733,7 +742,25 @@ in
       "/mnt/media/radarr/radarr.db"
       "/mnt/media/lidarr/lidarr.db"
     ];
+    # blobs.db is 967MB of posters and thumbnails, and it straddles a sector
+    # sdd can no longer read (sector 4294534448, unrecovered read error, hit on
+    # every attempt since 2026-08-27). Plex regenerates artwork on demand, so
+    # this is the one listed database whose loss is recoverable — keep reading
+    # it nightly in case the sector retires, but do not let the dying disk mask
+    # a real failure in the four databases that matter.
+    optional = [
+      "${config.services.plex.dataDir}/Plex Media Server/Plug-in Support/Databases/com.plexapp.plugins.library.blobs.db"
+    ];
     readPaths = [ "/mnt/media" ];
+    # sonarr/radarr/lidarr run as olafkfreund:<service> and own their data
+    # directories 0700; joining each group is what gets the backup through the
+    # directory to the (already world-readable) database inside.
+    readGroups = [
+      config.services.plex.group
+      "sonarr"
+      "radarr"
+      "lidarr"
+    ];
   };
 
   features.audiobook-import = {

--- a/modules/services/sqlite-backup.nix
+++ b/modules/services/sqlite-backup.nix
@@ -47,6 +47,31 @@ in
       '';
     };
 
+    optional = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        Databases whose failure must not fail the run. For a source sitting on
+        known-bad media: the read is still attempted every night — a pending
+        sector sometimes becomes readable again, and a reallocation on write
+        can retire it — but an unrecoverable error is logged as a warning
+        rather than turning the unit red. Reserve this for data that can be
+        rebuilt; a database listed here is one nobody is watching.
+      '';
+    };
+
+    readGroups = mkOption {
+      type = types.listOf types.str;
+      default = [ config.services.plex.group ];
+      description = ''
+        Groups the unit joins. Every directory on the path to a listed database
+        must be traversable by one of them: a DynamicUser belongs to no group
+        by default, and a 0700 service data directory turns a perfectly
+        readable database into "not found" from inside the namespace — the
+        stat fails on the directory, not the file.
+      '';
+    };
+
     destination = mkOption {
       type = types.str;
       default = "/mnt/img_pool/backups/sqlite";
@@ -97,12 +122,12 @@ in
       serviceConfig = {
         Type = "oneshot";
 
-        # DynamicUser can read the databases without help: they are mode 0644
-        # under world-traversable directories. The plex group is only needed to
-        # WRITE into the destination, whose owner cannot be pinned to a UID
-        # that changes on every run.
+        # The databases are mode 0644, but not every directory holding one is
+        # traversable by a stranger: the *arr data directories are 0700. The
+        # groups are needed to read those, and to WRITE into the destination,
+        # whose owner cannot be pinned to a UID that changes on every run.
         DynamicUser = true;
-        SupplementaryGroups = [ config.services.plex.group ];
+        SupplementaryGroups = cfg.readGroups;
 
         ProtectSystem = "strict";
         ProtectHome = true;
@@ -113,14 +138,32 @@ in
       };
 
       script = ''
+        # nixpkgs prepends `set -e` to every systemd `script`, and this one is
+        # built the other way round: each database is attempted, failures are
+        # accumulated in rc, and the run reports them at the end. Left on, the
+        # first `ls` in the prune loop that matches nothing exits 2 —
+        # pipefail propagates it, -e aborts — and the unit dies before
+        # `exit "$rc"`, red for a database that has simply never been
+        # snapshotted yet.
+        set +e
         set -uo pipefail
         ts=$(date +%Y%m%d-%H%M%S)
         rc=0
 
+        is_optional() {
+          for o in ${lib.escapeShellArgs cfg.optional}; do
+            [ "$o" = "$1" ] && return 0
+          done
+          return 1
+        }
+
         for src in ${lib.escapeShellArgs cfg.databases}; do
           db=$(basename "$src")
           if [ ! -f "$src" ]; then
-            echo "[sqlite-backup] $src not found; skipping" >&2
+            # Not "not found": -f is equally false when the file is there but
+            # its directory is not traversable from inside the namespace, and a
+            # message claiming absence sends you looking for the wrong bug.
+            echo "[sqlite-backup] $src unreadable (missing, or its directory is not traversable by this unit); skipping" >&2
             continue
           fi
 
@@ -134,6 +177,9 @@ in
           # train you to ignore the one that matters.
           if sqlite3 "$src" ".backup '$out'"; then
             echo "[sqlite-backup] $db -> $(basename "$out") ($(stat -c %s "$out") bytes)"
+          elif is_optional "$src"; then
+            echo "[sqlite-backup] WARNING: $db unreadable, continuing (listed as optional)" >&2
+            rm -f "$out"
           else
             echo "[sqlite-backup] ERROR: backup of $src failed" >&2
             rm -f "$out"


### PR DESCRIPTION
The *arr data directories are 0700 olafkfreund:<service>, so the backup's
DynamicUser could not traverse them and reported existing databases as
"not found". Relax them to 0750 via tmpfiles and join sonarr/radarr/lidarr
through a new readGroups option; correct the misleading skip message.

Plex's blobs.db straddles a sector sdd can no longer read. Add an optional
list so its failure warns instead of turning the unit red, while still
being retried nightly.

Also drop the implicit `set -e` nixpkgs prepends to systemd scripts: this
one accumulates failures in rc, and a no-match `ls` in the prune loop was
killing the run before it could report them.
