### PR TITLE
fix(p510): make the Sunshine web UI usable, and wake the display on connect

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -362,6 +362,11 @@ in
       # or the web UI cannot even set its own password. The hostname forms are
       # here too because avahi publishes p510.local and ~/.ssh/config reaches
       # this box by IP.
+      # The monitor on this desk gets switched off, and Sunshine streams
+      # exactly what the compositor shows -- so without this, connecting to a
+      # dark screen gives a black picture and a log with nothing wrong in it.
+      wakeDisplay = true;
+
       webOrigins = [
         "https://192.168.1.75:47990"
         "https://p510:47990"

--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -355,7 +355,19 @@ in
     #
     # Both stay on: RDP for GNOME, Sunshine for Omarchy, and which one answers
     # depends on the session picked at the greeter.
-    sunshine.enable = true;
+    sunshine = {
+      enable = true;
+
+      # Administered from p620 over the LAN, so its address has to be trusted
+      # or the web UI cannot even set its own password. The hostname forms are
+      # here too because avahi publishes p510.local and ~/.ssh/config reaches
+      # this box by IP.
+      webOrigins = [
+        "https://192.168.1.75:47990"
+        "https://p510:47990"
+        "https://p510.local:47990"
+      ];
+    };
   };
 
   # Enable encrypted API keys

--- a/modules/desktop/sunshine.nix
+++ b/modules/desktop/sunshine.nix
@@ -1,5 +1,6 @@
 { config
 , lib
+, pkgs
 , ...
 }:
 # Sunshine: stream this machine's Wayland session to a Moonlight client.
@@ -29,6 +30,42 @@
 let
   inherit (lib) mkIf mkEnableOption mkOption types;
   cfg = config.features.sunshine;
+
+  # Wake the output before a stream starts.
+  #
+  # Sunshine captures whatever the compositor puts on the monitor, so a
+  # DPMS-off output streams as solid black -- with a completely clean log:
+  # CLIENT CONNECTED, capture on the right monitor, encoder running, no
+  # errors, nothing to suggest the picture is missing rather than dark.
+  #
+  # hyprctl comes from /run/current-system/sw/bin deliberately, not from
+  # pkgs.hyprland. omarchy-sole-hyprland.nix puts the Hyprland that nixarchy
+  # pins into the system profile, and that is the build actually running the
+  # session; nixpkgs carries a different version, and the Lua dispatcher API
+  # this calls is version-sensitive.
+  #
+  # The signature is resolved from the runtime directory rather than trusted
+  # from the environment: this runs from a systemd user service that need not
+  # have inherited HYPRLAND_INSTANCE_SIGNATURE from the session.
+  #
+  # It always exits 0. Sunshine aborts the whole stream if a prep command
+  # fails, so a host with no Hyprland running, or a renamed dispatcher after
+  # an upgrade, must degrade to "no wake" and not to "no streaming".
+  wakeDisplayScript = pkgs.writeShellScript "sunshine-wake-display" ''
+    set -u
+    runtime="''${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+    sig="''${HYPRLAND_INSTANCE_SIGNATURE:-}"
+    if [ -z "$sig" ]; then
+      newest=$(ls -td "$runtime"/hypr/*/ 2>/dev/null | head -1) || true
+      [ -n "$newest" ] && sig=$(basename "$newest")
+    fi
+    if [ -n "$sig" ]; then
+      HYPRLAND_INSTANCE_SIGNATURE="$sig" XDG_RUNTIME_DIR="$runtime" \
+        /run/current-system/sw/bin/hyprctl dispatch \
+        'hl.dsp.dpms({ action = "enable" })' >/dev/null 2>&1 || true
+    fi
+    exit 0
+  '';
 in
 {
   options.features.sunshine = {
@@ -60,6 +97,29 @@ in
         This is a real privilege on a real binary, and it is the reason this
         option is spelled out instead of hardcoded: a host that would rather
         take the portal route can turn it off in one line.
+      '';
+    };
+
+    wakeDisplay = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Turn the display back on when a client connects.
+
+        Sunshine streams what the compositor renders to the monitor, so a
+        screen that has been switched off produces a black stream and a
+        completely clean log -- CLIENT CONNECTED, capture on the correct
+        monitor, encoder running, no errors. Nothing distinguishes "the
+        picture is dark" from "the picture is missing", which makes it an
+        expensive half hour to diagnose.
+
+        Sunshine cannot wake an output on its own, and it will not be woken by
+        the client's input either, so without this every session that starts
+        while the screen is off is a black one.
+
+        Implemented as global_prep_cmd, not per-application, so it covers
+        every entry including any still defined in the web UI's own apps
+        list. Hyprland only.
       '';
     };
 
@@ -102,12 +162,27 @@ in
       enable = true;
       inherit (cfg) openFirewall capSysAdmin;
 
-      # Comma-separated, no spaces, as the option's own parser expects; an
-      # entry it cannot read is dropped with "Invalid 'csrf_allowed_origins'
-      # entry rejected" and the origin stays blocked.
-      settings = lib.mkIf (cfg.webOrigins != [ ]) {
-        csrf_allowed_origins = lib.concatStringsSep "," cfg.webOrigins;
-      };
+      settings =
+        # Comma-separated, no spaces, as the option's own parser expects; an
+        # entry it cannot read is dropped with "Invalid 'csrf_allowed_origins'
+        # entry rejected" and the origin stays blocked.
+        lib.optionalAttrs (cfg.webOrigins != [ ])
+          {
+            csrf_allowed_origins = lib.concatStringsSep "," cfg.webOrigins;
+          }
+        # A JSON array of do/undo pairs, which is why this is built with
+        # toJSON rather than written out by hand. No undo: the screen is left
+        # on after a session, because a host that someone also sits at should
+        # not have its monitor switched off by a remote disconnect.
+        // lib.optionalAttrs cfg.wakeDisplay {
+          global_prep_cmd = builtins.toJSON [
+            {
+              "do" = "${wakeDisplayScript}";
+              undo = "";
+              elevated = false;
+            }
+          ];
+        };
 
       # Start with the session rather than waiting for someone to run it.
       # Pointless without autologin on a headless-reboot host; harmless with.

--- a/modules/desktop/sunshine.nix
+++ b/modules/desktop/sunshine.nix
@@ -62,12 +62,52 @@ in
         take the portal route can turn it off in one line.
       '';
     };
+
+    webOrigins = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "https://192.168.1.75:47990" "https://myhost:47990" ];
+      description = ''
+        Origins allowed to use Sunshine's web UI, as scheme://host:port.
+
+        Sunshine trusts only localhost, 127.0.0.1 and [::1] by default and
+        refuses every POST from anywhere else with
+
+          CSRF Protection Error
+          The request was blocked by CSRF protection.
+
+        That includes the request that creates the first username and
+        password, so reaching the UI across the LAN is not merely restricted
+        -- the page loads and nothing on it can be submitted. Every host that
+        is administered from another machine needs its own address here.
+
+        Include the port: the browser sends it in the Origin header, so
+        "https://host" does not match "https://host:47990".
+
+        Setting this has a side effect worth knowing, and it comes from
+        upstream's module rather than from here: Sunshine is only handed a
+        config file when some setting differs from the default, and that file
+        lives in the Nix store, read-only. So as soon as this list is
+        non-empty the web UI's Configuration tab can no longer save --
+        settings belong in this repository from then on. Credentials and
+        client pairings are not affected; those live in
+        ~/.config/sunshine/sunshine_state.json, which stays writable.
+      '';
+    };
   };
+
 
   config = mkIf cfg.enable {
     services.sunshine = {
       enable = true;
       inherit (cfg) openFirewall capSysAdmin;
+
+      # Comma-separated, no spaces, as the option's own parser expects; an
+      # entry it cannot read is dropped with "Invalid 'csrf_allowed_origins'
+      # entry rejected" and the origin stays blocked.
+      settings = lib.mkIf (cfg.webOrigins != [ ]) {
+        csrf_allowed_origins = lib.concatStringsSep "," cfg.webOrigins;
+      };
 
       # Start with the session rather than waiting for someone to run it.
       # Pointless without autologin on a headless-reboot host; harmless with.


### PR DESCRIPTION
Two things stopped Sunshine being usable on p510 from another machine. Both are verified on the host, both are one option.

## 1. The web UI refused everything submitted to it

Opening `https://192.168.1.75:47990` loaded the page and then rejected every POST:

> **CSRF Protection Error** — The request was blocked by CSRF protection. If you are accessing Sunshine from a non-default URL or reverse proxy, add that origin to the `csrf_allowed_origins` option in your configuration.

Sunshine trusts **localhost, 127.0.0.1 and `[::1]` only** — including for the POST that creates the first username and password. So a host administered from elsewhere doesn't have a restricted web UI, it has an unusable one.

`features.sunshine.webOrigins` takes a list and comma-joins it. The **port matters**: the browser sends it in the `Origin` header, so `https://host` does not match `https://host:47990`. p510 lists its LAN address plus the `p510` and `p510.local` forms — avahi publishes the mDNS name and `~/.ssh/config` reaches the box by IP.

Verified live before writing it:

| | before | after |
|---|---|---|
| `/welcome` | 307 bounce | **200** |
| cross-origin POST | CSRF error | `{"error":"Invalid Username"}` — past CSRF, into the handler, rejecting a deliberately empty payload |

## 2. Connecting gave a black screen

The session log was **completely clean** — `CLIENT CONNECTED`, capture on the correct monitor, `libx264` at 79 Mbps, no errors. The output was just DPMS-off, and screencopy of a sleeping output is solid black:

```
hyprctl monitors  ->  dpmsStatus: 0   disabled: false
```

Nothing distinguishes "the picture is dark" from "the picture is missing", which is what made it expensive to find. Sunshine can't wake an output, and the client's input doesn't wake it either — so every session starting while that screen is off is a black one.

`features.sunshine.wakeDisplay` adds a `global_prep_cmd`. Global rather than per-application, so it covers every entry — including ones still defined in the web UI's own apps list — without declaring `applications` and taking that page over.

Three things the script has to get right, all tested with the display **off** and the session environment **stripped**:

- **Resolves `HYPRLAND_INSTANCE_SIGNATURE` from the runtime dir** rather than trusting the environment — it runs from a systemd user service that needn't have inherited it. Tested with the variable explicitly unset; it still found the socket and woke the screen (`dpmsStatus: 0` → `1`).
- **`hyprctl` from `/run/current-system/sw/bin`, not `pkgs.hyprland`.** `omarchy-sole-hyprland.nix` puts the Hyprland nixarchy pins into the system profile and that's the build running the session; nixpkgs carries a different version, and the Lua dispatcher API is version-sensitive. The dispatcher spelling is Omarchy's own, lifted from `omarchy-hyprland-monitor-internal`: `hl.dsp.dpms({ action = "enable" })`.
- **Always exits 0.** The docs are explicit that *"if any of the prep-commands fail, starting the application is aborted"* — so a host with no Hyprland, or a dispatcher renamed by an upgrade, must degrade to "no wake" and never to "no streaming".

No `undo`: the screen stays on afterwards rather than being switched off under whoever is sitting at it.

## Verified

```
csrf_allowed_origins = https://192.168.1.75:47990,https://p510:47990,https://p510.local:47990
global_prep_cmd      = [{"do":"/nix/store/...-sunshine-wake-display","elevated":false,"undo":""}]
```

p510 evaluates clean; p620/razer untouched (`services.sunshine.enable = false`). The wake script's store hash is byte-identical before and after `nixpkgs-fmt`, so formatting didn't touch the shell body.

## One consequence, upstream's design not mine

nixpkgs' module (`sunshine.nix:183-191`) hands Sunshine a config file **only** when a setting differs from the default — and that file is in the read-only Nix store:

```
"/run/wrappers/bin/sunshine" "/nix/store/...-sunshine.conf"
```

So **the web UI's Configuration tab can no longer save** once this deploys; settings live in this repo instead. Credentials and client pairings are unaffected — those are in `~/.config/sunshine/sunshine_state.json`, which stays writable. The Apps page also stays usable, which is why `wakeDisplay` uses `global_prep_cmd` rather than declaring `applications`.

Anything still wanted from the stale 2024 `~/.config/sunshine/sunshine.conf` (`nvenc_twopass`, `min_threads`) has to move into `settings` to have any effect.

## Related

- #1588 — Sunshine still software-encodes; independent of this and unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB