### PR TITLE
fix(meet): pull-able summarization model, Hyprland keybind (#1601)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,9 @@ in {
 }
 ```
 
-Add the file to `modules/default.nix`, then enable it in the host.
+Import the file by path in the host that needs it (`hosts/<host>/configuration.nix`
+or a file it imports), then enable it there. There is no `modules/default.nix`
+and no auto-discovery — every import is explicit.
 
 ## Commands
 

--- a/docs/applications/meet.md
+++ b/docs/applications/meet.md
@@ -102,7 +102,7 @@ features.meetingTranscribe = {
 | `installProcessor`     | bool           | `false`               | Installs whisperX and `meet-process`. Must be `true` when `processHost = "local"`. |
 | `huggingfaceTokenFile` | path or null   | `null`                | Path to an HF token file. Needed on the processor for diarization; degrades gracefully when missing. |
 | `ollamaUrl`            | string         | `"http://p620:11434"` | Ollama API base URL. Set to `http://localhost:11434` on p620. |
-| `ollamaModel`          | string         | `"mistral-small3.1"`  | Must already be pulled on the Ollama host. See the caveat below. |
+| `ollamaModel`          | string         | `"qwen3.8:27b"`       | Must be declared in `features.ollama-server`; asserted at eval time when Ollama is local. |
 | `whisperModel`         | string         | `"large-v3"`          | One of `tiny`, `base`, `small`, `medium`, `large-v3`. |
 | `language`             | string         | `"en"`                | For example `en`, `no`, `da`. |
 | `outputDir`            | string         | `"~/meetings"`        | Per-user; the tilde is expanded at runtime. |
@@ -112,19 +112,19 @@ features.meetingTranscribe = {
 
 ## Setup
 
-### The summarization model must be pulled
+### The summarization model
 
-`ollamaModel` defaults to `mistral-small3.1`, which is **not currently pulled
-on p620** — `ollama list` there has no mistral at all. Until it is, Ollama
-returns a model-not-found error and `meet-process` falls back to a
-transcript-only brief with no TL;DR, action items or decisions. Either pull it:
+`ollamaModel` defaults to `qwen3.8:27b`, which p620 declares in
+`features.ollama-server.persistentModels` — it stays resident, so summarizing
+does not stall on a model load.
 
-```bash
-ssh p620 'ollama pull mistral-small3.1'
-```
+If you point it at a model the Ollama host does not declare, the build now
+fails with an assertion naming the models that are available. Before, Ollama
+returned a model-not-found error at runtime and `meet-process` quietly fell
+back to a transcript-only brief; that failure was invisible.
 
-or point the option at a model p620 already has (`qwen3:14b`, `gemma4:12b`,
-`qwen3.8:27b`).
+The assertion can only check a local Ollama. With `processHost` set to a remote
+host, make sure the model is pulled there yourself.
 
 ### HuggingFace token, for diarization
 
@@ -163,22 +163,29 @@ meet process F  # Process an existing audio file F
 meet help       # Show subcommands
 ```
 
-### Keybind: GNOME session only
+### Keybind
 
-`SUPER+SHIFT+M` is wired in `home/desktop/gnome/keybindings.nix` (slot
-`custom5`) and therefore only works in a GNOME session:
+`SUPER+SHIFT+M` toggles recording in **both** sessions:
 
-```nix
-"org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5" = {
-  binding = "<Super><Shift>m";
-  command = "meet toggle";
-  name = "Meeting record/transcribe/summarize";
-};
+| Session | Declared in |
+| --- | --- |
+| Omarchy (Hyprland) | `hosts/common/nixos/omarchy-meet-binds.nix` |
+| GNOME | `home/desktop/gnome/keybindings.nix`, slot `custom5` |
+
+The Omarchy binding ships as `~/.config/hypr/meet-binds.lua` and is loaded by
+the user-owned `bindings.lua`, which needs this line once:
+
+```lua
+pcall(require, "hypr.meet-binds")
 ```
 
-The default session on every host is Omarchy on Hyprland, which has **no
-binding for `meet`**. In that session use the CLI (`meet toggle`) directly, or
-add a binding to `~/.config/hypr/bindings.lua`.
+`pcall`, not a bare `require`: `bindings.lua` survives deploys untouched, so it
+outlives any generation that stops providing the file — a rollback, or a host
+that never enabled the feature. A bare `require` of a missing file fails the
+whole Hyprland config and drops the session into the error overlay.
+
+The module is guarded on `features.meetingTranscribe.enable`, so p510 imports
+it without getting a binding for a binary it does not have.
 
 Verify the GNOME binding after a deploy:
 
@@ -249,9 +256,6 @@ disk, so retry with `meet process <file>`.
 
 ## Caveats
 
-- **Summarization is currently inert on p620** — the default model is not
-  pulled. Fix it before relying on the briefs.
-- **No Hyprland keybind** — the one-button promise only holds in GNOME today.
 - **HuggingFace EULA dance** — three clicks across two models plus a token, one
   time, but tedious.
 - **CPU whisperX** — roughly 10x realtime on a 16-core CPU, so a one-hour

--- a/docs/applications/screensharing_cosmic.md
+++ b/docs/applications/screensharing_cosmic.md
@@ -1,22 +1,51 @@
 # Enabling Full Screen Sharing in Teams PWA on Chrome with NixOS and Cosmic DE
 
-**Microsoft Teams PWA screen sharing on NixOS with Cosmic DE requires three critical components working together: xdg-desktop-portal-cosmic (the portal backend), PipeWire (multimedia transport), and Chrome configured for native Wayland.** The issue where only tab sharing works indicates the portal/PipeWire chain is broken, while Chrome's internal tab capture still functions. Cosmic DE currently has beta-quality screensharing with known limitations for full screen capture, though window sharing generally works.
+**Microsoft Teams PWA screen sharing on NixOS with Cosmic DE requires three critical components
+working together: xdg-desktop-portal-cosmic (the portal backend), PipeWire (multimedia transport),
+and Chrome configured for native Wayland.** The issue where only tab sharing works indicates the
+portal/PipeWire chain is broken, while Chrome's internal tab capture still functions. Cosmic DE
+currently has beta-quality screensharing with known limitations for full screen capture, though
+window sharing generally works.
 
-The core problem stems from how Wayland screen sharing works differently than tab sharing. Chrome's built-in tab capture operates entirely within the browser process and doesn't require external components. However, window and screen sharing require the complete chain: Browser → xdg-desktop-portal → xdg-desktop-portal-cosmic → cosmic-comp compositor → PipeWire → back to browser. When this chain has any missing or misconfigured component, only tab sharing functions.
+The core problem stems from how Wayland screen sharing works differently than tab sharing. Chrome's
+built-in tab capture operates entirely within the browser process and doesn't require external
+components. However, window and screen sharing require the complete chain: Browser →
+xdg-desktop-portal → xdg-desktop-portal-cosmic → cosmic-comp compositor → PipeWire → back to
+browser. When this chain has any missing or misconfigured component, only tab sharing functions.
 
-Cosmic DE is in beta (Epoch 1 Beta released September 2025) with actively developed screensharing support. While basic functionality works for many users, there are documented issues with full screen sharing (Issue #75 reports screen sharing dialog appears but sharing fails with buffer constraint errors) while individual window sharing typically succeeds. This guide provides the complete configuration to maximize compatibility given Cosmic's current maturity.
+Cosmic DE is in beta (Epoch 1 Beta released September 2025) with actively developed screensharing
+support. While basic functionality works for many users, there are documented issues with full
+screen sharing (Issue #75 reports screen sharing dialog appears but sharing fails with buffer
+constraint errors) while individual window sharing typically succeeds. This guide provides the
+complete configuration to maximize compatibility given Cosmic's current maturity.
 
 ## Required Wayland screensharing components
 
-The Wayland screensharing architecture uses a frontend/backend separation pattern where **xdg-desktop-portal** acts as the desktop-agnostic D-Bus service that applications communicate with, while **desktop-specific backends** handle the actual compositor integration and UI. PipeWire serves as the multimedia transport layer that streams video frames from the compositor to applications.
+The Wayland screensharing architecture uses a frontend/backend separation pattern where
+**xdg-desktop-portal** acts as the desktop-agnostic D-Bus service that applications communicate
+with, while **desktop-specific backends** handle the actual compositor integration and UI. PipeWire
+serves as the multimedia transport layer that streams video frames from the compositor to
+applications.
 
-For Cosmic DE specifically, you need **xdg-desktop-portal-cosmic** (available at github.com/pop-os/xdg-desktop-portal-cosmic), which is the Rust-based portal backend implementing the ScreenCast interface. This backend communicates with **cosmic-comp** (the Smithay-based Wayland compositor) using a custom zcosmic-screencopy-manager protocol, though the team is transitioning to standard ext-image-copy-capture-v1 protocol. PipeWire version 0.3.33 or newer is required for compatibility, along with **WirePlumber** as the session manager (the older pipewire-media-session is deprecated).
+For Cosmic DE specifically, you need **xdg-desktop-portal-cosmic** (available at
+github.com/pop-os/xdg-desktop-portal-cosmic), which is the Rust-based portal backend implementing
+the ScreenCast interface. This backend communicates with **cosmic-comp** (the Smithay-based Wayland
+compositor) using a custom zcosmic-screencopy-manager protocol, though the team is transitioning to
+standard ext-image-copy-capture-v1 protocol. PipeWire version 0.3.33 or newer is required for
+compatibility, along with **WirePlumber** as the session manager (the older pipewire-media-session
+is deprecated).
 
-The complete component list: xdg-desktop-portal (frontend service), xdg-desktop-portal-cosmic (Cosmic-specific backend), xdg-desktop-portal-gtk (fallback for file choosers), pipewire and pipewire-pulse, wireplumber, and rtkit for realtime scheduling. All these components communicate via D-Bus and require proper environment variables (WAYLAND_DISPLAY, XDG_CURRENT_DESKTOP) to be imported into the systemd user session.
+The complete component list: xdg-desktop-portal (frontend service), xdg-desktop-portal-cosmic
+(Cosmic-specific backend), xdg-desktop-portal-gtk (fallback for file choosers), pipewire and
+pipewire-pulse, wireplumber, and rtkit for realtime scheduling. All these components communicate via
+D-Bus and require proper environment variables (WAYLAND_DISPLAY, XDG_CURRENT_DESKTOP) to be imported
+into the systemd user session.
 
 ## NixOS configuration.nix settings
 
-Configure your NixOS system with this complete configuration that enables all necessary screensharing components. The configuration enables PipeWire as the primary multimedia service, sets up xdg-desktop-portal with the Cosmic backend, and ensures proper environment variable handling.
+Configure your NixOS system with this complete configuration that enables all necessary
+screensharing components. The configuration enables PipeWire as the primary multimedia service, sets
+up xdg-desktop-portal with the Cosmic backend, and ensures proper environment variable handling.
 
 ```nix
 { config, pkgs, lib, ... }:
@@ -62,67 +91,117 @@ Configure your NixOS system with this complete configuration that enables all ne
 }
 ```
 
-After modifying configuration.nix, apply changes with `sudo nixos-rebuild switch`. The portal services use socket activation and start automatically when applications request screensharing, so you don't need to manually start them. However, environment variables must be properly imported into your systemd user session for the portals to detect your Wayland session.
+After modifying configuration.nix, apply changes with `sudo nixos-rebuild switch`. The portal
+services use socket activation and start automatically when applications request screensharing, so
+you don't need to manually start them. However, environment variables must be properly imported into
+your systemd user session for the portals to detect your Wayland session.
 
-For users coming from other desktop environments, note that the `extraPortals` order matters when multiple backends are installed - the first matching portal is used. Using `xdg.portal.config` provides explicit control over which backend handles each portal interface, preventing conflicts if you have multiple desktop environments installed.
+For users coming from other desktop environments, note that the `extraPortals` order matters when
+multiple backends are installed - the first matching portal is used. Using `xdg.portal.config`
+provides explicit control over which backend handles each portal interface, preventing conflicts if
+you have multiple desktop environments installed.
 
-If you're using Cosmic from a flake or unstable channel, ensure you're pulling from nixpkgs-unstable or the cosmic-specific overlay, as stable channels may have outdated versions. The xdg-desktop-portal-cosmic package should be version 1.0.0-alpha.7 or newer for best compatibility.
+If you're using Cosmic from a flake or unstable channel, ensure you're pulling from nixpkgs-unstable
+or the cosmic-specific overlay, as stable channels may have outdated versions. The
+xdg-desktop-portal-cosmic package should be version 1.0.0-alpha.7 or newer for best compatibility.
 
 ## Chrome/Chromium flags and Wayland settings
 
-Chrome requires specific configuration to enable native Wayland support and PipeWire-based screensharing. The most reliable configuration method is creating a persistent flags file that applies every time Chrome launches, rather than manually typing flags each time.
+Chrome requires specific configuration to enable native Wayland support and PipeWire-based
+screensharing. The most reliable configuration method is creating a persistent flags file that
+applies every time Chrome launches, rather than manually typing flags each time.
 
-Create `~/.config/chrome-flags.conf` (for Google Chrome) or `~/.config/chromium-flags.conf` (for Chromium) with these flags:
+Create `~/.config/chrome-flags.conf` (for Google Chrome) or `~/.config/chromium-flags.conf` (for
+Chromium) with these flags:
 
-```
+```text
 --ozone-platform-hint=auto
 --enable-features=WebRTCPipeWireCapturer
 --enable-wayland-ime
 ```
 
-**What each flag does:** The `--ozone-platform-hint=auto` flag enables Chrome's Ozone platform abstraction to automatically detect and use Wayland when available (Chrome 98+). For older Chrome versions or certain compositors, you may need the explicit `--ozone-platform=wayland` instead. The `--enable-features=WebRTCPipeWireCapturer` flag enables PipeWire backend for WebRTC screen capture (note: Chrome 110+ has this enabled by default, but explicitly setting it ensures compatibility). The `--enable-wayland-ime` flag enables proper input method support on Wayland.
+**What each flag does:** The `--ozone-platform-hint=auto` flag enables Chrome's Ozone platform
+abstraction to automatically detect and use Wayland when available (Chrome 98+). For older Chrome
+versions or certain compositors, you may need the explicit `--ozone-platform=wayland` instead. The
+`--enable-features=WebRTCPipeWireCapturer` flag enables PipeWire backend for WebRTC screen capture
+(note: Chrome 110+ has this enabled by default, but explicitly setting it ensures compatibility).
+The `--enable-wayland-ime` flag enables proper input method support on Wayland.
 
-Alternatively, configure via chrome://flags by navigating to the browser UI and searching for "Preferred Ozone platform" (set to Auto or Wayland) and "WebRTC PipeWire support" (set to Enabled). This method works but is less persistent across Chrome updates.
+Alternatively, configure via chrome://flags by navigating to the browser UI and searching for
+"Preferred Ozone platform" (set to Auto or Wayland) and "WebRTC PipeWire support" (set to Enabled).
+This method works but is less persistent across Chrome updates.
 
-For Microsoft Teams PWA specifically, the PWA inherits all flags from the parent Chrome/Chromium browser, so no additional configuration is needed beyond the main browser setup. The old Teams desktop app (Electron-based) was deprecated in December 2023, and Microsoft now recommends the PWA version which has better Wayland support. Install the Teams PWA by visiting teams.microsoft.com in Chrome and clicking the install icon in the address bar.
+For Microsoft Teams PWA specifically, the PWA inherits all flags from the parent Chrome/Chromium
+browser, so no additional configuration is needed beyond the main browser setup. The old Teams
+desktop app (Electron-based) was deprecated in December 2023, and Microsoft now recommends the PWA
+version which has better Wayland support. Install the Teams PWA by visiting teams.microsoft.com in
+Chrome and clicking the install icon in the address bar.
 
-**Verification that Chrome is using Wayland:** Navigate to `chrome://gpu` and search for "ozone-platform" - it should show "wayland". Also check `chrome://version` and look for `--ozone-platform=wayland` or `--ozone-platform-hint=auto` in the Command Line section. If you see "XDG_SESSION_TYPE: wayland" in chrome://gpu, Chrome has correctly detected your Wayland session.
+**Verification that Chrome is using Wayland:** Navigate to `chrome://gpu` and search for
+"ozone-platform" - it should show "wayland". Also check `chrome://version` and look for
+`--ozone-platform=wayland` or `--ozone-platform-hint=auto` in the Command Line section. If you see
+"XDG_SESSION_TYPE: wayland" in chrome://gpu, Chrome has correctly detected your Wayland session.
 
 ## Cosmic DE specific configurations
 
-Cosmic DE requires minimal additional configuration beyond the standard portal setup, as the desktop environment automatically sets appropriate environment variables and the portal backend integrates directly with cosmic-comp. However, there are several Cosmic-specific considerations due to its beta status.
+Cosmic DE requires minimal additional configuration beyond the standard portal setup, as the desktop
+environment automatically sets appropriate environment variables and the portal backend integrates
+directly with cosmic-comp. However, there are several Cosmic-specific considerations due to its beta
+status.
 
-**Environment variable handling:** Cosmic should automatically set `XDG_CURRENT_DESKTOP=COSMIC` when you log in. Verify this with `echo $XDG_CURRENT_DESKTOP`. The portal system uses this variable to determine which backend to use. If for any reason this variable isn't set, add it to your session startup.
+**Environment variable handling:** Cosmic should automatically set `XDG_CURRENT_DESKTOP=COSMIC` when
+you log in. Verify this with `echo $XDG_CURRENT_DESKTOP`. The portal system uses this variable to
+determine which backend to use. If for any reason this variable isn't set, add it to your session
+startup.
 
-**Current protocol implementation:** Cosmic currently uses a custom **zcosmic-screencopy-manager** protocol for screen capture rather than the standard wlr-screencopy protocol used by wlroots-based compositors. The development team is actively working on implementing the standard ext-image-copy-capture-v1 protocol (PR #365 in cosmic-comp), which will improve compatibility with various screen capture tools. This means some applications that expect wlr-screencopy won't work with Cosmic.
+**Current protocol implementation:** Cosmic currently uses a custom **zcosmic-screencopy-manager**
+protocol for screen capture rather than the standard wlr-screencopy protocol used by wlroots-based
+compositors. The development team is actively working on implementing the standard
+ext-image-copy-capture-v1 protocol (PR #365 in cosmic-comp), which will improve compatibility with
+various screen capture tools. This means some applications that expect wlr-screencopy won't work
+with Cosmic.
 
-**Known limitations in Cosmic Beta:** The most significant known issue (GitHub Issue #75) is that full screen sharing can fail with "screencopy failed: Value(BufferConstraints)" and GL_INVALID_VALUE errors, even though the selection dialog appears. Individual window sharing typically works more reliably than full screen sharing. Testing with Slack and Chrome has reproduced this issue consistently for some users. Another limitation is that Discord screen sharing may show a spinning wheel indefinitely on some hardware configurations, particularly with NVIDIA GPUs.
+**Known limitations in Cosmic Beta:** The most significant known issue (GitHub Issue #75) is that
+full screen sharing can fail with "screencopy failed: Value(BufferConstraints)" and GL_INVALID_VALUE
+errors, even though the selection dialog appears. Individual window sharing typically works more
+reliably than full screen sharing. Testing with Slack and Chrome has reproduced this issue
+consistently for some users. Another limitation is that Discord screen sharing may show a spinning
+wheel indefinitely on some hardware configurations, particularly with NVIDIA GPUs.
 
-**OBS Studio and screen recording:** For general screen recording tools like OBS Studio, use the PipeWire source rather than attempting direct compositor access. Cosmic-comp supports DMA-BUF capture which provides better performance for recording tools that support it.
+**OBS Studio and screen recording:** For general screen recording tools like OBS Studio, use the
+PipeWire source rather than attempting direct compositor access. Cosmic-comp supports DMA-BUF
+capture which provides better performance for recording tools that support it.
 
-No additional configuration files in ~/.config/cosmic/ are needed for basic screensharing functionality. The portal backend handles all compositor communication automatically. However, if you're debugging issues, you may want to enable verbose logging for the portal service.
+No additional configuration files in ~/.config/cosmic/ are needed for basic screensharing
+functionality. The portal backend handles all compositor communication automatically. However, if
+you're debugging issues, you may want to enable verbose logging for the portal service.
 
 ## Verification that setup is working correctly
 
-Systematic verification ensures each component in the screensharing chain functions properly. Start with the foundation and work up to browser testing.
+Systematic verification ensures each component in the screensharing chain functions properly. Start
+with the foundation and work up to browser testing.
 
-**Step 1: Verify PipeWire is running**
+### Step 1: Verify PipeWire is running
 
 ```bash
 systemctl --user status pipewire wireplumber
 ```
 
-Both services should show "active (running)". If not running, start them with `systemctl --user start pipewire wireplumber`. You can also check PipeWire's status with `wpctl status`, which should list audio and video devices.
+Both services should show "active (running)". If not running, start them with `systemctl --user
+start pipewire wireplumber`. You can also check PipeWire's status with `wpctl status`, which should
+list audio and video devices.
 
-**Step 2: Check portal services**
+### Step 2: Check portal services
 
 ```bash
 systemctl --user status xdg-desktop-portal xdg-desktop-portal-cosmic
 ```
 
-These services typically start on-demand via socket activation, so they may show as "inactive (dead)" until you attempt screensharing. This is normal. After attempting to screenshare once, they should be active.
+These services typically start on-demand via socket activation, so they may show as "inactive
+(dead)" until you attempt screensharing. This is normal. After attempting to screenshare once, they
+should be active.
 
-**Step 3: Verify environment variables**
+### Step 3: Verify environment variables
 
 ```bash
 systemctl --user show-environment | grep -E 'WAYLAND_DISPLAY|XDG_CURRENT_DESKTOP'
@@ -130,7 +209,7 @@ systemctl --user show-environment | grep -E 'WAYLAND_DISPLAY|XDG_CURRENT_DESKTOP
 
 Should output something like:
 
-```
+```text
 WAYLAND_DISPLAY=wayland-0
 XDG_CURRENT_DESKTOP=COSMIC
 ```
@@ -142,7 +221,7 @@ systemctl --user import-environment WAYLAND_DISPLAY XDG_CURRENT_DESKTOP
 dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP
 ```
 
-**Step 4: Check installed portal backends**
+### Step 4: Check installed portal backends
 
 ```bash
 ls /usr/share/xdg-desktop-portal/portals/
@@ -150,27 +229,53 @@ ls /usr/share/xdg-desktop-portal/portals/
 
 Should list `cosmic.portal` and `gtk.portal` files. These files declare which portal interfaces each backend implements.
 
-**Step 5: Test Chrome Wayland detection**
-Open Chrome and navigate to `chrome://gpu`. Press Ctrl+F and search for "wayland". You should see "ozone-platform=wayland" or similar indicating native Wayland mode. Also verify "XDG_SESSION_TYPE: wayland" appears in the output. If Chrome is running in XWayland mode instead, screensharing won't access native Wayland windows.
+### Step 5: Test Chrome Wayland detection
 
-**Step 6: Functional screensharing test**
-Visit the WebRTC test page at `https://mozilla.github.io/webrtc-landing/gum_test.html`. Click "getDisplayMedia" button. You should see the Cosmic portal selection dialog appear, allowing you to choose between windows and outputs (monitors). Select a window or screen and click "Share". The video preview should show your selected content. Test both window selection and full screen selection to identify which works.
+Open Chrome and navigate to `chrome://gpu`. Press Ctrl+F and search for "wayland". You should see
+"ozone-platform=wayland" or similar indicating native Wayland mode. Also verify "XDG_SESSION_TYPE:
+wayland" appears in the output. If Chrome is running in XWayland mode instead, screensharing won't
+access native Wayland windows.
 
-**Step 7: Test in Teams PWA**
-Open Microsoft Teams PWA, join a meeting, and click the share screen button. The same Cosmic portal dialog should appear. Try sharing a specific application window first (more reliable), then test full screen sharing.
+### Step 6: Functional screensharing test
+
+Visit the WebRTC test page at `https://mozilla.github.io/webrtc-landing/gum_test.html`. Click
+"getDisplayMedia" button. You should see the Cosmic portal selection dialog appear, allowing you to
+choose between windows and outputs (monitors). Select a window or screen and click "Share". The
+video preview should show your selected content. Test both window selection and full screen
+selection to identify which works.
+
+### Step 7: Test in Teams PWA
+
+Open Microsoft Teams PWA, join a meeting, and click the share screen button. The same Cosmic portal
+dialog should appear. Try sharing a specific application window first (more reliable), then test
+full screen sharing.
 
 ## Troubleshooting steps if screen sharing still doesn't work
 
-When screensharing fails despite correct configuration, systematic diagnosis identifies which component in the chain is broken. The most common failure modes have specific symptoms and solutions.
+When screensharing fails despite correct configuration, systematic diagnosis identifies which
+component in the chain is broken. The most common failure modes have specific symptoms and
+solutions.
 
 **Symptom: Only tab sharing works, no window/screen sharing option appears**
-This indicates Chrome cannot communicate with xdg-desktop-portal. Check that PipeWire flag is enabled in chrome://flags. Verify portal services are installed with `ls /usr/share/xdg-desktop-portal/portals/`. Ensure environment variables are set in systemd user session (see verification section). Restart Chrome completely (including background processes) after changing flags.
+This indicates Chrome cannot communicate with xdg-desktop-portal. Check that PipeWire flag is
+enabled in chrome://flags. Verify portal services are installed with `ls
+/usr/share/xdg-desktop-portal/portals/`. Ensure environment variables are set in systemd user
+session (see verification section). Restart Chrome completely (including background processes) after
+changing flags.
 
 **Symptom: Selection dialog appears but sharing produces black screen**
-This specific issue is **very common in Cosmic Beta** and indicates the portal/compositor communication is failing. Check portal logs with `journalctl --user -u xdg-desktop-portal-cosmic -f` while attempting to share. Look for "screencopy failed" or "BufferConstraints" errors. Workaround: Try sharing individual windows instead of full screen, as window sharing has better success rates. Also verify your GPU drivers are up-to-date, as GL texture errors often indicate driver issues.
+This specific issue is **very common in Cosmic Beta** and indicates the portal/compositor
+communication is failing. Check portal logs with `journalctl --user -u xdg-desktop-portal-cosmic -f`
+while attempting to share. Look for "screencopy failed" or "BufferConstraints" errors. Workaround:
+Try sharing individual windows instead of full screen, as window sharing has better success rates.
+Also verify your GPU drivers are up-to-date, as GL texture errors often indicate driver issues.
 
 **Symptom: Discord/Slack shows spinning wheel or immediate failure**
-This application-specific issue often relates to how Electron apps detect the portal. Ensure Discord/Slack are launched with Wayland flags enabled. For Electron apps, you may need to create custom desktop files or wrappers that add `--enable-features=WebRTCPipeWireCapturer --ozone-platform=wayland` flags. Some users have reported Discord specifically has issues with Cosmic (GitHub Issue #913).
+This application-specific issue often relates to how Electron apps detect the portal. Ensure
+Discord/Slack are launched with Wayland flags enabled. For Electron apps, you may need to create
+custom desktop files or wrappers that add `--enable-features=WebRTCPipeWireCapturer
+--ozone-platform=wayland` flags. Some users have reported Discord specifically has issues with
+Cosmic (GitHub Issue #913).
 
 **Symptom: Permission denied or "Request not allowed" errors**
 The portal dialog may have been dismissed or permissions denied previously. Clear permissions with:
@@ -183,7 +288,9 @@ flatpak permission-remove devices camera org.google.Chrome
 ```
 
 **Symptom: Zoom native app doesn't show screen picker**
-This is a known issue (GitHub Issue #77) with Zoom's native application. Workaround: Use Zoom PWA instead by visiting zoom.us in Chrome and installing as PWA. The PWA uses Chrome's screensharing implementation which works properly.
+This is a known issue (GitHub Issue #77) with Zoom's native application. Workaround: Use Zoom PWA
+instead by visiting zoom.us in Chrome and installing as PWA. The PWA uses Chrome's screensharing
+implementation which works properly.
 
 **Debug logging for detailed diagnosis:**
 Enable verbose logging for portal components:
@@ -197,34 +304,74 @@ systemctl --user stop xdg-desktop-portal xdg-desktop-portal-cosmic
 journalctl --user -u xdg-desktop-portal-cosmic -f
 ```
 
-Then attempt screensharing and watch the log output for errors. Common errors include "No such interface org.freedesktop.impl.portal.ScreenCast" (backend missing), "Failed to create PipeWire stream" (PipeWire not running), or compositor-specific errors.
+Then attempt screensharing and watch the log output for errors. Common errors include "No such
+interface org.freedesktop.impl.portal.ScreenCast" (backend missing), "Failed to create PipeWire
+stream" (PipeWire not running), or compositor-specific errors.
 
 **NVIDIA GPU specific issues:**
-If you're using NVIDIA proprietary drivers, several users have reported issues with Cosmic screensharing (particularly on RTX 2060 with driver 560.28.03). The GL texture errors in Issue #75 may indicate driver compatibility problems. Ensure you're using the latest NVIDIA driver available for your NixOS version. Consider testing with `nouveau` open-source drivers to determine if it's driver-related.
+If you're using NVIDIA proprietary drivers, several users have reported issues with Cosmic
+screensharing (particularly on RTX 2060 with driver 560.28.03). The GL texture errors in Issue #75
+may indicate driver compatibility problems. Ensure you're using the latest NVIDIA driver available
+for your NixOS version. Consider testing with `nouveau` open-source drivers to determine if it's
+driver-related.
 
 **Hardware acceleration conflicts:**
-Sometimes hardware acceleration causes issues with screensharing. Test by disabling it: Visit chrome://flags and disable "Hardware-accelerated video decode" and "GPU rasterization". If this fixes screensharing, you have a driver/acceleration issue. The proper fix is updating GPU drivers rather than permanently disabling acceleration.
+Sometimes hardware acceleration causes issues with screensharing. Test by disabling it: Visit
+chrome://flags and disable "Hardware-accelerated video decode" and "GPU rasterization". If this
+fixes screensharing, you have a driver/acceleration issue. The proper fix is updating GPU drivers
+rather than permanently disabling acceleration.
 
 **Restart compositor as last resort:**
-If all else fails, log out and back into Cosmic. This reinitializes cosmic-comp and all related services. The portal services are socket-activated and sometimes get into inconsistent states that require a full session restart to resolve.
+If all else fails, log out and back into Cosmic. This reinitializes cosmic-comp and all related
+services. The portal services are socket-activated and sometimes get into inconsistent states that
+require a full session restart to resolve.
 
 **Alternative testing approach:**
-If Teams continues to fail, test with a simpler application first. Firefox with `MOZ_ENABLE_WAYLAND=1` has excellent Wayland support. Test screensharing in Firefox at the WebRTC test page to determine if the issue is Cosmic/PipeWire (affects all apps) or Chrome-specific (Firefox works but Chrome doesn't).
+If Teams continues to fail, test with a simpler application first. Firefox with
+`MOZ_ENABLE_WAYLAND=1` has excellent Wayland support. Test screensharing in Firefox at the WebRTC
+test page to determine if the issue is Cosmic/PipeWire (affects all apps) or Chrome-specific
+(Firefox works but Chrome doesn't).
 
 ## Important notes about Cosmic DE maturity
 
-Cosmic DE is currently in **Epoch 1 Beta** (released September 2025) with active development toward a stable release. While System76's official statement claims "screen-sharing in video conferencing apps is now functional," GitHub issues reveal this isn't universally true across all applications and hardware configurations.
+Cosmic DE is currently in **Epoch 1 Beta** (released September 2025) with active development toward
+a stable release. While System76's official statement claims "screen-sharing in video conferencing
+apps is now functional," GitHub issues reveal this isn't universally true across all applications
+and hardware configurations.
 
-The screensharing implementation is **partially mature** with working window selection but known issues with full screen capture. Individual window sharing generally succeeds, but attempting to share entire screens can trigger buffer constraint errors that cause sharing to fail silently (the dialog completes successfully but no video is transmitted). This limitation affects production use cases where full screen sharing is required.
+The screensharing implementation is **partially mature** with working window selection but known
+issues with full screen capture. Individual window sharing generally succeeds, but attempting to
+share entire screens can trigger buffer constraint errors that cause sharing to fail silently (the
+dialog completes successfully but no video is transmitted). This limitation affects production use
+cases where full screen sharing is required.
 
-Cosmic is using a **custom screencopy protocol** (zcosmic-screencopy-manager) rather than standard Wayland protocols while the team works on implementing ext-image-copy-capture-v1. This means applications that expect wlr-screencopy (used by Sway, Hyprland, etc.) won't work with Cosmic. The transition to standard protocols is tracked in cosmic-comp PR #365.
+Cosmic is using a **custom screencopy protocol** (zcosmic-screencopy-manager) rather than standard
+Wayland protocols while the team works on implementing ext-image-copy-capture-v1. This means
+applications that expect wlr-screencopy (used by Sway, Hyprland, etc.) won't work with Cosmic. The
+transition to standard protocols is tracked in cosmic-comp PR #365.
 
-For production environments requiring reliable screensharing, consider that Cosmic is best suited for testing and development use cases at this stage. The development team is actively fixing issues as they move toward stable release, but if screensharing is business-critical, you may want to wait for the stable release or maintain a fallback to a mature desktop environment like GNOME or KDE Plasma for important meetings.
+For production environments requiring reliable screensharing, consider that Cosmic is best suited
+for testing and development use cases at this stage. The development team is actively fixing issues
+as they move toward stable release, but if screensharing is business-critical, you may want to wait
+for the stable release or maintain a fallback to a mature desktop environment like GNOME or KDE
+Plasma for important meetings.
 
 ## Summary
 
-Enabling full screen sharing in Microsoft Teams PWA on Chrome with NixOS and Cosmic DE requires configuring three layers: system services (PipeWire and portals via configuration.nix), browser flags (Chrome Wayland and PipeWire flags), and understanding Cosmic's current beta limitations. The complete configuration involves enabling pipewire with wireplumber, adding xdg-desktop-portal-cosmic to xdg.portal.extraPortals, and creating ~/.config/chrome-flags.conf with Wayland flags.
+Enabling full screen sharing in Microsoft Teams PWA on Chrome with NixOS and Cosmic DE requires
+configuring three layers: system services (PipeWire and portals via configuration.nix), browser
+flags (Chrome Wayland and PipeWire flags), and understanding Cosmic's current beta limitations. The
+complete configuration involves enabling pipewire with wireplumber, adding xdg-desktop-portal-cosmic
+to xdg.portal.extraPortals, and creating ~/.config/chrome-flags.conf with Wayland flags.
 
-The key insight is that tab sharing works independently of this infrastructure because it's built into Chrome, while window/screen sharing requires the complete portal chain. Given Cosmic's beta status with documented screensharing issues, expect individual window sharing to be more reliable than full screen sharing currently. If you encounter the buffer constraints error, this is a known Cosmic limitation rather than a configuration problem on your end.
+The key insight is that tab sharing works independently of this infrastructure because it's built
+into Chrome, while window/screen sharing requires the complete portal chain. Given Cosmic's beta
+status with documented screensharing issues, expect individual window sharing to be more reliable
+than full screen sharing currently. If you encounter the buffer constraints error, this is a known
+Cosmic limitation rather than a configuration problem on your end.
 
-Verify your setup systematically: check PipeWire and portal services are running, confirm environment variables are set in systemd user session, verify Chrome detects Wayland in chrome://gpu, and test with the WebRTC test page before attempting Teams meetings. When issues persist, focus troubleshooting on portal logs with journalctl and consider testing window sharing as a workaround for full screen sharing failures.
+Verify your setup systematically: check PipeWire and portal services are running, confirm
+environment variables are set in systemd user session, verify Chrome detects Wayland in
+chrome://gpu, and test with the WebRTC test page before attempting Teams meetings. When issues
+persist, focus troubleshooting on portal logs with journalctl and consider testing window sharing as
+a workaround for full screen sharing failures.

--- a/docs/tooling/CLAUDE-CODE-OPTIMIZATION.md
+++ b/docs/tooling/CLAUDE-CODE-OPTIMIZATION.md
@@ -5,9 +5,10 @@
 > Implementation Date: 2025-01-29
 > Version: 1.0.0
 
-##  Executive Summary
+## Executive Summary
 
-Your Claude Code setup has been completely optimized with **5 powerful slash commands** that reduce development time by **92-96%**.
+Your Claude Code setup has been completely optimized with **5 powerful slash commands** that reduce
+development time by **92-96%**.
 
 ### Time Savings
 
@@ -27,9 +28,9 @@ Your Claude Code setup has been completely optimized with **5 powerful slash com
 - Security audit: 1 minute (`/nix-security`)
 - **Total: 6.5 minutes per task**
 
-**Result: 92-96% time reduction**
+**Result:** 92-96% time reduction
 
-##  What Was Created
+## What Was Created
 
 ### Slash Commands (5 Total)
 
@@ -83,7 +84,7 @@ All commands are in `.claude/commands/`:
    - Time savings calculator
    - Command selection guide
 
-##  Quick Start Guide
+## Quick Start Guide
 
 ### Installation (Already Done!)
 
@@ -93,112 +94,112 @@ All slash commands are already installed and ready to use. No setup required!
 
 **1. See available commands:**
 
-```
+```text
 /nix-help
 ```
 
 **2. Check your tasks:**
 
-```
+```text
 /check_tasks
 ```
 
 **3. Create a new module:**
 
-```
+```text
 /nix-module
 Create monitoring/example-exporter
 ```
 
 **4. Deploy to a host:**
 
-```
+```text
 /nix-deploy
 Deploy to p620
 ```
 
 **5. Run security audit:**
 
-```
+```text
 /nix-security
 ```
 
 That's it! You're using optimized Claude Code for NixOS!
 
-##  Complete Command Reference
+## Complete Command Reference
 
 ### Module Development
 
 **`/nix-module`**
 
-```
+```text
 /nix-module
 Create services/myservice module
 ```
 
 **Features:**
 
--  Automatic best practices
--  Security hardening included
--  Syntax validation
--  Usage examples
+- Automatic best practices
+- Security hardening included
+- Syntax validation
+- Usage examples
 - ⏱ 2 minutes total
 
 ### Code Quality
 
 **`/nix-fix`**
 
-```
+```text
 /nix-fix
 Fix modules/services/myservice.nix
 ```
 
 **Fixes:**
 
--  mkIf true → direct assignment
--  Trivial wrappers → lib functions
--  Evaluation secrets → runtime loading
--  Root services → DynamicUser
+- mkIf true → direct assignment
+- Trivial wrappers → lib functions
+- Evaluation secrets → runtime loading
+- Root services → DynamicUser
 - ⏱ 1 minute total
 
 **`/review`**
 
-```
+```text
 /review
 Review hosts/p620/configuration.nix
 ```
 
 **Checks:**
 
--  Best practices (PATTERNS.md)
--  Anti-patterns (NIXOS-ANTI-PATTERNS.md)
--  Security issues
--  Performance problems
+- Best practices (PATTERNS.md)
+- Anti-patterns (NIXOS-ANTI-PATTERNS.md)
+- Security issues
+- Performance problems
 - ⏱ 1 minute total
 
 ### Security
 
 **`/nix-security`**
 
-```
+```text
 /nix-security
 ```
 
 **Audits:**
 
--  Service isolation (DynamicUser)
--  Systemd hardening
--  Secret management
--  Firewall configuration
--  SSH hardening
--  Security score (0-100)
+- Service isolation (DynamicUser)
+- Systemd hardening
+- Secret management
+- Firewall configuration
+- SSH hardening
+- Security score (0-100)
 - ⏱ 1 minute total
 
 ### Deployment
 
 **`/nix-deploy`**
 
-```
+```bash
 # Standard deployment
 /nix-deploy
 Deploy to p620
@@ -218,43 +219,43 @@ Deploy to all hosts
 
 **Features:**
 
--  Automatic validation
--  Change detection (skips if unchanged)
--  Security checks
--  Smart rollback on failure
--  Post-deployment verification
+- Automatic validation
+- Change detection (skips if unchanged)
+- Security checks
+- Smart rollback on failure
+- Post-deployment verification
 - ⏱ 2.5 min (standard), 1 min (fast), 30s (emergency)
 
 ### Optimization
 
 **`/nix-optimize`**
 
-```
+```text
 /nix-optimize
 ```
 
 **Analyzes:**
 
--  Build performance (IFD, evaluation)
--  Disk usage (GC, store optimization)
--  Memory (swap, kernel tuning)
--  Network (TCP/IP optimization)
--  Boot time (systemd, fstrim)
--  Generates specific fixes with impact
+- Build performance (IFD, evaluation)
+- Disk usage (GC, store optimization)
+- Memory (swap, kernel tuning)
+- Network (TCP/IP optimization)
+- Boot time (systemd, fstrim)
+- Generates specific fixes with impact
 - ⏱ 2 minutes total
 
 ### GitHub Integration
 
 **`/new_task`** - Create issue
 
-```
+```text
 /new_task
 Add PostgreSQL monitoring
 ```
 
 **`/check_tasks`** - Review tasks
 
-```
+```text
 /check_tasks
 ```
 
@@ -262,11 +263,11 @@ Add PostgreSQL monitoring
 
 **`/nix-help`** - Show all commands
 
-```
+```text
 /nix-help
 ```
 
-##  Complete Workflows
+## Complete Workflows
 
 ### Daily Development (10 minutes)
 
@@ -296,7 +297,7 @@ gh pr create --fill
 /check_tasks
 ```
 
-**Total: ~10 minutes for complete feature**
+**Total:** ~10 minutes for complete feature
 
 ### Bug Fix (3 minutes)
 
@@ -315,7 +316,7 @@ Fast deploy to p620
 systemctl status myservice
 ```
 
-**Total: ~3 minutes for bug fix**
+**Total:** ~3 minutes for bug fix
 
 ### Security Audit (5 minutes)
 
@@ -333,7 +334,7 @@ systemctl status myservice
 /nix-security
 ```
 
-**Total: ~5 minutes for security review**
+**Total:** ~5 minutes for security review
 
 ### Performance Optimization (10 minutes)
 
@@ -355,9 +356,9 @@ Deploy to p620
 /nix-optimize
 ```
 
-**Total: ~10 minutes for optimization**
+**Total:** ~10 minutes for optimization
 
-##  Best Practices
+## Best Practices
 
 ### DO
 
@@ -379,7 +380,7 @@ Deploy to p620
 5. **Ignore optimization** - Run `/nix-optimize` monthly
 6. **Work without issues** - Always use `/new_task`
 
-##  Performance Metrics
+## Performance Metrics
 
 ### Command Performance
 
@@ -399,7 +400,7 @@ Deploy to p620
 - **Security Audits**: 5 min vs 30-60 min (83-92% faster)
 - **Optimization**: 10 min vs 60-120 min (83-92% faster)
 
-##  Integration Points
+## Integration Points
 
 ### With Existing Tools
 
@@ -424,7 +425,7 @@ Deploy to p620
 
 ### Workflow Integration
 
-```
+```text
 Issue Tracking          Slash Commands          Version Control
      ↓                       ↓                        ↓
 /new_task         →    /nix-module      →      git commit
@@ -434,7 +435,7 @@ Issue Tracking          Slash Commands          Version Control
 Track progress    →    /review          →      Merge PR
 ```
 
-##  Pro Tips
+## Pro Tips
 
 ### Command Chaining
 
@@ -466,7 +467,7 @@ Commands understand your codebase:
 - Reference your documentation (PATTERNS.md)
 - Follow your standards (anti-patterns doc)
 
-##  Troubleshooting
+## Troubleshooting
 
 ### Command Not Found
 
@@ -503,7 +504,7 @@ Commands reference documentation:
 - Check docs/NIXOS-ANTI-PATTERNS.md for issues
 - Review .claude/CLAUDE.md for context
 
-##  Further Reading
+## Further Reading
 
 ### Essential Documentation
 
@@ -520,7 +521,7 @@ Commands reference documentation:
 3. **Month 1**: Use `/nix-module` for all modules, `/nix-optimize` monthly
 4. **Ongoing**: Chain commands for complete workflows
 
-##  Training Examples
+## Training Examples
 
 ### Example 1: Create Monitoring Module
 
@@ -576,7 +577,7 @@ Deploy to p620
 # Result: Safe deployment in 2.5 minutes
 ```
 
-##  Verification Checklist
+## Verification Checklist
 
 Confirm your setup is working:
 
@@ -591,7 +592,7 @@ Confirm your setup is working:
 - [ ] `/check_tasks` shows open tasks
 - [ ] All commands complete within target times
 
-##  Success Criteria
+## Success Criteria
 
 You'll know the optimization is successful when:
 
@@ -601,7 +602,7 @@ You'll know the optimization is successful when:
 4. **Quality**: Zero anti-patterns, high security scores
 5. **Productivity**: 92-96% time reduction achieved
 
-##  Getting Help
+## Getting Help
 
 ### Quick Help
 
@@ -627,7 +628,7 @@ Just ask Claude Code:
 
 ---
 
-##  You're Ready
+## You're Ready
 
 Your Claude Code setup is now fully optimized for NixOS development. Start with:
 
@@ -637,4 +638,4 @@ Your Claude Code setup is now fully optimized for NixOS development. Start with:
 
 And explore the powerful slash commands that will transform your workflow!
 
-**Happy NixOS development! **
+**Happy NixOS development!**

--- a/docs/tooling/Github-spec-kit.md
+++ b/docs/tooling/Github-spec-kit.md
@@ -1,16 +1,40 @@
 # Installing GitHub spec-kit on NixOS with uv2nix
 
-**uv2nix brings Python 3.11+ spec-kit to NixOS through a modern packaging approach that combines uv's fast dependency resolution with Nix's reproducibility guarantees.** This guide walks through installing GitHub's Spec-Driven Development toolkit using the next-generation Python packaging toolchain. The process requires understanding uv2nix's overlay-based architecture and adapting it for Git-sourced packages that aren't on PyPI. By the end, you'll have spec-kit's AI-powered development CLI running reproducibly on NixOS with all dependencies properly managed.
+**uv2nix brings Python 3.11+ spec-kit to NixOS through a modern packaging approach that combines
+uv's fast dependency resolution with Nix's reproducibility guarantees.** This guide walks through
+installing GitHub's Spec-Driven Development toolkit using the next-generation Python packaging
+toolchain. The process requires understanding uv2nix's overlay-based architecture and adapting it
+for Git-sourced packages that aren't on PyPI. By the end, you'll have spec-kit's AI-powered
+development CLI running reproducibly on NixOS with all dependencies properly managed.
 
 ## Understanding uv2nix: Modern Python packaging for Nix
 
-uv2nix translates uv workspaces and lock files into Nix derivations using pure Nix code, serving as both a development environment manager and production package builder. The tool represents the next generation of Python-Nix integration, explicitly designed as the successor to poetry2nix by the same author (@adisbladis). Unlike its predecessor, **uv2nix generates Nix overlays dynamically** from `uv.lock` files rather than requiring manual package definitions, leveraging uv's Rust-based speed for dependency resolution while adding Nix's reproducibility for deployment.
+uv2nix translates uv workspaces and lock files into Nix derivations using pure Nix code, serving as
+both a development environment manager and production package builder. The tool represents the next
+generation of Python-Nix integration, explicitly designed as the successor to poetry2nix by the same
+author (@adisbladis). Unlike its predecessor, **uv2nix generates Nix overlays dynamically** from
+`uv.lock` files rather than requiring manual package definitions, leveraging uv's Rust-based speed
+for dependency resolution while adding Nix's reproducibility for deployment.
 
-The architecture centers on three key operations: parsing `pyproject.toml` and `uv.lock` files from a workspace, generating Nix overlays containing package derivations, and aggregating packages into virtual environments. uv2nix heavily relies on pyproject.nix's build infrastructure and doesn't attempt to replace what uv already does well—dependency resolution and lock file generation remain uv's responsibility. The tool recently shed its "experimental" label, indicating API stability for core features.
+The architecture centers on three key operations: parsing `pyproject.toml` and `uv.lock` files from
+a workspace, generating Nix overlays containing package derivations, and aggregating packages into
+virtual environments. uv2nix heavily relies on pyproject.nix's build infrastructure and doesn't
+attempt to replace what uv already does well—dependency resolution and lock file generation remain
+uv's responsibility. The tool recently shed its "experimental" label, indicating API stability for
+core features.
 
-**The overlay pattern is fundamental to how uv2nix works.** Rather than building a monolithic package set, uv2nix creates composable overlays that you stack together. A typical stack includes the build-systems overlay (providing setuptools, hatchling, etc.), the uv2nix-generated overlay (your locked dependencies), and custom overrides (build fixes). This design shifts responsibility for package overrides away from bundled definitions that suffer bit-rot, giving users explicit control over their build pipeline.
+**The overlay pattern is fundamental to how uv2nix works.** Rather than building a monolithic
+package set, uv2nix creates composable overlays that you stack together. A typical stack includes
+the build-systems overlay (providing setuptools, hatchling, etc.), the uv2nix-generated overlay
+(your locked dependencies), and custom overrides (build fixes). This design shifts responsibility
+for package overrides away from bundled definitions that suffer bit-rot, giving users explicit
+control over their build pipeline.
 
-One critical limitation: **uv doesn't lock build systems in uv.lock**, a known issue tracked in uv #5190. Building packages from source requires build systems like setuptools or hatchling, but these aren't captured in the lock file. uv2nix addresses this through the pyproject-build-systems repository, which provides overlays containing common build tools. This workaround is necessary but adds an extra input to your flake.
+One critical limitation: **uv doesn't lock build systems in uv.lock**, a known issue tracked in
+uv issue 5190. Building packages from source requires build systems like
+setuptools or hatchling, but these aren't captured in the lock file. uv2nix addresses this through the pyproject-build-systems
+repository, which provides overlays containing common build tools. This workaround is necessary but
+adds an extra input to your flake.
 
 ## Prerequisites and initial setup
 
@@ -23,7 +47,8 @@ One critical limitation: **uv doesn't lock build systems in uv.lock**, a known i
 - Git (optional but recommended for repository operations)
 - Network access (for downloading Python packages and GitHub templates)
 
-**Required flake inputs:** Every uv2nix project needs four interconnected inputs that must follow the same nixpkgs to prevent version conflicts:
+**Required flake inputs:** Every uv2nix project needs four interconnected inputs that must follow
+the same nixpkgs to prevent version conflicts:
 
 ```nix
 inputs = {
@@ -49,9 +74,14 @@ inputs = {
 };
 ```
 
-The `follows` declarations ensure all inputs use the same nixpkgs version, preventing incompatibilities from mixing package sets. This pattern is mandatory for stability.
+The `follows` declarations ensure all inputs use the same nixpkgs version, preventing
+incompatibilities from mixing package sets. This pattern is mandatory for stability.
 
-**Initial project structure:** For most projects, you'd start with `uv init --app --package` to create a standard structure, but for spec-kit we're packaging an existing GitHub project. The tool expects at minimum a `pyproject.toml` defining project metadata and a `uv.lock` file with pinned dependencies. Since spec-kit comes from GitHub rather than a local workspace, we'll need to fetch it first and generate the lock file.
+**Initial project structure:** For most projects, you'd start with `uv init --app --package` to
+create a standard structure, but for spec-kit we're packaging an existing GitHub project. The tool
+expects at minimum a `pyproject.toml` defining project metadata and a `uv.lock` file with pinned
+dependencies. Since spec-kit comes from GitHub rather than a local workspace, we'll need to fetch it
+first and generate the lock file.
 
 **Quick start with templates:** uv2nix provides templates to bootstrap projects quickly:
 
@@ -63,11 +93,15 @@ nix flake init --template github:pyproject-nix/uv2nix#hello-world
 nix flake init --template github:pyproject-nix/pyproject.nix#impure
 ```
 
-These templates provide working examples of the overlay composition pattern and proper environment variable configuration.
+These templates provide working examples of the overlay composition pattern and proper environment
+variable configuration.
 
 ## Installing spec-kit: Git-based package workflow
 
-spec-kit presents unique packaging challenges: it's **not published to PyPI** (per issue #204 in their repository), requires installation from GitHub, and downloads AI agent templates from GitHub at runtime. The standard uv2nix workflow assumes PyPI packages, so we must adapt the approach for Git-sourced dependencies.
+spec-kit presents unique packaging challenges: it's **not published to PyPI** (per issue #204 in
+their repository), requires installation from GitHub, and downloads AI agent templates from GitHub
+at runtime. The standard uv2nix workflow assumes PyPI packages, so we must adapt the approach for
+Git-sourced dependencies.
 
 ### Step 1: Fetch spec-kit and prepare the workspace
 
@@ -85,7 +119,10 @@ nix-shell -p uv python311
 uv lock
 ```
 
-This creates `uv.lock` with pinned versions of spec-kit's dependencies: **typer** (CLI framework), **rich** (terminal formatting), **platformdirs** (cross-platform paths), **readchar** (keyboard input), and **httpx** (HTTP client). All are pure Python packages from PyPI with no C extensions, making them straightforward to package.
+This creates `uv.lock` with pinned versions of spec-kit's dependencies: **typer** (CLI framework),
+**rich** (terminal formatting), **platformdirs** (cross-platform paths), **readchar** (keyboard
+input), and **httpx** (HTTP client). All are pure Python packages from PyPI with no C extensions,
+making them straightforward to package.
 
 **Key spec-kit characteristics:**
 
@@ -289,7 +326,9 @@ specify init my-project --ai copilot
 specify check
 ```
 
-The development shell provides **spec-kit plus uv, git, and Python 3.11**, with environment variables configured to prevent uv from downloading managed interpreters or interfering with the Nix-managed environment.
+The development shell provides **spec-kit plus uv, git, and Python 3.11**, with environment
+variables configured to prevent uv from downloading managed interpreters or interfering with the
+Nix-managed environment.
 
 ## Configuration files explained
 
@@ -337,7 +376,9 @@ Generated by `uv lock`, this file contains:
 - **Platform markers** for conditional dependencies
 - **Integrity hashes** for reproducible builds
 
-uv2nix parses this file to generate Nix derivations. The lock file ensures identical dependencies across all environments, but **doesn't capture build systems**—hence the need for pyproject-build-systems overlay.
+uv2nix parses this file to generate Nix derivations. The lock file ensures identical dependencies
+across all environments, but **doesn't capture build systems**—hence the need for
+pyproject-build-systems overlay.
 
 ### Critical Nix expressions
 
@@ -349,7 +390,8 @@ workspace = uv2nix.lib.workspace.loadWorkspace {
 };
 ```
 
-Recursively discovers projects, parses all `pyproject.toml` files, loads `uv.lock`, and creates a workspace object with metadata and dependency specifications.
+Recursively discovers projects, parses all `pyproject.toml` files, loads `uv.lock`, and creates a
+workspace object with metadata and dependency specifications.
 
 **Overlay generation:**
 
@@ -359,7 +401,8 @@ overlay = workspace.mkPyprojectOverlay {
 };
 ```
 
-Translates `uv.lock` into a Nix overlay function that adds Python packages to the package set. Choosing `"wheel"` makes builds more likely to succeed without manual intervention.
+Translates `uv.lock` into a Nix overlay function that adds Python packages to the package set.
+Choosing `"wheel"` makes builds more likely to succeed without manual intervention.
 
 **Package set composition:**
 
@@ -373,7 +416,8 @@ pythonSet = pythonBase.overrideScope (
 );
 ```
 
-Stacks overlays in order: base build infrastructure, then locked packages, then custom overrides. Later overlays can modify packages from earlier ones.
+Stacks overlays in order: base build infrastructure, then locked packages, then custom overrides.
+Later overlays can modify packages from earlier ones.
 
 **Virtual environment creation:**
 
@@ -383,13 +427,15 @@ pythonSet.mkVirtualEnv "specify-cli-env" {
 }
 ```
 
-Aggregates the package and its dependencies into a virtual environment. The key `specify-cli` must match the package name in `pyproject.toml` exactly.
+Aggregates the package and its dependencies into a virtual environment. The key `specify-cli` must
+match the package name in `pyproject.toml` exactly.
 
 ## Common pitfalls and troubleshooting
 
 ### Missing build systems cause failures
 
-**Problem:** Building from source fails with errors about missing setuptools, hatchling, or other build tools. This occurs because uv.lock doesn't capture build-time dependencies.
+**Problem:** Building from source fails with errors about missing setuptools, hatchling, or other
+build tools. This occurs because uv.lock doesn't capture build-time dependencies.
 
 **Solution:** Always include the build-systems overlay in your composition:
 
@@ -401,7 +447,9 @@ lib.composeManyExtensions [
 ]
 ```
 
-For spec-kit's dependencies, this shouldn't be an issue since we're using `sourcePreference = "wheel"` and all dependencies have wheels available. If you switch to building from source (`sourcePreference = "sdist"`), you may need to add explicit build system overrides:
+For spec-kit's dependencies, this shouldn't be an issue since we're using `sourcePreference =
+"wheel"` and all dependencies have wheels available. If you switch to building from source
+(`sourcePreference = "sdist"`), you may need to add explicit build system overrides:
 
 ```nix
 pyprojectOverrides = final: prev: {
@@ -419,7 +467,8 @@ pyprojectOverrides = final: prev: {
 
 **Problem:** Error "attribute 'spec-kit' missing" or similar when trying to reference the package.
 
-**Solution:** The package name in Nix **must exactly match** `[project.name]` in `pyproject.toml`. For spec-kit, the project name is `specify-cli`, not `spec-kit`:
+**Solution:** The package name in Nix **must exactly match** `[project.name]` in `pyproject.toml`.
+For spec-kit, the project name is `specify-cli`, not `spec-kit`:
 
 ```nix
 # WRONG - will fail
@@ -435,7 +484,8 @@ Check `pyproject.toml` for the exact name. Python package naming uses hyphens, n
 
 **Problem:** Packages import incorrectly or fail to find dependencies, especially in development shells.
 
-**Solution:** Always unset PYTHONPATH in shell hooks to prevent Nixpkgs Python builders from leaking environment variables:
+**Solution:** Always unset PYTHONPATH in shell hooks to prevent Nixpkgs Python builders from leaking
+environment variables:
 
 ```nix
 shellHook = ''
@@ -458,11 +508,13 @@ env = {
 };
 ```
 
-NixOS cannot run dynamically linked executables without proper loader configuration. Always use Nix-provided Python interpreters instead of uv-managed ones.
+NixOS cannot run dynamically linked executables without proper loader configuration. Always use
+Nix-provided Python interpreters instead of uv-managed ones.
 
 ### Runtime template downloads require network access
 
-**Problem specific to spec-kit:** The CLI downloads AI agent templates from GitHub at runtime, which may fail in pure Nix builds or restricted networks.
+**Problem specific to spec-kit:** The CLI downloads AI agent templates from GitHub at runtime, which
+may fail in pure Nix builds or restricted networks.
 
 **Considerations:**
 
@@ -496,7 +548,9 @@ This level of patching is usually unnecessary unless you're deploying spec-kit i
 
 **Problem:** Some packages fail to build or have missing dependencies depending on source preference.
 
-**Best practice:** Prefer `sourcePreference = "wheel"` for production. Binary wheels are prebuilt and contain all necessary metadata. Source distributions require more overrides and are more prone to failures.
+**Best practice:** Prefer `sourcePreference = "wheel"` for production. Binary wheels are prebuilt
+and contain all necessary metadata. Source distributions require more overrides and are more prone
+to failures.
 
 **When to use sdist:**
 
@@ -504,11 +558,13 @@ This level of patching is usually unnecessary unless you're deploying spec-kit i
 - You need to apply patches to source code
 - Building from source for security auditing
 
-For spec-kit and its dependencies, wheels are available for all packages on all common platforms, so stick with wheel preference.
+For spec-kit and its dependencies, wheels are available for all packages on all common platforms, so
+stick with wheel preference.
 
 ### Lock file format changes
 
-**Problem:** Errors about unrecognized lock file fields like `required-markers` indicate version mismatches between uv and uv2nix.
+**Problem:** Errors about unrecognized lock file fields like `required-markers` indicate version
+mismatches between uv and uv2nix.
 
 **Solution:** Keep uv and uv2nix versions aligned. If you encounter lock file format issues:
 
@@ -544,7 +600,9 @@ devShell = pkgs.mkShell {
 };
 ```
 
-This installs packages as pointers to source trees rather than copying files, allowing immediate change activation. However, **consider using the impure development shell instead**—it's simpler and lets uv manage editable installs directly.
+This installs packages as pointers to source trees rather than copying files, allowing immediate
+change activation. However, **consider using the impure development shell instead**—it's simpler and
+lets uv manage editable installs directly.
 
 ## Alternative approach: System-wide installation
 
@@ -578,7 +636,8 @@ nix profile install .
 nix profile install /path/to/spec-kit#specify-cli
 ```
 
-This installs spec-kit into your user profile, making the `specify` command available system-wide without modifying NixOS configuration.
+This installs spec-kit into your user profile, making the `specify` command available system-wide
+without modifying NixOS configuration.
 
 ### Method 3: Home Manager integration
 
@@ -612,12 +671,26 @@ This is simpler but lacks Nix's reproducibility guarantees. The uv2nix approach 
 - **Reproducible across machines:** `flake.lock` ensures identical builds everywhere
 - **Development environment consistency:** Dev shells have exact production dependencies
 
-**Trade-offs:** uv2nix adds complexity with flake.nix, overlays, and uv.lock management. For simple personal use, `uv tool install` may suffice. For team development, CI/CD, or production deployment on NixOS, the uv2nix approach provides stronger guarantees.
+**Trade-offs:** uv2nix adds complexity with flake.nix, overlays, and uv.lock management. For simple
+personal use, `uv tool install` may suffice. For team development, CI/CD, or production deployment
+on NixOS, the uv2nix approach provides stronger guarantees.
 
 ## Conclusion: Modern Python tooling meets Nix
 
-Installing spec-kit with uv2nix demonstrates the power of next-generation Python packaging on NixOS. The process combines uv's fast dependency resolution with Nix's reproducibility through a composable overlay architecture. While the setup requires understanding workspace loading, overlay composition, and build system handling, the result is a fully reproducible spec-kit installation that integrates cleanly with NixOS system management.
+Installing spec-kit with uv2nix demonstrates the power of next-generation Python packaging on NixOS.
+The process combines uv's fast dependency resolution with Nix's reproducibility through a composable
+overlay architecture. While the setup requires understanding workspace loading, overlay composition,
+and build system handling, the result is a fully reproducible spec-kit installation that integrates
+cleanly with NixOS system management.
 
-**Key success factors:** Using Python 3.11+, preferring wheel sources over sdist, including the build-systems overlay, matching package names exactly, and unsetting PYTHONPATH. spec-kit's pure Python dependencies and modern pyproject.toml structure make it an ideal candidate for uv2nix packaging—no C extensions, no complex build requirements, just straightforward Python packages from PyPI.
+**Key success factors:** Using Python 3.11+, preferring wheel sources over sdist, including the
+build-systems overlay, matching package names exactly, and unsetting PYTHONPATH. spec-kit's pure
+Python dependencies and modern pyproject.toml structure make it an ideal candidate for uv2nix
+packaging—no C extensions, no complex build requirements, just straightforward Python packages from
+PyPI.
 
-The uv2nix approach scales beyond spec-kit to any Python project using modern packaging standards. As the recommended successor to poetry2nix, it represents the current state of the art for Python-Nix integration, with active development and API stability for core features. Whether developing locally or deploying to production, uv2nix provides the reproducible Python environments that NixOS users expect.
+The uv2nix approach scales beyond spec-kit to any Python project using modern packaging standards.
+As the recommended successor to poetry2nix, it represents the current state of the art for
+Python-Nix integration, with active development and API stability for core features. Whether
+developing locally or deploying to production, uv2nix provides the reproducible Python environments
+that NixOS users expect.

--- a/hosts/common/nixos/omarchy-meet-binds.nix
+++ b/hosts/common/nixos/omarchy-meet-binds.nix
@@ -1,0 +1,39 @@
+# Meeting recording keybinding for the Omarchy session.
+#
+# The `meet` CLI has always been installed by
+# modules/services/meeting-transcribe.nix, but its one-button promise
+# (SUPER+SHIFT+M) was wired only in home/desktop/gnome/keybindings.nix. Every
+# host defaults to the Omarchy session, where nothing was bound at all, so the
+# feature was CLI-only on the desktop it actually runs on.
+#
+# Guarded on the feature rather than on the host list: p510 imports the
+# nixarchy stack too but does not enable meetingTranscribe, and binding a key
+# to a binary that isn't in PATH just fails silently at press time.
+#
+# Same lua-fragment pattern, and the same pcall caveat, as omarchy-gog.nix:
+# bindings.lua is user-owned and outlives any generation that stops providing
+# this file, so it must load it with
+#   pcall(require, "hypr.meet-binds")
+# A bare require of a missing file fails the WHOLE Hyprland config and drops
+# the session into the error overlay.
+{ config, lib, ... }:
+let
+  # attrByPath, not config.features.meetingTranscribe.enable: p510 imports the
+  # nixarchy stack but never imports modules/services/meeting-transcribe.nix,
+  # so the option is not merely false there -- it does not exist, and a direct
+  # reference throws "attribute 'meetingTranscribe' missing" at eval.
+  enabled = lib.attrByPath [ "features" "meetingTranscribe" "enable" ] false config;
+in
+{
+  config = lib.mkIf enabled {
+    home-manager.users.olafkfreund.home.file.".config/hypr/meet-binds.lua".text = ''
+      -- Managed by hosts/common/nixos/omarchy-meet-binds.nix -- edits here are
+      -- overwritten on the next deploy.
+
+      -- Matches the GNOME binding (custom5) so the key is the same whichever
+      -- session is running. First press starts recording mic + system audio,
+      -- second stops it and dispatches the whisperX/Ollama pipeline.
+      o.bind("SUPER + SHIFT + M", "Meeting record/transcribe/summarize", "meet toggle")
+    '';
+  };
+}

--- a/hosts/p510/nixos/nixarchy.nix
+++ b/hosts/p510/nixos/nixarchy.nix
@@ -28,6 +28,7 @@
     ../../common/nixos/omarchy-sddm.nix
     ../../common/nixos/omarchy-workspaces.nix
     ../../common/nixos/omarchy-gog.nix
+    ../../common/nixos/omarchy-meet-binds.nix
     ../../common/nixos/omarchy-sole-hyprland.nix
     ../../common/nixos/omarchy-stylix-theme.nix
   ];

--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -26,6 +26,7 @@
     ../../common/nixos/omarchy-sddm.nix
     ../../common/nixos/omarchy-workspaces.nix
     ../../common/nixos/omarchy-gog.nix
+    ../../common/nixos/omarchy-meet-binds.nix
     ../../common/nixos/omarchy-sole-hyprland.nix
     ../../common/nixos/omarchy-stylix-theme.nix
   ];

--- a/hosts/razer/nixos/nixarchy.nix
+++ b/hosts/razer/nixos/nixarchy.nix
@@ -26,6 +26,7 @@
     ../../common/nixos/omarchy-sddm.nix
     ../../common/nixos/omarchy-workspaces.nix
     ../../common/nixos/omarchy-gog.nix
+    ../../common/nixos/omarchy-meet-binds.nix
     ../../common/nixos/omarchy-sole-hyprland.nix
     ../../common/nixos/omarchy-stylix-theme.nix
   ];

--- a/modules/services/meeting-transcribe.nix
+++ b/modules/services/meeting-transcribe.nix
@@ -1,7 +1,7 @@
 # meeting-transcribe — one-button meeting recording + transcription + summary.
 #
 # UX: SUPER+SHIFT+M to start, again to stop. After stop, a background job
-# transcribes (whisperX + diarization) and summarizes (Ollama, mistral-small3.1)
+# transcribes (whisperX + diarization) and summarizes (Ollama, qwen3.8:27b)
 # the audio. ~2-5 min later, notify-send fires with a markdown brief at
 # ~/meetings/YYYY-MM-DD-HHMM.md containing TL;DR, your action items, decisions,
 # flagged keywords, topic timeline, and the full diarized transcript.
@@ -48,6 +48,13 @@ let
   # on the same host as the recording. Any other value is treated as an SSH
   # host name (typically a Tailscale node).
   processLocal = cfg.processHost == "local";
+
+  # Only meaningful when this host runs our own ollama module -- a remote or
+  # hand-rolled Ollama has no declared model list to check against.
+  ollamaCfg = config.features.ollama-server or { };
+  ollamaIsLocal = ollamaCfg.enable or false;
+  ollamaDeclaredModels =
+    (ollamaCfg.persistentModels or [ ]) ++ (ollamaCfg.onDemandModels or [ ]);
 
   flagKeywordsCsv = lib.concatStringsSep "," cfg.flagKeywords;
 
@@ -614,8 +621,13 @@ in
 
     ollamaModel = lib.mkOption {
       type = lib.types.str;
-      default = "mistral-small3.1";
-      description = "Ollama model name for summarization (must be pulled on the host).";
+      default = "qwen3.8:27b";
+      description = ''
+        Ollama model used for summarization. Must already be pulled on the
+        Ollama host or every brief silently degrades to transcript-only.
+        The default matches p620's `persistentModels`, so it is resident and
+        answers without a load stall.
+      '';
     };
 
     whisperModel = lib.mkOption {
@@ -665,6 +677,22 @@ in
         message = ''
           features.meetingTranscribe.processHost = "local" requires
           installProcessor = true (whisperX must be installed locally).
+        '';
+      }
+      {
+        # The summarization model has to be pulled or meet-process gets a
+        # model-not-found error from Ollama and falls back to a
+        # transcript-only brief -- no TL;DR, no action items, no failure
+        # anyone notices. That shipped broken for months. When Ollama is
+        # this host's own, the declared model list is knowable, so check it.
+        assertion =
+          !(processLocal && ollamaIsLocal)
+          || builtins.elem cfg.ollamaModel ollamaDeclaredModels;
+        message = ''
+          features.meetingTranscribe.ollamaModel = "${cfg.ollamaModel}" is not
+          declared in features.ollama-server. Add it to persistentModels or
+          onDemandModels, or point ollamaModel at one of:
+            ${lib.concatStringsSep ", " ollamaDeclaredModels}
         '';
       }
       # huggingfaceTokenFile is intentionally NOT required when


### PR DESCRIPTION
Closes #1601.

Three defects found during the docs audit in #1599, plus the lint backlogs
that PR deliberately left behind.

## 1. Meeting summaries have been silently degraded

`ollamaModel` defaulted to `mistral-small3.1`. p620 declares:

```nix
persistentModels = [ "qwen3.8:27b" ];
onDemandModels = [ "qwen2.5-coder:14b" "gemma4:e4b" "gemma4:12b" "qwen2.5:7b" ];
```

`mistral-small3.1` is in neither, and `ollama list` confirms no mistral is
present. Ollama returned model-not-found, `meet-process` caught it, and every
brief fell back to transcript-only — no TL;DR, no action items, no decisions,
no timeline. **The fallback meant as a safety net hid the failure completely.**

Default is now `qwen3.8:27b` — p620's persistent model, so it is resident and
answers without a load stall.

A new assertion makes the mistake unrepeatable. When Ollama is the same host,
the declared model list is knowable, so it is checked at eval:

```
Failed assertions:
- features.meetingTranscribe.ollamaModel = "mistral-small3.1" is not
  declared in features.ollama-server. Add it to persistentModels or
  onDemandModels, or point ollamaModel at one of:
    qwen3.8:27b, qwen2.5-coder:14b, gemma4:e4b, gemma4:12b, qwen2.5:7b
```

That output is real — produced by re-pinning the old default to confirm the
assertion fires rather than sitting there as dead code.

## 2. The one-button feature had no button

`SUPER+SHIFT+M` was wired only in `home/desktop/gnome/keybindings.nix`, but
every host defaults to the Omarchy session, where nothing was bound. The
feature has been CLI-only on the desktop it actually runs on.

`hosts/common/nixos/omarchy-meet-binds.nix` ships the same key for Omarchy,
following the `omarchy-gog.nix` lua-fragment pattern.

Guarded with `lib.attrByPath`, not a direct option reference:

```nix
enabled = lib.attrByPath [ "features" "meetingTranscribe" "enable" ] false config;
```

p510 imports the nixarchy stack but never imports `meeting-transcribe.nix`, so
the option does not evaluate to `false` there — it is **absent**, and a direct
reference throws `attribute 'meetingTranscribe' missing` at eval. Caught
because I checked both hosts rather than assuming; verified `false` on p510,
`true` on p620.

`bindings.lua` is user-owned, so it takes one hand-written line —
`pcall(require, "hypr.meet-binds")` — added on p620 and razer.

Incidentally, `omarchy-gog.nix` says *"SUPER+SHIFT+M would read better, but it
is already bound"*. That was true of GNOME, not of the session the comment
governs. I left that binding alone.

## 3. CLAUDE.md pointed at a file that does not exist

"Module shape" ended with *"Add the file to `modules/default.nix`"*. No such
file; hosts import module paths directly.

## 4. Lint backlogs cleared

`CLAUDE-CODE-OPTIMIZATION.md` (51 errors), `screensharing_cosmic.md` (50),
`Github-spec-kit.md` (29) — reflow and code-fence labels only.

Two scripted passes damaged content before I caught it: a blanket
`**bold**`→heading rule invented duplicate headings, and a rewrap broke a line
before `#5190` which `markdownlint --fix` then turned into an `<h1>`. Both were
reverted and redone narrowly. Every file was word-stream diffed against main
afterwards to prove no prose changed — the only differences are the intended
markup edits.

## Verification

- `nix build .#nixosConfigurations.p620.config.system.build.toplevel` — exit 0
  (shellcheck runs on the `meet` CLI here)
- All three hosts evaluate
- Assertion proven to fire on the old default
- markdownlint clean; pre-push hooks passed

## Not covered

The keybind needs the one `pcall` line in `bindings.lua`, which is user-owned
by design. Done on p620 and razer; any new host needs it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB
