### PR TITLE
chore(nixarchy): enable dictation, drop t3-code

### DIFF
--- a/nixarchy-apps.nix
+++ b/nixarchy-apps.nix
@@ -18,7 +18,7 @@
   programs.nixarchy.apps = {
 
     # ── Service ─────────────────────────────────────────────────────
-    # _1password.enable = true;  #@ _1password  # unfree — Needs the module, not the package: unlocking requires a setuid helper that only programs._1password-gui installs. Set `settings.polkitPolicyOwners = [ "yourname" ]`.
+    # _1password.enable = true;  #@ _1password  # unfree — Needs the module, not the package: unlocking requires a setuid helper that only programs._1password-gui installs. Set `settings.polkitPolicyOwners = [ "yourname" ]`. 
     #   _1password.settings = { };  #@ _1password.settings
     # bitwarden.enable = true;  #@ bitwarden
     # dropbox.enable = true;  #@ dropbox  # unfree
@@ -54,7 +54,7 @@
     # nodejs.enable = true;  #@ nodejs  # mise' prebuilt Node is dynamically linked against paths NixOS does not have, so it often will not execute at all. This one does.
     # ocaml.enable = true;  #@ ocaml
     # php.enable = true;  #@ php
-    # python.enable = true;  #@ python  # Already on the system as a runtime dependency of Omarchy's own scripts, so this row shows dim on a stock install. Select it to say so in your configuration rather than relying on that.
+    # python.enable = true;  #@ python  # Already on the system as a runtime dependency of Omarchy's own scripts, so this row shows dim on a stock install. Select it to say so in your configuration rather than relying on that. 
     # rust.enable = true;  #@ rust  # rustup manages its own toolchains under ~/.rustup, the same as upstream. Use pkgs.cargo and pkgs.rustc instead if you would rather Nix pinned the compiler.
     # scala.enable = true;  #@ scala
     # symfony.enable = true;  #@ symfony  # unfree
@@ -62,10 +62,10 @@
 
     # ── AI ──────────────────────────────────────────────────────────
     # chatgpt.enable = true;  #@ chatgpt  # unfree
-    dictation.enable = true; # @ dictation
+    dictation.enable = true; #@ dictation
     # grok-bot.enable = true;  #@ grok-bot  # unfree
     # lm-studio.enable = true;  #@ lm-studio  # unfree
-    t3-code.enable = true; # @ t3-code
+    # t3-code.enable = true;  #@ t3-code
 
     # ── Editor ──────────────────────────────────────────────────────
     # cursor.enable = true;  #@ cursor  # unfree
@@ -79,14 +79,14 @@
     # heroic.enable = true;  #@ heroic
     # lutris.enable = true;  #@ lutris
     # minecraft.enable = true;  #@ minecraft
-    # retroarch.enable = true;  #@ retroarch  # Ships 13 free cores. For more -- including snes9x, genesis-plus-gx, mame and dolphin, which nixpkgs marks unfree -- set allowUnfree and override the package:   apps.retroarch.package =     pkgs.retroarch.withCores (c: [ c.snes9x c.mame c.dolphin ]);
+    # retroarch.enable = true;  #@ retroarch  # Ships 13 free cores. For more -- including snes9x, genesis-plus-gx, mame and dolphin, which nixpkgs marks unfree -- set allowUnfree and override the package:   apps.retroarch.package =     pkgs.retroarch.withCores (c: [ c.snes9x c.mame c.dolphin ]); 
     # steam.enable = true;  #@ steam  # unfree — A module, not a package: Steam needs an FHS wrapper to run at all.
     #   steam.settings = { };  #@ steam.settings
     # xbox-controllers.enable = true;  #@ xbox-controllers  # A kernel driver, so it is a hardware option rather than a package.
     #   xbox-controllers.settings = { };  #@ xbox-controllers.settings
 
     # ── Preinstalls ─────────────────────────────────────────────────
-    # obsidian.enable = true;  #@ obsidian  # unfree — Preinstalled upstream, opt-in here because it is unfree. Theme syncing needs the Omarchy theme selected under Appearance > Themes in the app; omarchy-theme-set-obsidian writes it on every theme change.
+    # obsidian.enable = true;  #@ obsidian  # unfree — Preinstalled upstream, opt-in here because it is unfree. Theme syncing needs the Omarchy theme selected under Appearance > Themes in the app; omarchy-theme-set-obsidian writes it on every theme change. 
   };
 }
 


### PR DESCRIPTION
Nixarchy app picker toggle: `dictation` on, `t3-code` off. `nixpkgs-fmt` normalised the indentation the picker rewrote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB