### PR TITLE
feat(nixarchy): boot to Omarchy's Plymouth splash, not stylix's

### DIFF
--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -52,6 +52,12 @@
   # selectable alongside the Omarchy session.
   programs.nixarchy.displayManager = true;
 
+  # Boot to Omarchy's splash, not stylix's. The option forces
+  # boot.plymouth.theme and themePackages together on purpose: forcing the
+  # name alone leaves NixOS asserting a theme that is not in the package list,
+  # which fails the build.
+  programs.nixarchy.bootSplash = "force";
+
   # ~/.config/hypr/hyprland.lua is home-manager's here, so the seed keeps it and
   # Omarchy's own config is never installed. The Omarchy session entry is what
   # makes that work: it runs Hyprland with --config against Omarchy's file and

--- a/hosts/razer/nixos/nixarchy.nix
+++ b/hosts/razer/nixos/nixarchy.nix
@@ -52,6 +52,12 @@
   # selectable alongside the Omarchy session.
   programs.nixarchy.displayManager = true;
 
+  # Boot to Omarchy's splash, not stylix's. The option forces
+  # boot.plymouth.theme and themePackages together on purpose: forcing the
+  # name alone leaves NixOS asserting a theme that is not in the package list,
+  # which fails the build.
+  programs.nixarchy.bootSplash = "force";
+
   # ~/.config/hypr/hyprland.lua is managed by home-manager here, so the seed
   # keeps it and Omarchy's own config is never installed. That is what the
   # Omarchy session entry is for: it runs Hyprland with --config against


### PR DESCRIPTION
`programs.nixarchy.bootSplash` was on its default, `"defer"`, which sets Omarchy's splash at `mkDefault` so anything naming a theme explicitly keeps it. Stylix does — which is why these machines booted to the stylix logo despite running Nixarchy.

`"force"` hands Plymouth to Omarchy:

```
p620   theme: omarchy  packages: [omarchy-4.0.1]
razer  theme: omarchy  packages: [omarchy-4.0.1]
p510   unchanged: stylix / [stylix-plymouth]
```

The option forces `boot.plymouth.theme` **and** `themePackages` together on purpose — forcing the name alone leaves NixOS asserting a theme absent from the package list, which fails the build. That is exactly what reaching for `lib.mkForce` on the theme by hand runs into, so the option exists to avoid it.

**p510 is deliberately excluded.** It is headless: the splash is never displayed, and changing it is initrd churn on the one machine whose boot nobody can watch.

## Note

Plymouth lives in the initrd, so unlike the rest of the desktop work this **needs a reboot** to appear — a switch is not enough.

Built on p620 and razer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB