### PR TITLE
fix(p510): re-register the runner over a stale entry of the same name

### DIFF
--- a/hosts/p510/nixos/github-runner.nix
+++ b/hosts/p510/nixos/github-runner.nix
@@ -115,6 +115,25 @@ in
       # successfully before failing to symlink its own _diag into it. So the
       # runner exists in the repository's settings and has never once run.
 
+      # Re-register over a runner that already has this name. Without it the
+      # very first real start fails, because the name was already taken by a
+      # registration left behind while this module was being written:
+      #
+      #   √ Connected to GitHub
+      #   A runner exists with the same name p510-nixarchy.
+      #
+      # Authentication succeeds and registration is refused, so the failure
+      # reads like a token problem and is not one. The module's own note about
+      # the workDir dead end says that runner "exists in the repository's
+      # settings and has never once run" -- this is that runner, still there.
+      #
+      # It is also the steady-state need, not just a one-off cleanup: a
+      # non-ephemeral runner keeps its GitHub-side registration across
+      # rebuilds, and the configure step re-runs whenever the unit's config
+      # changes. Deleting the stale one by hand fixes today; this fixes every
+      # time after it.
+      replace = true;
+
       # Not ephemeral. An ephemeral runner unregisters after every job, which
       # is the right shape for untrusted PRs and the wrong one here: this runs
       # nightly against a repository we own, and re-registering costs a token


### PR DESCRIPTION
## What

The runner failed its first real start on p510:

```
√ Connected to GitHub
A runner exists with the same name p510-nixarchy.
```

Authentication **succeeds** and registration is refused, so the failure reads like a token problem and isn't one. The name is held by the entry from the attempt that registered and then died on the `workDir` symlink — the one this module's own comment describes as existing in the repository's settings and having never once run. `gh api` still lists it:

```
id=21  name=p510-nixarchy  status=offline  busy=false
labels=self-hosted,Linux,X64,nixos,kvm,big
```

`replace = true` re-registers over it. That's the steady-state need rather than a one-off cleanup: a non-ephemeral runner keeps its GitHub-side registration across rebuilds and re-runs its configure step whenever the unit's config changes. Deleting the stale entry by hand fixes today; this fixes every time after it.

## Verified

- `services.github-runners.nixarchy.replace` → `true`
- p510 toplevel evaluates clean
- The unit on the running system carries no `replace` — it was built before this commit, which is why p510 still shows the failure

Needs a p510 deploy; no reboot.

## Scope reduced — the Sunshine change was removed

An earlier revision of this PR also flipped `services.sunshine.capSysAdmin` to `false`, claiming it restored hardware encoding. **That claim was wrong and has been dropped.** The investigation is recorded in #1588; the short version is that the two requirements conflict:

- NVENC needs KMS capture to get an importable frame — KMS capture needs `CAP_SYS_ADMIN`
- `CAP_SYS_ADMIN` sets `AT_SECURE`, which drops `LD_LIBRARY_PATH` — the only route to `libcuda.so.1`, since sunshine's ELF has an empty RUNPATH and libcuda is not in `ld.so.cache`

Both directions were tested on the host. With the capability, CUDA never loads and nvenc is never attempted. Without it, plus `LD_LIBRARY_PATH`, nvenc loads fine (`Loaded Nvenc version 13.0`, `Nvenc initialized successfully`) and then fails at `Couldn't scale frame: Invalid argument` on the wlroots-capture path. Neither configuration produces hardware encoding, so flipping the default would have been a guess dressed as a fix.

`capSysAdmin` therefore stays at its current default in this PR, and #1588 carries the evidence and the untested candidate fix (patching the driver path into RUNPATH, which survives `AT_SECURE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB