### PR TITLE
fix(sddm): exec Hyprland directly, not the uwsm wrapper

### DIFF
--- a/hosts/common/nixos/omarchy-sddm.nix
+++ b/hosts/common/nixos/omarchy-sddm.nix
@@ -20,8 +20,12 @@
 #
 # mkForce because the nixpkgs default is a plain assignment, not mkDefault.
 {
+  # Hyprland directly, not start-hyprland: programs.hyprland.withUWSM is on
+  # here, and the wrapper expects a systemd user session the sddm greeter user
+  # does not have. SDDM execs this command itself and needs neither uwsm nor
+  # the `--` separator upstream's config-file form uses.
   services.displayManager.sddm.wayland.compositorCommand = lib.mkForce (
-    "${config.programs.hyprland.package}/bin/start-hyprland -- --config "
+    "${config.programs.hyprland.package}/bin/Hyprland --config "
     + "${config.programs.nixarchy.package}/share/omarchy/default/sddm/hyprland.lua"
   );
 }


### PR DESCRIPTION
**#1545 landed the wrong binary.** It pointed the greeter's `compositorCommand` at `start-hyprland`:

```diff
- "${config.programs.hyprland.package}/bin/start-hyprland -- --config "
+ "${config.programs.hyprland.package}/bin/Hyprland --config "
```

`programs.hyprland.withUWSM` is on here, and that wrapper expects a systemd user session **the sddm greeter user does not have**. SDDM execs the command itself, so it needs neither uwsm nor the `--` separator upstream's config-file form uses.

Upstream Omarchy's `sddm.conf.d` writes `start-hyprland -- --config` because it's parsed out of an INI file rather than exec'd, and because Arch's Hyprland isn't uwsm-wrapped. Copying that string verbatim carried an assumption that doesn't hold on this configuration.

## Why it wasn't in #1545

This correction was staged in the worktree beside that work and never got committed with it. I merged #1545 without noticing, so `main` currently carries the version this fixes — which would have failed in the same way the change was written to prevent: a greeter that doesn't come up, on the host that has no fallback.

## Verification

- `nixosConfigurations.p620.config.system.build.toplevel` — builds
- `nixosConfigurations.razer.config.system.build.toplevel` — builds

As with #1545: a build isn't proof the greeter starts. The first reboot after switching is the real test — keep the previous generation available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5