### PR TITLE
fix(razer): put chrome --use-angle=gl where it actually applies

### DIFF
--- a/Users/olafkfreund/razer_home.nix
+++ b/Users/olafkfreund/razer_home.nix
@@ -57,12 +57,16 @@
     account = "olaf@freundcloud.com";
   };
 
-  # Razer Chrome — GPU completely disabled for stability on Optimus hybrid
+  # Razer Chrome — force ANGLE onto native GL. On this Intel-iris + Mesa +
+  # Ozone/Wayland stack, ANGLE's default backend can't import Wayland dmabufs as
+  # EGLImages (eglCreateImage EGL_BAD_MATCH), looping the GPU process and
+  # glitching pages. Native GL uses Mesa's EGL directly and fixes it.
   programs.chromium = {
     commandLineArgs = lib.mkForce [
       "--enable-features=UseOzonePlatform"
       "--ozone-platform=wayland"
       "--disable-features=VizDisplayCompositor"
+      "--use-angle=gl"
     ];
   };
 }

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -29,7 +29,6 @@ in
     ./nixos/memory.nix
     ./themes/stylix.nix # Re-enabled after upstream cache fix
     ./nixos/nixarchy.nix # Omarchy desktop, as an extra session
-    ./nixos/override # Razer-only package overrides (google-chrome --use-angle=gl)
 
     # Razer-specific additional modules
     ../../modules/development/default.nix

--- a/hosts/razer/nixos/override/default.nix
+++ b/hosts/razer/nixos/override/default.nix
@@ -1,14 +1,13 @@
 _: {
-  # Razer-specific package overrides (this host only; p620/p510 stay stock).
-  nixpkgs.overlays = [
-    # --use-angle=gl: on Razer's Intel-iris + Mesa + Ozone/Wayland stack, ANGLE's
-    # default backend can't import Wayland dmabufs as EGLImages (eglCreateImage
-    # EGL_BAD_MATCH), looping the GPU process and glitching pages. Native GL uses
-    # Mesa's EGL directly and fixes it. AMD (p620) doesn't hit this, so keep it here.
-    (_: prev: {
-      google-chrome = prev.google-chrome.override {
-        commandLineArgs = "--use-angle=gl";
-      };
-    })
-  ];
+  # Overlays for Razer-specific package overrides
+  # nixpkgs.overlays = [
+  #   (final: prev: {
+  #     microsoft-identity-broker = prev.microsoft-identity-broker.overrideAttrs (oldAttrs: {
+  #       src = pkgs.fetchurl {
+  #         url = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-identity-broker/microsoft-identity-broker_2.0.1_amd64.deb";
+  #         sha256 = "18z75zxamp7ss04yqwhclnmv3hjxrkb4r43880zwz9psqjwkm11";
+  #       };
+  #     });
+  #   })
+  # ];
 }


### PR DESCRIPTION
## Why
PR #1556 added `--use-angle=gl` via a `google-chrome` overlay, but `programs.chromium` re-applies its own `commandLineArgs`, so the flag never reached the launched browser (verified: `finalPackage` stayed stock `51wv89kx…`, flag absent from the wrapper).

## Fix
The winning definition is the `mkForce` list in `Users/olafkfreund/razer_home.nix` — the running Chrome already carries that list's other flags, proving it reaches the browser. Add `--use-angle=gl` there (mirroring `p620_home.nix`, which already has it). Revert #1556's dead overlay.

## Root cause it fixes
On razer's Intel-iris + Mesa + Ozone/Wayland stack, ANGLE's default backend can't import Wayland dmabufs as EGLImages (`eglCreateImage` EGL_BAD_MATCH), looping the GPU process → glitches/freezes/broken layout. Native GL fixes it (live-confirmed: error loop → 0).

Razer-only; p620 unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)