### PR TITLE
fix(gnome): drop gnome-photos, removed from nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -746,11 +746,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788048205,
-        "narHash": "sha256-66Y3PEB7EeQimbBOld4qXUnYCt/N6Bh4F3eI1zinnpU=",
+        "lastModified": 1788120028,
+        "narHash": "sha256-kUPG7RzVlpW4JGpNQbz8PYSpnhUPrjImOpb8qxfniDI=",
         "owner": "ogulcancelik",
         "repo": "herdr",
-        "rev": "4a3b04f59ba3b7d8a15cea187b23e1e80c343b0c",
+        "rev": "2290257acb2085ce6842ba5c7e3ca50c3ba64f02",
         "type": "github"
       },
       "original": {
@@ -787,11 +787,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787797243,
-        "narHash": "sha256-8+Q7NOB7RPajRjA4pbCDLzqH+MTjnG9x6LUPLfL2joA=",
+        "lastModified": 1788146656,
+        "narHash": "sha256-XmJmvk9rytTb7dCotO/aqR+YysB8HOqnprlOdv+LAF4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "99c9ec63390f1d8c14d95d9e8b17cc29cfbd4e11",
+        "rev": "82c265faf4e3161d6015db07c9b0f1ee36a9029b",
         "type": "github"
       },
       "original": {
@@ -1346,11 +1346,11 @@
         "zen-browser": "zen-browser"
       },
       "locked": {
-        "lastModified": 1788109473,
-        "narHash": "sha256-71DRoaENHcs9vsAd1bJOCvWExC+pv+MoIKjgpk+kLuw=",
+        "lastModified": 1788133850,
+        "narHash": "sha256-3bRYGZfylNUkbdqyjnCeX5IqOw3qD8kutUDJH9JvMn0=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "1df4cdac82a548a0693af0010688e5b265c2390d",
+        "rev": "02512c85708511eee2683c5d7f1bbd62f85eade4",
         "type": "github"
       },
       "original": {
@@ -1380,11 +1380,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787900134,
-        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
+        "lastModified": 1788039129,
+        "narHash": "sha256-pa4Q0qErvCvzCaaUph7Sm37RhR4xvPrYI8Lgz6k85+A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
+        "rev": "d2f67949798825fe853f7c5d0492b8bf016d3f88",
         "type": "github"
       },
       "original": {
@@ -1504,11 +1504,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1787900134,
-        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
+        "lastModified": 1788039129,
+        "narHash": "sha256-pa4Q0qErvCvzCaaUph7Sm37RhR4xvPrYI8Lgz6k85+A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
+        "rev": "d2f67949798825fe853f7c5d0492b8bf016d3f88",
         "type": "github"
       },
       "original": {
@@ -1673,11 +1673,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1787900134,
-        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
+        "lastModified": 1788039129,
+        "narHash": "sha256-pa4Q0qErvCvzCaaUph7Sm37RhR4xvPrYI8Lgz6k85+A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
+        "rev": "d2f67949798825fe853f7c5d0492b8bf016d3f88",
         "type": "github"
       },
       "original": {
@@ -1695,11 +1695,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788106444,
-        "narHash": "sha256-9s3G4q0SmVPUSgZSKX2+SmtWIYYHouDmQvYffB+qoEs=",
+        "lastModified": 1788159155,
+        "narHash": "sha256-D6ISFoynDFovMN5okdQmaob+05d8J+CevO534Hi+0lg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "be4520d1446b74fc4f00b58d8282a1c3bfd0fe3b",
+        "rev": "585bc86f7b5c9c6aaa58db83772ccaf40bd73f63",
         "type": "github"
       },
       "original": {

--- a/home/desktop/gnome/apps.nix
+++ b/home/desktop/gnome/apps.nix
@@ -54,7 +54,6 @@ in
         eog # Eye of GNOME (image viewer)
         totem # GNOME Videos (video player)
         gnome-music # Music player
-        gnome-photos # Photo manager
         gnome-sound-recorder # Audio recording
         easyeffects # Audio effects and noise canceling for Teams/meeting tools
         showtime # Media center application

--- a/modules/services/gnome/gnome-services.nix
+++ b/modules/services/gnome/gnome-services.nix
@@ -23,7 +23,6 @@
     epiphany
     geary
     gnome-music
-    gnome-photos
     yelp
     cheese
   ];


### PR DESCRIPTION
## Problem

Every host failed to evaluate after the nixpkgs bump:

```
error: 'gnome-photos' has been removed as it was archived upstream and
image editing was broken. Consider using 'loupe' or 'shotwell' instead.
```

This blocked `nhs` / `just update-commit-deploy` at the eval gate.

## Fix

`gnome-photos` was referenced twice, and the two references contradicted each other:

- `modules/services/gnome/gnome-services.nix` **excluded** it via `environment.gnome.excludePackages`
- `home/desktop/gnome/apps.nix` **installed** it

That is the same double-declaration pattern that puts a `.service` file in both `/run/current-system/sw` and `/etc/profiles/per-user/$USER`. Both references removed.

Removed rather than substituted — `eog` already covers image viewing. Nothing replaces the library-manager role; `shotwell` is the candidate if that turns out to be wanted.

## Verification

All three hosts evaluate to a toplevel `drvPath` again:

| host | drv |
|---|---|
| p620 | `3rc09dp7m7mjg96019pc1gz1lhzxqff2` |
| razer | `970ryspli1m01c98nh8mkh34g2844qmr` |
| p510 | `31lsr4sc0c7gr2awpn9qbfph1abmrrgr` |

## Also in this PR

The `flake.lock` bump the aborted `nhs` run left in the working tree, committed separately. The evals above were run against it.

## Note for follow-up

`gnome-music` still has the identical excluded-and-installed conflict (`gnome-services.nix` line 25 vs `apps.nix` line 55). It does not break eval, so it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB