### PR TITLE
chore: drop dead DMS references left after #1562

### DIFF
--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -1,12 +1,12 @@
 # Omarchy, vendored for NixOS.
 #
-# Same three settings as razer, and here for the same reasons -- this machine
-# and that one are shaped alike: greetd through the DankMaterialShell greeter,
-# niri and Hyprland both enabled, stylix owning the theme.
+# Same settings as razer, and here for the same reasons -- the two machines are
+# shaped alike: SDDM greeting, Omarchy the only Hyprland session, and the
+# Omarchy theme driving stylix (modules/desktop/stylix-theme.nix).
 #
-# Additive. The Omarchy session joins the existing entries and none of them
-# change: greetd keeps greeting, stylix keeps the boot splash, and Hyprland
-# sessions keep running the Hyprland this configuration chose.
+# This host offers exactly two sessions, Omarchy and GNOME. The greetd/
+# DankMaterialShell greeter, niri and the DMS sessions this comment used to
+# describe are all gone.
 { inputs
 , lib
 , pkgs
@@ -41,9 +41,9 @@
   # programs.hyprland.portalPackage at mkDefault priority, so matching it would
   # tie rather than yield, hence the force.
   #
-  # The matching .package force moved to omarchy-sole-hyprland.nix, which sets
-  # it to a session-less repackage so this Hyprland stops showing up as its own
-  # login entry next to Omarchy's.
+  # There is no matching .package force any more: omarchy-sole-hyprland.nix
+  # turns programs.hyprland off outright and restates what Nixarchy needs from
+  # it, which is what stops a second Hyprland entry appearing at login.
   programs.hyprland.portalPackage = lib.mkForce pkgs.xdg-desktop-portal-hyprland;
 
   # Omarchy's SDDM greeter is the login manager. It replaced the

--- a/hosts/razer/nixos/nixarchy.nix
+++ b/hosts/razer/nixos/nixarchy.nix
@@ -1,9 +1,9 @@
 # Omarchy, vendored for NixOS.
 #
-# Added to razer rather than p620 so the desktop this machine runs every day is
-# not the one being experimented on. Everything here is additive: the Omarchy
-# session appears alongside GNOME, niri, niri-dms, Hyprland, hyprland-dms and
-# hyprland-uwsm, and none of those change.
+# Added to razer first, so the desktop p620 runs every day was not the one being
+# experimented on. Both hosts carry it now and offer exactly two sessions,
+# Omarchy and GNOME -- the niri, niri-dms, hyprland-dms and hyprland-uwsm
+# entries this comment used to list are all gone.
 #
 # The three settings below are what `nix run github:olafkfreund/nixarchy#doctor`
 # printed for this machine. Each is here for a reason it named:
@@ -41,9 +41,9 @@
   # programs.hyprland.portalPackage at mkDefault priority, so matching it would
   # tie rather than yield, hence the force.
   #
-  # The matching .package force moved to omarchy-sole-hyprland.nix, which sets
-  # it to a session-less repackage so this Hyprland stops showing up as its own
-  # login entry next to Omarchy's.
+  # There is no matching .package force any more: omarchy-sole-hyprland.nix
+  # turns programs.hyprland off outright and restates what Nixarchy needs from
+  # it, which is what stops a second Hyprland entry appearing at login.
   programs.hyprland.portalPackage = lib.mkForce pkgs.xdg-desktop-portal-hyprland;
 
   # Omarchy's SDDM greeter is the login manager. It replaced the

--- a/modules/desktop/theme-owner.nix
+++ b/modules/desktop/theme-owner.nix
@@ -1,13 +1,18 @@
 { config, lib, pkgs, ... }:
 # Session-scoped theme ownership.
 #
-# Three systems want to colour the same applications and disagree about who
-# owns the config FILE, not about the colours:
+# Two systems want to colour the same applications and disagree about who owns
+# the config FILE, not about the colours:
 #
 #   stylix   build time  — generates the whole app config into the store
-#   DMS      runtime     — matugen writes ~/.config/<app>/dank-theme.*
 #   omarchy  runtime     — omarchy-theme-set writes
 #                          ~/.local/state/omarchy/current/theme/<app>.*
+#
+# A third, DMS (matugen writing ~/.config/<app>/dank-theme.*), was the reason
+# this module has an owner concept at all. DMS went away with niri, so omarchy
+# is now the only runtime owner and `theme-owner` always resolves to it. The
+# dms arm below is kept rather than deleted because it is what makes the
+# indirection general: a second runtime owner is a table entry, not a rewrite.
 #
 # Both runtime systems assume the app config is a hand-editable file with an
 # include line. Stylix's model is the opposite, which is why omarchy has been
@@ -226,11 +231,6 @@ in
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ themeOwner ];
-
-    # DMS only installs matugen, and only generates its theme files, when this
-    # is set. Without it the DMS side of every symlink is permanently missing
-    # and the fallback is all you would ever see.
-    programs.dms-shell.enableDynamicTheming = true;
 
     # graphical-session.target is reached by both the niri/Hyprland DMS
     # launchers and by uwsm in the Omarchy session, so one unit covers every


### PR DESCRIPTION
DMS went away with niri, but references to it survived in three places.

**No behaviour change** — the toplevel derivation hash is byte-identical on all three hosts, before and after:

```
p620   lpmk1li8xnjnn…  IDENTICAL
razer  whjxpi2li03jl…  IDENTICAL
p510   ha9i7vfdgw2p…   IDENTICAL
```

## `theme-owner.nix`

Removed `programs.dms-shell.enableDynamicTheming = true` — it set an option on a module whose own `enable` is `false`. Proven a no-op by the identical drv above.

Its header still introduced DMS as one of three live owners. It now says omarchy is the only runtime owner, **and why the `dms` arm is kept anyway**: that arm is what makes the indirection general, so a future second runtime owner stays a table entry rather than a rewrite. Deleting it is a ~30-line change to the module that owns terminal colours and belongs in its own PR, not buried here.

## `hosts/{p620,razer}/nixos/nixarchy.nix`

The `portalPackage` comment described *"a session-less repackage"* — an approach tried in #1562 and **abandoned** when the option type rejected it (`providedSessions != [ ]`). `omarchy-sole-hyprland.nix` forces the module off instead. A comment describing a discarded design is worse than a merely stale one.

The headers were also wrong about what exists:

- p620's claimed greetd through the DankMaterialShell greeter with niri and Hyprland both enabled — and contradicted the SDDM comment forty lines below it
- razer's listed the Omarchy session as appearing alongside GNOME, niri, niri-dms, Hyprland, hyprland-dms and hyprland-uwsm

Both hosts offer exactly Omarchy and GNOME.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB