### PR TITLE
fix(razer): force Chrome ANGLE onto native GL to stop EGL_BAD_MATCH glitches

### DIFF
--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -29,6 +29,7 @@ in
     ./nixos/memory.nix
     ./themes/stylix.nix # Re-enabled after upstream cache fix
     ./nixos/nixarchy.nix # Omarchy desktop, as an extra session
+    ./nixos/override # Razer-only package overrides (google-chrome --use-angle=gl)
 
     # Razer-specific additional modules
     ../../modules/development/default.nix

--- a/hosts/razer/nixos/override/default.nix
+++ b/hosts/razer/nixos/override/default.nix
@@ -1,13 +1,14 @@
 _: {
-  # Overlays for Razer-specific package overrides
-  # nixpkgs.overlays = [
-  #   (final: prev: {
-  #     microsoft-identity-broker = prev.microsoft-identity-broker.overrideAttrs (oldAttrs: {
-  #       src = pkgs.fetchurl {
-  #         url = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-identity-broker/microsoft-identity-broker_2.0.1_amd64.deb";
-  #         sha256 = "18z75zxamp7ss04yqwhclnmv3hjxrkb4r43880zwz9psqjwkm11";
-  #       };
-  #     });
-  #   })
-  # ];
+  # Razer-specific package overrides (this host only; p620/p510 stay stock).
+  nixpkgs.overlays = [
+    # --use-angle=gl: on Razer's Intel-iris + Mesa + Ozone/Wayland stack, ANGLE's
+    # default backend can't import Wayland dmabufs as EGLImages (eglCreateImage
+    # EGL_BAD_MATCH), looping the GPU process and glitching pages. Native GL uses
+    # Mesa's EGL directly and fixes it. AMD (p620) doesn't hit this, so keep it here.
+    (_: prev: {
+      google-chrome = prev.google-chrome.override {
+        commandLineArgs = "--use-angle=gl";
+      };
+    })
+  ];
 }


### PR DESCRIPTION
## What
Razer-only `google-chrome` override adding `--use-angle=gl`.

## Why
On razer's Intel-iris + Mesa + Ozone/Wayland stack, Chrome's default ANGLE backend cannot import Wayland dmabufs as EGLImages (`eglCreateImage` **EGL_BAD_MATCH 0x3009**), looping the GPU process every frame → visual glitches, freezes, and broken layout (notably on Reddit). Live A/B confirmed the error loop drops from every-frame to **zero** with `--use-angle=gl` (native GL via Mesa's EGL).

## Scope
- `hosts/razer/nixos/override/default.nix` — razer-only `nixpkgs.overlays` override.
- `hosts/razer/configuration.nix` — imported `./nixos/override` (was an orphan, never wired in).
- p620 (AMD) and p510 stay on stock Chrome — verified by differing store hashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)