### PR TITLE
docs(sddm): the greeter failure was a held VT, not weston

### DIFF
--- a/hosts/common/nixos/omarchy-sddm.nix
+++ b/hosts/common/nixos/omarchy-sddm.nix
@@ -1,22 +1,42 @@
 { config, lib, ... }:
 # Run SDDM's Wayland greeter inside Hyprland, not weston.
 #
-# NixOS defaults services.displayManager.sddm.wayland.compositorCommand to
-# `weston --shell=kiosk`. On razer's Optimus hybrid NVIDIA that greeter never
-# comes up: sddm-helper crashes with exit 1, the journal shows
-# SDDM::Auth::HELPER_TTY_ERROR, systemd hits the restart limit, and the machine
-# is left with no login manager. It is the same class of failure that made this
-# host avoid GDM -- a greeter compositor, not the display manager itself.
-#
-# Upstream Omarchy never used weston. Its etc/sddm.conf.d/10-wayland.conf says:
+# This matches what upstream Omarchy ships. Its etc/sddm.conf.d/10-wayland.conf:
 #
 #     [Wayland]
 #     CompositorCommand=start-hyprland -- --config /usr/share/sddm/hyprland.lua
 #
-# The greeter runs in Hyprland, which already works on this hardware -- it is
-# the session both hosts log into. nixarchy vendors that greeter config
-# (default/sddm/hyprland.lua: animations off, no logo, no splash) but never
-# sets compositorCommand, so NixOS' weston default won by omission.
+# nixarchy vendors that greeter config (default/sddm/hyprland.lua: animations
+# off, no logo, no splash) but never sets compositorCommand, so NixOS' weston
+# default wins by omission and the vendored file goes unused.
+#
+# CORRECTION. An earlier version of this comment claimed weston's greeter "never
+# comes up" on razer's Optimus NVIDIA, citing SDDM::Auth::HELPER_TTY_ERROR. That
+# was wrong, and the error says so if you read it:
+#
+#     [PAM] Authenticating... [PAM] returning.          <- auth SUCCEEDED
+#     Failed to take control of "/dev/tty1" ("olafkfreund"): Operation not permitted
+#     Auth: sddm-helper exited with 5                   <- HELPER_TTY_ERROR
+#
+# sddm-helper emits that from one place, UserSession.cpp: ioctl(TIOCSCTTY)
+# failing with EPERM, which the kernel returns when the tty is already some other
+# session's controlling terminal. It runs as root, so it is not permissions, and
+# it happens BEFORE the compositor is exec'd -- so no compositor, weston or
+# Hyprland, was ever on the failing path.
+#
+# What actually held tty1: a logind session created by greetd, stuck in
+# State=closing since 28 Aug on a machine that had not rebooted since 24 Aug.
+# SDDM's own VT picker (Display.cpp fetchAvailableVt) skips sessions in
+# `closing`, so it believed tty1 was free, claimed VT 1, and then could not take
+# it. Six failures and the daemon exits 23, systemd trips the start limit, and
+# the machine has no login manager.
+#
+# The fix was a reboot. Nothing here fixes it.
+#
+# This override is kept because it matches upstream, not because weston is known
+# to be broken here -- weston has never actually been observed failing on this
+# hardware. If a greeter problem ever recurs, check `loginctl list-sessions` for
+# a closing session on a VT before touching the compositor.
 #
 # mkForce because the nixpkgs default is a plain assignment, not mkDefault.
 {


### PR DESCRIPTION
This comment asserted that weston's greeter "never comes up" on razer's Optimus NVIDIA, citing `SDDM::Auth::HELPER_TTY_ERROR`. **That was wrong**, and the error said so:

```
[PAM] Authenticating... [PAM] returning.       ← auth SUCCEEDED
Failed to take control of "/dev/tty1" ("olafkfreund"): Operation not permitted
Auth: sddm-helper exited with 5                ← HELPER_TTY_ERROR
```

`sddm-helper` emits that from exactly one place — `UserSession.cpp`, `ioctl(TIOCSCTTY)` returning `EPERM`, which the kernel does when the tty is already another session's controlling terminal. The helper runs as **root**, so it's not permissions, and it happens **before the compositor is exec'd**. No compositor was ever on the failing path — which is precisely why replacing weston with Hyprland changed nothing.

## What actually held tty1

```
Id=148  VTNr=1  TTY=tty1  Type=wayland  Service=greetd
        Timestamp=Fri 2026-08-28 14:55:18 BST   State=closing
```

A logind session created by **greetd**, wedged in `State=closing` since 28 Aug, on a machine that hadn't rebooted since 24 Aug.

The sting: SDDM's own VT picker (`Display.cpp::fetchAvailableVt`) **skips sessions in `closing`**. So it believed tty1 was free, claimed VT 1, and then couldn't take it. Six failures → daemon exits 23 → systemd trips the start limit → no login manager.

**The fix was a reboot.** This file fixes nothing.

## Why the override stays anyway

It matches what upstream Omarchy ships (`etc/sddm.conf.d/10-wayland.conf`). It is **not** kept because weston is known broken here — weston has never actually been observed failing on this hardware. The comment now distinguishes those two claims, and points the next reader at `loginctl list-sessions` before they go suspecting the compositor.

## Verification

- `nixosConfigurations.razer` — builds
- `nixosConfigurations.p620` — builds
- Comment-only change; no evaluated behaviour differs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5