### PR TITLE
gogcli quick capture, mail notifications, and a Meet keybinding

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1419,11 +1419,11 @@
         "zen-browser": "zen-browser"
       },
       "locked": {
-        "lastModified": 1788037684,
-        "narHash": "sha256-9EoX9o4MvpFUz9AlpDITmnXIQDo0p1TA+iLf0i8iCrI=",
+        "lastModified": 1788043158,
+        "narHash": "sha256-3eRRcOQX+njSRi2EaTwxKeRppErOkl2l18LUZtxg4tg=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "63a5244b2c7aaf3bfe95a7a3bf9d1b25ba5d12d3",
+        "rev": "106d0a95162330290ed945d5130b09ab2715a563",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1419,11 +1419,11 @@
         "zen-browser": "zen-browser"
       },
       "locked": {
-        "lastModified": 1788012749,
-        "narHash": "sha256-k3i5R23ogjW6IrMVkR3AZMUg0xPmT7BNVCPtXLqgJvs=",
+        "lastModified": 1788037684,
+        "narHash": "sha256-9EoX9o4MvpFUz9AlpDITmnXIQDo0p1TA+iLf0i8iCrI=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "ed42c2f36c0dbc174dbd449ba709a0b58ec887a3",
+        "rev": "63a5244b2c7aaf3bfe95a7a3bf9d1b25ba5d12d3",
         "type": "github"
       },
       "original": {

--- a/home/shell/gogcli/default.nix
+++ b/home/shell/gogcli/default.nix
@@ -39,6 +39,25 @@ let
       exec ${getExe cfg.package} "$@"
     '';
   };
+
+  # Desktop commands driving gog. xdg-utils is present because the mail
+  # notifier resolves an absolute xdg-open to hand to the notification's exec
+  # hint: that argv is run by the shell, not by this script, so it cannot rely
+  # on the wrapper's PATH.
+  captureCmd = name: pkgs.writeShellApplication {
+    inherit name;
+    runtimeInputs = [
+      gogWrapped
+      pkgs.gum
+      pkgs.jq
+      pkgs.libnotify
+      pkgs.wl-clipboard
+      pkgs.xdg-utils
+    ];
+    text = builtins.readFile (./. + "/${name}.sh");
+  };
+
+  mailWatch = captureCmd "omarchy-gmail-watch";
 in
 {
   options.programs.gogDashboard = {
@@ -89,6 +108,12 @@ in
       description = "How often the collector refreshes the store files (systemd time span).";
     };
 
+    mailInterval = mkOption {
+      type = types.str;
+      default = "90s";
+      description = "How often to poll Gmail for new unread mail (systemd time span).";
+    };
+
     maxItems = mkOption {
       type = types.ints.positive;
       default = 6;
@@ -100,15 +125,9 @@ in
     home.packages = [
       gogWrapped
       pkgs.jq
+      mailWatch
     ]
-    ++ map
-      # Quick-capture commands, surfaced in the Omarchy menu and bar.
-      (name: pkgs.writeShellApplication {
-        inherit name;
-        runtimeInputs = [ gogWrapped pkgs.gum pkgs.jq pkgs.libnotify pkgs.wl-clipboard ];
-        text = builtins.readFile (./. + "/${name}.sh");
-      })
-      [ "omarchy-cmd-note" "omarchy-cmd-upload" ];
+    ++ map captureCmd [ "omarchy-cmd-note" "omarchy-cmd-upload" "omarchy-cmd-meet" ];
 
     # GOG_HOME keeps gogcli's config/data/state under a stable per-user root so
     # the file-based keyring and the import are deterministic across services.
@@ -149,6 +168,30 @@ in
         '');
       };
       Install.WantedBy = [ "default.target" ];
+    };
+
+    # New-mail notifier. Polling, not push: Gmail's push needs a public HTTPS
+    # endpoint via Pub/Sub, which is not worth a desktop notifier. The popup
+    # carries an exec hint, so clicking it opens the thread in the browser.
+    systemd.user.services.gog-mail-watch = {
+      Unit = {
+        Description = "Notify on new unread Gmail";
+        After = [ "gog-token-import.service" ];
+      };
+      Service = {
+        Type = "oneshot";
+        Environment = [ "GOG_HOME=${config.home.homeDirectory}/.config/gogcli" ];
+        ExecStart = getExe mailWatch;
+      };
+    };
+
+    systemd.user.timers.gog-mail-watch = {
+      Unit.Description = "Poll Gmail for new unread mail";
+      Timer = {
+        OnBootSec = "2m";
+        OnUnitActiveSec = cfg.mailInterval;
+      };
+      Install.WantedBy = [ "timers.target" ];
     };
 
     # Collector: pull the three feeds and write store files atomically.

--- a/home/shell/gogcli/default.nix
+++ b/home/shell/gogcli/default.nix
@@ -18,6 +18,27 @@ let
   inherit (lib) mkOption mkEnableOption mkIf mkPackageOption types getExe;
   cfg = config.programs.gogDashboard;
   storeDir = "${config.home.homeDirectory}/.splashboard/store";
+
+  # `gog` with its keyring unlocked. The file keyring backend refuses to open
+  # without GOG_KEYRING_PASSWORD in any non-TTY context — a bar widget, a hook,
+  # an agent, or the collector below — and the password lives in agenix rather
+  # than the session environment. Same pattern as gogmail-tmux in
+  # home/shell/tmux. Falls through untouched when the secret is absent, so an
+  # interactive shell still gets the normal password prompt.
+  #
+  # Everything that invokes gog must go through this, not cfg.package directly.
+  gogWrapped = pkgs.writeShellApplication {
+    name = "gog";
+    runtimeInputs = [ pkgs.coreutils ];
+    text = ''
+      export GOG_HOME="''${GOG_HOME:-$HOME/.config/gogcli}"
+      if [ -r ${cfg.keyringPasswordFile} ]; then
+        GOG_KEYRING_PASSWORD="$(cat ${cfg.keyringPasswordFile})"
+        export GOG_KEYRING_PASSWORD
+      fi
+      exec ${getExe cfg.package} "$@"
+    '';
+  };
 in
 {
   options.programs.gogDashboard = {
@@ -76,7 +97,18 @@ in
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package pkgs.jq ];
+    home.packages = [
+      gogWrapped
+      pkgs.jq
+    ]
+    ++ map
+      # Quick-capture commands, surfaced in the Omarchy menu and bar.
+      (name: pkgs.writeShellApplication {
+        inherit name;
+        runtimeInputs = [ gogWrapped pkgs.gum pkgs.jq pkgs.libnotify pkgs.wl-clipboard ];
+        text = builtins.readFile (./. + "/${name}.sh");
+      })
+      [ "omarchy-cmd-note" "omarchy-cmd-upload" ];
 
     # GOG_HOME keeps gogcli's config/data/state under a stable per-user root so
     # the file-based keyring and the import are deterministic across services.
@@ -133,7 +165,7 @@ in
         Environment = [ "GOG_HOME=${config.home.homeDirectory}/.config/gogcli" ];
         ExecStart = getExe (pkgs.writeShellScriptBin "gog-dashboard-refresh" ''
           set -u
-          GOG=${getExe cfg.package}
+          GOG=${getExe gogWrapped}
           JQ=${getExe pkgs.jq}
           ACCT=${lib.escapeShellArg cfg.account}
           N=${toString cfg.maxItems}

--- a/home/shell/gogcli/omarchy-cmd-meet.sh
+++ b/home/shell/gogcli/omarchy-cmd-meet.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # omarchy:summary=Create a Google Meet, copy the link, and join it
 # omarchy:args=[--access open|trusted|restricted]
 # omarchy:examples=omarchy-cmd-meet | omarchy-cmd-meet --access open

--- a/home/shell/gogcli/omarchy-cmd-meet.sh
+++ b/home/shell/gogcli/omarchy-cmd-meet.sh
@@ -1,0 +1,25 @@
+# omarchy:summary=Create a Google Meet, copy the link, and join it
+# omarchy:args=[--access open|trusted|restricted]
+# omarchy:examples=omarchy-cmd-meet | omarchy-cmd-meet --access open
+
+# trusted: signed-in Google users join directly, anyone else knocks.
+# Pass --access open to let anyone with the link straight in.
+access=trusted
+[[ ${1:-} == --access && -n ${2:-} ]] && access=$2
+
+if ! out=$(gog meet create --access "$access" --json 2>&1); then
+  notify-send -u critical -a Omarchy "Meet failed" "${out:-gog meet create failed}"
+  exit 1
+fi
+
+uri=$(jq -r '.meeting_uri // empty' <<<"$out")
+[[ -n $uri ]] || {
+  notify-send -u critical -a Omarchy "Meet failed" "No meeting_uri in response"
+  exit 1
+}
+
+# Clipboard first: the link is the point, and it must survive the browser
+# failing to launch.
+printf '%s' "$uri" | wl-copy || true
+notify-send -a Omarchy "Meet ready — link copied" "$uri" || true
+xdg-open "$uri" >/dev/null 2>&1 &

--- a/home/shell/gogcli/omarchy-cmd-note.sh
+++ b/home/shell/gogcli/omarchy-cmd-note.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # omarchy:summary=Capture a quick note into Google Tasks
 # omarchy:args=[note text...]
 # omarchy:examples=omarchy-cmd-note | omarchy-cmd-note "Call the dentist"

--- a/home/shell/gogcli/omarchy-cmd-note.sh
+++ b/home/shell/gogcli/omarchy-cmd-note.sh
@@ -1,0 +1,23 @@
+# omarchy:summary=Capture a quick note into Google Tasks
+# omarchy:args=[note text...]
+# omarchy:examples=omarchy-cmd-note | omarchy-cmd-note "Call the dentist"
+
+# The "Private" list. Overridable because the id is opaque and would change if
+# the list were ever deleted and recreated; `gog tasks lists` prints the new one.
+TASKLIST=${GOG_TASKLIST:-aFRDVDU4N2ZVaGxwOENqUA}
+ACCOUNT=${GOG_ACCOUNT:-olaf@freundcloud.com}
+
+note=$*
+[[ -n $note ]] || note=$(gum input --placeholder "Note…" --prompt "note> " || true)
+[[ -n $note ]] || exit 0 # empty or cancelled: nothing to capture, not an error
+
+if err=$(gog tasks add "$TASKLIST" --account "$ACCOUNT" --title "$note" --json 2>&1 >/dev/null); then
+  # A dead notification daemon (headless, hooks, agents) must not turn a
+  # saved note into a reported failure under set -e.
+  notify-send -a Omarchy "Note saved" "$note" || true
+else
+  # Never fail silently — a dropped note is lost data, and the shell that
+  # launched this has nowhere to show stderr.
+  notify-send -u critical -a Omarchy "Note failed" "${err:-gog tasks add failed}"
+  exit 1
+fi

--- a/home/shell/gogcli/omarchy-cmd-upload.sh
+++ b/home/shell/gogcli/omarchy-cmd-upload.sh
@@ -1,0 +1,31 @@
+# omarchy:summary=Upload a file to Google Drive and copy its link
+# omarchy:args=[path]
+# omarchy:examples=omarchy-cmd-upload | omarchy-cmd-upload ~/Pictures/shot.png
+
+ACCOUNT=${GOG_ACCOUNT:-olaf@freundcloud.com}
+
+path=${1:-}
+[[ -n $path ]] || path=$(gum file "${HOME}" || true)
+[[ -n $path ]] || exit 0 # cancelled
+
+# Validate before spending an upload: gum file can return a directory, and an
+# unreadable path would otherwise surface as an opaque gog error.
+[[ -f $path && -r $path ]] || {
+  notify-send -u critical -a Omarchy "Upload failed" "Not a readable file: $path"
+  exit 1
+}
+
+# ponytail: no progress UI — fine for the screenshots and documents this is for.
+# If large uploads become normal, wrap in `gum spin` when stdout is a TTY.
+if out=$(gog drive upload "$path" --account "$ACCOUNT" --json 2>&1); then
+  link=$(jq -r '.file.webViewLink // empty' <<<"$out")
+  if [[ -n $link ]]; then
+    printf "%s" "$link" | wl-copy || true
+    notify-send -a Omarchy "Uploaded to Drive" "$(basename "$path") — link copied" || true
+  else
+    notify-send -a Omarchy "Uploaded to Drive" "$(basename "$path")" || true
+  fi
+else
+  notify-send -u critical -a Omarchy "Upload failed" "${out:-gog drive upload failed}"
+  exit 1
+fi

--- a/home/shell/gogcli/omarchy-cmd-upload.sh
+++ b/home/shell/gogcli/omarchy-cmd-upload.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # omarchy:summary=Upload a file to Google Drive and copy its link
 # omarchy:args=[path]
 # omarchy:examples=omarchy-cmd-upload | omarchy-cmd-upload ~/Pictures/shot.png

--- a/home/shell/gogcli/omarchy-gmail-watch.sh
+++ b/home/shell/gogcli/omarchy-gmail-watch.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # omarchy:summary=Notify on new unread mail; clicking the popup opens the thread
 # omarchy:args=[--seed]
 # omarchy:examples=omarchy-gmail-watch | omarchy-gmail-watch --seed

--- a/home/shell/gogcli/omarchy-gmail-watch.sh
+++ b/home/shell/gogcli/omarchy-gmail-watch.sh
@@ -1,0 +1,56 @@
+# omarchy:summary=Notify on new unread mail; clicking the popup opens the thread
+# omarchy:args=[--seed]
+# omarchy:examples=omarchy-gmail-watch | omarchy-gmail-watch --seed
+
+# Promotions and social are excluded deliberately: a notifier that fires for
+# newsletters gets muted within a day, which defeats the point.
+QUERY=${GOG_MAIL_QUERY:-"is:unread in:inbox -category:promotions -category:social"}
+ACCOUNT=${GOG_ACCOUNT:-olaf@freundcloud.com}
+MAX_NOTIFY=${GOG_MAIL_MAX_NOTIFY:-5}
+
+state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/omagog"
+seen="$state_dir/seen-threads"
+mkdir -p "$state_dir"
+
+# First run must not fire a notification per already-unread mail. Seeding
+# marks everything currently unread as old and stays silent.
+seed=0
+[[ ${1:-} == --seed || ! -f $seen ]] && seed=1
+
+out=$(gog gmail search "$QUERY" --account "$ACCOUNT" --max 25 --json 2>/dev/null) || exit 0
+ids=$(jq -r '.threads[]?.id // empty' <<<"$out")
+[[ -n $ids ]] || exit 0
+
+new=()
+while read -r id; do
+  [[ -n $id ]] || continue
+  grep -qxF "$id" "$seen" 2>/dev/null || new+=("$id")
+done <<<"$ids"
+
+# Record before notifying: a crash mid-notify must not re-fire the whole batch
+# on the next tick.
+printf '%s\n' "${new[@]}" >>"$seen" 2>/dev/null
+tail -n 500 "$seen" >"$seen.trim" 2>/dev/null && mv -f "$seen.trim" "$seen"
+
+((seed)) && exit 0
+((${#new[@]})) || exit 0
+
+# One batched call maps thread ids to their Gmail URLs, rather than one API
+# round trip per message.
+urls=$(gog gmail url "${new[@]}" --account "$ACCOUNT" 2>/dev/null)
+
+# Absolute path: the shell runs this argv itself, so it does not inherit the
+# PATH this script was given.
+opener=$(command -v xdg-open || echo xdg-open)
+
+count=0
+for id in "${new[@]}"; do
+  ((count++ < MAX_NOTIFY)) || break
+  url=$(awk -F'\t' -v i="$id" '$1==i{print $2; exit}' <<<"$urls")
+  [[ -n $url ]] || url="https://mail.google.com/mail/u/0/#all/$id"
+  subject=$(jq -r --arg i "$id" '.threads[]? | select(.id==$i) | .subject // "(no subject)"' <<<"$out")
+  sender=$(jq -r --arg i "$id" '.threads[]? | select(.id==$i) | .from // ""' <<<"$out")
+  # "Name <addr>" -> "Name"; bare addresses are left as they are.
+  sender=${sender%% <*}
+  omarchy-notification-send "${sender:-New mail}" "$subject" --exec "$opener" "$url" || true
+done

--- a/home/shell/gogcli/omarchy-gmail-watch.sh
+++ b/home/shell/gogcli/omarchy-gmail-watch.sh
@@ -17,6 +17,12 @@ mkdir -p "$state_dir"
 seed=0
 [[ ${1:-} == --seed || ! -f $seen ]] && seed=1
 
+# Create the state file now, not after the fetch. A seed run that finds no
+# matching mail would otherwise leave the file absent, so the next run would
+# seed again and swallow the first real new mail -- the one notification that
+# matters most.
+((seed)) && : >>"$seen"
+
 out=$(gog gmail search "$QUERY" --account "$ACCOUNT" --max 25 --json 2>/dev/null) || exit 0
 ids=$(jq -r '.threads[]?.id // empty' <<<"$out")
 [[ -n $ids ]] || exit 0

--- a/hosts/common/nixos/omarchy-gog.nix
+++ b/hosts/common/nixos/omarchy-gog.nix
@@ -1,0 +1,40 @@
+# Google Workspace integration for the Omarchy session, shared by p620 and
+# razer. The commands themselves come from home/shell/gogcli; this file is only
+# the desktop surfaces for them: menu rows and a keybinding.
+#
+# The menu jsonc is generated into the store and is not editable in ~/.config,
+# so rows have to be declared. The keybinding rides in its own lua file for the
+# same reason bindings.lua does not: bindings.lua is where Omarchy expects
+# personal edits and stays user-owned, so it keeps the one hand-written line
+#   require("hypr.gog-binds")
+# while everything it loads is managed here.
+{ ... }:
+{
+  programs.nixarchy.menu.extraEntries = {
+    "capture.note" = {
+      icon = "";
+      label = "Quick Note";
+      action = "omarchy-cmd-note";
+    };
+    "capture.upload" = {
+      icon = "";
+      label = "Upload to Drive";
+      action = "omarchy-cmd-upload";
+    };
+    "capture.meet" = {
+      icon = "";
+      label = "New Meet";
+      action = "omarchy-cmd-meet";
+    };
+  };
+
+  home-manager.users.olafkfreund.home.file.".config/hypr/gog-binds.lua".text = ''
+    -- Managed by hosts/common/nixos/omarchy-gog.nix -- edits here are
+    -- overwritten on the next deploy.
+
+    -- SUPER+SHIFT+M would read better, but it is already bound; V is free and
+    -- reads as "video call". The command copies the link before opening the
+    -- browser, so the link survives the browser failing to launch.
+    o.bind("SUPER + SHIFT + V", "New Google Meet (link copied)", "omarchy-cmd-meet")
+  '';
+}

--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -24,25 +24,10 @@
     ../../../nixarchy-apps.nix
     ../../common/nixos/omarchy-input.nix
     ../../common/nixos/omarchy-workspaces.nix
+    ../../common/nixos/omarchy-gog.nix
   ];
 
   programs.nixarchy.enable = true;
-
-  # Quick capture into Google Tasks / Drive, via the gog wrapper installed by
-  # home/shell/gogcli. The menu jsonc is generated and read-only in the store,
-  # so rows have to be declared here rather than edited in ~/.config.
-  programs.nixarchy.menu.extraEntries = {
-    "capture.note" = {
-      icon = "";
-      label = "Quick Note";
-      action = "omarchy-cmd-note";
-    };
-    "capture.upload" = {
-      icon = "";
-      label = "Upload to Drive";
-      action = "omarchy-cmd-upload";
-    };
-  };
 
   # Puts this user in the input group. Omarchy's shell reads the keyboard
   # device directly for its own key handling, which the group grants; without

--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -52,6 +52,20 @@
   # Plymouth is left alone deliberately: nixarchy only mkDefaults its own
   # splash, so stylix keeps this machine on 'stylix' with no mkForce needed.
 
+  # QtMultimedia for Omarchy shell plugins that want a camera preview
+  # (io.github.kristoferlund.webcam). quickshell's wrapper injects only
+  # qtdeclarative and qtwayland, so `import QtMultimedia` fails with "module is
+  # not installed" and the plugin's whole Panel.qml refuses to load -- the bar
+  # icon appears and clicking it does nothing.
+  #
+  # The wrapper *prefixes* NIXPKGS_QT6_QML_IMPORT_PATH rather than setting it,
+  # so a value set here is preserved and searched. systemPackages is what puts
+  # the multimedia backend under /run/current-system/sw/lib/qt-6/plugins, which
+  # QT_PLUGIN_PATH already covers; only the QML path needs saying out loud.
+  environment.systemPackages = [ pkgs.qt6.qtmultimedia ];
+  environment.sessionVariables.NIXPKGS_QT6_QML_IMPORT_PATH =
+    "${pkgs.qt6.qtmultimedia}/lib/qt-6/qml";
+
   home-manager.users.olafkfreund = {
     imports = [ inputs.nixarchy.homeManagerModules.nixarchy ];
     programs.nixarchy.enable = true;

--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -28,6 +28,22 @@
 
   programs.nixarchy.enable = true;
 
+  # Quick capture into Google Tasks / Drive, via the gog wrapper installed by
+  # home/shell/gogcli. The menu jsonc is generated and read-only in the store,
+  # so rows have to be declared here rather than edited in ~/.config.
+  programs.nixarchy.menu.extraEntries = {
+    "capture.note" = {
+      icon = "";
+      label = "Quick Note";
+      action = "omarchy-cmd-note";
+    };
+    "capture.upload" = {
+      icon = "";
+      label = "Upload to Drive";
+      action = "omarchy-cmd-upload";
+    };
+  };
+
   # Puts this user in the input group. Omarchy's shell reads the keyboard
   # device directly for its own key handling, which the group grants; without
   # it the session starts but never sees a keypress.

--- a/hosts/razer/nixos/nixarchy.nix
+++ b/hosts/razer/nixos/nixarchy.nix
@@ -24,6 +24,7 @@
     ../../../nixarchy-apps.nix
     ../../common/nixos/omarchy-input.nix
     ../../common/nixos/omarchy-workspaces.nix
+    ../../common/nixos/omarchy-gog.nix
   ];
 
   programs.nixarchy.enable = true;


### PR DESCRIPTION
Five commits that had accumulated on this branch locally and were never pushed.

| commit | |
|---|---|
| `28c41e5a7` | p620: add QtMultimedia for Omarchy shell plugins |
| `d0ae51028` | chore(flake): bump nixarchy for the web-app browser fix |
| `05ec424eb` | feat(gogcli): quick capture to Google Tasks and Drive |
| `67b28c90a` | feat(gogcli): new-mail notifications and a Meet keybinding |
| _(new)_ | fix(gogcli): tell shellcheck these are bash |

New scripts under `home/shell/gogcli/` — `omarchy-cmd-meet.sh`, `omarchy-cmd-note.sh`, `omarchy-cmd-upload.sh`, `omarchy-gmail-watch.sh` — wired through `home/shell/gogcli/default.nix` and `hosts/common/nixos/omarchy-gog.nix`.

## The shellcheck commit

The pre-push hook rejected all four new scripts with **SC2148**, "target shell is unknown". They have no shebang, and correctly so: `default.nix` feeds each to `writeShellApplication` via `builtins.readFile`, which supplies the shebang itself. Adding one to the source would plant a second `#!` partway down the generated script.

So `# shellcheck shell=bash` on line one — a directive, not a shebang. The `# omarchy:summary=` metadata still works where it is; omarchy greps for that line, it doesn't require it to be first.

## On the duplicate nixarchy bump

`main` already carries `#1540`, "bump nixarchy for the web-app browser fix", from the `update-commit-deploy.sh` automation — and this branch has `#1536` doing the same. They don't conflict (`git merge-tree`: zero conflict markers), and this branch's pin is the newer one:

```
this branch: 106d0a9   ← current nixarchy main
main:        63a5244   ← older
```

The merge keeps `106d0a9`, which is correct. Worth knowing the automation and a manual commit raced here.

## Verification

- `shellcheck home/shell/gogcli/*.sh` — clean
- `nixos-rebuild build --flake /etc/nixos` — succeeds (matters, since `writeShellApplication` runs shellcheck again at build time)
- Trial merge into `main` — 0 conflicts
- All pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5