### PR TITLE
chore(flake): bump nixarchy for the web-app browser fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1419,11 +1419,11 @@
         "zen-browser": "zen-browser"
       },
       "locked": {
-        "lastModified": 1788012749,
-        "narHash": "sha256-k3i5R23ogjW6IrMVkR3AZMUg0xPmT7BNVCPtXLqgJvs=",
+        "lastModified": 1788037684,
+        "narHash": "sha256-9EoX9o4MvpFUz9AlpDITmnXIQDo0p1TA+iLf0i8iCrI=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "ed42c2f36c0dbc174dbd449ba709a0b58ec887a3",
+        "rev": "63a5244b2c7aaf3bfe95a7a3bf9d1b25ba5d12d3",
         "type": "github"
       },
       "original": {

--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -52,6 +52,20 @@
   # Plymouth is left alone deliberately: nixarchy only mkDefaults its own
   # splash, so stylix keeps this machine on 'stylix' with no mkForce needed.
 
+  # QtMultimedia for Omarchy shell plugins that want a camera preview
+  # (io.github.kristoferlund.webcam). quickshell's wrapper injects only
+  # qtdeclarative and qtwayland, so `import QtMultimedia` fails with "module is
+  # not installed" and the plugin's whole Panel.qml refuses to load -- the bar
+  # icon appears and clicking it does nothing.
+  #
+  # The wrapper *prefixes* NIXPKGS_QT6_QML_IMPORT_PATH rather than setting it,
+  # so a value set here is preserved and searched. systemPackages is what puts
+  # the multimedia backend under /run/current-system/sw/lib/qt-6/plugins, which
+  # QT_PLUGIN_PATH already covers; only the QML path needs saying out loud.
+  environment.systemPackages = [ pkgs.qt6.qtmultimedia ];
+  environment.sessionVariables.NIXPKGS_QT6_QML_IMPORT_PATH =
+    "${pkgs.qt6.qtmultimedia}/lib/qt-6/qml";
+
   home-manager.users.olafkfreund = {
     imports = [ inputs.nixarchy.homeManagerModules.nixarchy ];
     programs.nixarchy.enable = true;


### PR DESCRIPTION
Relates to #1536.

`nixarchy` `ed42c2f` → `6115d69` — a single upstream commit: **"Web app keybindings opened the wrong browser, or none (#25)"**.

It fixes the other half of #1536, in the package rather than in our session variables:

- patches `omarchy-launch-webapp` to call `env -u BROWSER xdg-settings get default-web-browser` — the one caller upstream had not guarded, and the one every `SUPER+SHIFT` web-app binding goes through
- adds `chromium*` to the browser `case` arm, so NixOS's `chromium-browser.desktop` no longer falls through to a `chromium.desktop` that does not exist here
- adds a CI check that fails the build if a future bump drops one of those guards

Removing `BROWSER` from our own session variables (#1537) fixed the symptom on these machines. This fixes it for any shell that sets `BROWSER` at all, so the two are complementary rather than redundant.

Verified: p620 builds.