### PR TITLE
fix(sunshine): put driver dir in RUNPATH so NVENC survives capSysAdmin (#1588)

### DIFF
--- a/modules/desktop/sunshine.nix
+++ b/modules/desktop/sunshine.nix
@@ -162,6 +162,41 @@ in
       enable = true;
       inherit (cfg) openFirewall capSysAdmin;
 
+      # Put the driver directory in the binary's RUNPATH so NVENC survives the
+      # capability wrapper (#1588).
+      #
+      # capSysAdmin makes NixOS build /run/wrappers/bin/sunshine, so the
+      # process runs AT_SECURE. Sunshine's statically-linked ffmpeg reaches
+      # NVENC by dlopen'ing the bare soname "libcuda.so.1" at runtime, and
+      # under AT_SECURE the loader ignores LD_LIBRARY_PATH entirely --
+      # it searches the calling object's DT_RUNPATH and the trusted system
+      # directories, nothing else. libcuda.so.1 is in /run/opengl-driver/lib,
+      # which is in neither, so every hardware encoder fails and Sunshine
+      # silently settles on libx264:
+      #
+      #   Error: [CUDA @ 0x...] Cannot load libcuda.so.1
+      #   Info:  Encoder [nvenc] failed
+      #   Info:  Found H.264 encoder: libx264 [software]
+      #
+      # DT_RUNPATH is honoured under AT_SECURE -- only LD_LIBRARY_PATH and
+      # LD_PRELOAD are dropped -- so writing the path into the ELF is what
+      # makes the two settings compatible. That is precisely what
+      # addDriverRunpath does, and autoAddDriverRunpath applies it to every
+      # ELF in the output from a setup hook.
+      #
+      # This deliberately does NOT use `sunshine.override { cudaSupport = true; }`,
+      # which is the obvious-looking alternative and wrong twice over: it
+      # builds the whole CUDA toolkit for a library that is dlopen'd from the
+      # driver at runtime anyway, and its postFixup replaces $out/bin/sunshine
+      # with a wrapProgram shell script -- which cannot carry a file
+      # capability, so security.wrappers would have nothing to attach to.
+      #
+      # Harmless on a non-NVIDIA host: /run/opengl-driver/lib exists on every
+      # NixOS system and simply has no libcuda in it.
+      package = pkgs.sunshine.overrideAttrs (old: {
+        nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.autoAddDriverRunpath ];
+      });
+
       settings =
         # Comma-separated, no spaces, as the option's own parser expects; an
         # entry it cannot read is dropped with "Invalid 'csrf_allowed_origins'


### PR DESCRIPTION
Refs #1588. Deliberately not `Closes` — the build-time half is proven, the
runtime half needs a p510 deploy (see Verification).

## Root cause

Not what the issue theorised. `nm -D` on the running binary shows **zero**
cuda symbols, so `cudaSupport` is off and `SUNSHINE_ENABLE_CUDA=false` — the
`[CUDA @ 0x…]` prefix in the log is **ffmpeg's** `av_log` context, not
Sunshine's own CUDA code.

Sunshine's statically-linked ffmpeg reaches NVENC by `dlopen`ing the bare
soname `libcuda.so.1`. `capSysAdmin` makes NixOS build
`/run/wrappers/bin/sunshine`, so the process runs `AT_SECURE`, where the
loader ignores `LD_LIBRARY_PATH` and consults only the calling object's
`DT_RUNPATH` plus the trusted system directories. `libcuda.so.1` lives in
`/run/opengl-driver/lib`, which is in neither — so nvenc, vulkan and vaapi
failed in turn and Sunshine settled on libx264 at 1440p while an RTX 3070 Ti
idled.

Also corrected: `capSysAdmin` was already `true` (our module defaults it so),
not left at upstream's `false` as the issue assumed.

## Fix

`DT_RUNPATH` *is* honoured under `AT_SECURE` — only `LD_LIBRARY_PATH` and
`LD_PRELOAD` are dropped — so writing the driver path into the ELF is what
makes `capSysAdmin` and hardware encoding compatible.

```nix
package = pkgs.sunshine.overrideAttrs (old: {
  nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.autoAddDriverRunpath ];
});
```

## Why not `override { cudaSupport = true; }`

The obvious-looking alternative, wrong twice over: it builds the whole CUDA
toolkit for a library the driver supplies at runtime anyway, and its
`postFixup` replaces `$out/bin/sunshine` with a `wrapProgram` shell script —
which cannot carry a file capability, so `security.wrappers.source` would
have nothing to attach to.

## Verification

Built on p620 from `.#nixosConfigurations.p510.config.services.sunshine.package`:

- `/run/opengl-driver/lib` is now in `DT_RUNPATH` (absent in the running binary)
- output is still a raw ELF, so the capability wrapper still works

Remaining, needs a p510 deploy — and per the issue's own caveat it must be
confirmed by an nvenc encoder being **selected**, not merely by the CUDA
errors disappearing, since nvenc initialises happily and then fails at the
frame stage:

```
just p510
ssh p510 'journalctl --user-unit sunshine -n 200 --no-pager | grep -iE "Found H.264|nvenc"'
```

## Notes

Harmless on non-NVIDIA hosts: `/run/opengl-driver/lib` exists on every NixOS
system and simply has no libcuda in it.

Probably worth an upstream nixpkgs report — sunshine's own module offers
`capSysAdmin`, and enabling it breaks hardware encoding for every NVIDIA user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB