### PR TITLE
feat(desktop): add proton-vpn-cli for the OmaProton VPN widget

### DIFF
--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -203,6 +203,11 @@ in
     # importable for building Gemini-powered AI agents. See
     # pkgs/google-antigravity-py/ for the platform-wheel install.
     pkgs.customPkgs.google-antigravity-py
+    # Official Proton VPN CLI (binary: `protonvpn`). Drives NetworkManager
+    # directly; no daemon or NM plugin of its own. Here for the OmaProton
+    # VPN bar widget, whose in-panel installer is a pacman call the Nixarchy
+    # shim refuses -- the CLI has to come from the flake instead.
+    pkgs.proton-vpn-cli
   ];
 
   # Firefox (identical across interactive hosts)


### PR DESCRIPTION
## What

Adds `pkgs.proton-vpn-cli` to `Users/olafkfreund/profile.nix` (the interactive-host list: p620 + razer).

## Why

The [OmaProton VPN](https://github.com/grichard99/omaproton-vpn) Omarchy plugin is a Quickshell bar widget that drives the official `protonvpn` CLI. Its in-panel "Install Proton VPN CLI" button runs:

```
omarchy-install-app "Proton VPN CLI" proton-vpn-cli   ->   omarchy-pkg-add
```

which on Nixarchy is the shim that refuses and prints the declarative route. So the CLI comes from the flake.

nixpkgs `proton-vpn-cli` 1.0.2 is fully wrapped — NetworkManager, `keyring`, `secretstorage` and `proton-keyring-linux` are all in its closure — so no daemon, system service or NM plugin is needed. p510 is headless and skipped.

## Test

- `nix eval .#nixosConfigurations.{p620,razer}.config.system.build.toplevel.drvPath` — both evaluate
- Binary is `bin/protonvpn`; NetworkManager is active on both hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB