### PR TITLE
p510 takes two CI jobs at once

### DIFF
--- a/hosts/p510/nixos/github-runner.nix
+++ b/hosts/p510/nixos/github-runner.nix
@@ -55,6 +55,22 @@ in
       description = "Repository the runner registers against.";
     };
 
+    instances = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 2;
+      description = ''
+        How many runners to register, and therefore how many jobs this machine
+        will accept at once -- a runner takes one job at a time, so this is the
+        only lever there is.
+
+        Two by default. One meant a release build, which owns the machine for
+        hours, queued every other check behind it; and because GitHub keeps
+        only one pending run per concurrency group, a third arrival cancelled
+        the waiting second. The install check went a whole day without a CI
+        result on a day it passed repeatedly by hand.
+      '';
+    };
+
     tokenFile = lib.mkOption {
       type = lib.types.path;
       default = config.age.secrets."api-github-token".path;
@@ -90,79 +106,113 @@ in
     # decides whether an ISO test finishes or wedges.
     systemd.services.nix-daemon.environment.TMPDIR = buildDir;
 
-    services.github-runners.nixarchy = {
-      inherit (cfg) url tokenFile;
-      enable = true;
-      name = "p510-nixarchy";
+    # One runner runs one job. That is not a setting, it is what a runner is,
+    # so "let p510 take two jobs at once" means two runner instances.
+    #
+    # Why it is worth doing: a release build occupies this machine for hours,
+    # and while it does, every other check queues behind it. GitHub keeps only
+    # ONE pending run per concurrency group, so a third arrival cancels the
+    # waiting second -- which is how checks.install came to have no CI success
+    # on a day it passed three times locally. A release should not blind the
+    # checks.
+    #
+    # Two, not more. Each of these jobs boots a VM and wants real cores and
+    # real memory; two heavy jobs on 40 cores and 94 GB is comfortable, and
+    # the point here is to stop one long job monopolising the machine, not to
+    # parallelise the queue.
+    #
+    # The first instance keeps the name it registered under. Renaming it would
+    # leave `p510-nixarchy` behind as a stale offline entry and re-register a
+    # runner that is working, for nothing.
+    services.github-runners = lib.listToAttrs (
+      map
+        (
+          i:
+          let
+            suffix = lib.optionalString (i > 1) "-${toString i}";
+          in
+          lib.nameValuePair "nixarchy${suffix}" {
+            inherit (cfg) url tokenFile;
+            enable = true;
+            name = "p510-nixarchy${suffix}";
 
-      # `nixos` and `kvm` are what the workflow selects on. `big` says this
-      # runner has room for the ISO test, so a future lighter runner can carry
-      # the same nixos label without being handed an hour-long job.
-      extraLabels = [
-        "nixos"
-        "kvm"
-        "big"
-      ];
+            # `nixos` and `kvm` are what the workflow selects on. `big` says this
+            # runner has room for the ISO test, so a future lighter runner can carry
+            # the same nixos label without being handed an hour-long job.
+            extraLabels = [
+              "nixos"
+              "kvm"
+              "big"
+            ];
 
-      # No workDir. It is tempting to move this too and it is the wrong lever: the work directory holds a git checkout, and the sixteen
-      # gigabytes belong to the nix build, which happens in the daemon's
-      # TMPDIR -- already pointed at /home/nix-build above. Left unset, the module
-      # uses its StateDirectory, which systemd creates with the right
-      # ownership for the dynamic user.
-      #
-      # Setting it cost an evening: a directory made by tmpfiles as root:root
-      # is not writable by a DynamicUser, and the runner registers with GitHub
-      # successfully before failing to symlink its own _diag into it. So the
-      # runner exists in the repository's settings and has never once run.
+            # No workDir. It is tempting to move this too and it is the wrong lever: the work directory holds a git checkout, and the sixteen
+            # gigabytes belong to the nix build, which happens in the daemon's
+            # TMPDIR -- already pointed at /home/nix-build above. Left unset, the module
+            # uses its StateDirectory, which systemd creates with the right
+            # ownership for the dynamic user.
+            #
+            # Setting it cost an evening: a directory made by tmpfiles as root:root
+            # is not writable by a DynamicUser, and the runner registers with GitHub
+            # successfully before failing to symlink its own _diag into it. So the
+            # runner exists in the repository's settings and has never once run.
 
-      # Re-register over a runner that already has this name. Without it the
-      # very first real start fails, because the name was already taken by a
-      # registration left behind while this module was being written:
-      #
-      #   √ Connected to GitHub
-      #   A runner exists with the same name p510-nixarchy.
-      #
-      # Authentication succeeds and registration is refused, so the failure
-      # reads like a token problem and is not one. The module's own note about
-      # the workDir dead end says that runner "exists in the repository's
-      # settings and has never once run" -- this is that runner, still there.
-      #
-      # It is also the steady-state need, not just a one-off cleanup: a
-      # non-ephemeral runner keeps its GitHub-side registration across
-      # rebuilds, and the configure step re-runs whenever the unit's config
-      # changes. Deleting the stale one by hand fixes today; this fixes every
-      # time after it.
-      replace = true;
+            # Re-register over a runner that already has this name. Without it the
+            # very first real start fails, because the name was already taken by a
+            # registration left behind while this module was being written:
+            #
+            #   √ Connected to GitHub
+            #   A runner exists with the same name p510-nixarchy.
+            #
+            # Authentication succeeds and registration is refused, so the failure
+            # reads like a token problem and is not one. The module's own note about
+            # the workDir dead end says that runner "exists in the repository's
+            # settings and has never once run" -- this is that runner, still there.
+            #
+            # It is also the steady-state need, not just a one-off cleanup: a
+            # non-ephemeral runner keeps its GitHub-side registration across
+            # rebuilds, and the configure step re-runs whenever the unit's config
+            # changes. Deleting the stale one by hand fixes today; this fixes every
+            # time after it.
+            replace = true;
 
-      # Not ephemeral. An ephemeral runner unregisters after every job, which
-      # is the right shape for untrusted PRs and the wrong one here: this runs
-      # nightly against a repository we own, and re-registering costs a token
-      # round trip before every job.
-      ephemeral = false;
+            # Not ephemeral. An ephemeral runner unregisters after every job, which
+            # is the right shape for untrusted PRs and the wrong one here: this runs
+            # nightly against a repository we own, and re-registering costs a token
+            # round trip before every job.
+            ephemeral = false;
 
-      # A checkout, a flake, and the tools the workflow calls directly.
-      # nixos-rebuild is not among them: nothing here rebuilds this machine.
-      extraPackages = with pkgs; [
-        git
-        gnutar
-        gzip
-        openssh
-        coreutils
-        jq
-      ];
+            # A checkout, a flake, and the tools the workflow calls directly.
+            # nixos-rebuild is not among them: nothing here rebuilds this machine.
+            extraPackages = with pkgs; [
+              git
+              # gawk, because its absence is what broke the first real nightly:
+              # the step shell is a Nix bash carrying coreutils and not much else,
+              # and `awk` in a workflow step died with exit 127 after the ISO had
+              # built perfectly well. The workflow no longer needs it; the next
+              # one written should not have to find this out again.
+              gawk
+              gnutar
+              gzip
+              openssh
+              coreutils
+              jq
+            ];
 
-      serviceOverrides = {
-        # The VM tests need KVM, and the runner's dynamic user needs to be let
-        # near it. Without this the tests still pass and take ten times as
-        # long, under TCG, which is the kind of regression nobody attributes to
-        # a permission.
-        DeviceAllow = [ "/dev/kvm rw" ];
-        SupplementaryGroups = [ "kvm" ];
+            serviceOverrides = {
+              # The VM tests need KVM, and the runner's dynamic user needs to be let
+              # near it. Without this the tests still pass and take ten times as
+              # long, under TCG, which is the kind of regression nobody attributes to
+              # a permission.
+              DeviceAllow = [ "/dev/kvm rw" ];
+              SupplementaryGroups = [ "kvm" ];
 
-        # An hour-long job that is killed at the fifty-ninth minute has cost
-        # the whole hour and told nobody anything.
-        TimeoutStartSec = "0";
-      };
-    };
+              # An hour-long job that is killed at the fifty-ninth minute has cost
+              # the whole hour and told nobody anything.
+              TimeoutStartSec = "0";
+            };
+          }
+        )
+        (lib.range 1 cfg.instances)
+    );
   };
 }


### PR DESCRIPTION
A self-hosted runner runs **one job at a time** — that is not a setting, it is what a runner is. So "let p510 take two jobs" means two runner instances, generated over a new `services.nixarchy-runner.instances` (default 2).

## Why

A day of evidence from the nixarchy side. A release build occupies this machine for hours, and while it does every other check queues behind it. GitHub keeps only **one** pending run per concurrency group, so a third arrival cancels the waiting second — which is how `checks.install` went a whole day with no CI result on a day it passed three times locally.

## Details

- The first instance keeps `p510-nixarchy`. Renaming it would leave a stale offline entry behind and re-register a working runner for nothing. The second is `p510-nixarchy-2`.
- Both carry `nixos,kvm,big`, so either can take either workflow's jobs.
- Two, not more: each job boots a VM and wants real cores and memory. The aim is to stop one long job monopolising the machine, not to parallelise the queue.
- **Adds `gawk`.** Its absence broke nixarchy's first real nightly — the step shell is a Nix bash carrying coreutils and little else, and `awk` died with exit 127 *after* the ISO had built fine. The workflow no longer needs it; the next one written shouldn't have to find this out.

## Verified

```
services.github-runners -> ["nixarchy","nixarchy-2"]
  nixarchy    name=p510-nixarchy    labels=["nixos","kvm","big"]
  nixarchy-2  name=p510-nixarchy-2  labels=["nixos","kvm","big"]
  extraPackages: git gawk gnutar gzip openssh coreutils jq
```

`nixosConfigurations.p510` evaluates to a toplevel; `nix fmt` clean.

## Deploy timing matters

**Do not switch while a CI job is running.** Activation restarts the runner unit and kills whatever it is executing. At the time of writing p510 is hours into building the `v4.0.1-3` release. This wants deploying once the runner is idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5