### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -762,11 +762,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787944733,
-        "narHash": "sha256-EAgIvOFIFezEVTCGqJuY/uyCNrXkwMhThkEGTloSrn4=",
+        "lastModified": 1787951204,
+        "narHash": "sha256-oAFIDAy7gx539STBvtUAh/fIESpKtxJa3MH/xhkbI2A=",
         "owner": "ogulcancelik",
         "repo": "herdr",
-        "rev": "82e6a80eb3ae39fb3d3ebd4d1fed19389767e605",
+        "rev": "c2637dc182ddc5425108824d5ed15d24ce38c4e3",
         "type": "github"
       },
       "original": {
@@ -1784,11 +1784,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787948416,
-        "narHash": "sha256-4HgstquSDJx/SZLc4a4c5MU7PgssJQzkeKUEn7FIRZ4=",
+        "lastModified": 1787990307,
+        "narHash": "sha256-7xTwhi7f3NbSG2PaiK386UeJKkil1XBO9pdH7HQAXBk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dca23a11a33e4af6cf15d10299764ea56ea4d50f",
+        "rev": "b74eb22f9d5a80b33be05a46de519f2260d81ba1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=p620, scope=all).

Built and verified locally against nixosConfigurations.p620 before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)