### PR TITLE
fix(omarchy): put the Omarchy session on the UK layout (#1510)

### DIFF
--- a/hosts/common/nixos/omarchy-input.nix
+++ b/hosts/common/nixos/omarchy-input.nix
@@ -1,0 +1,34 @@
+# Omarchy input overrides, shared by p620 and razer.
+#
+# Omarchy's default/hypr/input.lua takes the layout from /etc/vconsole.conf:
+#
+#   local kb_layout = vconsole.XKBLAYOUT or "us"
+#
+# NixOS writes only KEYMAP and FONT into that file, so XKBLAYOUT is never set
+# and every Omarchy session came up on a US layout -- while niri, the
+# home-manager Hyprland session and services.xserver.xkb were all on gb from
+# hosts/common/shared-variables.nix. Rather than bend /etc/vconsole.conf into a
+# shape systemd does not ask for, override it in the file Omarchy provides for
+# exactly this, ~/.config/hypr/input.lua, which its hyprland.lua requires after
+# the defaults.
+#
+# force: the nixarchy seed copies Omarchy's own input.lua here with `cp -rn`, so
+# without it home-manager finds that file in the way and refuses to link.
+{ ... }:
+{
+  home-manager.users.olafkfreund.home.file.".config/hypr/input.lua" = {
+    force = true;
+    text = ''
+      -- Managed by hosts/common/nixos/omarchy-input.nix. Personal input
+      -- overrides go here; what is set replaces Omarchy's defaults.
+      -- https://wiki.hypr.land/Configuring/Basics/Variables/#input
+
+      hl.config({
+        input = {
+          kb_layout = "gb",
+          kb_variant = "",
+        },
+      })
+    '';
+  };
+}

--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -22,6 +22,7 @@
   imports = [
     inputs.nixarchy.nixosModules.nixarchy
     ../../../nixarchy-apps.nix
+    ../../common/nixos/omarchy-input.nix
   ];
 
   programs.nixarchy.enable = true;

--- a/hosts/razer/nixos/nixarchy.nix
+++ b/hosts/razer/nixos/nixarchy.nix
@@ -22,6 +22,7 @@
   imports = [
     inputs.nixarchy.nixosModules.nixarchy
     ../../../nixarchy-apps.nix
+    ../../common/nixos/omarchy-input.nix
   ];
 
   programs.nixarchy.enable = true;


### PR DESCRIPTION
Closes #1510.

Omarchy's `default/hypr/input.lua` takes its layout from `/etc/vconsole.conf`:

```lua
local kb_layout = vconsole.XKBLAYOUT or "us"
```

NixOS writes only `KEYMAP` and `FONT` into that file, so `XKBLAYOUT` is never set and every Omarchy session came up **us** — while niri, the home-manager Hyprland session and `services.xserver.xkb` were all on `gb` from `hosts/common/shared-variables.nix`.

The Omarchy session is a separate Hyprland, launched with `--config <omarchy>/share/omarchy/config/hypr/hyprland.lua`, so nothing in `home/desktop/wayland/hyprland.nix` reaches it. Its `hyprland.lua` does `require("hypr.input")` after the defaults, which makes `~/.config/hypr/input.lua` the override point Omarchy itself provides — better than bending `/etc/vconsole.conf` into a shape systemd does not ask for.

Shared by p620 and razer, the two hosts that run Omarchy.

`home.file` needs `force = true` here: the nixarchy seed copies Omarchy's own `input.lua` into place with `cp -rn`, so without it home-manager finds that file in the way and refuses to link.

## Verified

Applied live on p620 (`hyprctl reload`) — all 12 keyboards now report `active=English (UK)`:

```
keychron-keychron-q10-max-keyboard: gb active=English (UK)
razer-razer-basilisk-x-hyperspeed-keyboard: gb active=English (UK)
...
```

Both `nixosConfigurations.{p620,razer}` evaluate the rendered file clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB