### PR TITLE
feat(p510): run Nixarchy for real, with Sunshine for remote (#1584)

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -59,7 +59,11 @@ in
       # ../../home/desktop/gnome/default.nix # Home Manager module - can't import here
     ];
 
-  host.class = "headless-rdp";
+  # Was "headless-rdp" until this host got a monitor and the Omarchy session
+  # (hosts/p510/nixos/nixarchy.nix). The value is not decoration: it gates
+  # stylix's GNOME target in modules/desktop/stylix-theme.nix, which was off
+  # here purely because nothing was ever going to look at GNOME on this box.
+  host.class = "workstation";
 
   # Basic networking configuration (detailed config in ./nixos/network.nix)
   networking = {
@@ -298,10 +302,9 @@ in
     ai = {
       enable = true;
       antigravity-cli = true;
-      # claude-desktop is a GUI app — p510 has GNOME via the workstation
-      # template (RDP'd, since host.class = "headless-rdp"), so it CAN
-      # run here and is useful for driving the k3d cluster from p510 via
-      # RDP when off-LAN.
+      # claude-desktop is a GUI app, and this host has a monitor and an
+      # Omarchy session now, so it runs on the desktop directly as well as
+      # over Sunshine or an RDP'd GNOME session.
       claude-desktop = true;
     };
 
@@ -342,6 +345,16 @@ in
     gnome-remote-desktop = {
       enable = true;
     };
+
+    # Sunshine: the remote path to the Omarchy session. gnome-remote-desktop
+    # above cannot serve it -- it is a GNOME Shell component and renders GNOME
+    # -- so with Hyprland as this host's session, RDP reaches a desktop nobody
+    # is using. Sunshine captures the compositor's own output and encodes it on
+    # the RTX 3070 Ti. Connect with any Moonlight client.
+    #
+    # Both stay on: RDP for GNOME, Sunshine for Omarchy, and which one answers
+    # depends on the session picked at the greeter.
+    sunshine.enable = true;
   };
 
   # Enable encrypted API keys
@@ -384,28 +397,37 @@ in
     ];
   };
 
-  # Display manager: GDM for headless GNOME RDP access
+  # Login manager: Omarchy's SDDM greeter, switched on by
+  # programs.nixarchy.displayManager in ./nixos/nixarchy.nix. backend = "none"
+  # keeps GDM off; SDDM enumerates wayland-sessions, so the Omarchy Hyprland
+  # session and GNOME both stay selectable. Same arrangement as p620 and razer.
+  #
+  # autoLogin, unlike on those two, stays on. Sunshine is a systemd user
+  # service and only exists inside a live graphical session, so on a host that
+  # reboots unattended the alternative is a greeter nobody is there to answer
+  # and no remote desktop until someone walks over to it. See the divergence
+  # note in ./nixos/nixarchy.nix.
   desktop.displayManager = {
-    backend = "gdm";
+    backend = "none";
     autoLogin = {
       enable = true;
       user = "olafkfreund";
     };
   };
 
-  # GDM greeter visual baseline (only shown when autoLogin can't proceed,
-  # e.g. after a session crash). Keeps clock 24h and forces dark colour
-  # scheme so the greeter doesn't flash light during boot transitions.
-  programs.dconf.profiles.gdm.databases = [{
-    settings = {
-      "org/gnome/desktop/interface" = {
-        clock-format = "24h";
-        color-scheme = "prefer-dark";
-      };
-    };
-  }];
+  # Preselect the Omarchy session. Without this SDDM has no default and falls
+  # through to whatever /var/lib/sddm/state.conf remembers -- which on this
+  # host is gnome.desktop, the session it has been logging into all along.
+  #
+  # A fallback only: SDDM rewrites state.conf on every login and the remembered
+  # session wins, so the first Omarchy login is what makes it stick. GNOME stays
+  # in the session menu either way.
+  services.displayManager.defaultSession = "omarchy";
 
-  # Desktop manager configuration - Full GNOME for headless RDP access
+  # GNOME stays installed and selectable at the SDDM greeter; it is no longer
+  # the session this host boots into. It is also what features.gnome-remote-
+  # desktop can still serve over RDP, now that GDM is gone and that daemon is
+  # tied to a live GNOME session rather than a remote-login one.
   services.desktopManager.gnome.enable = true;
 
   # GNOME services for full desktop functionality.

--- a/hosts/p510/nixos/nixarchy.nix
+++ b/hosts/p510/nixos/nixarchy.nix
@@ -1,49 +1,99 @@
-{ inputs, ... }:
-# Omarchy on the headless media server, as a selectable session only.
+{ inputs
+, lib
+, pkgs
+, ...
+}:
+# Omarchy, vendored for NixOS. Same shape as p620 and razer.
 #
-# This host is class headless-rdp: it already runs X, GNOME and GDM, and
-# gnome-remote-desktop serves that GNOME session over RDP. Nixarchy joins as an
-# extra entry; nothing that keeps the box reachable changes. Three settings do
-# the work, and each one is here because leaving it out breaks something
-# measurable:
+# This file used to say the opposite of everything below it. p510 was class
+# headless-rdp: GDM autologged into GNOME, gnome-remote-desktop served that
+# session over RDP, and Omarchy was added as a selectable entry that nothing
+# could ever select -- SDDM off so the RDP path kept its display manager,
+# defaultSession pinned to gnome so autologin did not wander off into
+# Hyprland. It worked exactly as designed, which is to say the session was
+# installed and never once started: seven days of journal held no
+# start-hyprland, no wayland-wm@, no omarchy-launch-shell, and ~/.config/hypr
+# did not exist.
 #
-#   displayManager = false
-#     The nixarchy module turns SDDM on by default. Verified by evaluating this
-#     host with it left alone: services.displayManager.sddm.enable flipped
-#     false -> true, which would swap the display manager out from under the
-#     RDP path on a machine with no monitor attached.
-#
-#   defaultSession = "gnome"
-#     autoLogin is on here (user olafkfreund) and defaultSession was unset, so
-#     NixOS picked the session for us. Adding Omarchy changed
-#     sessionData.autologinSession from "gnome" to "omarchy" -- the server
-#     would have booted into Hyprland instead of the session RDP serves.
-#     Pinning it keeps autologin on GNOME regardless of what else is offered.
-#
-#   omarchy-sole-hyprland.nix
-#     Same reason as p620: the nixarchy module enables programs.hyprland, which
-#     registers a second, config-less Hyprland session next to Omarchy's.
-#
-# Deliberately NOT imported from p620's setup: omarchy-sddm.nix (GDM stays),
-# nixarchy-apps.nix (that is the desktop app selection and has no business in
-# this closure), and the stylix theme hook (nobody switches themes here).
+# The machine has a monitor now and is going to be used, so the three settings
+# that held Omarchy at arm's length are inverted and this host joins the
+# template the other two share. What that costs is written down under
+# "Divergences" at the bottom, because two of the reasons for the old
+# arrangement are still true.
 {
   imports = [
     inputs.nixarchy.nixosModules.nixarchy
+    ../../../nixarchy-apps.nix
+    ../../common/nixos/omarchy-input.nix
+    ../../common/nixos/omarchy-sddm.nix
+    ../../common/nixos/omarchy-workspaces.nix
+    ../../common/nixos/omarchy-gog.nix
     ../../common/nixos/omarchy-sole-hyprland.nix
+    ../../common/nixos/omarchy-stylix-theme.nix
   ];
 
   programs.nixarchy.enable = true;
-  programs.nixarchy.user = "olafkfreund";
-  programs.nixarchy.displayManager = false;
 
-  # Omarchy's preinstalled application set, off. It is the bulk of what
-  # nixarchy costs here: with it on the closure went 50.52 -> 57.56 GiB, and
-  # the additions are desktop software this host has no use for -- cef-binary
-  # (1.9 GiB, the runtime behind the web-app wrappers), Pinta, cliamp,
-  # KDDockWidgets, CUPS. The session itself still works; only the app bundle
-  # is skipped. Media-server packages come from this host's own modules.
+  # Puts this user in the input group. Omarchy's shell reads the keyboard
+  # device directly for its own key handling, which the group grants; without
+  # it the session starts but never sees a keypress.
+  programs.nixarchy.user = "olafkfreund";
+
+  # nixarchy pins its own Hyprland and does not defer -- nixpkgs defines
+  # programs.hyprland.portalPackage at mkDefault priority, so matching it would
+  # tie rather than yield, hence the force.
+  programs.hyprland.portalPackage = lib.mkForce pkgs.xdg-desktop-portal-hyprland;
+
+  # Omarchy's SDDM greeter is the login manager, replacing GDM. This is the
+  # setting the old comment argued hardest against, and the argument was sound
+  # while RDP was the only way in: flipping it swaps the display manager on a
+  # machine with no monitor attached. There is a monitor now, and Sunshine
+  # (features.sunshine, modules/desktop/sunshine.nix) is what serves the
+  # session remotely, so GDM is no longer load-bearing.
+  #
+  # SDDM enumerates wayland-sessions, so GNOME stays selectable next to
+  # Omarchy -- nothing is removed from the login menu, the default just moves.
+  programs.nixarchy.displayManager = true;
+
+  # Boot to Omarchy's splash. The option forces boot.plymouth.theme and
+  # themePackages together on purpose: forcing the name alone leaves NixOS
+  # asserting a theme that is not in the package list, which fails the build.
+  #
+  # "force" rather than "defer" for the same reason as the other two hosts --
+  # this fleet's stylix names a theme of its own, and defer would yield to it.
+  programs.nixarchy.bootSplash = "force";
+
+  # ── Divergences from p620 and razer ──────────────────────────────────────
+  #
+  # preinstalls stays off. Omarchy's application bundle measured 50.52 -> 57.56
+  # GiB of closure when it was tried here, and cef-binary alone is 1.9 GiB. The
+  # root filesystem holding /nix is 226 GB at 80% -- 47 GB free -- so this is
+  # the one part of the template that is not a one-line copy, and turning it on
+  # is a disk decision rather than a desktop one. Nothing about the session
+  # needs it: alacritty, ghostty, kitty and foot are all already on this host
+  # from our own modules, so Omarchy's terminal bindings work as shipped.
+  #
+  #   programs.nixarchy.preinstalls = true;   # <- when there is room
+  #
+  # Autologin stays ON, where p620 sets nothing and razer deliberately turns it
+  # off. Sunshine is a systemd *user* service, so it exists only inside a live
+  # graphical session; this machine reboots unattended and serves media, and an
+  # unattended reboot that lands on a greeter is an unattended reboot with no
+  # remote desktop until someone walks to it. razer's reason for the opposite
+  # choice does not apply here -- that is Optimus PRIME-sync hardware where
+  # greeter respawn is broken, and this host is pure NVIDIA.
+  #
+  # RDP is not removed, but it changes character. features.gnome-remote-desktop
+  # stays enabled and its system daemon serves a GNOME session; with GDM gone
+  # that daemon loses the remote-login path it had here and behaves the way it
+  # does on razer -- user-mode, tied to a live GNOME session. So RDP into a
+  # fresh GNOME desktop is what this change gives up, and Sunshine into the
+  # Omarchy session is what replaces it. Log into GNOME at SDDM and RDP works
+  # as before.
   programs.nixarchy.preinstalls = false;
 
-  services.displayManager.defaultSession = "gnome";
+  home-manager.users.olafkfreund = {
+    imports = [ inputs.nixarchy.homeManagerModules.nixarchy ];
+    programs.nixarchy.enable = true;
+  };
 }

--- a/hosts/p510/themes/stylix.nix
+++ b/hosts/p510/themes/stylix.nix
@@ -1,6 +1,9 @@
 _: {
   # System-level Stylix configuration is fully shared via
-  # modules/desktop/stylix-theme.nix. The GNOME target is now gated by
-  # host.class in that module (headless-rdp → false), so no override needed.
+  # modules/desktop/stylix-theme.nix. Its GNOME target is gated on host.class
+  # there, and this host is class workstation since it gained a monitor and the
+  # Omarchy session, so the target is on and no override is needed. The palette
+  # itself follows the Omarchy theme -- ../nixos/nixarchy.nix imports
+  # omarchy-stylix-theme.nix, the same hook p620 and razer use.
   imports = [ ../../../modules/desktop/stylix-theme.nix ];
 }

--- a/modules/desktop/default.nix
+++ b/modules/desktop/default.nix
@@ -5,6 +5,7 @@
     ./cosmic-remote-desktop.nix
     ./theme-owner.nix
     ./ddcutil.nix
+    ./sunshine.nix
   ];
 
   # Make sure the adwaita-qt packages are installed

--- a/modules/desktop/sunshine.nix
+++ b/modules/desktop/sunshine.nix
@@ -1,0 +1,77 @@
+{ config
+, lib
+, ...
+}:
+# Sunshine: stream this machine's Wayland session to a Moonlight client.
+#
+# This exists because p510 gained a monitor and an Omarchy session, and the
+# remote path it used to have does not reach that session. gnome-remote-desktop
+# serves GNOME -- it is a GNOME Shell component using GNOME's own screencast
+# pipeline -- so with Hyprland as the session there is nothing on the other end
+# of RDP. Sunshine captures the compositor's output directly instead, which is
+# compositor-agnostic, and encodes on the GPU.
+#
+# Two things about this service are unusual enough to state:
+#
+#   It is a systemd USER service, not a system one. Upstream's module puts it in
+#   the user session because it has to talk to the running compositor. So it
+#   comes up when a graphical session does and not a moment sooner: on a host
+#   that reboots unattended, remote access therefore depends on that session
+#   existing without a human at the keyboard. That is why p510 keeps autologin
+#   on while p620 and razer do not.
+#
+#   The hardening rules in CLAUDE.md do not apply and cannot. DynamicUser,
+#   ProtectHome and ProtectSystem = "strict" all assume a service that needs
+#   nothing of the user's session; this one needs the user's Wayland socket,
+#   their GPU device nodes and their input devices. Sandboxing it to the point
+#   the rules ask for is the same as switching it off, so the deliberate
+#   exception is recorded here rather than silently taken.
+let
+  inherit (lib) mkIf mkEnableOption mkOption types;
+  cfg = config.features.sunshine;
+in
+{
+  options.features.sunshine = {
+    enable = mkEnableOption "Sunshine desktop streaming host (for Moonlight clients)";
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Open the ports Sunshine needs. It is not one port: 47984/47989/48010
+        TCP and 47998-48000/48002/48010 UDP, which is why this defers to
+        upstream's own option rather than listing them here and drifting.
+
+        Sunshine's web UI (47990) is HTTPS with a self-signed certificate and
+        its own login, set on first visit. Leave this on only on a network
+        where that is an acceptable front door.
+      '';
+    };
+
+    capSysAdmin = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Grant the Sunshine binary CAP_SYS_ADMIN, which is what KMS capture
+        needs on Wayland. Without it Sunshine falls back to a portal-based
+        path that Hyprland can serve but which re-prompts, or fails outright
+        with "Couldn't find any working capture method".
+
+        This is a real privilege on a real binary, and it is the reason this
+        option is spelled out instead of hardcoded: a host that would rather
+        take the portal route can turn it off in one line.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.sunshine = {
+      enable = true;
+      inherit (cfg) openFirewall capSysAdmin;
+
+      # Start with the session rather than waiting for someone to run it.
+      # Pointless without autologin on a headless-reboot host; harmless with.
+      autoStart = true;
+    };
+  };
+}


### PR DESCRIPTION
## What

p510 has a monitor now, so the three settings that kept Omarchy installed-but-unreachable are inverted and this host joins the template p620 and razer share.

| | before | after |
|---|---|---|
| `programs.nixarchy.displayManager` | `false` (GDM kept for RDP) | `true` — Omarchy's SDDM greeter |
| `services.displayManager.defaultSession` | `gnome` | `omarchy` |
| `desktop.displayManager.backend` | `gdm` | `none` |
| `programs.nixarchy.bootSplash` | unset (`defer`) | `force` — **Omarchy's Plymouth** |
| `host.class` | `headless-rdp` | `workstation` |
| remote path | gnome-remote-desktop (GNOME only) | **Sunshine** (Omarchy) + GNOME RDP retained |

Plus the shared Omarchy modules the other two hosts import — `omarchy-input`, `omarchy-sddm`, `omarchy-workspaces`, `omarchy-gog`, `omarchy-stylix-theme` — and `nixarchy-apps.nix`, without which the Omarchy menu appears to enable applications and builds none.

`host.class` is not cosmetic: it gates Stylix's GNOME target in `modules/desktop/stylix-theme.nix`, which was off here only because nobody was ever going to look at GNOME on this box.

## It really was unreachable, not just unused

- 7 days of journal: **no** `start-hyprland`, **no** `wayland-wm@`, **no** `omarchy-launch-shell`
- `~/.config/hypr` and `~/.config/omarchy` did not exist — the seed had never run
- The session was offered by a greeter that autologged into GNOME before anyone could pick it, and the only remote path was `gnome-remote-desktop` — a GNOME Shell component, which cannot render Hyprland

## Sunshine

New `modules/desktop/sunshine.nix`, `features.sunshine.enable`. Captures the compositor's own output and encodes on the RTX 3070 Ti; any Moonlight client connects.

Two things the module writes down rather than leaving implicit:

- It is a systemd **user** service, so it lives inside the graphical session. That's why this host **keeps autologin** while p620 and razer don't — an unattended reboot landing on a greeter is an unattended reboot with no remote desktop.
- CLAUDE.md's `DynamicUser` / `ProtectHome` / `ProtectSystem = "strict"` rules **cannot** apply to a service that needs the user's Wayland socket, GPU device nodes and input devices. Sandboxing it that far is the same as switching it off, so the exception is recorded, not silently taken.

`capSysAdmin` is exposed as an option (default on) because it is a real privilege on a real binary — it's what KMS capture needs on Wayland — and a host that would rather take the portal route can turn it off in one line.

## Verified by evaluation

| Check | Result |
| --- | --- |
| `sessionPackages` | `["omarchy-wayland-session", "gnome-session-50.1"]` — still exactly two, sole-Hyprland holds |
| `defaultSession` | `"omarchy"` |
| `sddm.enable` / `gdm.enable` | `true` / `false` |
| `autoLogin` | `{ enable = true; user = "olafkfreund"; }` |
| `boot.plymouth` | `theme = "omarchy"`, `themePackages = ["omarchy-4.0.1"]` |
| Sunshine | user unit present, `capSysAdmin`, ports 47984/47989/47990/48010 open |
| Stylix GNOME target | now `true` (follows `host.class`) |
| p620 toplevel `.drv` | **byte-identical** before and after — adding `sunshine.nix` to `modules/desktop/default.nix` is a no-op for other hosts |

**Not built and not deployed on p510**, per the standing rule for that host.

## Two things to know before deploying

**1. Trade-off, stated in the code.** With GDM gone, `gnome-remote-desktop` loses its remote-login path and behaves as it does on razer — user-mode, tied to a live GNOME session. RDP into a *fresh* GNOME desktop is what this gives up; Sunshine into Omarchy replaces it. Log into GNOME at the SDDM greeter and RDP works as before.

**2. `preinstalls` stays off** — the one part of the template not copied. It measured 50.52 → 57.56 GiB of closure on this host, cef-binary alone is 1.9 GiB, and `/` (which holds `/nix`) is 226 GB at **80%, 47 GB free**. The session doesn't need it: alacritty, ghostty, kitty and foot are already here from our own modules, so Omarchy's terminal bindings work as shipped. One commented line in `nixarchy.nix` turns it on when there's room — say the word if you'd rather have the app bundle now.

Also worth a first-boot check: Sunshine's web UI on **47990** is HTTPS with a self-signed cert and a password set on first visit, and `openFirewall` exposes it on the LAN.

Closes #1584

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB