### PR TITLE
fix(xdg): let Omarchy own ~/.local/share/applications/mimeapps.list

### DIFF
--- a/home/desktop/com.nix
+++ b/home/desktop/com.nix
@@ -20,6 +20,14 @@
   ];
   xdg = {
     mime.enable = true;
+
+    # Home Manager also symlinks the deprecated copy at
+    # ~/.local/share/applications/mimeapps.list. Omarchy writes web-app handler
+    # associations there when a PWA is installed, and a read-only store symlink
+    # makes those writes fail silently. Leave that path unmanaged; the
+    # XDG-spec location (~/.config/mimeapps.list) stays declarative below.
+    dataFile."applications/mimeapps.list".enable = false;
+
     mimeApps = {
       enable = true;
       defaultApplications = {


### PR DESCRIPTION
Closes #1538.

Home Manager's `xdg.mimeApps` module unconditionally symlinks a second, deprecated copy of the list into the data dir — its own comment says so:

```nix
# Deprecated but still used by some applications.
xdg.dataFile."applications/mimeapps.list".source = config.xdg.configFile."mimeapps.list".source;
```

That made `~/.local/share/applications/mimeapps.list` a read-only store symlink, so Omarchy's web-app installer could not register handler associations there — and failed silently, since nothing checks the write.

Disabling that single `dataFile` entry (`enable = false`, documented in Home Manager as *"allows specific files to be disabled"*) releases the path while keeping everything else declarative.

## Verified on the p620 build

```
~/.local/share/applications/mimeapps.list  ->  absent from home-manager-files (unmanaged)
~/.config/mimeapps.list                    ->  still present (declarative)
```

The nine `xdg.mimeApps` blocks across the config all feed `~/.config/mimeapps.list`, the XDG-spec location, and are unaffected.

## Note

Not merged/deployed yet — after switching, Home Manager removes the old symlink, leaving the directory writable. The file will not exist until something creates it; that is expected and spec-legal.