### PR TITLE
fix(home): stop exporting BROWSER so xdg-settings resolves properly

### DIFF
--- a/home/development/languages.nix
+++ b/home/development/languages.nix
@@ -300,7 +300,6 @@ in
       # General development
       {
         EDITOR = "nvim";
-        BROWSER = "google-chrome-stable";
         TERM = "foot";
       }
 

--- a/home/shell/zsh.nix
+++ b/home/shell/zsh.nix
@@ -556,7 +556,6 @@ in
         else
           export TERM=xterm-256color
         fi
-        export BROWSER="google-chrome-stable"
         export EDITOR="nvim"
         export VISUAL="$EDITOR"
 


### PR DESCRIPTION
Closes #1536.

The Omarchy browser keybinding opened a Chrome PWA window (Lidarr) instead of Chrome.

## Cause

`xdg-settings` short-circuits on `$BROWSER` before it ever consults mimeapps:

```sh
if [ -n "$BROWSER" ]; then
    local browser=$(binary_to_desktop_file "${BROWSER%%:*}")
```

`binary_to_desktop_file` returns the **first alphabetical** `.desktop` in `~/.local/share/applications/` whose `Exec` is `google-chrome-stable`. There are 67 Chrome PWA shortcuts there, so it wins:

```
BROWSER set:    chrome-aamlbainilhgmgbgbgcbcihnfgcnkgbd-Default.desktop
BROWSER unset:  google-chrome.desktop
```

`omarchy-launch-webapp` then matches that against `google-chrome*|brave*|…|chromium*`, matches none, and falls back to a hardcoded `chromium.desktop` — which does not exist here (ours is `chromium-browser.desktop`). The `sed` yields nothing and the command degrades to `uwsm-app -- --app=<url>` with no binary, which is why it failed silently.

`mimeapps.list` was already correct — `x-scheme-handler/http=google-chrome.desktop` in `[Default Applications]`, and zero PWA entries in either file. The env var was the sole override.

## Two sites, not one

```
home/development/languages.nix:303   home.sessionVariables
home/shell/zsh.nix:559               raw export in zsh initContent
```

Removing only the first would leave the zsh export re-setting it in every interactive shell.

## Verified

Built p620 and inspected the generated profile: `BROWSER` occurrences in `hm-session-vars.sh` = **0**, and none left in `etc-zshrc`.

## Note for whoever hits this again

`xdg-settings set default-web-browser` cannot fix it: both `mimeapps.list` files are read-only `/nix/store` symlinks (home-manager `xdg.mimeApps`), and `xdg-settings` refuses outright while `$BROWSER` is set — *"$BROWSER is set and can't be changed with xdg-settings"*.

## Two upstream bugs, not fixed here

- `omarchy-launch-webapp`'s `chromium.desktop` fallback can never resolve on NixOS, where the file is `chromium-browser.desktop`.
- It exits successfully when browser resolution yields nothing, instead of failing loudly.
