### PR TITLE
p620: add the Omarchy desktop as an extra session

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -31,6 +31,7 @@ in
     ./nixos/memory.nix
     ./nixos/load.nix
     ./themes/stylix.nix # Re-enabled after upstream cache fix
+    ./nixos/nixarchy.nix # Omarchy desktop, as an extra session
 
     # P620-specific additional modules
     ../../modules/development/default.nix

--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -1,0 +1,43 @@
+# Omarchy, vendored for NixOS.
+#
+# Same three settings as razer, and here for the same reasons -- this machine
+# and that one are shaped alike: greetd through the DankMaterialShell greeter,
+# niri and Hyprland both enabled, stylix owning the theme.
+#
+# Additive. The Omarchy session joins the existing entries and none of them
+# change: greetd keeps greeting, stylix keeps the boot splash, and Hyprland
+# sessions keep running the Hyprland this configuration chose.
+{ inputs
+, lib
+, pkgs
+, ...
+}:
+{
+  imports = [ inputs.nixarchy.nixosModules.nixarchy ];
+
+  programs.nixarchy.enable = true;
+
+  # nixarchy pins its own Hyprland and does not defer -- nixpkgs defines
+  # programs.hyprland.package at mkDefault priority, so matching it would tie
+  # rather than yield. desktop.hyprland already sets it here, so keep ours.
+  programs.hyprland.package = lib.mkForce pkgs.hyprland;
+  programs.hyprland.portalPackage = lib.mkForce pkgs.xdg-desktop-portal-hyprland;
+
+  # greetd already greets. nixarchy would otherwise enable SDDM, and two
+  # display managers is not a working configuration. The existing greeter picks
+  # the Omarchy session up from wayland-sessions like any other.
+  programs.nixarchy.displayManager = false;
+
+  # ~/.config/hypr/hyprland.lua is home-manager's here, so the seed keeps it and
+  # Omarchy's own config is never installed. The Omarchy session entry is what
+  # makes that work: it runs Hyprland with --config against Omarchy's file and
+  # needs nothing of ours, so both desktops coexist.
+  #
+  # Plymouth is left alone deliberately: nixarchy only mkDefaults its own
+  # splash, so stylix keeps this machine on 'stylix' with no mkForce needed.
+
+  home-manager.users.olafkfreund = {
+    imports = [ inputs.nixarchy.homeManagerModules.nixarchy ];
+    programs.nixarchy.enable = true;
+  };
+}


### PR DESCRIPTION
Same change as #1484, now on p620. The two machines are shaped alike — greetd through the DankMaterialShell greeter, niri and Hyprland both enabled, stylix owning the theme — so the settings are identical.

## Not the first machine to try it

razer has been running this since this morning. `nixarchy-verify` inside its Omarchy session:

```
16 passed, 0 failed, 3 worth a look
  ✓ Omarchy shell running          ✓ hardware rendering (Intel UHD + RTX 3080)
  ✓ bluetoothd sees 1 adapter      ✓ portal reports dark
  ✓ cursor follows the theme       ✓ Vulkan detected, 14 ICD files
  ✓ functions wired in (/etc/zshrc) ✓ compose sequences resolve
```

The three notes are deliberate: browser accent is opt-in, the boot splash is stylix by choice, RetroArch is not selected.

## Additive here too

Built and inspected before switching, not merely evaluated:

| | |
|---|---|
| sessions | `omarchy` joins hyprland, hyprland-dms, hyprland-uwsm, niri, niri-dms, Yaru — none displaced |
| `display-manager.service` | → `greetd` |
| `plymouthd.conf` | `Theme=stylix` |
| `sw/bin/Hyprland` | `hyprland-0.56.2` — ours, not nixarchy’s pin |

## The three settings

- `programs.hyprland.package = lib.mkForce pkgs.hyprland` — nixarchy pins its own and does not defer, because nixpkgs defines that option at `mkDefault` priority and matching it ties rather than yields.
- `programs.nixarchy.displayManager = false` — greetd already greets; two display managers is not a working configuration.
- the home-manager import — that half installs the menus, theme hooks and shell chain.

`~/.config/hypr/hyprland.lua` stays home-manager’s. The Omarchy session runs Hyprland with `--config` against Omarchy’s own file, so both desktops work without either owning that path.

## What deploying to razer produced upstream

Six fixes, none of which a VM could have shown — `start-hyprland` supervision, Vulkan detection, a graphics check that could not fail, wrapped-process detection, a shell-function check that could not see what it asked about, and an over-eager warning. All are in the nixarchy revision this branch locks.