### PR TITLE
fix(omarchy): key workspace blocks on monitor name, add rogue-window grab (#1517)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1419,11 +1419,11 @@
         "zen-browser": "zen-browser"
       },
       "locked": {
-        "lastModified": 1787937600,
-        "narHash": "sha256-X7jtT/jDfeNQaNyC0sZjzJDAg0r5n/TX3ztLljz4uj4=",
+        "lastModified": 1787947981,
+        "narHash": "sha256-jQBvqCgac+Pr+MupI8T3sJSFkarTPUV/EijHH/Z2GI8=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "dde11702a1fc730472f19929fc7eae2bd14a12d8",
+        "rev": "e7d5a6f087b37d011f3f27ef9bf2838374d56d5a",
         "type": "github"
       },
       "original": {

--- a/hosts/common/nixos/omarchy-workspaces.nix
+++ b/hosts/common/nixos/omarchy-workspaces.nix
@@ -15,6 +15,12 @@
 # Generic over monitor count, so the same file is right on razer's single
 # panel (where a group degenerates to a plain workspace) and on p620's three.
 #
+# hyprsplit was reviewed as an alternative (#1517) and cannot replace this: its
+# dispatchers are all scoped "on the current monitor", which is the one thing we
+# need not to be. Two of its ideas are worth having though, and are implemented
+# below: name-ordered blocks (its force_monitor_priority) and a rogue-window
+# grab for when a display is unplugged.
+#
 # Loaded by ~/.config/hypr/bindings.lua with
 #   require("hypr.workspace-groups")
 # which is the one line that stays hand-written: bindings.lua is where Omarchy
@@ -28,10 +34,30 @@
 
     local WS_PER_MONITOR = 10
 
-    -- Monitor id N owns the block N*10+1 .. N*10+10, so group G is workspace
-    -- G on the first monitor, G+10 on the second, G+20 on the third.
-    local function member(mon, group)
-      return mon.id * WS_PER_MONITOR + group
+    -- Blocks follow monitor *name*, sorted, not Hyprland's monitor id: ids are
+    -- handed out in connection order and shuffle when a display is unplugged
+    -- and plugged back in. p620's ARZOPA is a portable that comes and goes, so
+    -- keying on id would silently renumber every block underneath you. Sorting
+    -- by name is stable, and on both hosts it happens to give exactly the
+    -- assignment the ids did (DP-1, DP-2, HDMI-A-1 / eDP-1), so nothing moves.
+    local function ordered_monitors()
+      local mons = hl.get_monitors()
+      table.sort(mons, function(a, b) return a.name < b.name end)
+      return mons
+    end
+
+    -- The Nth monitor by name owns the block (N-1)*10+1 .. N*10, so group G is
+    -- workspace G on the first, G+10 on the second, G+20 on the third.
+    local function member(index, group)
+      return (index - 1) * WS_PER_MONITOR + group
+    end
+
+    local function index_of(target)
+      for index, mon in ipairs(ordered_monitors()) do
+        if mon.name == target.name then
+          return index
+        end
+      end
     end
 
     -- The rules have to be persistent: set_workspace silently no-ops on a
@@ -39,10 +65,10 @@
     -- nothing -- so something must create the whole block up front. Pinning
     -- each block to its own output also stops a click in the bar dragging a
     -- workspace onto the wrong screen.
-    for _, mon in ipairs(hl.get_monitors()) do
+    for index, mon in ipairs(ordered_monitors()) do
       for group = 1, WS_PER_MONITOR do
         hl.workspace_rule({
-          workspace = tostring(member(mon, group)),
+          workspace = tostring(member(index, group)),
           monitor = mon.name,
           persistent = true,
         })
@@ -50,8 +76,8 @@
     end
 
     local function focus_group(group)
-      for _, mon in ipairs(hl.get_monitors()) do
-        mon:set_workspace({ workspace = member(mon, group) })
+      for index, mon in ipairs(ordered_monitors()) do
+        mon:set_workspace({ workspace = member(index, group) })
       end
     end
 
@@ -59,9 +85,9 @@
     -- remembering it, so a bar click or a direct SUPER+N cannot leave the
     -- arrow keys cycling from a stale position.
     local function current_group()
-      for _, mon in ipairs(hl.get_monitors()) do
+      for index, mon in ipairs(ordered_monitors()) do
         if mon.focused and mon.active_workspace then
-          local group = mon.active_workspace.id - mon.id * WS_PER_MONITOR
+          local group = mon.active_workspace.id - (index - 1) * WS_PER_MONITOR
           if group >= 1 and group <= WS_PER_MONITOR then
             return group
           end
@@ -79,8 +105,9 @@
     local function move_to_group(group, follow)
       local win = hl.get_active_window()
       local mon = (win and win.monitor) or hl.get_monitor_at_cursor()
-      if mon then
-        hl.dispatch(hl.dsp.window.move({ workspace = member(mon, group), follow = follow }))
+      local index = mon and index_of(mon)
+      if index then
+        hl.dispatch(hl.dsp.window.move({ workspace = member(index, group), follow = follow }))
       end
       focus_group(group)
     end
@@ -103,6 +130,27 @@
         move_to_group(group, false)
       end)
     end
+
+    -- Unplugging a display leaves its windows on workspaces that no longer
+    -- belong to any monitor -- pull the ARZOPA and everything on 21-30 is
+    -- unreachable. Sweep them onto the workspace in front of you. (hyprsplit
+    -- calls this grab_rogue_windows.)
+    local function grab_rogue_windows()
+      local live = #ordered_monitors() * WS_PER_MONITOR
+      local here = hl.get_active_workspace()
+      if not here then
+        return
+      end
+      for _, win in ipairs(hl.get_windows()) do
+        local ws = win.workspace
+        -- id < 1 is a special workspace (scratchpad), which is never stranded.
+        if ws and ws.id >= 1 and ws.id > live then
+          hl.dispatch(hl.dsp.window.move({ window = win, workspace = here.id, follow = false }))
+        end
+      end
+    end
+
+    o.bind("SUPER + CTRL + G", "Reclaim windows from unplugged displays", grab_rogue_windows)
 
     -- Step through the groups. Omarchy ships SUPER+CTRL+LEFT/RIGHT as
     -- "move grouped window focus", which is what these replace.

--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -28,6 +28,11 @@
 
   programs.nixarchy.enable = true;
 
+  # Puts this user in the input group. Omarchy's shell reads the keyboard
+  # device directly for its own key handling, which the group grants; without
+  # it the session starts but never sees a keypress.
+  programs.nixarchy.user = "olafkfreund";
+
   # nixarchy pins its own Hyprland and does not defer -- nixpkgs defines
   # programs.hyprland.package at mkDefault priority, so matching it would tie
   # rather than yield. desktop.hyprland already sets it here, so keep ours.

--- a/hosts/razer/nixos/nixarchy.nix
+++ b/hosts/razer/nixos/nixarchy.nix
@@ -28,6 +28,11 @@
 
   programs.nixarchy.enable = true;
 
+  # Puts this user in the input group. Omarchy's shell reads the keyboard
+  # device directly for its own key handling, which the group grants; without
+  # it the session starts but never sees a keypress.
+  programs.nixarchy.user = "olafkfreund";
+
   # nixarchy pins its own Hyprland and does not defer -- nixpkgs defines
   # programs.hyprland.package at mkDefault priority, so matching that would tie
   # rather than yield. This machine already sets it through desktop.hyprland,


### PR DESCRIPTION
Closes #1517.

## hyprsplit review outcome

[hyprsplit](https://github.com/shezdy/hyprsplit) cannot replace `omarchy-workspaces.nix`: every one of its dispatchers is scoped *"on the current monitor"*, which is precisely the thing this must not be, and it numbers workspaces 1-10 / 11-20 identically so it does not help the bar display either. Two of its ideas do fix real gaps here, and are ported rather than taken as a dependency.

Correction to #1512: hyprsplit is **no longer a compiled plugin** — since Hyprland 0.55 it is a plain Lua library. That was my stated reason for rejecting it and it was wrong; the correct reason is the scoping above. (`pkgs.hyprlandPlugins.hyprsplit` is still the legacy C++ one at `0.54.3-unstable`, wrong for 0.56 regardless.)

## Blocks keyed on monitor name

Ids are handed out in connection order and shuffle when a display is unplugged and replugged. p620's ARZOPA is a portable that comes and goes, so keying on `mon.id` could silently renumber every block underneath you.

On both hosts the name order reproduces the id order exactly — `DP-1`, `DP-2`, `HDMI-A-1` on p620, `eDP-1` on razer — so **nothing moves on upgrade**. Verified against the live session after reload:

```
DP-1: ws1..ws10   DP-2: ws11..ws20   HDMI-A-1: ws21..ws30
```

## `SUPER+CTRL+G` — reclaim windows from unplugged displays

Unplug the ARZOPA and everything on ws21-30 is unreachable. This sweeps windows off workspaces that no longer belong to any monitor onto the one in front of you. Special workspaces (negative ids, the scratchpad) are left alone. `SUPER+G` was already "Toggle window grouping"; `SUPER+CTRL+G` was free and sits with the other group bindings.

Verified end to end by stranding a real window on ws31 with three monitors live:
```
stranded on ws31 mon=1  →  reclaimed to ws11 mon=1
```
Test window closed, no ws>30 left behind, no Lua errors on reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB