### PR TITLE
fix(nixarchy): put Hyprland back on PATH, login was broken

### DIFF
--- a/hosts/common/nixos/omarchy-sole-hyprland.nix
+++ b/hosts/common/nixos/omarchy-sole-hyprland.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ lib, pkgs, inputs, ... }:
 # Nixarchy is the only Hyprland session offered at login.
 #
 # programs.hyprland is enabled by the nixarchy module itself, not by us, so
@@ -20,6 +20,10 @@
 # Nixarchy's own session is untouched: it runs the Hyprland its flake pins, a
 # different store path from pkgs.hyprland, launched with --config against
 # Omarchy's own file.
+let
+  # The exact build nixarchy's session script invokes.
+  hyprland = inputs.nixarchy.inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system}.hyprland;
+in
 {
   programs.hyprland.enable = lib.mkForce false;
 
@@ -50,7 +54,33 @@
   services.graphical-desktop.enable = true;
   services.xserver.desktopManager.runXdgAutostartIfNone = lib.mkDefault true;
 
-  # cap_sys_nice for the compositor, and /share/hypr on the path for anything
-  # looking up hyprland data files.
+  # The compositor binaries. programs.hyprland puts these in the system profile
+  # via `environment.systemPackages = [ cfg.package ]`, and forcing the module
+  # off without restating that line is what broke login on razer (#1566):
+  # Omarchy's session script calls start-hyprland by absolute store path, but
+  # start-hyprland then execs `Hyprland` BY NAME, so with nothing on PATH it
+  # failed with
+  #
+  #   ERR from start-hyprland ]: failed to obtain hyprland version string (bad json)
+  #   ERR from start-hyprland ]: fork(): execvp failed: No such file or directory
+  #
+  # and the unit died with result 'protocol'. hyprctl went missing with it,
+  # which breaks every hyprctl-based omarchy command too. The SDDM greeter kept
+  # working throughout because it invokes Hyprland by absolute path.
+  #
+  # This must be the Hyprland NIXARCHY pins, not pkgs.hyprland: they are
+  # different versions (0.56.0 vs 0.56.2) and it is the nixarchy one the
+  # session script runs, so a mismatched start-hyprland and compositor is
+  # exactly what we would be reintroducing.
+  environment.systemPackages = [ hyprland ];
   environment.pathsToLink = [ "/share/hypr" ];
+
+  # cap_sys_nice, as programs.hyprland sets it. /run/wrappers/bin precedes the
+  # system profile on PATH, so this is the Hyprland start-hyprland finds.
+  security.wrappers.Hyprland = {
+    owner = "root";
+    group = "root";
+    capabilities = "cap_sys_nice+ep";
+    source = lib.getExe hyprland;
+  };
 }


### PR DESCRIPTION
**Regression from #1562. razer could not log in to the Omarchy session; p620 was equally broken and only looked fine because its running session predated the deploy.**

## Cause

`omarchy-sole-hyprland.nix` forces `programs.hyprland.enable = false` and restates that module's effects by hand. It restated the portal, uwsm, polkit and the `wayland-session.nix` defaults — and missed:

```nix
environment.systemPackages = [ cfg.package ];
```

Omarchy's session script calls `start-hyprland` by absolute store path, so it starts. But `start-hyprland` then execs **`Hyprland` by name**:

```
ERR from start-hyprland ]: failed to obtain hyprland version string (bad json)
ERR from start-hyprland ]: fork(): execvp failed: No such file or directory
wayland-wm@start\x2dhyprland.service: Failed with result 'protocol'
```

uwsm's `waitenv` then times out waiting for `WAYLAND_DISPLAY` / `HYPRLAND_INSTANCE_SIGNATURE` and the session is torn down. `hyprctl` went missing too, breaking every `hyprctl`-based omarchy command.

## Why it shipped looking healthy

Nothing external showed a fault — no failed units, greeter up, session list correct. The **SDDM greeter invokes Hyprland by absolute path** and never consults PATH, so it kept working perfectly. A successful `nix build` never exercises a session start, and I verified the greeter's session *list* rather than a login.

## Fix

`environment.systemPackages` and `security.wrappers.Hyprland` (cap_sys_nice) restored, from `inputs.nixarchy.inputs.hyprland` — **not** `pkgs.hyprland`. nixarchy pins 0.56.0, nixpkgs has 0.56.2, and it is nixarchy's build the session script runs; pairing a 0.56.0 `start-hyprland` with a 0.56.2 compositor would reintroduce a subtler version of the same class of bug.

The file's comment already claimed cap_sys_nice while the code never set it — that was the tell.

## Verification

On the **built** systems, not just evaluated:

```
Hyprland        → /nix/store/a2g9hgna…-hyprland-0.56.0+date=2026-08-24_0bd11c7/bin/Hyprland
hyprctl         → …/bin/hyprctl
start-hyprland  → …/bin/start-hyprland
wrapper         cap_sys_nice+ep, same source
```

Byte-identical to the store path the session script invokes. All three hosts build; all three get the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB