### PR TITLE
fix(meet): summarize without diarization, and name the right pyannote repo (#1614)

### DIFF
--- a/docs/applications/meet.md
+++ b/docs/applications/meet.md
@@ -145,9 +145,12 @@ transcript with no speaker labels.
 
 1. Sign up at [huggingface.co/join](https://huggingface.co/join).
 2. Accept the terms on
-   [`pyannote/speaker-diarization-3.1`](https://huggingface.co/pyannote/speaker-diarization-3.1)
-   and
-   [`pyannote/segmentation-3.0`](https://huggingface.co/pyannote/segmentation-3.0).
+   [`pyannote/speaker-diarization-community-1`](https://huggingface.co/pyannote/speaker-diarization-community-1).
+
+   That is the model **whisperX 3.8.6 actually requests**. Earlier revisions
+   of this page named `speaker-diarization-3.1` and `segmentation-3.0`;
+   accepting those two leaves diarization failing with a 403
+   `GatedRepoError`, because neither is the repo whisperX asks for.
 3. Generate a read token at
    [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens).
 4. Store it in agenix from a machine that has the user key:
@@ -247,11 +250,16 @@ pactl list sources short | grep monitor
 You should see `${default_sink}.monitor`. If not, the default sink is
 something unusual (a hardware loopback, say) — switch the default and retry.
 
-### whisperX hangs on `pyannote/speaker-diarization-3.1`
+### Diarization fails with a 403 `GatedRepoError`
 
-The HF token file is missing or the EULAs are not accepted. Either accept both
-models' EULAs and add the token, or drop `huggingfaceTokenFile` from the host
-config and accept a plain, non-diarized transcript.
+The token is readable but the account has not been granted access to
+`pyannote/speaker-diarization-community-1`. Accept the conditions there.
+
+whisperX no longer dies on this: it retries without `--diarize`, so you still
+get a transcript and a full summary — only the per-speaker attribution and the
+Participants section are lost. A token that is present but unauthorized used
+to be *worse* than no token at all, because whisperX aborted before producing
+any transcript.
 
 ### Brief has a transcript but no summary
 

--- a/modules/services/meeting-transcribe.nix
+++ b/modules/services/meeting-transcribe.nix
@@ -31,8 +31,10 @@
 #
 # Setup (one-time, post-deploy on p620):
 #   1. Sign up at https://huggingface.co/join (free).
-#   2. Accept terms at https://huggingface.co/pyannote/speaker-diarization-3.1
-#      (and the dependency https://huggingface.co/pyannote/segmentation-3.0).
+#   2. Accept terms at
+#      https://huggingface.co/pyannote/speaker-diarization-community-1
+#      That is what whisperX 3.8.6 requests -- NOT speaker-diarization-3.1,
+#      which earlier revisions of this file and the docs both named.
 #   3. Create a read token at https://huggingface.co/settings/tokens.
 #   4. ./scripts/manage-secrets.sh create api-huggingface  (paste token).
 #   5. just quick-deploy p620 && just quick-deploy razer.
@@ -346,15 +348,34 @@ let
       # whisperX writes <BASE>.json into --output_dir. CPU device is the
       # safe default on AMD (ROCm wheels for CTranslate2 are not yet in
       # nixpkgs); 16-core Threadripper still gets ~10x realtime on large-v3.
-      whisperx \
-        --model "$WHISPER_MODEL" \
-        --language "$LANGUAGE" \
-        --device cpu \
-        --compute_type int8 \
-        --output_dir "$OUTPUT_DIR" \
-        --output_format json \
-        "''${DIARIZE_ARGS[@]}" \
-        "$AUDIO_FILE" >&2
+      run_whisperx() {
+        whisperx \
+          --model "$WHISPER_MODEL" \
+          --language "$LANGUAGE" \
+          --device cpu \
+          --compute_type int8 \
+          --output_dir "$OUTPUT_DIR" \
+          --output_format json \
+          "$@" \
+          "$AUDIO_FILE" >&2
+      }
+
+      # A token that is present but NOT authorized for the gated pyannote
+      # repo is worse than no token: whisperX aborts with GatedRepoError and
+      # there is no transcript at all, where an absent token merely skips
+      # diarization. Retry undiarized so the recording always survives.
+      if ! run_whisperx "''${DIARIZE_ARGS[@]}"; then
+        if [[ ''${#DIARIZE_ARGS[@]} -gt 0 ]]; then
+          echo "meet-process: diarization failed (gated pyannote repo, or a bad HF token) -- retrying without it" >&2
+          run_whisperx || {
+            echo "meet-process: whisperX failed even without diarization" >&2
+            exit 1
+          }
+        else
+          echo "meet-process: whisperX failed" >&2
+          exit 1
+        fi
+      fi
 
       if [[ ! -s "$JSON_FILE" ]]; then
         echo "meet-process: whisperX produced no JSON at $JSON_FILE" >&2
@@ -378,12 +399,23 @@ let
 
       SYSTEM_PROMPT="You are an expert meeting analyst. Extract structured information from a diarized meeting transcript and return ONLY valid JSON matching the provided schema. Never invent facts not stated in the transcript. If a section has no entries, return an empty array — never omit a field."
 
+      # Without diarization the transcript carries no SPEAKER_XX labels, and
+      # a prompt that demands user_speaker_label / participants[].label /
+      # flagged_moments[].speaker then asks for something unobtainable. Models
+      # do not answer "null" to that -- gemma4:12b loops until num_predict,
+      # returns an empty body, and the whole summary is lost (#1613). Since
+      # the module deliberately supports running with no HF token at all, the
+      # undiarized case has to summarize too: relax the speaker fields rather
+      # than let the run degrade to transcript-only.
+      if grep -q 'SPEAKER_' <<<"$TRANSCRIPT_TXT"; then
+        SPEAKER_RULE="One of those speakers IS the user; identify which one from context (who others address by name, who hosts the meeting, who takes notes)."
+      else
+        SPEAKER_RULE="This transcript has NO speaker labels (diarization was unavailable). Set user_speaker_label to null, participants to [], and every flagged_moments[].speaker and other_action_items[].assignee to null. Infer action items from names spoken aloud in the text instead. Do not invent SPEAKER_XX labels."
+      fi
+
       USER_PROMPT=$(cat <<PROMPT
-      The user is $USER_NAME ($USER_EMAIL). The transcript below uses speaker
-      labels like SPEAKER_00. One of those speakers IS the user; identify
-      which one from context (who others address by name, who hosts the
-      meeting, who takes notes, who matches the user's role). Use that to
-      separate the user's own action items from others'.
+      The user is $USER_NAME ($USER_EMAIL). $SPEAKER_RULE
+      Use that to separate the user's own action items from others'.
 
       Return a JSON object with EXACTLY these fields:
       {
@@ -513,7 +545,7 @@ let
         if [[ "$N" -eq 0 ]]; then
           echo "_None._"
         else
-          jq -r '.other_action_items[] | "- [ ] **\(.assignee):** \(.task)\(if .deadline then "  _(\(.deadline))_" else "" end)"' <<<"$SUMMARY_JSON"
+          jq -r '.other_action_items[] | "- [ ] \(if .assignee then "**\(.assignee):** " else "" end)\(.task)\(if .deadline then "  _(\(.deadline))_" else "" end)"' <<<"$SUMMARY_JSON"
         fi
         echo ""
 
@@ -543,7 +575,7 @@ let
         if [[ "$N" -eq 0 ]]; then
           echo "_No flagged moments._"
         else
-          jq -r '.flagged_moments[] | "- \(.timestamp) **\(.speaker)** [\(.keyword)] — \(.context)"' <<<"$SUMMARY_JSON"
+          jq -r '.flagged_moments[] | "- \(.timestamp)\(if .speaker then " **\(.speaker)**" else "" end) [\(.keyword)] — \(.context)"' <<<"$SUMMARY_JSON"
         fi
         echo ""
 


### PR DESCRIPTION
Closes #1614. Follow-on from #1611 — running the pipeline again got further and
found three more defects.

## The headline

**`meet` now produces a complete brief.** That had never happened in this
repo's history; every prior run yielded nothing or transcript-only.

```markdown
## TL;DR
The team plans to ship the cash change on Friday. The discussion focused on
resolving the migration notes blocker and setting a deadline for the security review.

## 🎯 Your action items
- [ ] Write the migration notes  _(Thursday)_
  _Identified as the last blocker for the cash change shipment._

## 📋 Action items (others)
- [ ] decide about the deadline for the security review

## 🔑 Key decisions
- Ship the cash change on Friday

## 🚩 Flagged (blocker,deadline,urgent,incident,risk,escalate)
- 00:03 [blocker] — migration notes are the last blocker
- 00:11 [deadline] — decide about the deadline for the security review
```

103 s, from an **undiarized** transcript. It correctly separated *your* action
item from the other one, using only the name spoken aloud.

## What was wrong

**1. Our instructions named the wrong model.** whisperX 3.8.6 requests
`pyannote/speaker-diarization-community-1`; the docs and module header both
said `speaker-diarization-3.1` + `segmentation-3.0`. Following our own setup
guide leaves diarization returning 403 forever.

**2. A present-but-unauthorized token was worse than no token.** Absent token
→ whisperX skips diarization and still transcribes. Gated repo → whisperX
**aborts**, so there is no transcript to fall back to. Now it retries without
`--diarize`.

**3. Undiarized transcripts produced no summary.** The module claims the
feature should "work end-to-end before the HF account/token is set up". It
could not: with no `SPEAKER_XX` labels, a prompt hard-requiring
`user_speaker_label` / `participants[].label` / `flagged_moments[].speaker`
sent gemma4:12b into a loop to `num_predict` and an empty body. The prompt now
detects the absence of labels and instructs the model to null those fields and
infer assignees from spoken names.

Plus: stop rendering a literal `null` where an assignee or speaker is unknown —
a case the undiarized path now legitimately produces. Verified 0 occurrences.

## Verification

Every claim here came from running it:

| | |
|---|---|
| Retry fires on the gated repo | `diarization failed … retrying without it` in the log |
| Recording survives | brief written every run, exit 0 |
| Undiarized summary works | full brief above, 103 s |
| No literal `null` | `grep -c null` → 0 |
| Builds | p620 toplevel, shellcheck passes |
| Docs | markdownlint clean |

## Still needs you

Accept access at
[`pyannote/speaker-diarization-community-1`](https://huggingface.co/pyannote/speaker-diarization-community-1)
for actual speaker labels. Everything else works without it now — which is
the point of fix 3. Until then the Participants section reads
_"No diarization data."_ rather than failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB
