### PR TITLE
gh on the CI runner, because a release died on it

### DIFF
--- a/hosts/p510/nixos/github-runner.nix
+++ b/hosts/p510/nixos/github-runner.nix
@@ -191,6 +191,19 @@ in
               # built perfectly well. The workflow no longer needs it; the next
               # one written should not have to find this out again.
               gawk
+              # gh, for the same reason and at a higher cost: release.yml's
+              # publish step is `gh release create`, and it died with exit 127
+              # after building both ISOs, splitting them and writing the notes.
+              # Four release attempts had failed before one reached that line,
+              # so this was the first time it ran at all.
+              #
+              # The comment above says the next workflow should not have to
+              # rediscover the missing-tool problem. It did, one workflow
+              # later, because gawk was added and the general lesson was not.
+              # The rule is: a step shell here has coreutils, git and what is
+              # named in this list. Anything else has to be added before a
+              # workflow can use it.
+              gh
               gnutar
               gzip
               openssh


### PR DESCRIPTION
`release.yml`'s publish step is `gh release create`, and it died with:

```
line 1: gh: command not found
Process completed with exit code 127
```

after building both ISOs, splitting them and writing the release notes. Four release attempts had failed earlier for unrelated reasons, so this was **the first time that line ran at all**.

## The same bug as this morning, one workflow later

The comment beside `gawk` in this file already says:

> gawk, because its absence is what broke the first real nightly: the step shell is a Nix bash carrying coreutils and not much else... The workflow no longer needs it; **the next one written should not have to find this out again.**

It did, because `gawk` was added and the general lesson was not. So the rule is written down now: **a step shell on this runner has coreutils, git, and what is named in that list — anything else has to be added before a workflow can use it.**

## Verified

```
services.github-runners.nixarchy.extraPackages
  ["git","gawk","gh","gnutar","gzip","openssh","coreutils","jq"]
```

`nixosConfigurations.p510` evaluates; `nix fmt` clean.

## Deploy note

p510 is running CI. Activation restarts the runner units and kills whatever they are executing — worth checking both runners are `busy=false` first, as `v4.0.1-3` was lost exactly this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VFe59s7BspTamgenHc1P5