### PR TITLE
perf(eval): make evaluation IFD-free, share one pkgs-unstable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -297,11 +297,15 @@
           # Stylix theming module - re-enabled after upstream cache fix
           stylixModule = [ inputs.stylix.nixosModules.stylix ];
           system = "x86_64-linux";
+          # One instantiation, shared by specialArgs and
+          # home-manager.extraSpecialArgs. Importing it twice cost a
+          # second nixpkgs fixpoint (~1-2s of eval) for nothing.
+          pkgsUnstable = import nixpkgs-unstable (mkPkgs nixpkgs-unstable system);
         in
         {
           inherit system;
           specialArgs = {
-            pkgs-unstable = import nixpkgs-unstable (mkPkgs nixpkgs-unstable system);
+            pkgs-unstable = pkgsUnstable;
             inherit inputs host hostTypes;
             username = primaryUser; # Primary user for backward compatibility
             hostUsers = allUsers; # All users for this host
@@ -347,7 +351,7 @@
                     inputs.dankcalendar.homeModules.dank-calendar
                   ];
                   extraSpecialArgs = {
-                    pkgs-unstable = import nixpkgs-unstable (mkPkgs nixpkgs-unstable system);
+                    pkgs-unstable = pkgsUnstable;
                     inherit
                       inputs
                       nixpkgs

--- a/home/desktop/theme/qt.nix
+++ b/home/desktop/theme/qt.nix
@@ -55,11 +55,11 @@ in
 
     # KDE globals configuration for dark mode
     # This ensures KDE applications use dark theme even outside Plasma
-    file.".config/kdeglobals" = {
-      text = ''
-        ${builtins.readFile "${pkgs.kdePackages.breeze}/share/color-schemes/BreezeDark.colors"}
-      '';
-    };
+    # source, not readFile: reading a built package's output is
+    # import-from-derivation, which forces breeze to be realised in the middle
+    # of evaluation -- a synchronous substitution on a cold store.
+    file.".config/kdeglobals".source =
+      "${pkgs.kdePackages.breeze}/share/color-schemes/BreezeDark.colors";
 
     # Add environment variables for Qt application integration
     sessionVariables = {

--- a/modules/development/claude-hooks.nix
+++ b/modules/development/claude-hooks.nix
@@ -4,8 +4,10 @@ let
   inherit (lib) mkOption mkIf mkEnableOption mkDefault types;
   cfg = config.features.claude-hooks;
 
-  # Create the hook scripts for desktop notifications
-  needsPermissionsScript = pkgs.writeShellScript "needs-permissions.sh" ''
+  # Hook script bodies. Kept as plain strings: building them with
+  # writeShellScript only to read them back with builtins.readFile is
+  # import-from-derivation, which stalls evaluation on a build.
+  needsPermissionsText = ''
     #!/usr/bin/env bash
 
     # Send notification when Claude needs permissions
@@ -17,7 +19,7 @@ let
     fi
   '';
 
-  notifyReadyScript = pkgs.writeShellScript "notify-ready.sh" ''
+  notifyReadyText = ''
     #!/usr/bin/env bash
 
     # Send notification when Claude is done processing
@@ -62,8 +64,8 @@ in
 
       # Make notification scripts available in the user environment
       home.packages = mkIf (cfg.enablePermissionNotifications || cfg.enableReadyNotifications) [
-        (pkgs.writeScriptBin "claude-notify-permissions" (builtins.readFile needsPermissionsScript))
-        (pkgs.writeScriptBin "claude-notify-ready" (builtins.readFile notifyReadyScript))
+        (pkgs.writeScriptBin "claude-notify-permissions" needsPermissionsText)
+        (pkgs.writeScriptBin "claude-notify-ready" notifyReadyText)
       ];
     }];
   };


### PR DESCRIPTION
Closes #1531.

## What this is not

This started as an attempt to cut evaluation time. **It does not cut evaluation time.** Benchmarked, two runs each:

| | p620 | razer |
|---|---|---|
| main | 39.03s / 39.05s | 39.74s / 40.27s |
| this branch | 39.40s / 39.01s | 42.60s / 39.59s |

Unchanged, within noise. On a warm store the IFD reads a path that is already realised, so removing it saves nothing locally. Keeping the change anyway, as a robustness fix — see below.

For the record, an eval profile bisected where the ~40s actually goes: forcing `environment.systemPackages` drvPaths is ~20s and `home.packages` ~22.6s, and those sum to the whole toplevel eval. Module-system fixpoint is ~1s. So ~95% is the raw cost of evaluating ~1,500 package derivations, and only trimming packages moves it. eval-cache (no repeat-run speedup), GC (2.7% of cpu), overlays, and duplicate nixpkgs across the 129 input nodes were all measured and ruled out.

## What it is

Evaluation was not IFD-free — two `builtins.readFile` calls on built outputs made nix stop and build things mid-eval:

1. **`home/desktop/theme/qt.nix`** read `BreezeDark.colors` out of `pkgs.kdePackages.breeze` to generate `~/.config/kdeglobals`. Now `source = "${pkgs.kdePackages.breeze}/…"` — a store-path reference is not IFD. Chosen over inlining the file contents so it cannot drift from upstream breeze. Verified the resulting file is the real scheme (10 `[Colors:*]`/`[ColorEffects:*]` sections).

2. **`modules/development/claude-hooks.nix`** built both hook scripts with `writeShellScript`, then read them back 45 lines later to pass to `writeScriptBin`. The derivation existed only to be read. Bodies are now plain strings.

Also: `flake.nix` imported `nixpkgs-unstable` twice per host (once for `specialArgs`, once for `home-manager.extraSpecialArgs`). Now one shared binding in `makeNixosSystem`.

## Verified

```
p620: IFD-free    razer: IFD-free    p510: IFD-free
```

All three hosts evaluate under `--no-allow-import-from-derivation`, and all three build:

```
p620  OK -> /nix/store/rrqicvdg5xpiflsmid9yh4szzbzbrxxm-nixos-system-p620-…
razer OK -> /nix/store/nfsb22kz7k00wihb7ax7gsb3fqdbhy2m-nixos-system-razer-…
p510  OK -> /nix/store/qzhj0zxn395s8idn2i3d0lblpadglipl-nixos-system-p510-…
```

The practical benefit is on a cold or GC'd store, and in CI: evaluation no longer blocks on a synchronous ~39.5 MB substitution it cannot parallelise.
