### PR TITLE
nixarchy: fix every web app shortcut, and cliamp's keybinding

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1419,11 +1419,11 @@
         "zen-browser": "zen-browser"
       },
       "locked": {
-        "lastModified": 1787926279,
-        "narHash": "sha256-2ju2P1v6Olgs0Lw9HDqAnZLoleVCtKp9PatIh1ZmExo=",
+        "lastModified": 1787937600,
+        "narHash": "sha256-X7jtT/jDfeNQaNyC0sZjzJDAg0r5n/TX3ztLljz4uj4=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "68c136b33ec693ed05cbddc914fa78db0dab9084",
+        "rev": "dde11702a1fc730472f19929fc7eae2bd14a12d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps nixarchy `89d246e → dde1170`. Fixes all eleven web app shortcuts and one keybinding.

## What was broken

Clicking **Google Messages** gave:

```
Error: Path "--app=https://messages.google.com/web/conversations" does not exist!
```

So did YouTube, Basecamp, Discord, Contacts, Maps, Photos, WhatsApp, X — plus HEY and Zoom through their handlers. **Eleven shortcuts, one cause.**

`omarchy-launch-webapp` resolves the browser by reading `Exec=` out of a `.desktop` file and handing the binary to `uwsm-app`. When that lookup finds nothing the substitution is empty, so `--app=<url>` lands where the *program* should be and uwsm-app reports it as a missing path — naming the URL, which reads like the URL is at fault.

The lookup failed because the fallback names `chromium.desktop`, which is Arch’s name. NixOS installs `chromium-browser.desktop`. Our default browser reports as `chrome-<id>-Default.desktop`, a Chrome web-app profile entry that matches none of the patterns upstream lists — so **every** launch took that fallback.

Both names are accepted now, and the script lists the browsers it can see when it cannot resolve one, instead of passing a flag to uwsm-app as a program.

## Also in this bump

**`cliamp`** — `SUPER + SHIFT + ALT + M` was failing on a package that reached nixpkgs *after* nixarchy’s own text was written saying it had not. Installed now, text corrected.

**Every keybinding is checked**, against the session PATH in a VM rather than at build time — the first attempt ran in a build sandbox and reported `btop`, `cliamp` and `obsidian` missing on a machine that had all three. Two named exceptions with reasons: `omawrite` is Omarchy’s own writing application and is packaged nowhere, so `SUPER + SHIFT + W` has nothing to launch on any machine; `obsidian` is unfree and opt-in, since an unfree package in the always-on set aborts the whole rebuild.

## Verified

Both hosts build, and `chromium-browser.desktop` is present in the shipped `omarchy-launch-webapp` on each. nixarchy CI green on `dde1170`.