### PR TITLE
nixarchy: name the desktop user, and bump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1419,11 +1419,11 @@
         "zen-browser": "zen-browser"
       },
       "locked": {
-        "lastModified": 1787937600,
-        "narHash": "sha256-X7jtT/jDfeNQaNyC0sZjzJDAg0r5n/TX3ztLljz4uj4=",
+        "lastModified": 1787947981,
+        "narHash": "sha256-jQBvqCgac+Pr+MupI8T3sJSFkarTPUV/EijHH/Z2GI8=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "dde11702a1fc730472f19929fc7eae2bd14a12d8",
+        "rev": "e7d5a6f087b37d011f3f27ef9bf2838374d56d5a",
         "type": "github"
       },
       "original": {

--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -28,6 +28,11 @@
 
   programs.nixarchy.enable = true;
 
+  # Puts this user in the input group. Omarchy's shell reads the keyboard
+  # device directly for its own key handling, which the group grants; without
+  # it the session starts but never sees a keypress.
+  programs.nixarchy.user = "olafkfreund";
+
   # nixarchy pins its own Hyprland and does not defer -- nixpkgs defines
   # programs.hyprland.package at mkDefault priority, so matching it would tie
   # rather than yield. desktop.hyprland already sets it here, so keep ours.

--- a/hosts/razer/nixos/nixarchy.nix
+++ b/hosts/razer/nixos/nixarchy.nix
@@ -28,6 +28,11 @@
 
   programs.nixarchy.enable = true;
 
+  # Puts this user in the input group. Omarchy's shell reads the keyboard
+  # device directly for its own key handling, which the group grants; without
+  # it the session starts but never sees a keypress.
+  programs.nixarchy.user = "olafkfreund";
+
   # nixarchy pins its own Hyprland and does not defer -- nixpkgs defines
   # programs.hyprland.package at mkDefault priority, so matching that would tie
   # rather than yield. This machine already sets it through desktop.hyprland,


### PR DESCRIPTION
Bumps `nixarchy` to `e7d5a6f` and sets the new `programs.nixarchy.user` on both hosts.

## What the bump carries

A deep read of upstream's tree against ours found things wired on Arch and simply absent here:

- **The lock screen never locked.** The PAM stack was named `hyprlock`, but `omarchy-lock-password` is what asks for the password — so authentication had nothing to answer it.
- **Eight user services** upstream starts had no NixOS equivalent (bluetooth agent, sleep lock, crash watch, internal-monitor recovery, fcitx5).
- **First run replayed on every login** — the state files upstream seeds at install were never placed.
- **Three scripts reported success they hadn't achieved**, editing read-only `/etc` paths; they now name the NixOS option and exit nonzero.

## `programs.nixarchy.user`

Puts the user in the `input` group, which the Omarchy shell needs to read the keyboard device directly — without it the session starts but never sees a keypress. The existing `omarchy-input.nix` is unrelated despite the name: that one sets the keyboard *layout*.

## Input method

Both hosts run GNOME, so `i18n.inputMethod.type` stays `ibus`. The bump also carries the fix that makes that possible: nixarchy set the same option at `mkDefault`, which **tied** with GNOME's rather than yielding, and neither host would evaluate at all until it moved off that priority. Caught by a dry-build before deploying.

## Verified

Both toplevels build. Evaluated against the real host configs:

```
inputMethod.type   = ibus     ← GNOME wins, as intended
olafkfreund groups = ... input ...
lock PAM present   = yes
bt-agent unit      = yes
```

Not yet switched — deploying by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5