### PR TITLE
fix(nhs): fall back to boot when only nvidia units fail

### DIFF
--- a/scripts/test-nvidia-fallback-guard.sh
+++ b/scripts/test-nvidia-fallback-guard.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Does only_nvidia_units_failed() classify real activation output correctly?
+#
+# The matcher decides whether a failed `nh os switch` is downgraded to "stage
+# for next boot and ask for a reboot" or left as a hard failure that rolls the
+# host back. Getting it wrong in the permissive direction means a genuinely
+# broken deploy is reported as success, so the interesting cases here are the
+# ones it must REFUSE.
+#
+# The function is extracted from the deploy script rather than copied: a copy of
+# a matcher in a test is a test of the copy.
+set -euo pipefail
+
+src="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/update-commit-deploy.sh"
+eval "$(sed -n '/^only_nvidia_units_failed() {/,/^}/p' "$src")"
+
+fails=0
+check() { # check <expect: yes|no> <description> <output text>
+  local expect="$1" desc="$2" text="$3" f got
+  f=$(mktemp)
+  printf '%s\n' "$text" >"$f"
+  if only_nvidia_units_failed "$f"; then got=yes; else got=no; fi
+  rm -f "$f"
+  if [ "$got" = "$expect" ]; then
+    printf '  ok       %s\n' "$desc"
+  else
+    printf '  FAIL     %s (expected %s, got %s)\n' "$desc" "$expect" "$got"
+    fails=$((fails + 1))
+  fi
+}
+
+# The real p510 line, 2026-08-31, 595.91.07 loaded vs 595.99.02 wanted.
+check yes "p510's three nvidia units" \
+  'starting the following units: accounts-daemon.service, polkit.service
+Failed to start nvidia-power-limit.service
+warning: the following units failed: nvidia-container-toolkit-cdi-generator.service, nvidia-persistenced.service, nvidia-power-limit.service'
+
+check yes "a single nvidia unit" \
+  'warning: the following units failed: nvidia-persistenced.service'
+
+# The one that matters: a real failure must not be waved through because a GPU
+# unit happens to be in the list.
+check no "nvidia plus something else" \
+  'warning: the following units failed: nvidia-persistenced.service, home-assistant.service'
+
+check no "no nvidia at all" \
+  'warning: the following units failed: thermald.service'
+
+check no "no failed-units line" \
+  'activating the configuration...
+the following new units were started: libvirtd.service'
+
+# A rollback appends its own list; the switch attempt's is the last one written
+# before the caller reacts, so tail -1 must win.
+check no "rollback line last, mixed units" \
+  'warning: the following units failed: nvidia-persistenced.service
+warning: the following units failed: nvidia-persistenced.service, docker.service'
+
+if [ "$fails" -ne 0 ]; then
+  printf '\n%d case(s) failed\n' "$fails"
+  exit 1
+fi
+printf '\nall cases passed\n'

--- a/scripts/update-commit-deploy.sh
+++ b/scripts/update-commit-deploy.sh
@@ -419,16 +419,61 @@ ELEV=(--elevation-strategy passwordless)
 # leaving the user to run a separate `nh os boot` manually. After the user
 # reboots once, the inhibiting change is "done" and future `switch` calls
 # work normally — this is a one-time pain per critical change.
+# The second reason a switch cannot finish: the nvidia driver version changed.
+#
+# This one does NOT trip the pre-switch inhibitor. Activation runs to the end
+# and then the GPU units fail, because the new userspace (nvidia-smi,
+# persistenced, the CDI generator) is talking to the kernel module still in
+# memory, which is the old version. The display stack holds that module, so
+# activation cannot reload it -- only a reboot can. Seen on p510 2026-08-31,
+# 595.91.07 loaded against a generation wanting 595.99.02:
+#
+#   warning: the following units failed: nvidia-container-toolkit-cdi-generator.service,
+#     nvidia-persistenced.service, nvidia-power-limit.service
+#
+# nvidia-power-limit exits 18 there, which is nvidia-smi's NVML mismatch code.
+#
+# Left unhandled this reads as a broken deploy and the caller rolls back --
+# which restores matching userspace, so afterwards every one of those units is
+# `active` and the host looks perfectly healthy. That is a genuinely misleading
+# postmortem, and re-running `switch` reproduces it exactly.
+#
+# ALL of the failed units must be nvidia ones. A real failure that happens to
+# include a GPU unit has to stay a failure, so one non-nvidia name in the list
+# disqualifies the whole fallback.
+only_nvidia_units_failed() {
+  local list non_nvidia
+  # Last occurrence: a rollback appends its own line, and the switch attempt's
+  # list is the one being classified.
+  list=$(sed -n 's/.*the following units failed: *//p' "$1" | tail -1)
+  [ -n "$list" ] || return 1
+  non_nvidia=$(printf '%s\n' "${list//,/$'\n'}" \
+    | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+    | grep -v '^$' \
+    | grep -cv '^nvidia-' || true)
+  [ "$non_nvidia" -eq 0 ]
+}
+
 nh_switch_or_boot() {
   # Args: nh os switch arguments (e.g. --hostname razer [--target-host razer] .)
-  local out rc
+  local out rc reason="" note=""
   out=$(mktemp)
   set +e
   nh os switch "${ELEV[@]}" "$@" 2>&1 | tee "$out"
   rc=${PIPESTATUS[0]}
   set -e
-  if [ "$rc" -ne 0 ] && grep -qE "switchInhibitors|Pre-switch checks failed" "$out"; then
-    warn "switch refused: a critical-component change requires a reboot."
+
+  if [ "$rc" -ne 0 ]; then
+    if grep -qE "switchInhibitors|Pre-switch checks failed" "$out"; then
+      reason="a critical-component change requires a reboot"
+    elif only_nvidia_units_failed "$out"; then
+      reason="the nvidia driver version changed and the old kernel module is still loaded"
+      note="Until then anything using the GPU stays degraded: the driver userspace and the loaded kernel module are different versions."
+    fi
+  fi
+
+  if [ -n "$reason" ]; then
+    warn "switch refused: ${reason}."
     log "falling back to: nh os boot $*"
     if ! nh os boot "${ELEV[@]}" "$@"; then
       rm -f "$out"
@@ -438,6 +483,7 @@ nh_switch_or_boot() {
     warn "============================================================"
     warn "REBOOT REQUIRED on ${HOST} to complete this deployment."
     warn "Run:  ssh ${HOST} 'sudo systemctl reboot'   (or local reboot)"
+    if [ -n "$note" ]; then warn "$note"; fi
     warn "============================================================"
     return 0
   fi


### PR DESCRIPTION
## The problem, from tonight's p510 deploy

An nvidia driver version bump **cannot** be applied by `nh os switch`. The new userspace (`nvidia-smi`, `persistenced`, the CDI generator) talks to the kernel module still in memory, the display stack holds that module so activation can't reload it, and three units fail together:

```
nvidia-container-toolkit-cdi-generator.service
nvidia-persistenced.service
nvidia-power-limit.service      <- exits 18, nvidia-smi's NVML mismatch code
```

p510 hit this with **595.91.07 loaded** against a generation wanting **595.99.02**. The deploy failed and rolled back.

`nh_switch_or_boot` already knows how to handle "this needs a reboot" — it stages the closure with `nh os boot` and says so. But its guard was:

```bash
grep -qE "switchInhibitors|Pre-switch checks failed"
```

The nvidia case **clears** the pre-switch inhibitor and fails *after* activation, so the fallback never fired.

### Why it's so hard to read

The rollback restores matching userspace, so afterwards all three units report `active`, `nvidia-smi` lists the GPU, and the host looks perfectly healthy — while refusing to update. On top of that the script advised *"Re-run after upstream regression clears"*, and re-running `switch` reproduces it exactly. There is no upstream regression.

## The change

A second reason is added alongside the inhibitor one:

```bash
elif only_nvidia_units_failed "$out"; then
  reason="the nvidia driver version changed and the old kernel module is still loaded"
```

`only_nvidia_units_failed()` requires **every** name in the failed-units list to be an nvidia one — a real failure that happens to include a GPU unit must stay a failure. It reads the *last* such line, so a rollback's own list can't be mistaken for the switch's.

The reboot notice gains one line about the GPU staying degraded until the reboot, conditional on this reason since it isn't true of the inhibitor case.

## Test

`scripts/test-nvidia-fallback-guard.sh` — six cases, all passing:

```
  ok       p510's three nvidia units          (the real captured line)
  ok       a single nvidia unit
  ok       nvidia plus something else         <- must REFUSE
  ok       no nvidia at all                   <- must REFUSE
  ok       no failed-units line               <- must REFUSE
  ok       rollback line last, mixed units    <- must REFUSE
```

The three refusals are the point: getting this wrong in the permissive direction reports a broken deploy as a success. The test **extracts** the function from the deploy script rather than copying it, because a copy of a matcher only tests the copy.

Also verified `bash -n` clean, and the script was edited with nothing running — `pgrep` checked first, since bash reads scripts lazily by byte offset and editing a live one executes garbage.

## Not covered on purpose

This doesn't try to predict the situation before switching (compare `/proc/driver/nvidia/version` against the new closure and go straight to `boot`). That would avoid the failed activation entirely, but it needs the check to work for both local and `--target-host` deploys. This change makes the existing recovery path fire; the pre-flight version check is a separate improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB