### PR TITLE
p620: import the app selection, and bump nixarchy

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1419,11 +1419,11 @@
         "zen-browser": "zen-browser"
       },
       "locked": {
-        "lastModified": 1787913583,
-        "narHash": "sha256-Zaer/BAPkrRga899FW696DHe4IhFxJGyLyDay1Svz1E=",
+        "lastModified": 1787926279,
+        "narHash": "sha256-2ju2P1v6Olgs0Lw9HDqAnZLoleVCtKp9PatIh1ZmExo=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "89d246e2c55cf28ea4166352fca0937e4c791eb7",
+        "rev": "68c136b33ec693ed05cbddc914fa78db0dab9084",
         "type": "github"
       },
       "original": {

--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -13,7 +13,16 @@
 , ...
 }:
 {
-  imports = [ inputs.nixarchy.nixosModules.nixarchy ];
+  # nixarchy-apply copies ~/.config/nixarchy/apps.nix to the flake root as
+  # nixarchy-apps.nix and stops there -- a flake cannot read a file outside its
+  # own tree, so the selection has to be copied in, and importing it is left to
+  # us. razer has had this line since #1504; p620 never did, so the selection
+  # landed in the flake and nothing read it. `dictation.enable = true` was
+  # enabled in the menu, copied by apply, and built by nobody.
+  imports = [
+    inputs.nixarchy.nixosModules.nixarchy
+    ../../../nixarchy-apps.nix
+  ];
 
   programs.nixarchy.enable = true;
 


### PR DESCRIPTION
Fixes `dictation.enable = true` installing nothing on p620.

## What was wrong

`nixarchy-apply` copies `~/.config/nixarchy/apps.nix` to the flake root as `nixarchy-apps.nix` — a flake cannot read a file outside its own tree, so the copy is unavoidable. **Importing that copy is ours to do.**

razer got the line in #1504. p620 did not. So the selection landed in the flake and nothing read it, while every step reported success:

- the Omarchy menu marked the app enabled
- `nixarchy-apply` reported copying the selection
- the rebuild ran to completion

…and nothing was built. The same repo, the same menu, the same apply, a different answer per host — which is what made it hard to see.

With the import, `voxtype` is in the built system. Verified before opening this.

## The nixarchy bump (89d246e → 68c136b)

Fixes the same trap upstream so no other machine can hit it silently: `apply` now looks for anything in the flake referencing `nixarchy-apps.nix` and says so plainly when nothing does, naming the line to add. Checked both directions — fires without the import, stops once it is there.

Also in this bump, all found by running nixarchy on real hardware rather than in a VM:

| | |
|---|---|
| shell rc files | locate themselves instead of falling back to `/usr/share/omarchy`, which can never exist here — anything sourcing them without `OMARCHY_PATH` already set got no aliases or functions |
| `programs.nixarchy.bootSplash` | `"force"` takes Omarchy’s Plymouth theme over stylix; `mkForce` on `boot.plymouth.theme` alone fails the build, because `themePackages` stays stylix’s |
| `nixarchy-verify` graphics | reported "hardware rendering" on any machine, llvmpipe included — it matched a header containing no renderer. Now reads what aquamarine logged, and can actually fail |

## Scope

Only p620’s import line and `flake.lock`. Nothing in `~/.config/nixarchy/apps.nix` was changed by this branch.