### PR TITLE
fix(sddm): default to the Omarchy session, not GNOME

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -389,6 +389,15 @@ in
   # session and GNOME both stay selectable.
   desktop.displayManager.backend = "none";
 
+  # Preselect the Omarchy session. Without this SDDM has no default and falls
+  # through to whatever /var/lib/sddm/state.conf remembers, which was
+  # gnome.desktop -- so every boot came up in GNOME rather than Omarchy.
+  #
+  # A fallback only: SDDM rewrites state.conf on every login and the remembered
+  # session wins, so the first Omarchy login is what makes it stick. GNOME
+  # stays in the session menu either way.
+  services.displayManager.defaultSession = "omarchy";
+
   desktop.hyprland.enable = true;
 
   # k3d cluster — Phase 2 of docs/plans/2026-08-20-k3d-p510-to-p620-migration.md.

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -324,6 +324,15 @@ in
   # selectable.
   desktop.displayManager.backend = "none";
 
+  # Preselect the Omarchy session. Without this SDDM has no default and falls
+  # through to whatever /var/lib/sddm/state.conf remembers, which was
+  # gnome.desktop -- so every boot came up in GNOME rather than Omarchy.
+  #
+  # A fallback only: SDDM rewrites state.conf on every login and the remembered
+  # session wins, so the first Omarchy login is what makes it stick. GNOME
+  # stays in the session menu either way.
+  services.displayManager.defaultSession = "omarchy";
+
   desktop.hyprland.enable = true;
 
   # Terminals follow whichever shell owns the session: DMS in the DMS sessions,


### PR DESCRIPTION
Closes #1549.

SDDM had no `defaultSession` on p620 or razer, so it fell through to whatever `/var/lib/sddm/state.conf` remembered — `gnome.desktop` — and every boot came up in GNOME rather than Omarchy.

```nix
services.displayManager.defaultSession = "omarchy";
```

## Worth knowing, because it makes the setting look broken

This is a **fallback only**. SDDM rewrites `state.conf` on every login, and the remembered session beats `DefaultSession`. On a machine that has already logged into GNOME, setting this changes nothing until that value is cleared or an Omarchy login overwrites it. After the first Omarchy login it sticks on its own.

I hit exactly that while verifying: I cleared `state.conf`, but a live GNOME session had already re-recorded it, so the first "fix" was silently undone.

GNOME stays in the session menu.

## Verified on razer

```
/etc/sddm.conf.d/00-nixos.conf:  DefaultSession=omarchy.desktop
/var/lib/sddm/state.conf:        Session=   (cleared)
display-manager: active, 0 failed, sddm-greeter on tty1
Omarchy session comes up
```

Both hosts build.