### PR TITLE
chore(citrix): note the requireFile tarball is gone

### DIFF
--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -370,8 +370,9 @@ in
   systemd.services.gnome-remote-desktop.wantedBy = lib.mkForce [ ];
 
   # Citrix Workspace for client project remote access
-  # Disabled — no longer needed. Module + overlay + package retained so this
-  # can be flipped back to true without re-installing anything.
+  # Disabled — no longer needed. Module + overlay + package retained, but the
+  # requireFile tarball was deleted: re-enabling needs a fresh manual download
+  # via pkgs/citrix-workspace/fetch-citrix.sh first.
   services.citrix-workspace = {
     enable = false;
     acceptLicense = true;


### PR DESCRIPTION
Deleted the gitignored 516 MB `linuxx64-25.08.10.111.tar.gz` from `pkgs/citrix-workspace/` — untracked, so no history rewrite. Repo drops 977 MB → 485 MB; `pkgs/` drops 493 MB → 828 KB.

Safe: `services.citrix-workspace.enable = false` on razer and nothing citrix-related is in the store, so `requireFile` is never evaluated.

Only code change is the comment, which previously promised a re-enable "without re-installing anything" — that no longer holds now the tarball is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB