### PR TITLE
feat(fastfetch): use Omarchy's own config, drop the Alien HUD

### DIFF
--- a/home/shell/fastfetch/default.nix
+++ b/home/shell/fastfetch/default.nix
@@ -1,189 +1,42 @@
-# fastfetch — Alien HUD readout.
+# fastfetch — Omarchy's own readout.
 #
-# Logo: the Aliens motion tracker (assets/logos/motion-tracker.gif), rendered
-# to ANSI at BUILD time rather than by fastfetch's runtime `chafa` logo type.
-# Runtime image logos need the terminal's pixel-per-cell size
-# (getCharacterPixelDimensions); that query fails whenever stdout is not a
-# real terminal and is unreliable through tmux and herdr — where this actually
-# runs — and fastfetch then falls back to the built-in NixOS logo with no
-# warning. Pre-rendering makes it deterministic everywhere, costs nothing at
-# shell start, and pins the art in the store so razer gets the identical frame.
+# The config is taken verbatim from the nixarchy package
+# ($OMARCHY_PATH/etc/fastfetch/config.jsonc) rather than rebuilt here, so the
+# branding tracks whatever upstream ships and needs no maintenance of ours. It
+# is strict JSON despite the .jsonc name, so fromJSON reads it directly.
 #
-# Panel: the key holds a fixed-width box cell and the value prints outside it,
-# which is the only way to get a boxed look out of fastfetch — it has no
-# right-margin alignment. Keep `panelWidth` and the rule lines in step; the
-# `row`/`rule` helpers below do the padding so nothing is hand-counted.
-{ config, lib, pkgs, ... }:
+# The package is reached through `inputs.nixarchy`, never a literal store path:
+# that path changes on every omarchy or nixpkgs bump.
+#
+# Its logo comes from ~/.config/omarchy/branding/about.txt, which Omarchy owns
+# and retints with the theme -- nothing to declare here.
+#
+# This replaced a hand-built "Alien HUD" readout (git history, or
+# /tmp/fastfetch-hud.nix.bak on p620 at the time of the swap). Three things went
+# with it and are worth knowing if it is ever missed: a stylix-derived colour
+# scheme, a boxed panel layout, and a pre-rendered ANSI logo that existed
+# because fastfetch's runtime chafa logo needs the terminal's pixel-per-cell
+# size and that query fails under tmux and herdr, silently falling back to the
+# stock NixOS logo. Omarchy's config uses a plain text logo, so that trap does
+# not apply to it.
+{ pkgs, inputs, ... }:
 let
-  inherit (lib) concatStrings genList stringLength;
-  inherit (config.lib.stylix) colors;
+  omarchy = inputs.nixarchy.packages.${pkgs.stdenv.hostPlatform.system}.omarchy;
+  omarchyFastfetch = "${omarchy}/share/omarchy/etc/fastfetch/config.jsonc";
 
-  # fastfetch emits whatever is inside {# } as an SGR sequence, so a truecolor
-  # escape built from the Stylix palette keeps this file free of literal hex.
-  sgr = name: "{#38;2;${colors."${name}-rgb-r"};${colors."${name}-rgb-g"};${colors."${name}-rgb-b"}}";
-  green = sgr "base0B"; # phosphor — section titles, live values
-  cream = sgr "base05"; # plate cream — labels
-  dim = sgr "base03"; # hairline rules
-  amber = sgr "base09"; # bar-graph amber — hardware
-  cyan = sgr "base0C"; # readouts
-  reset = "{#0}";
-
-  panelWidth = 11; # inner label field, in cells
-  pad = s: concatStrings (genList (_: " ") (panelWidth - stringLength s));
-
-  # "  │ LABEL       │ " — the value lands after the closing bar.
-  row = colour: label: "  ${dim}│ ${colour}${label}${pad label}${dim}│${reset} ";
-
-  # "  ├─ TITLE ─────┤" — a section rule with an inline title, the plates'
-  # panel-label tab. A bare string in `modules` is read as a module *name*, so
-  # every drawn line has to be a custom module.
-  #
-  # Inner width is `panelWidth + 1` — the leading space in `row` plus the
-  # label field. Lengths are measured on the ASCII title only: Nix's
-  # stringLength counts bytes, and every box character here is 3 of them.
-  innerWidth = panelWidth + 1;
-  dashes = n: concatStrings (genList (_: "─") n);
-  rule = left: right: title: {
-    type = "custom";
-    format = "  ${dim}${left}─ ${green}${title}${dim} ${dashes (innerWidth - 3 - stringLength title)}${right}${reset}";
-  };
-
-  plainRule = left: right: {
-    type = "custom";
-    format = "  ${dim}${left}${dashes innerWidth}${right}${reset}";
-  };
-
+  # Standalone `tracker` command -- the animated motion tracker on its own,
+  # unrelated to the fastfetch config, so the branding swap does not remove it.
   trackerGif = ../../../assets/logos/motion-tracker.gif;
-
-  # Frame 16 of the tracker loop — sweep at full extent with the contact blip
-  # visible. ImageMagick extracts the frame (chafa has no frame selector),
-  # chafa turns it into truecolor symbols. `--polite on` keeps the
-  # cursor-hide/show escapes out of the file so it can be dumped verbatim.
-  #
-  # `--symbols sextant` is what makes it legible. Symbol density sets the
-  # sampling grid, not the cell size: at 40x20 cells half-blocks (1x2 per
-  # cell) sample the image at only 40x40 px, which reduces the scope to a
-  # green triangle with every arc and radial gone. Sextants (2x3) sample the
-  # same 40x20 footprint at 80x60. Octants (2x4) would give 80x80, but they
-  # are Unicode 16 and not reliably drawn yet; sextants are Unicode 13 and
-  # foot/ghostty render them from their built-in glyph tables regardless of
-  # the terminal font.
-  trackerLogo = pkgs.runCommand "alien-tracker-logo.ans"
-    {
-      nativeBuildInputs = [ pkgs.imagemagick pkgs.chafa ];
-    } ''
-    magick "${trackerGif}[16]" frame.png
-    chafa --format symbols --symbols sextant --size 40x20 \
-          --colors full --animate off --polite on frame.png > $out
-  '';
-
-  # The moving tracker, on demand, in any terminal: chafa plays the GIF
-  # itself. `tracker` loops until interrupted, `tracker 5` runs 5s.
   trackerAnim = pkgs.writeShellScriptBin "tracker" ''
     exec ${pkgs.chafa}/bin/chafa --symbols sextant --colors full \
          --size 40x20 --duration "''${1:-inf}" ${trackerGif}
   '';
-
-  # Animated logo, but only where it actually works.
-  #
-  # fastfetch itself never animates: it renders one frame and exits. In kitty
-  # it does not have to — `kitten icat` uploads the GIF as kitty graphics
-  # frames (verified: 1 a=T + 43 a=f + a=a for this 44-frame file) and the
-  # TERMINAL loops them on its own after icat exits, so fastfetch buffering
-  # icat's output and dumping it still ends up animating. `--loop` defaults to
-  # -1, forever, and fastfetch does not override it.
-  #
-  # Everywhere else the static sextant render stays: foot and ghostty have no
-  # kitty graphics, and fastfetch refuses image logos inside a multiplexer
-  # outright ("Image logo is not supported in terminal multiplexers",
-  # src/logo/image/image.c) — in all those cases asking for kitty-icat would
-  # silently fall back to the built-in NixOS logo, which is worse than static.
-  # Hence the runtime probe rather than a fixed logo.type.
-  #
-  # Caveat: fastfetch's icat path emits \e[2J\e[3J first, so a fastfetch run
-  # in kitty clears the screen AND the scrollback. Harmless at shell start,
-  # noticeable mid-session.
-  fastfetchHud = pkgs.symlinkJoin {
-    name = "fastfetch-hud";
-    paths = [ pkgs.fastfetch ];
-    postBuild = ''
-      rm "$out/bin/fastfetch"
-      cat > "$out/bin/fastfetch" <<'WRAPPER'
-      #!${pkgs.runtimeShell}
-      if [ -z "$TMUX" ] && [ -z "$HERDR_ENV" ] && [ -n "$KITTY_WINDOW_ID" ] \
-         && command -v kitten >/dev/null 2>&1; then
-        exec ${pkgs.fastfetch}/bin/fastfetch \
-             --logo-type kitty-icat --logo ${trackerGif} "$@"
-      fi
-      exec ${pkgs.fastfetch}/bin/fastfetch "$@"
-      WRAPPER
-      sed -i 's/^      //' "$out/bin/fastfetch"
-      chmod +x "$out/bin/fastfetch"
-    '';
-  };
 in
 {
   home.packages = [ trackerAnim ];
 
   programs.fastfetch = {
     enable = true;
-    package = fastfetchHud;
-    settings = {
-      logo = {
-        type = "file-raw";
-        source = "${trackerLogo}";
-        width = 40;
-        height = 20;
-        padding = { top = 1; right = 3; };
-      };
-      display = {
-        separator = " ";
-      };
-      modules = [
-        {
-          type = "custom";
-          format = "  ${green}W E Y L A N D - Y U T A N I${reset}  ${dim}·${reset}  ${cream}CLASS M${reset}";
-        }
-        {
-          type = "title";
-          # A single space, not "": fastfetch reads an empty key as "unset"
-          # and falls back to printing the module name ("Title:").
-          key = " ";
-          format = "${dim}UNIT${reset} ${green}{host-name}${reset}  ${dim}·${reset}  ${cream}{user-name}${reset}";
-        }
-        { type = "break"; }
-
-        (rule "┌" "┐" "SYSTEM")
-        { type = "os"; key = row cream "OS"; outputColor = "green"; }
-        { type = "kernel"; key = row cream "KERNEL"; outputColor = "green"; }
-        { type = "packages"; key = row cream "PACKAGES"; outputColor = "green"; }
-        { type = "uptime"; key = row cream "UPTIME"; outputColor = "green"; }
-
-        (rule "├" "┤" "HARDWARE")
-        { type = "host"; key = row cream "CHASSIS"; outputColor = "yellow"; }
-        { type = "cpu"; key = row cream "CPU"; outputColor = "yellow"; }
-        { type = "gpu"; key = row cream "GPU"; outputColor = "yellow"; }
-        { type = "memory"; key = row cream "MEMORY"; outputColor = "yellow"; }
-        # Root only — the default lists every mount, which stacks three
-        # identical DISK cells and breaks the panel's rhythm.
-        { type = "disk"; key = row cream "DISK"; folders = "/"; outputColor = "yellow"; }
-
-        (rule "├" "┤" "SESSION")
-        { type = "wm"; key = row cream "WM"; outputColor = "cyan"; }
-        { type = "shell"; key = row cream "SHELL"; outputColor = "cyan"; }
-        { type = "terminal"; key = row cream "TERMINAL"; outputColor = "cyan"; }
-        { type = "terminalfont"; key = row cream "FONT"; outputColor = "cyan"; }
-
-        (rule "├" "┤" "LINK")
-        { type = "localip"; key = row cream "IP"; format = "{ipv4} ({ifname})"; outputColor = "magenta"; }
-        (plainRule "└" "┘")
-
-        { type = "break"; }
-        {
-          type = "custom";
-          format = "  ${dim}MU-TH-UR 6000${reset}  ${dim}·${reset}  ${amber}ENG-SYS${reset}  ${dim}·${reset}  ${cyan}ALL SUBSYSTEMS ${green}ONLINE${reset}";
-        }
-      ];
-    };
+    settings = builtins.fromJSON (builtins.readFile omarchyFastfetch);
   };
 }


### PR DESCRIPTION
fastfetch now reads Omarchy's own config verbatim from the nixarchy package instead of rebuilding one here, so the branding tracks upstream with no maintenance of ours.

```nix
omarchy = inputs.nixarchy.packages.${pkgs.stdenv.hostPlatform.system}.omarchy;
settings = builtins.fromJSON (builtins.readFile
  "${omarchy}/share/omarchy/etc/fastfetch/config.jsonc");
```

Despite the `.jsonc` name it is strict JSON, so `fromJSON` reads it directly. Verified the result is key-for-key identical to the source:

```
logo, display, modules  →  all identical
modules count           →  32 vs 32
```

The package is reached through `inputs.nixarchy`, never a literal store path — that path changes on every omarchy or nixpkgs bump. Its logo is `~/.config/omarchy/branding/about.txt`, which Omarchy owns and retints with the theme, so nothing about it is declared here.

## What was removed

189 lines → 43. The old module was a hand-built "Alien HUD" readout. Three things went with it, recorded in the new file's header rather than left to git history:

- a stylix-derived colour scheme (it already followed the theme)
- the boxed panel layout
- **a logo pre-rendered to ANSI at build time** — this one is worth keeping in mind. It existed because fastfetch's runtime `chafa` logo needs the terminal's pixel-per-cell size, and that query fails under tmux and herdr, falling back to the stock NixOS logo with no warning. Omarchy's config uses a plain text logo so the trap does not apply, but it is the reason not to reach for the runtime type if an image logo is ever wanted again.

The standalone `tracker` command is **kept** — it is the motion tracker as its own binary, unrelated to the fastfetch config, so a branding swap should not silently remove it.

Built on p620, razer and p510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB