### PR TITLE
feat(razer): switch power management from TLP to power-profiles-daemon

### DIFF
--- a/hosts/razer/nixos/cpu.nix
+++ b/hosts/razer/nixos/cpu.nix
@@ -11,8 +11,12 @@ _: {
 
   # Intel-specific power management
   services.thermald.enable = true;
+  # TLP disabled in favour of power-profiles-daemon (see power.nix) so the
+  # Omarchy bar / power plugins get switchable power-saver/balanced/performance
+  # profiles. Settings kept dormant below for an easy revert. Trade-off: loses
+  # TLP's per-AC/BAT CPU caps and the i915 GPU freq bounds; thermald still runs.
   services.tlp = {
-    enable = true;
+    enable = false;
     settings = {
       CPU_SCALING_GOVERNOR_ON_AC = "performance";
       CPU_SCALING_GOVERNOR_ON_BAT = "powersave";

--- a/hosts/razer/nixos/power.nix
+++ b/hosts/razer/nixos/power.nix
@@ -2,8 +2,9 @@
 , lib
 , ...
 }: {
-  # Enable System76 power daemon for intelligent power management
-  hardware.system76.power-daemon.enable = true;
+  # System76 power daemon disabled: it conflicts with power-profiles-daemon
+  # (both manage CPU power), which is now the chosen profile provider below.
+  hardware.system76.power-daemon.enable = false;
 
   # Thermal and power management services
   services = {
@@ -19,9 +20,11 @@
       percentageAction = 3;
     };
 
-    # Power profiles management
+    # Power profiles management — provides powerprofilesctl + the 3 switchable
+    # profiles the Omarchy bar/power plugins use. intel_pstate is in active mode,
+    # so PPD drives profiles via EPP. Replaces TLP (cpu.nix) + system76-power.
     power-profiles-daemon = {
-      enable = false;
+      enable = true;
       # Set default profile (options: power-saver, balanced, performance)
       # The following line is commented out as the default is 'balanced'
       # extraConfig.defaults.default-profile = "balanced";


### PR DESCRIPTION
## Why
Razer had **both** TLP and system76-power active, neither providing switchable profiles — so the Omarchy bar / power plugins had no `powerprofilesctl`. This enables in-bar power-saver/balanced/performance.

## Change (razer-only)
- `cpu.nix`: `services.tlp.enable = false` (settings kept dormant for revert)
- `power.nix`: `hardware.system76.power-daemon.enable = false`, `services.power-profiles-daemon.enable = true`

intel_pstate is in **active** mode, so PPD drives profiles via EPP.

## Trade-off
Loses TLP's per-AC/BAT CPU caps + i915 GPU freq bounds (#464). `thermald` still handles thermals.

## Verified
Razer config evaluates with no PPD-vs-TLP/system76 assertion failures; `ppd=true, tlp=false, system76=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)