### PR TITLE
fix(nhs): never leave the checkout stranded on the lock-bump branch

### DIFF
--- a/scripts/update-commit-deploy.sh
+++ b/scripts/update-commit-deploy.sh
@@ -365,7 +365,7 @@ built. Nothing was committed or deployed; re-run from a clean tree."
   if ! git push -u origin "${branch_name}"; then
     git checkout main
     git branch -D "${branch_name}" 2>/dev/null || true
-    err "branch push failed (maybe an orphan branch with the same name exists on origin? \`gh api -X DELETE repos/:owner/:repo/git/refs/heads/${branch_name}\` to clean up)."
+    err "branch push failed. The name is a hash of flake.lock, so an earlier run that produced this same lock already owns it — usually as a still-open PR, not an orphan. Check \`gh pr list --head ${branch_name}\` first and merge or close it; only if there is no PR, delete the ref with \`gh api -X DELETE repos/:owner/:repo/git/refs/heads/${branch_name}\`."
   fi
 
   log "opening PR"
@@ -656,6 +656,15 @@ if [ -n "${PR_URL:-}" ]; then
     warn "PR merge failed — ${HOST} is on the new generation but the lock is NOT on main."
     warn "  PR still open at: ${PR_URL}"
     warn "  Manual fix: merge via the UI, then  git checkout main && git pull --ff-only origin main"
+    # Return to main even though the merge failed. Leaving the checkout on the
+    # lock-bump branch is how a host ends up silently building the wrong tree:
+    # razer sat on chore/lock-bump-all-676bfa20 for two hours, three merges
+    # behind, and every deploy from it looked like it worked while shipping
+    # neither the module nor the app selection those merges had added.
+    #
+    # The branch is KEPT, unlike the failure paths above: the PR is still open
+    # and still needs it.
+    git checkout main 2>/dev/null || warn "  could not return to main — you are still on ${BRANCH_NAME}"
   else
     log "syncing local main"
     git checkout main


### PR DESCRIPTION
Step 12 returned to main only inside the else of `gh pr merge` — when the
merge succeeded. If it failed the script warned and stopped, leaving the
checkout standing on chore/lock-bump-<hash>.

That is not cosmetic. razer sat on chore/lock-bump-all-676bfa20 for two hours
while main moved three merges ahead, and every rebuild from it looked like it
worked: activation succeeded, generations incremented, and the tree being
built had neither modules/desktop/theme-owner.nix nor nixarchy-apps.nix. It
read as "the config does not work" rather than "the host is on the wrong
branch", which is the expensive kind of wrong.

Return to main on that path too. The branch is kept, unlike the earlier
failure paths, because the PR is still open and still needs it.

Also rewrite the push-failure message. It blamed an orphan ref, but the branch
name is a hash of flake.lock, so the usual owner of a colliding name is an
earlier run's still-open PR — and following the message's advice would delete
the branch out from under it. Point at `gh pr list --head` first.
