### PR TITLE
fix(meet): restore diarization and never lose a recording (#1611)

### DIFF
--- a/docs/applications/meet.md
+++ b/docs/applications/meet.md
@@ -156,6 +156,22 @@ transcript with no speaker labels.
    ./scripts/manage-secrets.sh edit api-huggingface
    ```
 
+   **The secret must be owned by the user**, not root. `meet-process` runs as
+   you and enables diarization only if `[[ -r /run/agenix/api-huggingface ]]`.
+   agenix defaults to `root:root 0400`, so without an explicit `owner` that
+   test fails *silently*: whisperX runs without `--diarize`, the transcript
+   has no `SPEAKER_XX` labels, and the summarizer is then asked for
+   `user_speaker_label` and `participants[].label` that cannot exist. That
+   sent gemma4:12b into a generation loop until the 600 s curl timeout.
+
+   ```nix
+   api-huggingface = {
+     file = ../../secrets/api-huggingface.age;
+     owner = "olafkfreund";
+     mode = "0400";
+   };
+   ```
+
 5. Deploy: `just quick-deploy p620`.
 
 `secrets/api-huggingface.age` exists in the repo and is encrypted to
@@ -239,12 +255,20 @@ config and accept a plain, non-diarized transcript.
 
 ### Brief has a transcript but no summary
 
-Ollama could not answer. Most likely the configured `ollamaModel` is not
-pulled on the Ollama host; see the setup section above. Check with:
+Ollama could not answer, and the brief says which of the three ways it failed:
+the call timed out, the body came back empty (generation hit `num_predict`),
+or the JSON could not be parsed. In every case the transcript is still written —
+a recording is never lost.
 
-```bash
-ssh p620 'ollama list'
-```
+Most likely causes, in order:
+
+1. **Diarization is off**, so the transcript has no speaker labels and the
+   model loops on the `SPEAKER_XX` fields. Check the token is readable *as
+   your user*: `test -r /run/agenix/api-huggingface && echo ok`.
+2. The configured `ollamaModel` is not pulled: `ssh p620 'ollama list'`.
+
+Generation is capped at `num_predict: 4096`, so a runaway fails in well under
+a minute rather than hanging for the full 600 s curl timeout.
 
 ### "Remote processing failed" on razer
 

--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -166,7 +166,16 @@ in
   # Diarization auto-enables once `secrets/api-huggingface.age` exists;
   # until then meet-process falls back to plain transcription.
   age.secrets = lib.mkIf (builtins.pathExists ../../secrets/api-huggingface.age) {
-    api-huggingface.file = ../../secrets/api-huggingface.age;
+    api-huggingface = {
+      file = ../../secrets/api-huggingface.age;
+      # meet-process runs as the user, not root, and guards diarization on
+      # `[[ -r $HF_TOKEN_PATH ]]`. agenix defaults to root:root 0400, so that
+      # test failed silently: whisperX ran without --diarize, produced a
+      # transcript with no SPEAKER_XX labels, and the summarizer then looped
+      # forever trying to fill the SPEAKER_XX fields the prompt demands.
+      owner = "olafkfreund";
+      mode = "0400";
+    };
   };
   features.meetingTranscribe = {
     enable = true;

--- a/modules/services/meeting-transcribe.nix
+++ b/modules/services/meeting-transcribe.nix
@@ -431,7 +431,7 @@ let
           model: $model,
           stream: false,
           format: "json",
-          options: { temperature: 0.2, num_ctx: 32768 },
+          options: { temperature: 0.2, num_ctx: 32768, num_predict: 4096 },
           messages: [
             { role: "system", content: $system },
             { role: "user",   content: $user }
@@ -439,33 +439,42 @@ let
         }')
 
       echo "meet-process: calling ollama ($OLLAMA_MODEL @ $OLLAMA_URL)" >&2
-      RESPONSE=$(curl -sS --max-time 600 \
-        -H 'Content-Type: application/json' \
-        -d "$REQUEST" \
-        "$OLLAMA_URL/api/chat") || {
-          echo "meet-process: ollama call failed" >&2
-          exit 1
-        }
-
-      SUMMARY_JSON=$(jq -r '.message.content // empty' <<<"$RESPONSE")
-      if [[ -z "$SUMMARY_JSON" ]]; then
-        echo "meet-process: empty ollama response: $RESPONSE" >&2
-        exit 1
-      fi
-
-      # Verify the LLM returned parseable JSON; on failure, still write the
-      # transcript so the recording isn't lost.
-      if ! jq empty <<<"$SUMMARY_JSON" 2>/dev/null; then
-        echo "meet-process: ollama returned invalid JSON, falling back to transcript-only" >&2
+      # Never lose a recording. Previously only the invalid-JSON branch wrote
+      # anything: a curl timeout or an empty body exited 1, leaving the user
+      # with an .opus file and no brief at all. Every ollama failure now
+      # writes the transcript and exits 0.
+      write_transcript_fallback() {
+        echo "meet-process: $1 -- writing transcript-only brief" >&2
         {
           echo "# Meeting: $BASE"
           echo ""
-          echo "_Ollama returned invalid JSON — transcript-only fallback._"
+          echo "_No summary: $1._"
           echo ""
           echo "## Full transcript"
           echo ""
           echo "$TRANSCRIPT_TXT"
         } > "$MD_FILE"
+      }
+
+      RESPONSE=$(curl -sS --max-time 600 \
+        -H 'Content-Type: application/json' \
+        -d "$REQUEST" \
+        "$OLLAMA_URL/api/chat") || {
+          echo "meet-process: ollama call failed" >&2
+          write_transcript_fallback "ollama call failed (timeout or connection error)"
+          exit 0
+        }
+
+      SUMMARY_JSON=$(jq -r '.message.content // empty' <<<"$RESPONSE")
+      if [[ -z "$SUMMARY_JSON" ]]; then
+        write_transcript_fallback "ollama returned an empty body (generation may have hit num_predict)"
+        exit 0
+      fi
+
+      # Verify the LLM returned parseable JSON; on failure, still write the
+      # transcript so the recording isn't lost.
+      if ! jq empty <<<"$SUMMARY_JSON" 2>/dev/null; then
+        write_transcript_fallback "ollama returned invalid JSON"
         exit 0
       fi
 


### PR DESCRIPTION
Closes #1611.

You asked whether we were on point. **We were not** — a real end-to-end run
produced no brief at all. This fixes why.

## The run

Synthesized a 15 s two-voice meeting and put it through `meet process` on p620.
whisperX transcribed it correctly. Then:

```
meet-process: transcribing meeting.opus (model=large-v3, diarize=0)
Warning: You are sending unauthenticated requests to the HF Hub.
meet-process: calling ollama (gemma4:12b @ http://localhost:11434)
curl: (28) Operation timed out after 600001 milliseconds with 0 bytes received
meet-process: ollama call failed
```

`~/meetings/` was empty.

## Root cause chain

1. `/run/agenix/api-huggingface` is `root:root 0400` — the host declared
   `api-huggingface.file = ...` with **no `owner`**.
2. `meet-process` runs as the **user** and guards diarization on
   `[[ -r "$HF_TOKEN_PATH" ]]`. That test fails **silently**.
3. whisperX runs without `--diarize` → transcript has **no `SPEAKER_XX` labels**.
4. The prompt demands `user_speaker_label`, `participants[].label` and
   `flagged_moments[].speaker` — unsatisfiable from a label-less transcript.
5. gemma4:12b loops: **28,000+ tokens** at 50 t/s, never terminating.
6. curl hits 600 s → `exit 1` → nothing written.

Established by differential test, not inference: the identical prompt **with**
`SPEAKER_XX` labels finishes in **429 tokens**; **without** them it was still
generating at 120 s.

## Step 6 is a second, independent bug

The transcript-only fallback exists so a recording is never lost — but it only
covered the **invalid JSON** branch. A curl failure or an empty body both
`exit 1` before writing anything, leaving an `.opus` file and no brief. The
opposite of the stated intent, and the reason this run lost everything rather
than degrading.

## Fixes

| | |
|---|---|
| `owner = "olafkfreund"` on the secret | removes the runaway **at source** |
| `num_predict: 4096` | bounds a runaway to ~40 s, not 600 s (measured: `done_reason=length` at 38 s) |
| one `write_transcript_fallback` on all three failure paths | transcript always written; the brief names which failure occurred |

The helper is defined **before** the curl block. My first patch put it after —
bash resolves functions at call time, and the first caller is the curl-failure
branch, so it would have died with "command not found" on exactly the path
that lost your recording.

## Verified

- p620 builds (shellcheck runs on the script)
- `bash -n` clean on the built script
- helper defined at line 142, called at 160 / 166 / 173
- secret resolves to `olafkfreund` / `0400`
- markdownlint clean

## Confirmed good in the same run

**VRAM held at 53% for the entire run, peak included.** The #1608 sizing fix
works and the desktop stayed usable throughout — the failure here is unrelated
to it.

## Still unproven after this merge

That diarization actually succeeds — that needs the deploy plus a HF token
whose pyannote EULAs are accepted. I will re-run the same end-to-end test to
confirm, rather than calling it fixed because it builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB
