### PR TITLE
fix(p510): stop the Plex software-transcode stampede tripping the PSU (#1616)

### DIFF
--- a/hosts/p510/nixos/cpu.nix
+++ b/hosts/p510/nixos/cpu.nix
@@ -1,9 +1,34 @@
 { lib, pkgs, ... }: {
-  # CPU frequency scaling for Xeon workstation
+  # CPU frequency scaling. Deliberately NOT "performance" any more.
+  #
+  # p510 hard-power-cut a fourth time on 2026-09-01 at 22:26. The GPU was not
+  # the cause: its 130W cap had been in force for 6.5 hours. What the journal
+  # shows in the final 30 seconds is Plex going from 7 to 12 concurrent
+  # streams, exceeding the 3070 Ti's ~3-session NVENC limit, and falling back
+  # to SOFTWARE x264 -- five transcoder processes spawned between 22:26:00 and
+  # 22:26:02, each loading liblibx264_encoder.so. On 20 Broadwell-EP cores
+  # held at maximum by the "performance" governor, that is the power spike
+  # that tripped a 490W supply also feeding a GPU and three spinning disks.
+  #
+  # intel_pstate in active mode offers only "performance" and "powersave", and
+  # "powersave" here is the DYNAMIC governor (the intel_pstate equivalent of
+  # schedutil), not a fixed-low one. For a box that idles most of the day and
+  # transcodes in bursts, "performance" bought nothing and cost headroom:
+  # measured 2693MHz at idle before, 1200MHz after.
   powerManagement = {
     enable = true;
-    cpuFreqGovernor = "performance"; # For workstation loads
+    cpuFreqGovernor = "powersave";
   };
+
+  # Hard ceiling on the P-state, which the governor alone does not give. 70%
+  # caps sustained turbo around 2.5GHz -- still above the 2.2GHz base, so
+  # transcoding is unaffected, while removing the top of the power curve where
+  # a Xeon draws far past its 135W TDP. Written via tmpfiles because
+  # intel_pstate exposes this only through sysfs and it does not survive a
+  # reboot on its own.
+  systemd.tmpfiles.rules = [
+    "w /sys/devices/system/cpu/intel_pstate/max_perf_pct - - - - 70"
+  ];
 
   # Workstation-oriented scheduler tuning
   boot.kernel.sysctl = {

--- a/hosts/p510/nixos/nvidia.nix
+++ b/hosts/p510/nixos/nvidia.nix
@@ -64,10 +64,33 @@
   # — which matters beyond tidiness, because one permanently-failed unit makes
   # every subsequent switch return exit 4 and can roll the deploy back.
   #
-  # 130W is deliberately left as-is. The card's stock limit is 290W and the
-  # PSU now has ~110W more headroom, but the freezes above are why this cap
-  # exists at all, so raising it is a separate decision backed by its own
-  # testing rather than a side effect of pulling a card.
+  # 2026-09-01: it happened a FOURTH time, at 22:26 mid-Plex-NVENC-transcode,
+  # with the 130W cap verified in force for the preceding 6.5 hours. Same
+  # signature as the other three: no MCE, no thermal event, the journal simply
+  # stops mid-write. So the cap was doing its job and was not enough.
+  #
+  # Why: `nvidia-smi -pl` bounds AVERAGE board power, not instantaneous draw.
+  # Ampere is notorious for sub-millisecond transients around 2x the limit, so
+  # a 130W cap still throws ~260W spikes at a 490W supply that also has a
+  # turbo-ing 20-core Xeon and three spinning disks on it. That is why every
+  # crash happened while a GPU ramped FROM IDLE rather than under sustained
+  # load -- sustained draw was never the problem.
+  #
+  # Two changes, because -pl alone provably was not enough:
+  #   -pl 100    the card's floor (min_limit reports 100W), cutting both the
+  #              average and the transient ceiling proportionally.
+  #   -lgc 0,1500  caps the boost clock at 1500MHz of a possible 2100. Boost
+  #              transients scale with clock, so this blunts the spike itself
+  #              rather than the average. NVENC is a fixed-function block and
+  #              does not use the graphics clock, so Plex transcoding is
+  #              unaffected -- verified: Plex healthy, HTTP 200, after both
+  #              settings were applied live.
+  #
+  # Ordering matters as much as the values. plex.service had no dependency on
+  # this unit and both entered active at the same second, so on a cold boot
+  # Plex could open an NVENC session while the card was still at its 290W
+  # default -- exactly the ramp-from-idle window that kills this machine.
+  # `before = [ "plex.service" ]` closes that race.
   #
   # This runs as root on purpose — setting a power limit needs CAP_SYS_ADMIN
   # and /dev/nvidiactl, so the usual DynamicUser/ProtectHome hardening cannot
@@ -76,6 +99,8 @@
     description = "Cap NVIDIA board power to fit p510's 490W PSU";
     after = [ "nvidia-persistenced.service" ];
     wants = [ "nvidia-persistenced.service" ];
+    # Nothing may touch the GPU until the cap is on. See the race above.
+    before = [ "plex.service" ];
     wantedBy = [ "multi-user.target" ];
     serviceConfig = {
       Type = "oneshot";
@@ -83,7 +108,8 @@
       # Persistence mode keeps the limit across client detach; -pl is not
       # sticky across a driver reload, hence re-applying at every boot.
       ExecStart = [
-        "${config.hardware.nvidia.package.bin}/bin/nvidia-smi -i 0 -pl 130"
+        "${config.hardware.nvidia.package.bin}/bin/nvidia-smi -i 0 -pl 100"
+        "${config.hardware.nvidia.package.bin}/bin/nvidia-smi -i 0 -lgc 0,1500"
       ];
       ProtectSystem = "strict";
       ProtectHome = true;

--- a/hosts/p510/nixos/plex.nix
+++ b/hosts/p510/nixos/plex.nix
@@ -301,9 +301,26 @@
   # Rate-limit the unit's journal so one runaway session can't drown the log
   # again. 2000 messages per 30s is far above normal Plex chatter and still
   # caps a burst at a few thousand lines instead of ten thousand.
+  #
+  # CPUQuota is the power backstop, not a performance tuning knob. p510
+  # hard-power-cut on 2026-09-01 22:26 when Plex went 7 -> 12 concurrent
+  # streams, blew past the 3070 Ti's ~3-session NVENC limit and fell back to
+  # SOFTWARE x264: five transcoder processes spawned in two seconds, each
+  # loading liblibx264_encoder.so, on 40 threads with no cgroup limit at all
+  # (CPUQuota was infinity). The 490W supply, also feeding a GPU and three
+  # spinning disks, cut 26 seconds later.
+  #
+  # The Plex-side caps (TranscodeCountLimit=3, _CPU-TranscodeCountLimit=1)
+  # are the primary fix, but they live in Plex's own Preferences.xml, which
+  # nothing here manages and a Plex upgrade or a settings reset can undo.
+  # 1600% = 16 of 40 threads, enforced by the kernel regardless of what Plex
+  # thinks it is allowed to do. Well above what 3 NVENC transcodes need, and
+  # far below the all-core stampede that tripped the PSU.
   systemd.services.plex.serviceConfig = {
     LogRateLimitIntervalSec = "30s";
     LogRateLimitBurst = 2000;
+    CPUAccounting = true;
+    CPUQuota = "1600%";
   };
 
   systemd.services.nzbget = {


### PR DESCRIPTION
Closes #1616.

p510 hard-power-cut a **fourth** time (19 Aug, 20 Aug, 31 Aug, 1 Sep). No
shutdown sequence, no MCE, no thermal event — the journal stops mid-write.

## The GPU was not the cause

`nvidia-power-limit` applied the 130 W cap at **15:55:38**; the machine died at
**22:26**. The cap was in force for 6.5 hours. The starting premise does not
survive the log.

## What the log shows

```
21:56:28  TPU: hardware transcoding: final decoder: nvdec, final encoder: nvenc
22:26:00  PlexMediaServer[638068]: loading liblibx264_encoder.so
22:26:01  PlexMediaServer[638089]: loading liblibx264_encoder.so
22:26:01  PlexMediaServer[638094]: loading liblibx264_encoder.so
22:26:01  PlexMediaServer[638135]: loading liblibx264_encoder.so
22:26:02  TPU: hardware transcoding: final decoder: , final encoder:
22:26:28  *** power cut ***
```

Stream count peaked at **12 live**. The 3070 Ti caps concurrent NVENC sessions
at ~3, so Plex fell back to **software x264** for the surplus — five
transcoders in two seconds, across **40 threads**, `performance` governor
holding every core at maximum, `CPUQuota=infinity`. A 490 W supply (DMI
confirmed) also feeding a GPU and three spinning disks does not survive that.

## Everything involved was unbounded

| | was | now |
| --- | --- | --- |
| `TranscodeCountLimit` | `0` unlimited | `3` (runtime) |
| `_CPU-TranscodeCountLimit` | `0` unlimited **software** | `1` (runtime) |
| `plex.service` `CPUQuota` | `infinity` | **`1600%`** |
| governor | `performance`, 2693 MHz idle | **`powersave`**, 1200 MHz idle |
| `max_perf_pct` | 100 | **70** |
| GPU | 130 W / 2100 MHz | **100 W / 1500 MHz** |
| cap→plex ordering | **none** | **`before = [ "plex.service" ]`** |

That last row is its own bug: both units entered active **in the same second**,
so on a cold boot Plex could open an NVENC session while the card was still at
its 290 W default.

## Reasoning worth keeping

- **`-pl` bounds *average* board power, not transients.** Ampere spikes to ~2×
  its limit sub-millisecond, and those scale with clock — which is why every
  crash happened while a GPU *ramped from idle*, never under sustained load.
  Hence `-lgc`, which blunts the spike rather than the average. NVENC is
  fixed-function and ignores the graphics clock, so transcoding is unaffected.
- **`powersave` is not a low-power trap here.** Under intel_pstate active mode
  only `performance` and `powersave` exist, and `powersave` *is* the dynamic
  governor.
- **`_CPU-TranscodeCountLimit` is the surgical knob** — it caps software
  transcodes specifically, the thing that drew the power, leaving cheap NVENC
  transcodes alone. My first guess (`TranscoderMaxSimultaneous`) returned HTTP
  400; it does not exist.
- **`CPUQuota` exists because Preferences.xml is not managed by Nix.** A Plex
  upgrade or settings reset can undo the runtime caps; the kernel one holds.

## Verified

Every setting applied live first — Plex stayed active on HTTP 200, zero failed
units throughout — then confirmed in the **generated** units, not just source:

```
Before=plex.service
nvidia-smi -i 0 -pl 100
nvidia-smi -i 0 -lgc 0,1500
CPUQuota=1600%   CPUAccounting=true
cpuFreqGovernor = powersave
w /sys/devices/system/cpu/intel_pstate/max_perf_pct - - - - 70
```

## Not addressed

A 490 W PSU running a 20-core Xeon, a 3070 Ti and three spinning disks has no
margin. These caps buy headroom; they do not add capacity. **If it recurs with
all of this deployed, the PSU is the next suspect.**

Sunshine was **not** involved — idle, zero streams. But it logs
`Found H.264 encoder: libx264 [software]` and never initialises NVENC, so
streaming would add CPU load rather than GPU. Separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB
