### PR TITLE
chore(home): drop 70 home.packages entries the system already provides

### DIFF
--- a/Users/common/base-home.nix
+++ b/Users/common/base-home.nix
@@ -37,12 +37,8 @@
       # Essential utilities
       coreutils
       file
-
-      # Network tools
-
-      # Text processing
-
-      # Archive tools
+      # wget/curl, less/nano, archive tools and findutils/which are
+      # system-wide via modules/nixos/packages/core.nix.
     ];
   };
 

--- a/Users/common/base-home.nix
+++ b/Users/common/base-home.nix
@@ -36,23 +36,13 @@
     packages = with pkgs; [
       # Essential utilities
       coreutils
-      findutils
-      which
       file
 
       # Network tools
-      wget
-      curl
 
       # Text processing
-      less
-      nano
 
       # Archive tools
-      unzip
-      zip
-      gnutar
-      gzip
     ];
   };
 

--- a/Users/olafkfreund/p510_home.nix
+++ b/Users/olafkfreund/p510_home.nix
@@ -108,8 +108,6 @@
     # Server development essentials
     # docker, docker-compose, kubectl, k9s: installed system-wide.
     # Re-declaring at user level produces buildEnv collisions.
-    git
-    gh
 
     # Intel Xeon + NVIDIA specific tools
     intel-gpu-tools
@@ -123,7 +121,6 @@
     # Database tools for development
     postgresql
     redis
-    sqlite
 
     # Network development and monitoring
     netcat
@@ -137,24 +134,17 @@
     iotop
 
     # File operations
-    ripgrep
-    fd
     sd
     tree
 
     # Archive and compression
-    unzip
-    p7zip
 
     # System analysis
     lsof
     strace
 
     # API development and testing
-    curl
-    wget
     httpie
-    jq
     # yq-go provided by developer/server-admin profiles
 
     # Text processing

--- a/Users/olafkfreund/p510_home.nix
+++ b/Users/olafkfreund/p510_home.nix
@@ -137,15 +137,12 @@
     sd
     tree
 
-    # Archive and compression
-
     # System analysis
     lsof
     strace
 
     # API development and testing
     httpie
-    # yq-go provided by developer/server-admin profiles
 
     # Text processing
     gnused

--- a/home/desktop/theme/qt.nix
+++ b/home/desktop/theme/qt.nix
@@ -43,7 +43,6 @@ in
       # Qt theming packages
       libsForQt5.qtstyleplugin-kvantum
       qt6Packages.qtstyleplugin-kvantum
-      adwaita-qt
       adwaita-qt6
       qt6Packages.qt6ct
 

--- a/home/desktop/wayland/shell.nix
+++ b/home/desktop/wayland/shell.nix
@@ -19,7 +19,6 @@
   # jq: parse the compositor's JSON IPC. wl-screenrec/slurp: HW-encoded recording.
   home.packages = with pkgs; [
     wl-mirror
-    jq
     wl-screenrec
     slurp
     swaybg # static wallpaper for niri/labwc (Stylix only themes GNOME's bg)

--- a/home/desktop/wayland/shell.nix
+++ b/home/desktop/wayland/shell.nix
@@ -16,7 +16,8 @@
 # on the niri and Hyprland sessions.
 {
   # wl-mirror: mirror an output to a window (niri has no native mirroring).
-  # jq: parse the compositor's JSON IPC. wl-screenrec/slurp: HW-encoded recording.
+  # wl-screenrec/slurp: HW-encoded recording. (jq, used to parse the
+  # compositor's JSON IPC, is system-wide.)
   home.packages = with pkgs; [
     wl-mirror
     wl-screenrec

--- a/home/development/codex-cli.nix
+++ b/home/development/codex-cli.nix
@@ -31,10 +31,6 @@
     prettier
     eslint
     python313Packages.black # Python formatter (pin py3.13 to match languages.nix/nvim.nix; bare `black` is py3.14 now and collides in home-manager-path)
-    rustfmt # Rust formatter
-    nixpkgs-fmt # Nix formatter
-    jq # JSON processing for API responses
-    curl # API testing
     httpie # User-friendly HTTP client
   ];
 }

--- a/home/development/gitlab/default.nix
+++ b/home/development/gitlab/default.nix
@@ -73,8 +73,7 @@ in
         # GitLab CI local testing
         (mkIf cfg.ciLocal.enable gitlab-ci-local)
 
-        # Additional related tools
-
+        # git, jq, curl and yq-go are system-wide.
       ] ++ cfg.packages;
 
       # GitLab Runner configuration (if enabled)

--- a/home/development/gitlab/default.nix
+++ b/home/development/gitlab/default.nix
@@ -74,10 +74,6 @@ in
         (mkIf cfg.ciLocal.enable gitlab-ci-local)
 
         # Additional related tools
-        git # Core git functionality
-        jq # JSON processing for API responses
-        curl # HTTP client for GitLab API
-        yq-go # YAML processing for CI/CD files
 
       ] ++ cfg.packages;
 

--- a/home/development/lsp-servers.nix
+++ b/home/development/lsp-servers.nix
@@ -17,18 +17,12 @@
       typescript-language-server
 
       # 3. Go - gopls (Claude Code: gopls@claude-code-lsps)
-      gopls
-      go
       delve
-      gore
       gotests
 
       # 4. Rust - rust-analyzer (Claude Code: rust-analyzer@claude-code-lsps)
-      rust-analyzer
-      cargo
       rustc
       clippy
-      rustfmt
 
       # 5. Java - jdtls (Claude Code: jdtls@claude-code-lsps)
       jdt-language-server
@@ -56,7 +50,6 @@
       # === ADDITIONAL IMPORTANT LSP SERVERS ===
 
       # Nix - nixd (feature-rich); nil is system-wide via modules/pkgs
-      nixd
 
       # Terraform - terraform-ls
       terraform-ls
@@ -123,7 +116,6 @@
       valgrind
 
       # Debugging tools
-      gdb
       lldb
     ];
 

--- a/home/development/lsp-servers.nix
+++ b/home/development/lsp-servers.nix
@@ -16,11 +16,11 @@
       typescript
       typescript-language-server
 
-      # 3. Go - gopls (Claude Code: gopls@claude-code-lsps)
+      # 3. Go - gopls and go are system-wide via modules/pkgs
       delve
       gotests
 
-      # 4. Rust - rust-analyzer (Claude Code: rust-analyzer@claude-code-lsps)
+      # 4. Rust - rust-analyzer, cargo and rustfmt are system-wide
       rustc
       clippy
 
@@ -49,7 +49,7 @@
 
       # === ADDITIONAL IMPORTANT LSP SERVERS ===
 
-      # Nix - nixd (feature-rich); nil is system-wide via modules/pkgs
+      # Nix - nil and nixd are both system-wide
 
       # Terraform - terraform-ls
       terraform-ls

--- a/home/profiles/developer/default.nix
+++ b/home/profiles/developer/default.nix
@@ -127,8 +127,6 @@
     # Text processing and analysis
     xmlstarlet
 
-    # Performance and monitoring
-
     # File operations optimized for development
     sd
 

--- a/home/profiles/developer/default.nix
+++ b/home/profiles/developer/default.nix
@@ -101,8 +101,6 @@
   # Developer-specific packages
   home.packages = with pkgs; [
     # Version control and collaboration
-    git
-    gh
     git-lfs
     delta
     difftastic
@@ -115,13 +113,10 @@
     # Language-specific tools
     nodejs_24 # Use nodejs_24 to match system-wide installation
     python3
-    go
     rustc
-    cargo
 
     # Database tools
     postgresql
-    sqlite
     redis
 
     # API development
@@ -130,18 +125,12 @@
     httpie
 
     # Text processing and analysis
-    jq
-    yq-go # Use Go version consistently across all configurations
     xmlstarlet
 
     # Performance and monitoring
-    tokei
 
     # File operations optimized for development
-    ripgrep
-    fd
     sd
-    eza
 
     # Network development tools
     netcat

--- a/home/profiles/server-admin/default.nix
+++ b/home/profiles/server-admin/default.nix
@@ -108,10 +108,6 @@
     ncdu
     tree
     rsync
-    curl
-    wget
-    jq
-    yq-go # Use Go version consistently across all configurations
 
     # Network tools
     nmap
@@ -121,13 +117,9 @@
     whois
 
     # File operations
-    ripgrep
-    fd
     sd
 
     # Archive tools
-    unzip
-    p7zip
 
     # Process management
     psmisc

--- a/home/profiles/server-admin/default.nix
+++ b/home/profiles/server-admin/default.nix
@@ -119,8 +119,6 @@
     # File operations
     sd
 
-    # Archive tools
-
     # Process management
     psmisc
     procps

--- a/home/shell/clipse/default.nix
+++ b/home/shell/clipse/default.nix
@@ -38,7 +38,6 @@ let
 in
 {
   home.packages = [
-    pkgs.clipse
     pkgs.wl-clipboard
     open-clip
   ];

--- a/home/shell/yazi/default.nix
+++ b/home/shell/yazi/default.nix
@@ -127,7 +127,6 @@ in
     };
     home.packages = with pkgs; [
       imagemagick
-      ffmpegthumbnailer
       fontpreview
       unar
       poppler

--- a/home/shell/zsh-ai-cmd.nix
+++ b/home/shell/zsh-ai-cmd.nix
@@ -65,8 +65,6 @@ in
     # Ensure zsh-ai-cmd package is installed
     home.packages = with pkgs; [
       zsh-ai-cmd
-      curl
-      jq
     ];
 
     # Configure zsh to load and initialize the plugin

--- a/home/shell/zsh.nix
+++ b/home/shell/zsh.nix
@@ -16,8 +16,6 @@ in
 
   # Optimized package selection - only essential packages
   home.packages = with pkgs; [
-    # Core shell
-
     # Essential lightweight plugins
     zsh-edit
     zsh-autopair

--- a/home/shell/zsh.nix
+++ b/home/shell/zsh.nix
@@ -17,7 +17,6 @@ in
   # Optimized package selection - only essential packages
   home.packages = with pkgs; [
     # Core shell
-    zsh
 
     # Essential lightweight plugins
     zsh-edit
@@ -26,22 +25,14 @@ in
     any-nix-shell
 
     # Modern shell tools
-    atuin # Better history
     zoxide # Smart directory navigation
-    eza # Better ls
     bat # Better cat
-    ripgrep # Better grep
-    fd # Better find
-    bottom # Better top
     dust # Better du
-    tokei # Code statistics
 
     # Development tools
-    lazygit
     delta # Better git diff
 
     # Productivity
-    glow # Markdown viewer
     # claude-code managed by claude-integration module
   ];
 


### PR DESCRIPTION
Closes #1533.

Removes 70 `home.packages` entries across 13 files that duplicate an identical system package.

**The system side is kept in every case.** System packages are on `PATH` for root and every user, so dropping those would break `sudo rg`, service scripts and other users; the home copy was pure redundancy for the one user already receiving them.

## How the scope was decided

Three filters, each of which excluded something a naive name-based pass would have deleted:

**1. Matched on outPath, not name.**

| host | identical store path in both layers | same name, different build |
| --- | --- | --- |
| p620 | 98 | 3 |
| razer | 91 | 3 |
| p510 | 69 | 2 |

`firefox`, `neovim`, `tesseract`, `bind` and `nvtop` appear in both layers under the same name but resolve to **different store paths** — home-manager wraps them with user config. Deleting the home copy would have silently replaced your configured Neovim with the bare system one. Excluded.

**2. Only names duplicated on all three hosts.** 107 names were duplicated on at least one host, but only 59 on every host. The other 48 (`bat`, `foot`, `starship`, `nodejs`, `obsidian`, `tmux`, …) would regress whichever host has no system copy. Excluded.

**3. Only lines genuinely inside a `home.packages` list**, located by tracking bracket depth rather than grepping bare names, so an entry in `extraPackages`, `buildInputs` or a program's own package list cannot be hit by accident.

## Where they were

```
11  home/profiles/developer/default.nix      8  home/development/lsp-servers.nix
10  Users/common/base-home.nix               4  home/development/codex-cli.nix
10  Users/olafkfreund/p510_home.nix          4  home/development/gitlab/default.nix
 9  home/shell/zsh.nix                       2  home/shell/zsh-ai-cmd.nix
 8  home/profiles/server-admin/default.nix   4  (qt.nix, wayland/shell.nix, clipse, yazi)
```

Only 2 of the duplicates came from `programs.<tool>.enable`; the rest were hand-written.

## Verified

All three hosts evaluate, all three build:

```
p620  OK -> /nix/store/lmc3lx8sxr4lrqm2zwwx6dhwhgh2gm4i-nixos-system-p620-…
razer OK -> /nix/store/bl45bg013i7nakh95kxv88h8wa1hpr9z-nixos-system-razer-…
p510  OK -> /nix/store/bl4fkqnfcybszvhz528xczd98fcm0kxl-nixos-system-p510-…
```

and all 37 distinct removed names are still present in all three closures, at the same store paths — nothing left the system, it just stopped being declared twice.

## Not addressed

The 48 partial duplicates still need a per-host layering decision, and the four dead `hosts/{p620,razer}/*-options.nix` files (never imported) are still there.
