### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1695,11 +1695,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788216126,
-        "narHash": "sha256-BhNob/0/KdOwtqWXyuF/aJyxMckoCGSZnh0rWitcupE=",
+        "lastModified": 1788216787,
+        "narHash": "sha256-1wYmIRw8Bt67qoIW2BmIvzQt7/9vJ0exvRK/+LJ3DU8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e8acc7527d56cd727f488452014823da19f83c60",
+        "rev": "19d8ccc905d0f0712b27ad2967e05b41603e87b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=p510, scope=all).

Built and verified locally against nixosConfigurations.p510 before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)