### PR TITLE
Answer the ZFS question none of these machines are asking

### DIFF
--- a/hosts/common/nixos/zfs-import.nix
+++ b/hosts/common/nixos/zfs-import.nix
@@ -1,0 +1,23 @@
+# Silence nixpkgs' boot.zfs.forceImportRoot deprecation notice.
+#
+# None of these machines use ZFS. p510, p620 and razer are ext4 throughout
+# (plus vfat for the ESP, and nfs/tmpfs where they apply), and
+# `boot.zfs.enabled` evaluates false on all three. The warning fires anyway:
+# it is emitted whenever the option sits at its default, not when a pool is
+# actually imported, so it appears on every evaluation of every host and says
+# nothing about this configuration.
+#
+# What the option does, since silencing a data-loss warning deserves knowing:
+# forceImportRoot makes the initrd import the root pool with `zpool import -f`,
+# overriding ZFS's own guard against importing a pool another system may still
+# have open. That guard exists to stop two machines writing the same pool.
+# Upstream is flipping the default to false in 26.11 because forcing it is the
+# dangerous choice, and false is what a machine with no pool at all should say.
+#
+# So this is not "quieting a warning we should heed". It is answering a
+# question that does not apply, with the answer that will be the default
+# anyway. If a ZFS root is ever added to one of these hosts, revisit this line
+# rather than inheriting it.
+{
+  boot.zfs.forceImportRoot = false;
+}

--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -25,6 +25,7 @@ in
       ../common/nixos/i18n.nix
       ../common/nixos/envvar.nix
       ../common/nixos/host-class.nix
+      ../common/nixos/zfs-import.nix
       ../common/nixos/inotify-limits.nix
       ./nixos/github-runner.nix # Self-hosted CI for nixarchy's VM checks
       ./nixos/cpu.nix

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -26,6 +26,7 @@ in
     ../common/nixos/hosts.nix
     ../common/nixos/envvar.nix
     ../common/nixos/host-class.nix
+    ../common/nixos/zfs-import.nix
     ../common/nixos/inotify-limits.nix
     ./nixos/cpu.nix
     ./nixos/memory.nix

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -23,6 +23,7 @@ in
     ../common/nixos/hosts.nix
     ../common/nixos/envvar.nix
     ../common/nixos/host-class.nix
+    ../common/nixos/zfs-import.nix
     ../common/nixos/inotify-limits.nix
     ./nixos/cpu.nix
     ./nixos/laptop.nix


### PR DESCRIPTION
Every evaluation of every host prints:

```
evaluation warning: `boot.zfs.forceImportRoot` is using the default value of `true`.
It is highly recommended to set it to `false`, the new default from 26.11 on,
to reduce the risk of data loss.
```

## It does not apply here

None of these machines use ZFS:

| host | `boot.zfs.enabled` | filesystems |
|---|---|---|
| p510 | `false` | ext4, nfs, vfat |
| p620 | `false` | ext4, nfs, tmpfs, vfat |
| razer | `false` | ext4, vfat |

The warning fires on the option sitting at its default, not on a pool being imported — so it appears on every eval of every host and says nothing about this configuration.

## What is being silenced

Worth stating, since it is nominally a data-loss warning and silencing one deserves knowing why. `forceImportRoot` makes the initrd import the root pool with `zpool import -f`, overriding ZFS's own guard against importing a pool another system may still have open — the guard that stops two machines writing the same pool. Upstream is flipping the default to `false` in 26.11 because forcing it is the dangerous choice.

So this is not quieting a warning that should be heeded. It answers a question that does not apply, with the value that will be the default anyway. The module says so, and says to revisit the line rather than inherit it if a ZFS root is ever added.

## Verified

```
p510    forceImportRoot=false  zfs-warning=0  builds=yes
p620    forceImportRoot=false  zfs-warning=0  builds=yes
razer   forceImportRoot=false  zfs-warning=0  builds=yes
```

## Deploy timing

p510 is mid-release for nixarchy `v4.0.1-4` right now. **Do not switch it until that finishes** — activation restarts the runner units and kills the job, which is exactly how `v4.0.1-3` died. p620 and razer are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5