### PR TITLE
docs: bring README, docs/ and the published site up to date (#1595)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,12 @@ on:
   push:
     branches: [main]
     paths:
+      # mkdocs-full.yml is the config the published site is actually built
+      # from (docs_gen/site.nix invokes it); mkdocs.yml is the slim Backstage
+      # TechDocs one. Watching only the latter meant a nav or theme change to
+      # the real config never triggered a publish.
       - "mkdocs.yml"
+      - "mkdocs-full.yml"
       - "docs/**"
       - "docs_gen/**"
       - "modules/**"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -23,5 +23,6 @@
   },
   "MD060": {
     "style": "leading_and_trailing"
-  }
+  },
+  "MD046": false
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,19 @@ module** — never run `home-manager switch`; use `nixos-rebuild`.
 
 - **p620** — AMD workstation (primary dev; AMD ROCm). Workstation template.
 - **razer** — Intel/NVIDIA laptop (mobile dev). Laptop template.
-- **p510** — Intel Xeon/NVIDIA headless media server. Server template.
+- **p510** — Intel Xeon/NVIDIA media server **and desktop** (Plex, *arr, k3s,
+  Sunshine, self-hosted CI runner). Workstation template. **Never build or
+  deploy without asking first.**
 
-(DEX5550 offline; Samsung archived. Prometheus/Grafana/Loki removed — use
-`journalctl`/`systemctl` for system state.)
+All three run one Wayland session: **Omarchy on Hyprland** (packaged as
+Nixarchy, a flake input), with GNOME as a selectable fallback. niri, labwc,
+mango, Noctalia and DankMaterialShell are gone, inputs included; COSMIC is
+parked. See `docs/architecture/desktop.md`.
+
+(DEX5550 offline; Samsung and HP decommissioned. Prometheus/Grafana/Loki
+removed — use `journalctl`/`systemctl` for system state; `grafana-status` and
+friends no longer exist. There is no binary cache of our own — nothing listens
+on `p620:5000`.)
 
 ## Golden rules
 
@@ -34,8 +43,14 @@ module** — never run `home-manager switch`; use `nixos-rebuild`.
 5. **Secrets at runtime only.** Use agenix `passwordFile`/path references;
    never `builtins.readFile` a secret (it lands in the store).
 6. **Service hardening is mandatory.** `DynamicUser`, `ProtectSystem=strict`,
-   `NoNewPrivileges`, `ProtectHome` for any new service.
+   `NoNewPrivileges`, `ProtectHome` for any new service. The one standing
+   exception is `modules/desktop/sunshine.nix`, a systemd *user* service that
+   needs the session's Wayland socket, GPU nodes and input devices — the
+   exception is argued in the module, not taken silently.
 7. **No bare URLs**, minimal `with`, minimal `rec`, no IFD.
+8. **Branch, never commit to `main`.** `<type>/<issue#>-description`,
+   Conventional Commits with the issue number. No backticks in
+   `git commit -m` — double quotes do not stop command substitution.
 
 ## Workflow (issue-driven)
 
@@ -70,11 +85,13 @@ unverified commands, stop on the unexpected.
 ```text
 flake.nix              host definitions + inputs/overlays
 hosts/<host>/          per-host config (variables.nix, configuration.nix, hw)
-hosts/templates/       workstation | laptop | server base templates
+hosts/templates/       desktop.nix — one template, workstation | laptop
 modules/               feature + service modules (the core; behind flags)
 home/                  Home Manager config + role profiles
 Users/<user>/          per-user profile compositions
 secrets/               agenix-encrypted secrets
 docs/PATTERNS.md       best practices (READ FIRST)
 docs/NIXOS-ANTI-PATTERNS.md  what to avoid (READ FIRST)
+docs/architecture/desktop.md Nixarchy / Omarchy / Hyprland
+mkdocs.yml + mkdocs-full.yml  hand-synced nav — change BOTH
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,12 @@
 
 - `docs/PATTERNS.md` — module, package and security patterns
 - `docs/NIXOS-ANTI-PATTERNS.md` — anti-pattern catalogue and the code-review checklist
+- `docs/architecture/desktop.md` — Nixarchy/Omarchy/Hyprland, before touching
+  anything Hyprland-adjacent
+
+Docs live in `docs/` and are published to <https://nixos.freundcloud.com/>.
+Nav is hand-synced across `mkdocs.yml` (Backstage TechDocs) and
+`mkdocs-full.yml` (the published site) — a nav change must land in **both**.
 
 ## Hosts
 
@@ -14,7 +20,7 @@ imports one plus its own hardware config.
 | ----- | ------------- | ----- |
 | p620  | `workstation` | AMD GPU / ROCm. Set `services.ollama.package = pkgs.ollama-rocm`; `services.ollama.acceleration` was removed from nixpkgs (unrelated to this repo's own `acceleration` attribute in `hosts/common/hardware-profiles/`). |
 | razer | `laptop`      | Hybrid Intel/NVIDIA (Optimus). Heavy rebuilds: build on p620 via `just deploy-via-p620 razer`. |
-| p510  | `workstation` | Headless media server (Plex, NZBGet, k3s microvms). **Never build or deploy without asking first.** |
+| p510  | `workstation` | Media server (Plex, NZBGet, k3s microvms) **and desktop** since 2026-08-31: Omarchy session, Sunshine streaming, self-hosted GitHub Actions runner. **Never build or deploy without asking first.** |
 
 Home Manager profiles live in `home/profiles/{developer,server-admin}`. Home Manager is a
 **flake module** — never run `home-manager switch`.
@@ -104,11 +110,37 @@ Things the code no longer shows, so they are easy to get wrong:
   flake-wide. Reach the package through `inputs.nixarchy`, never
   `config.programs.nixarchy.package` — nixarchy consumes Stylix, so that closes
   the module fixpoint and evaluation dies with infinite recursion.
-- **p510 carries the Omarchy session too** (#1562), with `displayManager = false`
-  (the module turns SDDM on by default and would swap out the GDM serving RDP),
-  `defaultSession = "gnome"` (adding Omarchy flipped autologin from gnome to
-  omarchy on a headless box) and `preinstalls = false` (4 GiB of desktop
-  software, `cef-binary` alone 1.9 GiB). It is a selectable entry only —
-  `gnome-remote-desktop` serves GNOME, not Hyprland.
+- **p510 runs the Omarchy session for real** (#1585, superseding the
+  arrangement #1562 left behind). It got a monitor, so the three settings that
+  held Omarchy at arm's length were inverted: `displayManager = true` (Omarchy's
+  SDDM; GDM is gone), `defaultSession = "omarchy"` and `host.class =
+  "workstation"`. Two divergences from p620/razer remain, both deliberate:
+  `preinstalls = false` (4 GiB of desktop software, `cef-binary` alone 1.9 GiB;
+  `/` would go 50.5 → 57.6 GiB) and **autologin stays on** — Sunshine is a
+  systemd *user* service that only exists inside a live graphical session, so on
+  a host that reboots unattended the alternative is a greeter nobody is there to
+  answer. razer keeps autologin off because PRIME-sync Optimus misbehaves with a
+  greeter respawn; p510 is pure NVIDIA without PRIME.
+  `gnome-remote-desktop` can still serve GNOME over RDP but cannot serve
+  Hyprland — that is what Sunshine replaced.
+- **Sunshine** (`modules/desktop/sunshine.nix`, `features.sunshine`, p510 only)
+  is the standing exception to the DynamicUser/ProtectHome rule below: it needs
+  the session's Wayland socket, GPU nodes and input devices. Four traps, in the
+  order you hit them: it starts only with a graphical session; a DPMS-off output
+  streams solid black with a clean log (`wakeDisplay = true`, and the dispatcher
+  is Lua — `hl.dsp.dpms({ action = "enable" })`); `webOrigins` must include the
+  port or the web UI refuses every POST with a CSRF error; and setting *any*
+  option puts the config in the Nix store, making the web UI's Configuration tab
+  read-only. See `docs/applications/sunshine.md`.
+- **A GitHub Actions runner lives on p510** (`hosts/p510/nixos/github-runner.nix`,
+  `p510-nixarchy`) for nixarchy's KVM/ISO checks. `TMPDIR` points at `/home`
+  (CMR, 125 MB/s), never `/mnt/img_pool` — that is an SMR disk at ~9.5 MB/s and
+  a 16 GB VM install hangs there rather than failing cleanly. Nothing targets
+  the runner yet; nixarchy's workflows are still `runs-on: ubuntu-latest`.
+- **An NVIDIA driver version bump cannot be applied with `switch`** — the new
+  userspace meets the old in-memory module, three `nvidia-*` units fail and the
+  activation rolls back. `nhs` detects this and falls back to `boot` mode; the
+  reboot is still yours.
 - DEX5550 is offline; Samsung and HP are decommissioned.
-- MicroVMs are per-host files (`hosts/p510/microvm.nix`), not a shared module.
+- MicroVMs are per-host files (`hosts/p510/microvm.nix`, with the guests under
+  `hosts/p510/nixos/microvm/`), not a shared module.

--- a/README.md
+++ b/README.md
@@ -3,18 +3,24 @@
 Multi-host NixOS configuration using flakes, a single parameterised host
 template, Home Manager as a flake module, and Stylix-driven theming.
 
-Last verified: 2026-05-04 against `nixos-unstable` (NixOS 26.05).
+Last verified: 2026-09-01 against `nixos-unstable` (NixOS 26.11).
 
 ## Hosts
 
-| Host  | Class       | Hardware       | Role                              | Template            |
-|-------|-------------|----------------|-----------------------------------|---------------------|
-| p620  | workstation | AMD RX 7900    | Primary development, AI workloads | desktop/workstation |
-| p510  | workstation | Intel Xeon     | Headless media server (Plex)      | desktop/workstation |
-| razer | laptop      | Intel + NVIDIA | Mobile development, Secure Boot   | desktop/laptop      |
+| Host  | Class       | Hardware               | Role                                    | Template            |
+|-------|-------------|------------------------|-----------------------------------------|---------------------|
+| p620  | workstation | AMD RX 7900 (ROCm)     | Primary development, AI workloads       | desktop/workstation |
+| p510  | workstation | Intel Xeon + RTX 3070 Ti | Media server (Plex), k3s, CI runner, desktop | desktop/workstation |
+| razer | laptop      | Intel + NVIDIA         | Mobile development, Secure Boot         | desktop/laptop      |
 
-DEX5550 and Samsung have been removed from the configuration. References
-in older docs are stale.
+All three run the same Wayland session — see [Desktop](#desktop) below.
+
+**p510 is the always-on media server: never build or deploy it without
+asking first.** Heavy razer rebuilds should be built on p620
+(`just deploy-via-p620 razer`).
+
+DEX5550 is offline; Samsung and HP are decommissioned. References in older
+docs are stale.
 
 ## Architecture
 
@@ -22,9 +28,8 @@ in older docs are stale.
   (selects between `workstation` and `laptop` profiles via the
   `profile` argument). Surfaced through `lib/hostTypes.nix` as
   `hostTypes.workstation` / `hostTypes.laptop`. The previous
-  `server`/`hybrid`/`base` templates were removed; P510 also uses the
-  workstation template (headless via `host.class = "workstation"` and
-  no display manager).
+  `server`/`hybrid`/`base` templates were removed; p510 also uses the
+  workstation template, overriding only what genuinely differs.
 - Hardware GPU profiles in `hosts/common/hardware-profiles/` (`amd`,
   `nvidia`, `intel-integrated`).
 - Feature flags drive module enablement (see `lib/features.nix`).
@@ -33,14 +38,52 @@ in older docs are stale.
 - Overlays are split by purpose under `overlays/`:
   `default.nix`, `custom-packages.nix`, `cmake-compat.nix`,
   `python-compat.nix`, `upstream-fixes.nix`, `citrix-workspace.nix`.
-- Theming is centralised through Stylix (`base16` palette). Dependent
-  surfaces — GNOME Terminal, Zellij, COSMIC (full RON palette write,
-  30 fields) — derive their colours from
+- Theming is centralised through Stylix (`base16` palette), whose
+  source of truth is the **active Omarchy theme** — see [Theming](#theming).
+  Dependent surfaces — Plymouth, GRUB, the console, GTK, Qt, GNOME
+  Terminal, Zellij — derive their colours from
   `config.lib.stylix.colors`. The standalone `nix-colors` input has
   been removed.
 - Home Manager is loaded as a flake module from `flake.nix`. Do **not**
   run `home-manager switch` directly; user environments are activated
   by the system rebuild.
+
+## Desktop
+
+One Wayland session on every host: **Omarchy on Hyprland**, packaged for
+NixOS as [Nixarchy](https://github.com/olafkfreund/nixarchy) and consumed
+as a flake input. GNOME stays installed and selectable as a fallback.
+Everything else — niri, labwc, mango, Noctalia, DankMaterialShell — is
+gone, including the flake inputs. COSMIC is parked, not removed.
+
+| | p620 | razer | p510 |
+|---|---|---|---|
+| Sessions | `omarchy`, `gnome` | `omarchy`, `gnome` | `omarchy`, `gnome` |
+| Greeter | Omarchy's SDDM | Omarchy's SDDM | Omarchy's SDDM |
+| Default | `omarchy` | `omarchy` | `omarchy` |
+| Autologin | off | off | **on** (Sunshine needs a live session) |
+| Omarchy preinstalls | on | on | **off** (~4 GiB of closure) |
+
+Wired per host in `hosts/<host>/nixos/nixarchy.nix` plus shared fragments
+under `hosts/common/nixos/omarchy-*.nix`.
+
+Three things are easy to get wrong:
+
+- **`programs.hyprland` is enabled by the Nixarchy module, not by us.** It
+  supplies the portal, `uwsm` and the wayland-session basics, so it cannot
+  be turned off — but it also registers a second, indistinguishable
+  Hyprland login entry. `omarchy-sole-hyprland.nix` forces the module off
+  and restates what Nixarchy needs. Read that file before touching
+  anything Hyprland-adjacent; the two obvious workarounds both fail.
+- **Hyprland config here is Lua, not hyprlang.** Dispatchers are
+  namespaced: `hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })'`.
+  The string form (`"dpms on"`) silently does nothing.
+- **Two files at the flake root are written by Omarchy**, because a flake
+  cannot read outside its own tree: `nixarchy-apps.nix` (by
+  `nixarchy-apply`) and `nixarchy-theme.nix` (by `omarchy theme set`).
+  Both leave the tree dirty, and `nhs` refuses a dirty tree.
+
+Full detail: [docs/architecture/desktop.md](./docs/architecture/desktop.md).
 
 ## Quick Start
 
@@ -166,12 +209,18 @@ keys).
 
 ## Razer: Secure Boot
 
-razer boots via lanzaboote (`v1.0.0`) with `systemd-initrd`. Because
+razer boots via lanzaboote (`v1.1.0`) with `systemd-initrd`. Because
 the firmware ships a locked Setup Mode, MOK enrollment is handled by a
 shim+MOK module (`modules/razer/...`) that wraps `lzbt` and points
-`pkiBundle` at `/var/lib/sbctl` (the sbctl 0.18 default). Kernel is
-pinned to `linuxPackages_latest` to dodge the 6.18.24 + NVIDIA boot
-regression.
+`pkiBundle` at `/var/lib/sbctl` (the sbctl 0.18 default).
+
+Kernel is `linuxPackages_latest` (7.0.1) because 6.18.24 + `nvidia-open`
+failed to boot. `hosts/razer/nixos/boot.nix` documents the fallback:
+pin 6.18.22 via a separate module if 7.0.1 also fails.
+
+The ESP is 511 MiB against ~149 MiB of NVIDIA-firmware initrd per
+generation, so it holds very few generations. `--clean` escalates to a
+single generation rather than failing its own threshold.
 
 ## Live Installer
 
@@ -188,13 +237,23 @@ builder (`lib/live-images.nix`) can be re-instantiated if needed.
 
 ## Theming
 
-- Source of truth: `config.lib.stylix.colors` (base16 scheme).
+- Source of truth: the **active Omarchy theme**.
+  `omarchy theme set X` retints Omarchy's own 24 files immediately and a
+  `theme-set.d` hook writes `X` into `nixarchy-theme.nix` at the flake
+  root; `modules/desktop/stylix-theme.nix` maps that theme's
+  `colors.toml` onto base16 and feeds Stylix. Everything Omarchy cannot
+  reach at runtime follows at the **next rebuild**, not instantly.
+- Reach the package through `inputs.nixarchy`, never
+  `config.programs.nixarchy.package` — nixarchy consumes Stylix, so that
+  closes the module fixpoint and evaluation dies with infinite recursion.
+- Surfaces: `config.lib.stylix.colors` (base16 scheme) drives Plymouth,
+  GRUB, the console, GTK, Qt, fonts, cursor, icons, GNOME Terminal and
+  Zellij.
 - `assets/wallpapers/` contains all wallpapers; the active wallpaper is
   selected by the per-host theme module.
 - COSMIC: a writer derivation produces the full RON palette (30
-  fields) from the base16 scheme; no hardcoded hex values remain.
-- GNOME Terminal: palette derived from Stylix base16.
-- Zellij: theme derived from Stylix.
+  fields) from the base16 scheme. COSMIC itself is parked
+  (`desktop.cosmic.enable = false` everywhere); the writer stays wired.
 - GNOME profile: shared `home/profiles/desktop-user/profile.nix` and
   the `desktop.gnome.profile` module unify the wiring; the
   `desktop.displayManager` module unifies display-manager selection.
@@ -207,6 +266,17 @@ The following are intentionally absent from the current configuration:
 
 - Prometheus / Grafana / Loki / Alertmanager monitoring stack — system
   insight is now via `journalctl`, `systemctl`, and per-service logs.
+  Older docs still list `grafana-status` / `prometheus-status` helpers;
+  those commands no longer exist.
+- niri, labwc, mango, Noctalia and DankMaterialShell — modules,
+  sessions, greeters and flake inputs. Anything describing
+  `dms-shell.nix`, "Niri (DMS)", "Hyprland (DMS)" or
+  `${DESK_SHELL:-noctalia}` is describing a tree that no longer exists.
+- A binary cache of our own. There is no nix-serve/harmonia anywhere in
+  the repo and nothing listens on `p620:5000`. `modules/nix/nix.nix`
+  substitutes from cache.nixos.org and nix-community.cachix.org;
+  `flake.nix` adds cuda-maintainers and devenv as flake-level
+  `extra-substituters`. Tailscale is used for remote SSH, not caching.
 - `nix-colors` input (replaced by Stylix base16).
 - `termshark`, `wireshark`, `reddix`, `wasistlos`, `steampipe` modules
   and the standalone `cosmic-applet-package-updater` chain.
@@ -323,6 +393,12 @@ sudo nixos-rebuild switch --rollback   # Roll back to previous generation
   practices (read before writing modules).
 - [docs/NIXOS-ANTI-PATTERNS.md](./docs/NIXOS-ANTI-PATTERNS.md) —
   Anti-patterns and review checklist.
+- [docs/architecture/desktop.md](./docs/architecture/desktop.md) —
+  Nixarchy / Omarchy on Hyprland: sessions, theming, screen sharing.
+- [docs/applications/sunshine.md](./docs/applications/sunshine.md) —
+  Sunshine streaming on p510 and its four traps.
+- [docs/hosts/p510.md](./docs/hosts/p510.md) — p510: media stack, k3s,
+  the self-hosted CI runner, and its known quirks.
 - [docs/MCP-GUIDE.md](./docs/MCP-GUIDE.md) — MCP server integration.
 - [docs/guides/GITHUB-WORKFLOW.md](./docs/guides/GITHUB-WORKFLOW.md) —
   Issue-driven development workflow.

--- a/docs/NIXOS-ANTI-PATTERNS.md
+++ b/docs/NIXOS-ANTI-PATTERNS.md
@@ -1,14 +1,18 @@
 # NixOS Anti-Patterns and Best Practices
 
-> **Important**: These patterns were identified through community feedback, code review in GitHub issues #10, #11, and #12, and official Nix documentation from [nix.dev](https://nix.dev/tutorials/module-system/deep-dive) and the [Nixpkgs Manual](https://nixos.org/manual/nixpkgs/stable/).
+> **Important**: These patterns were identified through community feedback, code review in GitHub issues #10,
+> #11, and #12, and official Nix documentation from [nix.dev](https://nix.dev/tutorials/module-system/deep-dive)
+> and the [Nixpkgs Manual](https://nixos.org/manual/nixpkgs/stable/).
 
-##  Background
+## Background
 
-This document captures critical lessons learned from real community feedback and official Nix documentation about anti-patterns in NixOS configurations. These patterns were found in this repository and fixed based on expert review, helping establish guidelines for future development.
+This document captures critical lessons learned from real community feedback and official Nix documentation
+about anti-patterns in NixOS configurations. These patterns were found in this repository and fixed based on
+expert review, helping establish guidelines for future development.
 
 **Companion Document**: See [PATTERNS.md](./PATTERNS.md) for comprehensive best practices and recommended patterns.
 
-##  **Critical Anti-Patterns to Avoid**
+## **Critical Anti-Patterns to Avoid**
 
 ### **1. Nix Language Anti-Patterns**
 
@@ -47,7 +51,8 @@ in
 buildInputs = with pkgs; [ curl jq ];  # Limited, clear scope
 ```
 
-**Why problematic:** Static analysis tools can't determine variable sources, makes refactoring difficult, and creates ambiguity for newcomers.
+**Why problematic:** Static analysis tools can't determine variable sources, makes refactoring difficult, and
+creates ambiguity for newcomers.
 
 #### **Dangerous `rec` Usage**
 
@@ -111,7 +116,9 @@ config.myList = [ "item1" ];
 config.myList = [ "item2" ];  # Automatically merged to [ "item1" "item2" ]
 ```
 
-**Why problematic:** From [nix.dev](https://nix.dev/tutorials/module-system/deep-dive): "The module system evaluates all modules it receives, and any of them can define a particular option's value" with merging behavior determined by the option's declared type. Using the wrong type prevents proper composition.
+**Why problematic:** From [nix.dev](https://nix.dev/tutorials/module-system/deep-dive): "The module system
+evaluates all modules it receives, and any of them can define a particular option's value" with merging
+behavior determined by the option's declared type. Using the wrong type prevents proper composition.
 
 **Type merging behavior:**
 
@@ -150,7 +157,9 @@ in
 }
 ```
 
-**Official docs explain:** "The `config` argument passed to a module contains lazily-evaluated results from all imported modules, while the module's `config` attribute exposes that specific module's option values to the evaluation system."
+**Official docs explain:** "The `config` argument passed to a module contains lazily-evaluated results from
+all imported modules, while the module's `config` attribute exposes that specific module's option values to
+the evaluation system."
 
 #### **Reading Secrets During Evaluation**
 
@@ -352,7 +361,8 @@ environment.systemPackages = with pkgs; [
 ];
 ```
 
-**Why problematic:** Packages installed via `nix-env` aren't tracked in configuration, persist across rebuilds unexpectedly, and make rollbacks incomplete.
+**Why problematic:** Packages installed via `nix-env` aren't tracked in configuration, persist across rebuilds
+unexpectedly, and make rollbacks incomplete.
 
 #### **Misusing `environment.systemPackages`**
 
@@ -386,7 +396,7 @@ users.users.alice.packages = with pkgs; [
 }
 ```
 
-```
+```text
 #  GOOD - Modular structure
 /etc/nixos/
 ├── configuration.nix        # Main entry point
@@ -567,7 +577,9 @@ stdenv.mkDerivation {
 }
 ```
 
-**Why problematic:** From the [Nixpkgs Manual](https://nixos.org/manual/nixpkgs/stable/): Build helpers should receive dependencies through function arguments for composability. Incorrect categorization breaks cross-compilation and causes unnecessary rebuilds.
+**Why problematic:** From the [Nixpkgs Manual](https://nixos.org/manual/nixpkgs/stable/): Build helpers should
+receive dependencies through function arguments for composability. Incorrect categorization breaks
+cross-compilation and causes unnecessary rebuilds.
 
 #### **Using override Instead of overrideAttrs**
 
@@ -589,7 +601,8 @@ myPackage = originalPackage.overrideAttrs (oldAttrs: {
 });
 ```
 
-**Nixpkgs Manual states:** "overrideAttrs should be preferred in (almost) all cases" because it allows `stdenv.mkDerivation` to process input arguments properly.
+**Nixpkgs Manual states:** "overrideAttrs should be preferred in (almost) all cases" because it allows
+`stdenv.mkDerivation` to process input arguments properly.
 
 #### **Missing Meta Attributes**
 
@@ -624,7 +637,8 @@ stdenv.mkDerivation {
 }
 ```
 
-**Why required:** The manual emphasizes that metadata "enables filtering and discovery" in NixOS's package search and supports automated tooling.
+**Why required:** The manual emphasizes that metadata "enables filtering and discovery" in NixOS's package
+search and supports automated tooling.
 
 #### **Missing Phase Hooks**
 
@@ -654,7 +668,8 @@ stdenv.mkDerivation {
 }
 ```
 
-**Why important:** Phase hooks allow other modules and overlays to inject additional steps without completely overriding your phases.
+**Why important:** Phase hooks allow other modules and overlays to inject additional steps without completely
+overriding your phases.
 
 #### **Improper Use of pkgs.extend**
 
@@ -677,7 +692,8 @@ nixpkgs.overlays = [
 ];
 ```
 
-**Performance issue:** The manual notes that `extend` can cause unnecessary re-evaluation. Prefer explicit overlays in `nixpkgs.overlays` for large-scale changes.
+**Performance issue:** The manual notes that `extend` can cause unnecessary re-evaluation. Prefer explicit
+overlays in `nixpkgs.overlays` for large-scale changes.
 
 ### **10. Module System Anti-Patterns**
 
@@ -725,7 +741,8 @@ in
 }
 ```
 
-**From nix.dev:** "The module system performs type validation during evaluation, producing clear error messages" for type mismatches. Extend this with assertions for business logic validation.
+**From nix.dev:** "The module system performs type validation during evaluation, producing clear error
+messages" for type mismatches. Extend this with assertions for business logic validation.
 
 #### **Ignoring Priority System**
 
@@ -777,7 +794,8 @@ options.services.myservice = {
 }
 ```
 
-**Why essential:** Options form the public API of your module. Comprehensive descriptions enable users to configure your module correctly without reading implementation code.
+**Why essential:** Options form the public API of your module. Comprehensive descriptions enable users to
+configure your module correctly without reading implementation code.
 
 ### **11. Code Duplication Without Extraction**
 
@@ -853,7 +871,7 @@ in {
 - Easy to have definitions drift apart over time
 - 25+ lines of duplication eliminated by proper extraction
 
-##  **Required Patterns for NixOS**
+## **Required Patterns for NixOS**
 
 ### **1. Always Use Explicit Imports**
 
@@ -982,10 +1000,10 @@ Before submitting any NixOS configuration changes, verify:
 ## **When in Doubt - Decision Framework**
 
 1. **Check nixpkgs**: How do official modules handle similar functionality?
-1. **Ask the community**: NixOS Discourse or Matrix channels for guidance
-1. **Prefer explicit**: Make behavior obvious and discoverable, not magical
-1. **Trust the system**: NixOS modules handle most cases correctly without extra wrapping
-1. **Less is more**: Remove code and abstractions rather than adding unnecessary ones
+2. **Ask the community**: NixOS Discourse or Matrix channels for guidance
+3. **Prefer explicit**: Make behavior obvious and discoverable, not magical
+4. **Trust the system**: NixOS modules handle most cases correctly without extra wrapping
+5. **Less is more**: Remove code and abstractions rather than adding unnecessary ones
 
 ## **Real-World Example: Before and After**
 
@@ -1090,7 +1108,8 @@ Following these guidelines ensures NixOS configurations that are:
 - **Composable** with correct package and module patterns
 - **Trustworthy** with proper disclosure of AI assistance
 
-These patterns help both human developers and AI systems create better NixOS code that the community can rely on and build upon.
+These patterns help both human developers and AI systems create better NixOS code that the community can rely
+on and build upon.
 
 ## **Official Documentation References**
 
@@ -1098,14 +1117,18 @@ For comprehensive best practices and patterns, consult these resources:
 
 ### **Primary References:**
 
-- **[Nix Module System Deep Dive](https://nix.dev/tutorials/module-system/deep-dive)** - Official guide to the module system, type usage, and proper module composition
-- **[Nixpkgs Manual](https://nixos.org/manual/nixpkgs/stable/)** - Standard package writing conventions, build helpers, and overlay patterns
+- **[Nix Module System Deep Dive](https://nix.dev/tutorials/module-system/deep-dive)** - Official guide to the
+  module system, type usage, and proper module composition
+- **[Nixpkgs Manual](https://nixos.org/manual/nixpkgs/stable/)** - Standard package writing conventions, build
+  helpers, and overlay patterns
 - **[NixOS Manual](https://nixos.org/manual/nixos/stable/)** - System configuration and module development
 
 ### **Companion Documents:**
 
 - **[PATTERNS.md](./PATTERNS.md)** - Comprehensive guide to recommended patterns and best practices for this repository
-- **[CLAUDE.md](../CLAUDE.md)** - Project-specific guidelines and architecture documentation
+- **[CLAUDE.md](https://github.com/olafkfreund/nixos_config/blob/main/CLAUDE.md)** - Project-specific guidelines
+  and architecture documentation
+- **[Desktop (Nixarchy)](architecture/desktop.md)** - Nixarchy / Omarchy on Hyprland
 
 ### **Community Resources:**
 
@@ -1113,4 +1136,5 @@ For comprehensive best practices and patterns, consult these resources:
 - [NixOS Wiki](https://nixos.wiki/) - Community-maintained documentation
 - [Nixpkgs Repository](https://github.com/NixOS/nixpkgs) - Source of truth for established patterns
 
-When in doubt, always check how official nixpkgs modules handle similar functionality before implementing your own patterns.
+When in doubt, always check how official nixpkgs modules handle similar functionality before implementing your
+own patterns.

--- a/docs/Nixos/COMMANDS-INDEX.md
+++ b/docs/Nixos/COMMANDS-INDEX.md
@@ -445,18 +445,15 @@ just test-host          # Individual host testing
 
 ### Monitoring Integration
 
-Commands interact with monitoring:
+Commands read system state directly. The Prometheus/Grafana/Loki/Alertmanager
+stack was removed, so `grafana-status`, `prometheus-status` and
+`node-exporter-status` no longer exist and nothing listens on ports 9090/3001/9093.
 
 ```bash
-# Commands check:
-grafana-status          # Dashboard health
-prometheus-status       # Metrics collection
-node-exporter-status    # Exporter status
-
-# Commands access:
-http://p620:9090        # Prometheus
-http://p620:3001        # Grafana
-http://p620:9093        # Alertmanager
+systemctl --failed      # anything broken
+systemctl status <unit> # one unit
+journalctl -u <unit> -f # follow a unit
+journalctl -p err -b    # this boot's errors
 ```
 
 ### Documentation Integration

--- a/docs/Nixos/Quick-Reference.md
+++ b/docs/Nixos/Quick-Reference.md
@@ -120,12 +120,17 @@ just razer                  # Deploy to razer
 just p510                   # Deploy to p510
 ```
 
-### Monitoring
+### System state
+
+The Prometheus/Grafana/Loki/Alertmanager stack was removed; `grafana-status`,
+`prometheus-status` and `node-exporter-status` no longer exist.
 
 ```bash
-grafana-status           # Grafana status
-prometheus-status        # Prometheus status
-node-exporter-status     # Exporter status
+systemctl --failed                  # anything broken
+systemctl status <unit>             # one unit
+journalctl -u <unit> -f            # follow a unit
+journalctl -p err -b               # this boot's errors
+readlink /nix/var/nix/profiles/system   # current generation
 ```
 
 ## Emergency Procedures
@@ -162,31 +167,20 @@ ssh HOST "readlink /nix/var/nix/profiles/system"
 just emergency-deploy HOST
 ```
 
-## Monitoring Access
-
-### Web Interfaces
+## Service Web Interfaces
 
 ```bash
-# Grafana
-http://p620:3001
-# Login: admin / nixos-admin
-
-# Prometheus
-http://p620:9090
-
-# Alertmanager
-http://p620:9093
+# p510
+https://p510:47990          # Sunshine (Moonlight streaming host)
+http://p510:32400/web       # Plex
 ```
+
+There is no Grafana, Prometheus or Alertmanager on any host, and no binary
+cache server on p620 — nothing listens on `p620:5000`.
 
 ### CLI Checks
 
 ```bash
-# Prometheus targets
-curl -s http://p620:9090/api/v1/targets | jq
-
-# Active alerts
-curl -s http://p620:9093/api/v2/alerts | jq
-
 # Service status
 ssh HOST "systemctl status SERVICE"
 ```
@@ -280,12 +274,10 @@ docs/GITHUB-WORKFLOW.md       # GitHub workflow
 
 ### Critical Services
 
-**P620 (Monitoring Server):**
+**P620 (AI / build host):**
 
-- Prometheus (9090)
-- Grafana (3001)
-- Alertmanager (9093)
-- AI Services (Ollama)
+- Ollama (ROCm) + LiteLLM router
+- glance
 
 **P510 (Media Server):**
 
@@ -396,14 +388,12 @@ Ctrl+B d        # Detach session
 - [ ] Configuration tested: `just quick-test`
 - [ ] Git status clean: `git status`
 - [ ] No critical issues: `/check_tasks`
-- [ ] Monitoring operational: `grafana-status`
 - [ ] Rollback plan ready
 
 ### After Deployment
 
 - [ ] Services running: Check `systemctl --failed`
-- [ ] Monitoring updated: Check Grafana dashboards
-- [ ] No new alerts: Check Alertmanager
+- [ ] No new errors: `journalctl -p err -b`
 - [ ] Documentation updated
 - [ ] GitHub issues closed
 
@@ -431,7 +421,7 @@ done
 
 ## Support Resources
 
-### Documentation
+### Further reading
 
 - [README](./README.md) - Getting started
 - [Overview](./Command-System-Overview.md) - Complete guide
@@ -444,11 +434,11 @@ done
 - **GitHub CLI**: `gh --help`
 - **Claude Code**: `claude --help`
 
-### Monitoring
+### System insight
 
-- **Grafana**: Visualization and dashboards
-- **Prometheus**: Metrics collection
-- **Alertmanager**: Alert management
+- **journalctl** / **systemctl**: the whole story since the monitoring stack
+  was removed
+- **nvd** / **just diff HOST**: closure deltas before a deploy
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # NixOS Infrastructure Documentation
 
-Last Updated: 2026-05-04
+Last Updated: 2026-09-01
 
 ## Overview
 
@@ -26,6 +26,29 @@ flow, including remote hosts and offline-host pre-builds.
 `MCP-GUIDE.md`
 Model Context Protocol server integration: enabled servers, setup, and
 troubleshooting.
+
+## Architecture
+
+Rendered as the Architecture tab of the site; also readable in-repo.
+
+`architecture/desktop.md`
+Nixarchy / Omarchy on Hyprland — the sole Wayland session on all three
+hosts. Sessions and greeters, the two Omarchy-written files at the flake
+root, why `programs.hyprland` is forced off, Lua dispatchers, screen
+sharing, and what was removed. Read before touching anything
+Hyprland-adjacent.
+
+`architecture/theming.md`
+Stylix. The active Omarchy theme is the source of truth for colours; this
+covers the mapping onto base16 and what only follows at the next rebuild.
+
+`architecture/template-system.md`
+The single parameterised host template (workstation | laptop).
+
+`architecture/feature-flags.md`, `architecture/hardware-profiles.md`,
+`architecture/overlays.md`, `architecture/secrets.md`,
+`architecture/home-manager.md`, `architecture/philosophy.md`
+The remaining architecture notes.
 
 ## Guides
 
@@ -83,10 +106,17 @@ GitLab Runner configuration on NixOS.
 Declarative VS Code extension management.
 
 `applications/screensharing_cosmic.md`
-Screen sharing under COSMIC desktop with Wayland.
+Screen sharing under COSMIC desktop with Wayland. Historical — COSMIC is
+parked (`desktop.cosmic.enable = false` on every host). For the live path see
+`architecture/desktop.md`.
 
 `applications/P620-BIOS-NUMA-Configuration.md`
 P620 BIOS and NUMA tuning.
+
+`applications/sunshine.md`
+Sunshine desktop streaming on p510 (Moonlight clients): setup, and the four
+traps — user-service startup, black screen from a DPMS-off output, CSRF
+origins, and the read-only web UI.
 
 ## Tooling
 
@@ -157,7 +187,11 @@ When adding documentation:
 
 New to the repo
 Start with `PATTERNS.md`, then `NIXOS-ANTI-PATTERNS.md`, then the root
-`README.md`.
+`README.md`. For the desktop, `architecture/desktop.md`.
+
+Site nav
+`mkdocs.yml` (Backstage TechDocs) and `mkdocs-full.yml` (the published site)
+are hand-synced by design. A nav change must land in **both**.
 
 Deploying changes
 `UPDATE-DEPLOY.md` for the routine flow; `guides/deployment-guide.md`

--- a/docs/applications/sunshine.md
+++ b/docs/applications/sunshine.md
@@ -1,0 +1,118 @@
+# Sunshine (remote desktop streaming)
+
+Last Updated: 2026-09-01
+
+Sunshine streams a host's live Wayland session to a [Moonlight](https://moonlight-stream.org/)
+client. It is enabled on **p510** only, via `features.sunshine` in
+`modules/desktop/sunshine.nix`.
+
+## Why not GNOME Remote Desktop
+
+p510 used to be served over RDP by `gnome-remote-desktop`. That daemon is a GNOME
+Shell component using GNOME's own screencast pipeline, so once Hyprland became
+the session there was nothing on the other end of the connection. Sunshine
+captures the compositor's output directly, which is compositor-agnostic, and
+encodes on the GPU.
+
+## Enabling it
+
+```nix
+features.sunshine = {
+  enable = true;
+  wakeDisplay = true;
+  webOrigins = [
+    "https://192.168.1.75:47990"
+    "https://p510:47990"
+    "https://p510.local:47990"
+  ];
+};
+```
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `enable` | `false` | Turn the streaming host on |
+| `openFirewall` | `true` | Open the Moonlight + web UI ports |
+| `capSysAdmin` | `true` | KMS capture capability on the binary |
+| `wakeDisplay` | `false` | Wake a DPMS-off output when a client connects |
+| `webOrigins` | `[ ]` | Origins allowed to POST to the web UI |
+
+## First-time setup
+
+1. Browse to `https://<host>:47990` (self-signed certificate — accept it).
+2. Create the admin username and password on the `/welcome` page.
+3. Pair a Moonlight client; the PIN is entered in the web UI.
+
+## Four traps, in the order you will hit them
+
+### 1. It is a systemd *user* service
+
+Upstream's module puts Sunshine in the user session because it needs the user's
+Wayland socket, GPU device nodes and input devices. It therefore comes up when a
+graphical session does and **not a moment sooner**.
+
+On a host that reboots unattended, remote access depends on that session existing
+with nobody at the keyboard — which is why p510 keeps autologin on while p620 and
+razer do not.
+
+!!! note "The hardening rules do not apply here"
+    `DynamicUser`, `ProtectHome` and `ProtectSystem = "strict"` all assume a
+    service that needs nothing of the user's session. Sandboxing this one to the
+    level `CLAUDE.md` mandates is equivalent to switching it off, so the
+    exception is recorded in the module rather than silently taken.
+
+### 2. A connected stream that is solid black
+
+Sunshine captures whatever the compositor puts on the monitor, so a DPMS-off
+output streams as black — with a completely clean log: client connected, capture
+on the right monitor, encoder running, no errors.
+
+`wakeDisplay = true` fixes it with a `global_prep_cmd` that runs on connect.
+Two details matter if you ever touch that script:
+
+- Hyprland 0.56 config here is **Lua**. The dispatcher is
+  `hl.dsp.dpms({ action = "enable" })`; `hyprctl dispatch "dpms on"` is a no-op.
+- `hyprctl` must come from `/run/current-system/sw/bin`, not `pkgs.hyprland`.
+  `omarchy-sole-hyprland.nix` puts the Hyprland that Nixarchy pins into the
+  system profile, and that is the build actually running the session. nixpkgs
+  carries a different version and this dispatcher API is version-sensitive.
+- The script always exits `0`. Sunshine aborts the entire stream if a prep
+  command fails, so a missing Hyprland must degrade to "no wake", never to
+  "no streaming".
+
+There is deliberately no `undo`: a host someone also sits at should not have its
+monitor switched off by a remote disconnect.
+
+### 3. "CSRF Protection Error" on the web UI
+
+The web UI refuses cross-origin POSTs, so logging in from another machine fails
+with a CSRF toast and nothing on the page can be submitted. Add the address to
+`webOrigins`.
+
+**Include the port.** The browser sends it in the `Origin` header, so
+`https://p510` does not match `https://p510:47990`.
+
+### 4. Any setting at all makes the web UI read-only
+
+This comes from upstream's module, not from ours: Sunshine is only handed a
+config file when some setting differs from the default, and that file lives in
+the Nix store, read-only. As soon as `webOrigins` or `wakeDisplay` is set, the
+web UI's **Configuration** tab can no longer save — settings belong in this
+repository from then on.
+
+Credentials and client pairings are unaffected; those live in
+`~/.config/sunshine/sunshine_state.json`, which stays writable.
+
+## Known limitation
+
+Sunshine currently **software-encodes** on p510 despite the RTX 3070 Ti, tracked
+in [#1588](https://github.com/olafkfreund/nixos_config/issues/1588). The cause is
+a catch-22 around `capSysAdmin`: NixOS `security.wrappers` sets file
+capabilities, which makes the loader treat the process as `AT_SECURE` and drop
+`LD_LIBRARY_PATH` — the only route to `libcuda` on NixOS, since the binary's
+`DT_RUNPATH` is empty. Dropping the capability restores CUDA but loses KMS
+capture.
+
+The untested candidate fix is `addDriverRunpath $out/bin/sunshine` in
+`postFixup`, keeping `capSysAdmin = true`, since `DT_RUNPATH` survives
+`AT_SECURE`. Verify it by confirming an NVENC encoder is *selected*, not merely
+by CUDA errors disappearing.

--- a/docs/architecture/desktop.md
+++ b/docs/architecture/desktop.md
@@ -1,0 +1,138 @@
+# Desktop (Nixarchy / Omarchy on Hyprland)
+
+Last Updated: 2026-09-01
+
+## The problem
+
+This fleet went through five Wayland compositors — niri, labwc, mango, Hyprland
+and COSMIC — plus two shells (Noctalia, DankMaterialShell) and three greeters.
+Every one of them needed its own portal wiring, its own theme plumbing and its
+own session entry, and each combination broke in a different way. Screen sharing
+in particular fails silently whenever `XDG_CURRENT_DESKTOP` disagrees with the
+portal backend actually installed.
+
+## The solution
+
+**One Wayland session, on every host: Omarchy on Hyprland**, packaged for NixOS
+as [Nixarchy](https://github.com/olafkfreund/nixarchy) and consumed as a flake
+input. GNOME stays installed and selectable as a fallback. Everything else is
+gone, including the flake inputs.
+
+| Host | Sessions offered | Greeter | Default session |
+| --- | --- | --- | --- |
+| p620 | `omarchy`, `gnome` | SDDM (Omarchy's) | `omarchy` |
+| razer | `omarchy`, `gnome` | SDDM (Omarchy's) | `omarchy` |
+| p510 | `omarchy`, `gnome` | SDDM (Omarchy's) | `omarchy` |
+
+Each host wires it up in `hosts/<host>/nixos/nixarchy.nix`, which imports the
+Nixarchy module plus a set of shared fragments from `hosts/common/nixos/`:
+
+```nix
+imports = [
+  inputs.nixarchy.nixosModules.nixarchy
+  ../../../nixarchy-apps.nix            # app selection, copied in by nixarchy-apply
+  ../../common/nixos/omarchy-input.nix
+  ../../common/nixos/omarchy-sddm.nix
+  ../../common/nixos/omarchy-workspaces.nix
+  ../../common/nixos/omarchy-gog.nix
+  ../../common/nixos/omarchy-sole-hyprland.nix
+  ../../common/nixos/omarchy-stylix-theme.nix
+];
+
+programs.nixarchy.enable = true;
+programs.nixarchy.user = "olafkfreund";   # puts the user in the `input` group
+programs.nixarchy.displayManager = true;  # Omarchy's SDDM
+programs.nixarchy.bootSplash = "force";   # Omarchy's Plymouth theme
+```
+
+## Why two files sit at the flake root
+
+A flake cannot read a file outside its own tree. Two Omarchy features therefore
+write into the repository itself, and both leave the tree dirty — which matters,
+because `nhs` refuses to run on a dirty tree.
+
+| File | Written by | Read by |
+| --- | --- | --- |
+| `nixarchy-apps.nix` | `nixarchy-apply` (copies `~/.config/nixarchy/apps.nix`) | each host's `nixarchy.nix` |
+| `nixarchy-theme.nix` | the `theme-set.d` hook of `omarchy theme set X` | `modules/desktop/stylix-theme.nix` |
+
+!!! warning "Copying is not importing"
+    `nixarchy-apply` copies `apps.nix` in and stops there. Importing it is the
+    host's job. p620 lacked that import until recently, so app selections made
+    in the menu were copied into the flake and built by nobody.
+
+## Only one Hyprland entry at login
+
+`programs.hyprland` is enabled by the Nixarchy module itself, not by this repo.
+It supplies the portal, `uwsm` and the wayland-session basics, so it cannot
+simply be turned off — but it also registers its own Hyprland login entry,
+giving two indistinguishable choices at the greeter.
+
+There is no option to drop a single session.
+`hosts/common/nixos/omarchy-sole-hyprland.nix` therefore forces the module off
+and restates the parts Nixarchy needs. Read that file before touching anything
+Hyprland-adjacent; the two obvious workarounds both fail:
+
+- A filtered `mkForce` on `services.displayManager.sessionPackages` would have
+  to read the value it defines — infinite recursion.
+- A session-less repackage of the compositor is rejected by the option's own
+  type, which asserts `providedSessions != [ ]`.
+
+The `nix eval` diff of the whole system config before and after that file is
+empty apart from `sessionPackages`.
+
+## Configuration is Lua, not hyprlang
+
+Hyprland 0.56 config on these hosts is **Lua**. Dispatchers are namespaced under
+`hl.dsp.*`, so the string forms found in most documentation silently do nothing:
+
+```bash
+hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })'   # correct
+hyprctl dispatch "dpms on"                              # no-op here
+```
+
+User-facing config lives in `~/.config/hypr/` (`hyprland.lua`, `input.lua`,
+`monitors.lua`, `bindings.lua`), seeded by Nixarchy with `cp -rn`. Because the
+seed does not overwrite, a Home Manager file competing for the same path needs
+`force = true`.
+
+## Theming: Omarchy is the source of truth
+
+`omarchy theme set X` retints the 24 files Omarchy owns **immediately** and
+writes `X` into `nixarchy-theme.nix`. `modules/desktop/stylix-theme.nix` reads
+that name, loads the theme's `colors.toml` out of the Nixarchy package, maps its
+named roles onto base16 and hands the result to Stylix.
+
+Everything Omarchy cannot reach at runtime — Plymouth, GRUB, the console, GTK,
+Qt, fonts and the Home Manager targets — follows at the **next rebuild**, not
+instantly. Because `inputs.nixarchy` is flake-wide, p510 follows the same palette
+as the workstations.
+
+!!! danger "Reach the package through `inputs`"
+    Use `inputs.nixarchy`, never `config.programs.nixarchy.package`. Nixarchy
+    consumes Stylix, so reading its config from the module that *defines*
+    `stylix.base16Scheme` closes the module fixpoint and evaluation dies with
+    infinite recursion.
+
+See [Theming (Stylix)](theming.md) for the palette itself.
+
+## Screen sharing
+
+`xdg.portal.configPackages` carries `hyprland-portals.conf`, which routes
+`ScreenCast` to the Hyprland backend rather than wlr. Losing it is the classic
+screen-sharing failure on this fleet, so
+`omarchy-sole-hyprland.nix` names it explicitly rather than relying on a default.
+
+If a cast fails with *"unit is masked"*, the cause is almost always a stale
+`XDG_CURRENT_DESKTOP` from switching sessions without a clean re-login.
+
+## What was removed
+
+niri, labwc, mango, Noctalia and DankMaterialShell — modules, sessions, greeters
+and flake inputs. Any comment or document describing `dms-shell.nix`,
+*"Niri (DMS)"*, *"Hyprland (DMS)"* or `${DESK_SHELL:-noctalia}` is describing a
+tree that no longer exists.
+
+COSMIC is **parked, not removed**: `desktop.cosmic.enable = false` on every host,
+with the module at `modules/desktop/cosmic.nix` and the applets under
+`pkgs/cosmic-applets/` kept for an easy re-enable.

--- a/docs/architecture/template-system.md
+++ b/docs/architecture/template-system.md
@@ -73,18 +73,21 @@ is unique to it.
 
 !!! note "Why `mkDefault` everywhere"
     The template sets defaults, not hard values. A host that needs something
-    different (e.g. p510 running headless with no display manager) overrides
-    cleanly without fighting the template.
+    different (e.g. p510 disabling Omarchy's desktop preinstalls to save disk)
+    overrides cleanly without fighting the template.
 
-## Headless from the same template
+## A server from the same template
 
-p510 is a server, yet it uses the **workstation** template. Rather than
-maintain a separate `server` template (the old `server`/`hybrid`/`base`
-templates were removed), p510 simply:
+p510 is the always-on media server, yet it uses the **workstation** template.
+Rather than maintain a separate `server` template (the old
+`server`/`hybrid`/`base` templates were removed), it sets
+`host.class = "workstation"` and overrides only the handful of things that
+genuinely differ — currently `programs.nixarchy.preinstalls = false` and
+autologin on.
 
-- sets `host.class = "workstation"`,
-- disables the display manager and desktop compositor,
-- enables GNOME Remote Desktop for the rare time a GUI is needed.
+It was headless until 2026-08-31, when it gained a monitor and the Omarchy
+session; the `headless-rdp` value of `host.class` remains in the enum but no host
+uses it. See [p510](../hosts/p510.md).
 
 This keeps one template instead of three and avoids the divergence that the
 template system exists to prevent.

--- a/docs/architecture/theming.md
+++ b/docs/architecture/theming.md
@@ -1,5 +1,7 @@
 # Theming (Stylix)
 
+Last Updated: 2026-09-01
+
 ## The problem
 
 A consistent look across a desktop means keeping colours in sync across the
@@ -12,7 +14,48 @@ Theming is centralised through **Stylix** using a single **base16** palette.
 Every surface derives its colours from `config.lib.stylix.colors` rather than
 hard-coding hex values.
 
-The shared theme is defined once in `hosts/common/shared-variables.nix`:
+## Where the palette comes from
+
+The **active Omarchy theme is the source of truth for colours.**
+`modules/desktop/stylix-theme.nix` reads the theme name from
+`nixarchy-theme.nix` at the flake root, loads that theme's `colors.toml` out of
+the Nixarchy package, maps its named roles onto the sixteen base16 slots and
+hands the result to Stylix.
+
+```text
+omarchy theme set X
+  ├── retints the 24 files Omarchy owns          → immediately
+  └── theme-set.d hook writes X to nixarchy-theme.nix
+        └── stylix-theme.nix → Stylix → Plymouth, GRUB, console,
+            GTK, Qt, fonts, home-manager targets   → next rebuild
+```
+
+Three consequences:
+
+- Everything Omarchy cannot reach at runtime follows at the **next rebuild**,
+  not instantly.
+- Switching a theme leaves the tree dirty, and `nhs` refuses a dirty tree.
+- p510 follows the same palette as the workstations, because `inputs.nixarchy`
+  is flake-wide.
+
+Omarchy's `colors.toml` is a named-role palette rather than base16, but its roles
+cover all sixteen slots one-for-one. Three stock themes (`last-horizon`,
+`solitude`, `white`) ship no `orange` or `brown`, so `base09` and `base0F` fall
+back to yellow and muted rather than failing evaluation.
+
+!!! danger "Reach the package through `inputs`"
+    Use `inputs.nixarchy`, never `config.programs.nixarchy.package`. Nixarchy
+    consumes Stylix, so reading its config from the module that *defines*
+    `stylix.base16Scheme` closes the module fixpoint and evaluation dies with
+    infinite recursion.
+
+If the theme name is not present in the package — a user theme under
+`~/.config/omarchy/themes/`, which the flake cannot see — the build falls back to
+the checked-in YAML scheme rather than failing.
+
+## The fallback theme
+
+The fallback theme is defined once in `hosts/common/shared-variables.nix`:
 
 ```nix
 baseTheme = {
@@ -34,8 +77,12 @@ Surfaces that cannot consume Stylix automatically are wired to it explicitly:
 
 - **GNOME Terminal** and **Zellij** — colours generated from
   `config.lib.stylix.colors`.
+- **Plymouth, GRUB and the Linux console** — themed through Stylix, which is
+  the only way they can follow Omarchy at all.
+- **GTK and Qt**, fonts, cursor and the icon theme (Papirus, recoloured).
 - **COSMIC** — a full RON palette (all 30 fields) is written from the same
-  source, so the COSMIC desktop matches everything else.
+  source. COSMIC itself is parked (`desktop.cosmic.enable = false` on every
+  host), but the writer is kept wired for an easy re-enable.
 
 Because they all read one palette, changing `scheme` re-themes the entire stack
 in a single rebuild.
@@ -51,8 +98,13 @@ Terminal and popup opacity are pinned to `1.0`. Transparency was disabled
 deliberately: it caused rendering issues under COSMIC/GTK. The structure is kept
 so it can be re-enabled per host if a future desktop handles it cleanly.
 
+Omarchy manages its own window opacity and blur through
+`~/.config/hypr/`; those are runtime settings and are not driven from here.
+
 ## Per-host wallpaper
 
 The base theme carries a single wallpaper. Hosts may override it in their
 `variables.nix`; the mechanism is intentionally minimal because the rest of the
 palette is shared.
+
+See also: [Desktop (Nixarchy / Omarchy on Hyprland)](desktop.md).

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -20,8 +20,8 @@ auto-discovery to reason around.
 
 | Host | Profile | Hardware | Role |
 | --- | --- | --- | --- |
-| [**p620**](../hosts/p620.md) | workstation | AMD Ryzen + Radeon RX 7900 (ROCm) | Primary development, local AI inference, binary cache |
-| [**p510**](../hosts/p510.md) | workstation (headless) | Intel Xeon + NVIDIA | Plex media server, *arr automation, k3s MicroVMs |
+| [**p620**](../hosts/p620.md) | workstation | AMD Ryzen + Radeon RX 7900 (ROCm) | Primary development, local AI inference, build host |
+| [**p510**](../hosts/p510.md) | workstation | Intel Xeon + NVIDIA RTX 3070 Ti | Plex media server, *arr automation, k3s MicroVMs, self-hosted CI runner |
 | [**razer**](../hosts/razer.md) | laptop | Intel + NVIDIA (Optimus) | Mobile development, Secure Boot |
 
 !!! note "Decommissioned hosts"

--- a/docs/guides/HOST_SETUP.md
+++ b/docs/guides/HOST_SETUP.md
@@ -337,23 +337,13 @@ nixos-rebuild switch --flake .#new-hostname
 }
 ```
 
-## Monitoring and Logging
+## Logging
 
-### Basic Monitoring
+There is no metrics stack on this fleet (Prometheus/Grafana/Loki/Alertmanager
+were removed). System insight comes from the journal, so it is worth capping:
 
 ```nix
 {
-  # System monitoring
-  services.prometheus = {
-    exporters = {
-      node = {
-        enable = true;
-        enabledCollectors = [ "systemd" "filesystem" "network" ];
-      };
-    };
-  };
-
-  # Log management
   services.journald.extraConfig = ''
     SystemMaxUse=1G
     MaxRetentionSec=1month

--- a/docs/guides/deployment-guide.md
+++ b/docs/guides/deployment-guide.md
@@ -304,9 +304,10 @@ Use parallel commands whenever possible:
 - `just deploy-all-parallel`
 - `just build-all-parallel`
 
-### 4. Monitor Performance
+### 4. Watch the deploy
 
-Check deployment metrics in Grafana to identify bottlenecks.
+There is no metrics stack. Use `journalctl -f` on the target and
+`just diff HOST` for the closure delta before switching.
 
 ### 5. Use Appropriate Strategy
 
@@ -341,13 +342,19 @@ Example GitHub Actions workflow:
   run: just deploy-all-parallel
 ```
 
-### Monitoring Alerts
+### Deploy failures
 
-Grafana alerts configured for:
+There are no configured alerts. A failed deploy is caught by reading the
+`switch-to-configuration` output and `systemctl --failed` on the target.
 
-- Deployment failures
-- Performance degradation
-- Host connectivity issues
+Two known false alarms on this fleet:
+
+- **`switch` exits 4 on p510 and razer even on success** — p510 reloads the
+  user `dbus-broker` mid-switch; razer has a self-healing `syncthing-init`
+  race. Verify `/run/current-system` and `systemctl --failed`, not the exit
+  code. Never pipe the build through `tail`, which masks the real exit status.
+- **One permanently-dead unit rolls back the whole deploy** (e.g. `thermald`
+  on AMD). Read the "the following units failed" line and fix the unit.
 
 ## Future Optimizations
 

--- a/docs/hosts/index.md
+++ b/docs/hosts/index.md
@@ -10,13 +10,14 @@ each host has its own page with the full picture.
 
     ---
 
-    Primary development + local AI inference + binary cache.
+    Primary development + local AI inference + build host for razer.
 
 - :material-server: __[p510](p510.md)__ — Media Server
 
     ---
 
-    Headless Plex + *arr automation + k3s MicroVMs.
+    Plex + *arr automation + k3s MicroVMs + self-hosted CI runner.
+    Also a desktop since 2026-08-31.
 
 - :material-laptop: __[razer](razer.md)__ — Laptop
 
@@ -30,11 +31,12 @@ each host has its own page with the full picture.
 
 | | p620 | p510 | razer |
 | --- | --- | --- | --- |
-| __Profile__ | workstation | workstation (headless) | laptop |
+| __Profile__ | workstation | workstation | laptop |
 | __CPU__ | AMD Ryzen | Intel Xeon | Intel mobile |
-| __GPU__ | Radeon RX 7900 (ROCm) | NVIDIA (transcode) | Intel + NVIDIA (Optimus) |
-| __Role__ | Dev / AI / cache | Media server | Mobile dev |
-| __Desktop__ | Yes | Headless (remote GNOME) | Yes (GNOME) |
+| __GPU__ | Radeon RX 7900 (ROCm) | NVIDIA RTX 3070 Ti (transcode) | Intel + NVIDIA (Optimus) |
+| __Role__ | Dev / AI / build host | Media server + desktop | Mobile dev |
+| __Session__ | Omarchy (or GNOME) | Omarchy (or GNOME) | Omarchy (or GNOME) |
+| __Greeter__ | SDDM | SDDM, autologin | SDDM |
 | __Secure Boot__ | No | No | Yes (lanzaboote) |
 | __Display__ | 2× 2560×1440@120 | 1× 4K@30 | eDP 1920×1080@120 |
 | __NFS export__ | `/extdisk` | `/mnt/data` | `/extdisk` |
@@ -47,7 +49,10 @@ documenting per host:
 - __Development__, __virtualisation__, __AI__ (Ollama + cloud providers),
   __media__ tooling, __Syncthing__
 - __Tailscale__ mesh networking (local firewall delegated to Tailscale)
-- __agenix__ secrets, __Alien HUD__ Stylix theme
+- __Omarchy on Hyprland__ as the sole Wayland session, with GNOME as a
+  selectable fallback — see [Desktop](../architecture/desktop.md)
+- __agenix__ secrets; Stylix theming driven by the active
+  [Omarchy theme](../architecture/theming.md)
 - User `olafkfreund`, `Europe/London`, `en_GB.UTF-8`, UK keyboard
 
 ## What differs (and why)
@@ -55,7 +60,7 @@ documenting per host:
 | Dimension | p620 | p510 | razer |
 | --- | --- | --- | --- |
 | __Why it exists__ | Daily driver + GPU compute | Always-on media + services | Portable workstation |
-| __Signature services__ | Ollama (ROCm), LiteLLM router, glance, binary cache | Plex, recyclarr, FlareSolverr, audiobook/*arr MCP, k3s | OpenRazer, power mgmt |
+| __Signature services__ | Ollama (ROCm), LiteLLM router, glance | Plex, recyclarr, FlareSolverr, audiobook/*arr MCP, k3s, Sunshine, GitHub Actions runner | OpenRazer, power mgmt |
 | __Boot__ | Standard | Standard | Secure Boot (lanzaboote) |
 | __Docker__ | On | On | Off (libvirt + lxd/incus) |
 

--- a/docs/hosts/p510.md
+++ b/docs/hosts/p510.md
@@ -1,30 +1,57 @@
-# p510 — Media Server
+# p510 — Media Server & Workstation
 
-A headless Intel Xeon box that runs the media stack and a small k3s cluster. It
-uses the **workstation** template but runs without a local display.
+Last Updated: 2026-09-01
+
+An Intel Xeon box that runs the media stack, a small k3s cluster and — since
+2026-08-31 — a full Omarchy desktop on its own monitor.
 
 | | |
 | --- | --- |
-| **Profile** | `workstation` (headless) |
-| **GPU** | NVIDIA — proprietary driver, used for **hardware transcoding** |
-| **Display** | DP-2, 4K@30 (mostly unused; remote GNOME for occasional GUI) |
+| **Profile** | `workstation` |
+| **`host.class`** | `workstation` (was `headless-rdp` until this host got a monitor) |
+| **GPU** | NVIDIA RTX 3070 Ti @ `03:00.0` — proprietary driver, **hardware transcoding** |
+| **Session** | Omarchy on Hyprland (default) or GNOME, via Omarchy's SDDM |
+| **Login** | Autologin **on** — see below |
+| **Remote** | [Sunshine](../applications/sunshine.md) → Moonlight |
 | **NFS** | exports `/mnt/data` to `192.168.1.*` |
-| **Boot** | standard |
+| **Boot** | standard, Omarchy Plymouth theme |
 | **Source** | [`hosts/p510/`](https://github.com/olafkfreund/nixos_config/tree/main/hosts/p510) |
+
+!!! danger "Never build or deploy p510 without asking first"
+    This is the always-on media server for the house. Deploys are requested and
+    approved explicitly, never taken as implied by a change that touches it.
 
 ## Why this host is shaped the way it is
 
-p510 is the always-on **media server**. It pairs a power-efficient Xeon with an
-NVIDIA card specifically for Plex transcoding. Because it is headless, the
-desktop compositor and display manager are disabled — but it keeps GNOME
-available over **GNOME Remote Desktop** for the rare moment a GUI is needed,
-rather than maintaining a separate server template.
+p510 pairs a power-efficient Xeon with an NVIDIA card specifically for Plex
+transcoding, and stays on around the clock for that reason.
+
+It was headless for most of its life: GDM autologged into GNOME and
+`gnome-remote-desktop` served that session over RDP. Then it got a monitor. The
+three settings that had held Omarchy at arm's length were inverted and it now
+follows the same template as p620 and razer — see
+[Desktop (Nixarchy)](../architecture/desktop.md).
+
+GNOME stays installed and selectable at the greeter; it is simply no longer the
+session this host boots into.
+
+## Two deliberate divergences from p620 / razer
+
+| | p510 | p620 / razer | Why |
+| --- | --- | --- | --- |
+| `programs.nixarchy.preinstalls` | `false` | `true` | Omarchy's desktop preinstalls are ~4 GiB more closure (`cef-binary` alone is 1.9 GiB) and would take `/` from 50.5 to 57.6 GiB, ~80% full |
+| Autologin | **on** | off | Sunshine is a systemd *user* service that only exists inside a live graphical session. On a host that reboots unattended, the alternative is a greeter nobody is there to answer and no remote desktop until someone walks over to it |
+
+Autologin is off on razer specifically because PRIME-sync Optimus hardware
+misbehaves with a greeter respawn; p510 is pure NVIDIA without PRIME, so that
+reason does not apply here.
 
 ## What runs here
 
 ### Media stack
 
 - **Plex** media server with NVIDIA hardware transcoding.
+- **NZBGet**, **Sonarr**, **Radarr**.
 - **recyclarr-sync** — keeps *arr quality profiles in shape.
 - **FlareSolverr** — Cloudflare-challenge proxy for indexers.
 - **Audiobook automation** — `audiobookbay-automated`, an import pipeline
@@ -34,31 +61,85 @@ rather than maintaining a separate server template.
 
 ### Compute & virtualisation
 
-- **k3s MicroVMs** — a master plus two agents, defined under
-  `hosts/p510/nixos/microvm/`, giving a lightweight Kubernetes cluster.
+- **k3s MicroVMs** — a master plus two agents, defined per-host under
+  `hosts/p510/nixos/microvm/` (these are host files, not a shared module).
 - **Ollama server** for local inference.
 - **Virtualisation** and **Syncthing** enabled.
 
+### CI
+
+A **self-hosted GitHub Actions runner** (`hosts/p510/nixos/github-runner.nix`,
+registered as `p510-nixarchy`) for Nixarchy's heavy checks.
+`checks.install-iso` builds a 5.6 GB image, boots it and installs a 15.3 GB
+closure into a qcow2 — about an hour of wall clock and ~16 GB of build
+directory. A GitHub-hosted runner has 14 GB of disk and no usable nested
+virtualisation. p510 has 40 cores, 94 GB of RAM, `/dev/kvm` and 825 GB free on
+`/home`.
+
+!!! warning "The build directory is the easy thing to get wrong"
+    `TMPDIR` is pointed at `/home` (`WD10EZEX`, 7200 rpm CMR), **not**
+    `/mnt/img_pool`. The pool has the most free space and is the worst possible
+    target: `/dev/sdb1` is an `ST1000LM035`, a drive-managed **SMR** disk that
+    collapses to single-digit MB/s once its cache band fills — exactly the
+    sustained-write pattern a 16 GB VM install produces. Measured on the same
+    host, same day:
+
+    | | sequential 512M | 4M writes, `O_DSYNC` |
+    | --- | --- | --- |
+    | `/home` | 125 MB/s | 59.4 MB/s |
+    | `/mnt/img_pool` (SMR) | — | ~9.5 MB/s |
+
+    A Nix build that runs out of room in `TMPDIR` does not fail cleanly: qemu
+    takes an I/O error mid-install and the test hangs until something times out,
+    which reads as flakiness rather than as a full disk.
+
+The runner is `replace = true` and non-ephemeral, so it re-registers over a
+stale entry of the same name instead of dying with
+*"A runner exists with the same name"*.
+
 ### Access
 
-- **GNOME Remote Desktop** (native) for occasional graphical access.
+- **[Sunshine](../applications/sunshine.md)** → Moonlight for the graphical
+  session. `gnome-remote-desktop` can still serve GNOME over RDP, but it cannot
+  serve Hyprland.
 - **Tailscale** mesh; local firewall delegated to Tailscale.
 - **NFS** export of `/mnt/data` (the media library) to the LAN.
 
 ## Hardware notes
 
 Under `hosts/p510/nixos/`: NVIDIA setup (`nvidia.nix`), boot/CPU/memory/power
-tuning, the Plex configuration, recyclarr, and the MicroVM definitions. See the
-[p510 manifest](../reference/hosts/p510.md).
+tuning, the Plex configuration, recyclarr, the runner and the MicroVM
+definitions. See the [p510 manifest](../reference/hosts/p510.md).
+
+!!! note "`lspci` is not installed here"
+    Use `nvidia-smi -L` to enumerate GPUs. The host went from two cards to one
+    (RTX 3070 Ti) on 2026-08-24.
+
+!!! warning "`/mnt/media` disk health"
+    The `/mnt/media` drive has been reporting reallocated sectors for some time.
+    SMART reads `PASSED` regardless; do not treat that as reassurance. A
+    replacement has been ordered.
 
 !!! tip "Tautulli / Plex API"
     Media-analytics integrations read from Plex/Tautulli on this host. If you
     rotate the Tautulli API key, update the p510 configuration and redeploy.
 
+## Known quirks
+
+- **`switch` exits 4 here even on success.** `switch-to-configuration` reloads
+  the user `dbus-broker` and then talks over the dead connection. It is
+  cosmetic, and it also makes `nixos-upgrade.service` "fail" nightly. Verify the
+  end state (`/run/current-system`, `systemctl --failed`), not the exit code.
+- **An NVIDIA driver version bump cannot be applied with `switch`.** The new
+  userspace meets the old in-memory module, three `nvidia-*` units fail and the
+  whole activation rolls back. Use `nh os boot` and reboot; `nhs` now detects
+  this case and falls back automatically.
+
 ## Deploy
 
+Ask first — then, once approved:
+
 ```bash
-just test-host p510
-just quick-deploy p510
-just p510
+just test-host p510        # build only, always safe
+just quick-deploy p510     # deploy only if the closure changed
 ```

--- a/docs/hosts/p620.md
+++ b/docs/hosts/p620.md
@@ -16,9 +16,15 @@ cache that speeds up the other hosts.
 
 p620 has the only GPU in the fleet suitable for ML work (Radeon RX 7900 +
 ROCm), so it is the **local AI host**: it runs Ollama against the GPU and fronts
-it with a LiteLLM router. It is also powerful and always-on, which makes it the
-natural **binary cache server** — the other hosts pull builds from it instead of
-rebuilding.
+it with a LiteLLM router. It is also the fleet's **build host**: heavy rebuilds
+for razer are built here (`just deploy-via-p620 razer`) and the closure is copied
+over SSH.
+
+!!! warning "There is no binary cache server"
+    Earlier revisions of this page described p620 as running `nix-serve`. It does
+    not, and neither does any other host — nothing listens on `p620:5000`.
+    Substituters are `cache.nixos.org` and `nix-community.cachix.org` only. See
+    [Cache Strategy](../guides/CACHE-STRATEGY.md).
 
 ## What runs here
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ behind each architectural choice.
     ---
 
     Primary development and AI workloads. Radeon RX 7900 with ROCm, local
-    inference, binary cache server.
+    inference, build host for razer.
 
     [:octicons-arrow-right-24: Details](hosts/p620.md)
 
@@ -31,8 +31,8 @@ behind each architectural choice.
 
     ---
 
-    Headless Intel Xeon server. Plex media stack, NVIDIA transcoding,
-    k3s MicroVMs.
+    Intel Xeon server — and, since 2026-08-31, a desktop. Plex media stack,
+    NVIDIA transcoding, k3s MicroVMs, self-hosted CI runner, Sunshine.
 
     [:octicons-arrow-right-24: Details](hosts/p510.md)
 
@@ -73,10 +73,19 @@ behind each architectural choice.
 
     ---
 
-    A single base16 palette drives colours everywhere — terminals, Zellij,
-    COSMIC — from `config.lib.stylix.colors`.
+    The active Omarchy theme drives one base16 palette, and every surface —
+    Plymouth, GRUB, console, GTK, Qt, terminals — derives from it.
 
     [:octicons-arrow-right-24: Theming](architecture/theming.md)
+
+- :material-monitor-dashboard: **One Wayland session**
+
+    ---
+
+    Omarchy on Hyprland, packaged as Nixarchy, on all three hosts. GNOME stays
+    selectable; niri, labwc, mango and COSMIC are gone or parked.
+
+    [:octicons-arrow-right-24: Desktop](architecture/desktop.md)
 
 - :material-key: **agenix secrets**
 

--- a/mkdocs-full.yml
+++ b/mkdocs-full.yml
@@ -149,6 +149,7 @@ nav:
       - Feature Flags: architecture/feature-flags.md
       - Hardware Profiles: architecture/hardware-profiles.md
       - Overlays: architecture/overlays.md
+      - "Desktop (Nixarchy)": architecture/desktop.md
       - Theming (Stylix): architecture/theming.md
       - Secrets (agenix): architecture/secrets.md
       - Home Manager: architecture/home-manager.md
@@ -186,6 +187,7 @@ nav:
       - P620 BIOS / NUMA: applications/P620-BIOS-NUMA-Configuration.md
       - "k3d Cluster (ops)": applications/k3d-cluster.md
       - "Cloudflared Tunnel (host)": applications/cloudflared-tunnel.md
+      - "Sunshine (streaming)": applications/sunshine.md
   - Command System:
       - Overview: Nixos/README.md
       - Commands Index: Nixos/COMMANDS-INDEX.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,6 +154,7 @@ nav:
       - Feature Flags: architecture/feature-flags.md
       - Hardware Profiles: architecture/hardware-profiles.md
       - Overlays: architecture/overlays.md
+      - "Desktop (Nixarchy)": architecture/desktop.md
       - Theming (Stylix): architecture/theming.md
       - Secrets (agenix): architecture/secrets.md
       - Home Manager: architecture/home-manager.md
@@ -194,6 +195,7 @@ nav:
       - P620 BIOS / NUMA: applications/P620-BIOS-NUMA-Configuration.md
       - "k3d Cluster (ops)": applications/k3d-cluster.md
       - "Cloudflared Tunnel (host)": applications/cloudflared-tunnel.md
+      - "Sunshine (streaming)": applications/sunshine.md
   - Command System:
       - Overview: Nixos/README.md
       - Commands Index: Nixos/COMMANDS-INDEX.md

--- a/modules/desktop/stylix-theme.nix
+++ b/modules/desktop/stylix-theme.nix
@@ -56,10 +56,13 @@ let
   # Stylix wants "rrggbb" with no leading '#'; Omarchy writes "#rrggbb".
   stripHash = v: lib.removePrefix "#" v;
 
-  # p510 has no nixarchy at all and imports this same module, and a theme name
-  # that is not in the package (a user theme under ~/.config/omarchy/themes,
-  # which the flake cannot see) would be a dead path. Both fall back to the
-  # checked-in yaml rather than failing the build.
+  # A theme name that is not in the package -- a user theme under
+  # ~/.config/omarchy/themes, which the flake cannot see -- would be a dead
+  # path, and so would a host without nixarchy importing this module. Both fall
+  # back to the checked-in yaml rather than failing the build.
+  #
+  # (All three hosts carry nixarchy now. p510 did not until #1585, which is
+  # what the second half of this guard was originally written for.)
   useOmarchyTheme = omarchyPkg != null && builtins.pathExists omarchyColorsPath;
 
   omarchyScheme =


### PR DESCRIPTION
The docs still described the tree as it was in May 2026. Fixed the wrong
facts, filled the two subjects that had no page at all, and repaired the
quality gate.

Wrong facts corrected:

- p510 was documented as a headless media server with no display manager.
  It has been a full Omarchy/Hyprland workstation with SDDM, Plymouth and
  Sunshine since 2026-08-31. Rewrote docs/hosts/p510.md and corrected
  README, AGENTS.md, CLAUDE.md, docs/index.md, docs/hosts/index.md,
  docs/getting-started/overview.md and architecture/template-system.md.
- CLAUDE.md still carried the superseded arrangement from #1562
  (displayManager = false, defaultSession = gnome, "selectable entry
  only"). #1585 inverted all three.
- AGENTS.md claimed a server template exists in hosts/templates/. Only
  desktop.nix (workstation | laptop) does.
- Three pages still advertised p620 as a binary cache server. There is no
  nix-serve/harmonia anywhere in the repo. This was already corrected in
  CACHE-STRATEGY.md and deployment-guide.md but not in index.md,
  hosts/index.md or hosts/p620.md.
- README pinned lanzaboote v1.0.0; flake.nix pins v1.1.0. README also said
  razer's kernel was pinned to dodge 6.18.24; boot.nix documents a 7.0.1
  trial with a fallback plan.
- Purged the removed Prometheus/Grafana/Loki/Alertmanager stack and its
  helper commands from Quick-Reference.md, COMMANDS-INDEX.md,
  deployment-guide.md and HOST_SETUP.md.

New pages:

- docs/architecture/desktop.md. Nixarchy/Omarchy/Hyprland appeared in zero
  doc files despite being the sole Wayland session on all three hosts; the
  documented desktop story was still GNOME + COSMIC. Covers sessions and
  greeters per host, the two Omarchy-written files at the flake root, why
  programs.hyprland is forced off and why both obvious workarounds fail,
  Lua dispatchers, the theming path, and screen sharing.
- docs/applications/sunshine.md. Setup plus the four traps in the order
  they are hit, and the NVENC catch-22 from #1588.

Also:

- The Pages workflow watched mkdocs.yml but not mkdocs-full.yml, which is
  the config the published site is actually built from. A nav or theme
  change to the real config never triggered a publish.
- Fixed a pre-existing broken link (NIXOS-ANTI-PATTERNS.md -> ../CLAUDE.md)
  that had been failing the strict build gate.
- Corrected a stale comment in modules/desktop/stylix-theme.nix claiming
  p510 has no nixarchy. Comment-only; the guard logic is unchanged and
  still correct.

Verified: nix build .#docs succeeds and the strict build
(mkdocs build --strict -f mkdocs-full.yml) now passes with zero warnings.

Closes #1595

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB
