### PR TITLE
fix(meet): size the summarization model to the GPU (#1608)

### DIFF
--- a/docs/applications/meet.md
+++ b/docs/applications/meet.md
@@ -102,7 +102,7 @@ features.meetingTranscribe = {
 | `installProcessor`     | bool           | `false`               | Installs whisperX and `meet-process`. Must be `true` when `processHost = "local"`. |
 | `huggingfaceTokenFile` | path or null   | `null`                | Path to an HF token file. Needed on the processor for diarization; degrades gracefully when missing. |
 | `ollamaUrl`            | string         | `"http://p620:11434"` | Ollama API base URL. Set to `http://localhost:11434` on p620. |
-| `ollamaModel`          | string         | `"qwen3.8:27b"`       | Must be declared in `features.ollama-server`; asserted at eval time when Ollama is local. |
+| `ollamaModel`          | string         | `"gemma4:12b"`        | Must be declared in `features.ollama-server`; asserted at eval time when Ollama is local. |
 | `whisperModel`         | string         | `"large-v3"`          | One of `tiny`, `base`, `small`, `medium`, `large-v3`. |
 | `language`             | string         | `"en"`                | For example `en`, `no`, `da`. |
 | `outputDir`            | string         | `"~/meetings"`        | Per-user; the tilde is expanded at runtime. |
@@ -114,9 +114,20 @@ features.meetingTranscribe = {
 
 ### The summarization model
 
-`ollamaModel` defaults to `qwen3.8:27b`, which p620 declares in
-`features.ollama-server.persistentModels` — it stays resident, so summarizing
-does not stall on a model load.
+`ollamaModel` defaults to `gemma4:12b`, chosen to fit rather than to be the
+largest available. p620's card has 21.5 GB and `OLLAMA_CONTEXT_LENGTH` is
+32768, so at 7.6 GB it loads fully onto the GPU (~51% VRAM) and leaves the
+rest for the desktop.
+
+`qwen3.8:27b` was tried first and is the wrong shape: 17 GB of weights plus
+that KV cache overflows the card, Ollama splits it 88/12 GPU/CPU, VRAM hits
+94% and **the desktop freezes for the whole run**. Both models return valid
+JSON of equivalent quality here — this is extraction from a transcript, not
+reasoning — so the larger one buys nothing and costs a usable machine.
+
+`OLLAMA_KEEP_ALIVE` is 5m, so nothing stays resident between meetings: every
+run pays a cold load, 24s for `gemma4:12b` against ~59s for `qwen3.8:27b`.
+`persistentModels` only pre-pulls; it does not pin.
 
 If you point it at a model the Ollama host does not declare, the build now
 fails with an assertion naming the models that are available. Before, Ollama

--- a/modules/services/meeting-transcribe.nix
+++ b/modules/services/meeting-transcribe.nix
@@ -1,7 +1,7 @@
 # meeting-transcribe — one-button meeting recording + transcription + summary.
 #
 # UX: SUPER+SHIFT+M to start, again to stop. After stop, a background job
-# transcribes (whisperX + diarization) and summarizes (Ollama, qwen3.8:27b)
+# transcribes (whisperX + diarization) and summarizes (Ollama, gemma4:12b)
 # the audio. ~2-5 min later, notify-send fires with a markdown brief at
 # ~/meetings/YYYY-MM-DD-HHMM.md containing TL;DR, your action items, decisions,
 # flagged keywords, topic timeline, and the full diarized transcript.
@@ -621,12 +621,25 @@ in
 
     ollamaModel = lib.mkOption {
       type = lib.types.str;
-      default = "qwen3.8:27b";
+      default = "gemma4:12b";
       description = ''
-        Ollama model used for summarization. Must already be pulled on the
-        Ollama host or every brief silently degrades to transcript-only.
-        The default matches p620's `persistentModels`, so it is resident and
-        answers without a load stall.
+        Ollama model used for summarization. Must be declared in
+        `features.ollama-server` or every brief silently degrades to
+        transcript-only -- asserted below when Ollama is local.
+
+        Sized to fit, not maximised. p620's card has 21.5 GB and
+        OLLAMA_CONTEXT_LENGTH is 32768, so gemma4:12b (7.6 GB) loads fully
+        onto the GPU at ~51% VRAM and leaves the rest for the compositor.
+        qwen3.8:27b was tried first and is the wrong shape here: 17 GB of
+        weights plus that KV cache overflows the card, ollama splits it
+        88/12 GPU/CPU, VRAM hits 94% and the desktop freezes for the whole
+        run. Both return valid JSON of equivalent quality for this task --
+        it is transcript extraction, not reasoning -- so the larger model
+        buys nothing and costs a usable machine.
+
+        Note OLLAMA_KEEP_ALIVE is 5m: nothing stays resident between
+        meetings, so every run pays a cold load (24s for gemma4:12b,
+        ~59s for qwen3.8:27b). `persistentModels` only pre-pulls.
       '';
     };
 


### PR DESCRIPTION
Closes #1608. Corrects the `ollamaModel` default I set in #1602.

## What happened

While verifying the meet pipeline end to end on p620 after the deploy, the
desktop started lagging and freezing. It was my test request loading the
model, and it exposed that the default I chose does not fit the hardware.

## Measured, not inferred

p620's card has **21.5 GB** of VRAM; `OLLAMA_CONTEXT_LENGTH` is 32768.

| | `qwen3.8:27b` | `gemma4:12b` |
| --- | --- | --- |
| Weights | 17 GB | 7.6 GB |
| VRAM while loaded | **94%** | **51%** |
| Placement | 88% GPU / **12% CPU spill** | **100% GPU** |
| Cold load | ~59 s | **24 s** |
| Returns valid JSON | yes | yes |
| Attributed the action item correctly | yes | yes |

17 GB of weights plus that KV cache overflows the card, so Ollama splits the
model across GPU and CPU and VRAM sits at 94% — starving the compositor and
freezing the desktop for the whole run. Every meeting summary would have done
this.

Both models produce equivalent output for this task. It is extraction from a
transcript, not reasoning, so the larger model buys nothing and costs a usable
machine while it runs:

```json
{ "tldr": "The team agreed to ship the cache change this Friday, with Olaf
           preparing the migration notes by Thursday.",
  "decisions": ["Ship the cache change on Friday."],
  "action_items": [{"who": "Olaf", "what": "Write migration notes by Thursday"}] }
```

## Two claims in #1602 were wrong

That PR said the model "is resident and answers without a load stall".

- It is **not resident**: `OLLAMA_KEEP_ALIVE` is `5m`, and `ollama ps` was
  empty before the test.
- `persistentModels` **only pre-pulls**; it does not pin a model in VRAM.

So every summarization pays a cold load either way. The option description and
`docs/applications/meet.md` now state that with the numbers, instead of
repeating the wrong reasoning.

## Verification

- `gemma4:12b` returns valid JSON for a transcript, loading 100% onto the GPU
  at 51% VRAM
- All three hosts evaluate; `ollamaModel` resolves to `gemma4:12b`
- The assertion from #1602 still passes — `gemma4:12b` is already declared in
  `onDemandModels`
- markdownlint clean

## Note

`gemma4:12b` is a deliberate "fits the hardware" choice over "largest
available". If p620 ever gets a bigger card, `qwen3.8:27b` becomes viable
again — the reasoning is recorded next to the option so that decision can be
revisited with the numbers in hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB
