### PR TITLE
chore(claude-code): update to 2.1.252 (#1577)

### DIFF
--- a/pkgs/claude-code-native/default.nix
+++ b/pkgs/claude-code-native/default.nix
@@ -31,7 +31,7 @@
 let
   # Version from Anthropic's latest channel (matches npm)
   # Run `curl -fsSL "$GCS_BUCKET/latest"` to check latest
-  version = "2.1.251";
+  version = "2.1.252";
 
   # Claude Code reads clipboard images by shelling out to:
   #   xclip -selection clipboard -t TARGETS -o ... || wl-paste -l ...   (detect)
@@ -63,11 +63,11 @@ let
   sources = {
     x86_64-linux = {
       url = "${gcs_bucket}/${version}/linux-x64/claude";
-      hash = "sha256-/V8Q/w61ja7ASQBGaxQ+qYqrUKvyCKQivACOrsE/Yfc=";
+      hash = "sha256-pxWkUQXlk/yYCNA113eB+ISAuYl5danfQYN/DFkb1LM=";
     };
     aarch64-linux = {
       url = "${gcs_bucket}/${version}/linux-arm64/claude";
-      hash = "sha256-ZURb1N0EIHnMP6Q3kbVhNwoFyFmejsR1gOJagQUKu90=";
+      hash = "sha256-bAsy6qk2lUoPTUrSWV+EFq8ojZs8uvGePN2aldfIhT4=";
     };
   };
 


### PR DESCRIPTION
## What

Bumps `pkgs/claude-code-native/default.nix` from **2.1.251 → 2.1.252**. Three lines: `version` and both arch hashes.

Hashes from `./scripts/update-claude-code-native.sh 2.1.252` (`latest` channel; `stable` is still 2.1.236).

## Verification

| Check | Result |
| --- | --- |
| `$OUT/bin/claude --version` | `2.1.252 (Claude Code)` ✅ |
| `ldd` on the binary | no missing libs ✅ |
| p620 toplevel | builds ✅ |
| razer toplevel | builds ✅ |

p510 skipped locally — `claude-code-native` isn't in its closure (headless); CI's `check-configurations (p510)` covers evaluation.

Not deployed. Closes #1577

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB