### PR TITLE
fix(overlays): skip gtksourceview5 sandbox tests

### DIFF
--- a/overlays/upstream-fixes.nix
+++ b/overlays/upstream-fixes.nix
@@ -1,4 +1,16 @@
 _final: prev: {
+  # gtksourceview5 5.20.0's meson suite hangs in the build sandbox: 9 of 26
+  # tests (test-vim-*, test-view, test-buffer, ...) TIMEOUT after 50-90s
+  # because there is no locale and no XDG_RUNTIME_DIR. 17 pass, 0 actually
+  # fail. Stylix patches a base16 scheme into this package, so it is never in
+  # cache.nixos.org and every host rebuilds it locally; p510 is slow enough to
+  # hit the timeouts, which takes down pods -> system-path -> the whole
+  # toplevel. Skipping the checks costs no cache hits (there were none).
+  # Drop once nixpkgs makes those tests sandbox-safe (#1525).
+  gtksourceview5 = prev.gtksourceview5.overrideAttrs (_old: {
+    doCheck = false;
+  });
+
   # azure-cli 2.81.0 expects azure-mgmt-web v2024_11_01 which isn't packaged yet;
   # disable installCheck until nixpkgs catches up.
   azure-cli = prev.azure-cli.overrideAttrs (_old: {


### PR DESCRIPTION
Closes #1525.

## Why the build failed

`gtksourceview-5.20.0`'s meson suite hangs in the sandbox — no locale, no `XDG_RUNTIME_DIR`:

```
Ok: 17   Fail: 0   Timeout: 9
```

Nothing fails; 9 tests just sit there until meson gives up, and the failed derivation takes `pods-3.1.1` -> `system-path` -> the p510 toplevel with it.

## Why it never comes from cache

Stylix patches a base16 colour scheme into the package. Diffing `inputs.drvs` of ours against plain nixpkgs from our own flake input gives exactly one extra input:

```
> base16-alien-hud.xml.drv
```

Clean nixpkgs `gtksourceview-5.20.0` is **CACHED**; ours is a **MISS**. So every host compiles it, and this recurs on every bump. p510 is simply slow enough to hit the timeouts first.

That is why `doCheck = false` is the right lever here rather than a workaround: the package was already 100% uncacheable, so skipping the checks costs no cache hits.

## It is not removable

`gtksourceview-5` has seven direct consumers in p620's closure, several of them core GNOME:

```
libspelling  gnome-text-editor  rewaita  gnome-builder
gnome-calculator  newsflash  pods
```

so no amount of pruning packages avoids building it.

## Verified

- `nixosConfigurations.p510.pkgs.gtksourceview5` builds
- `nixosConfigurations.p510.pkgs.pods` — the derivation that actually failed — builds
