### PR TITLE
feat(pkgs): add notebooklm-go CLI on p620 + razer

### DIFF
--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -178,6 +178,17 @@ in
     # anchor pointing at a renamed note across ~2950 files. Paired with the
     # `obsidian` Claude Code skill in home/development/claude-code-skills.
     pkgs.customPkgs.obsidian-cli
+    # notebooklm-go (binary: `notebooklm`) — unofficial CLI for Google
+    # NotebookLM. Reverse-engineered against the internal batchexecute RPC and
+    # pinned to a release tag, so expect it to break when Google ships a new
+    # frontend bundle rather than when we change anything.
+    #
+    # Auth is your own Google session cookie, written by `notebooklm login` to
+    # ~/.config/notebooklm-go/auth.json. That path is deliberately outside the
+    # syncthing folders (modules/services/syncthing.nix covers ~/.claude and
+    # ~/.gemini only), so the credential stays on the host that created it and
+    # each host is logged in separately.
+    pkgs.customPkgs.notebooklm-go
     # herdr — TUI "agent multiplexer": run multiple AI coding agents in one
     # terminal workspace (tmux/zellij-style). From github:ogulcancelik/herdr.
     pkgs.herdr

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -46,6 +46,12 @@
   # GitLab TUI — terminal UI on top of the `glab` CLI (rcieri/glab-tui).
   glab-tui = pkgs.callPackage ./glab-tui { };
 
+  # notebooklm-go — unofficial CLI for Google NotebookLM's internal RPC.
+  # Reverse-engineered and pinned to a release tag on upstream's own advice;
+  # it breaks when Google's frontend bundle changes. See the derivation for
+  # the note on where the session cookie lives and why it is not agenix'd.
+  notebooklm-go = pkgs.callPackage ./notebooklm-go { };
+
   # Claude Code native binary (alternative to npm-based package)
   claude-code-native = pkgs.callPackage ./claude-code-native { };
 

--- a/pkgs/notebooklm-go/default.nix
+++ b/pkgs/notebooklm-go/default.nix
@@ -1,0 +1,90 @@
+# notebooklm-go — CLI for Google NotebookLM's internal batchexecute RPC.
+#
+# Reverse-engineered, unofficial, and the upstream README says so in three
+# separate places. Worth restating here because it changes how this should be
+# treated: the RPC method IDs come from Google's frontend bundle and can change
+# without notice, so this breaks on Google's schedule, not ours. Upstream's own
+# advice is to pin a release tag rather than track master, which is what the
+# `version` below does. Not in nixpkgs as of 2026-09.
+#
+# Authentication is your live Google session cookie, stored by the tool at
+# ~/.config/notebooklm-go/auth.json with 0600 perms. Nothing here declares it
+# and nothing should: it is created interactively by `notebooklm login`, it
+# rotates when Google rotates it, and it is a user credential rather than a
+# system secret -- so agenix is the wrong instrument. Two things follow.
+# First, the cookie carries the full power of the account, deletion included,
+# so a dedicated Google account is the cautious choice. Second, that path is
+# deliberately outside the syncthing folders in modules/services/syncthing.nix
+# (which cover ~/.claude and ~/.gemini only), so the credential does not
+# replicate to other hosts. Keep it that way.
+#
+# Bump: check `gh release view --repo LocalKinAI/notebooklm-go`, update version
+# + hash, then set vendorHash to lib.fakeHash and take the value nix reports.
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, makeWrapper
+, google-chrome
+}:
+
+buildGoModule rec {
+  pname = "notebooklm-go";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "LocalKinAI";
+    repo = "notebooklm-go";
+    rev = "v${version}";
+    hash = "sha256-6U+iV0lF7nmHRzvPV7VgBY92gFMky+LQUnlOwzWtcVU=";
+  };
+
+  vendorHash = "sha256-xPoa/axatOR5v1oPwDZVo6r7SnFqehLI2zSm6EyIfkk=";
+
+  # The repo is a library first; cmd/notebooklm is the CLI. Building only that
+  # keeps examples/ (three more main packages, one per demo) out of $out/bin,
+  # where they would otherwise land as `list_notebooks` and friends and
+  # collide with anything else claiming those very generic names.
+  subPackages = [ "cmd/notebooklm" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  ldflags = [ "-s" "-w" ];
+
+  # Put a browser on PATH for `notebooklm login`.
+  #
+  # The data path is pure HTTPS -- chromedp appears in exactly one file,
+  # login.go, and only for the optional interactive OAuth flow. That flow calls
+  # chromedp.NewExecAllocator without an ExecPath override, so chromedp falls
+  # back to searching PATH for a Chrome binary and fails with an unhelpful
+  # allocator error when it finds none. Wrapping is therefore about `login`
+  # alone: every other subcommand ignores this entirely, and the cookie-paste
+  # flow needs no browser at all.
+  #
+  # google-chrome rather than chromium because it is what this configuration
+  # already installs and sets as the default handler (home/desktop/com.nix), so
+  # the browser that opens is the one already signed in to Google -- which is
+  # the entire point of the flow.
+  postInstall = ''
+    wrapProgram $out/bin/notebooklm \
+      --prefix PATH : ${lib.makeBinPath [ google-chrome ]}
+  '';
+
+  meta = {
+    description = "Unofficial CLI and Go client for Google NotebookLM";
+    longDescription = ''
+      Drives NotebookLM from the shell: list and create notebooks, add PDF, URL
+      and text sources, trigger Audio Overviews, Mind Maps, Reports, Slide
+      Decks and Deep Research, and download the generated artifacts.
+
+      Talks to the same `batchexecute` endpoint the official web bundle uses,
+      authenticating with your own Google session cookie. Reverse-engineered
+      and unaffiliated with Google: expect it to break when the frontend
+      bundle changes, and prefer an account you can afford to lose.
+    '';
+    homepage = "https://github.com/LocalKinAI/notebooklm-go";
+    license = lib.licenses.asl20;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    mainProgram = "notebooklm";
+  };
+}


### PR DESCRIPTION
Requested: https://pkg.go.dev/github.com/LocalKinAI/notebooklm-go@v0.1.0

Unofficial CLI for Google NotebookLM over the same internal `batchexecute` RPC
the web bundle uses. Not in nixpkgs.

## Packaging notes

**Pinned to v0.1.0**, on upstream's own advice — the RPC method IDs come from
Google's frontend bundle and change without notice, so this breaks on Google's
schedule rather than ours.

**`subPackages = [ "cmd/notebooklm" ]`.** The repo is a library first, and
`examples/` holds three more `main` packages. Without this they install as
`list_notebooks`, `add_pdf_source` and `generate_audio_overview` — generic
enough to collide with anything else claiming those names.

**Wrapped with `google-chrome` on PATH.** The README says "no browser
automation", which is true of the *data path* only: `chromedp` appears in
exactly one file, `login.go`, for the interactive OAuth flow, and it calls
`NewExecAllocator` with no `ExecPath` override — so it searches `$PATH` and
fails with an opaque allocator error when it finds no browser. `google-chrome`
rather than `chromium` because it is what this config already installs and sets
as default handler, so the browser that opens is the one already signed in.
No closure cost on either host — chrome is installed there already.

## Auth

The user's own Google session cookie, written by `notebooklm login` to
`~/.config/notebooklm-go/auth.json` (0600).

Deliberately **not** declared in Nix and **not** agenix'd: it is created
interactively, rotates when Google rotates it, and is a user credential rather
than a system secret. That path also sits outside the syncthing folders
(`modules/services/syncthing.nix` covers `~/.claude` and `~/.gemini` only), so
it stays on the host that created it.

Worth knowing before use: the cookie carries the full power of the account,
deletion included. Upstream suggests a dedicated Google account.

## Hosts

p620 + razer. p510 runs the media stack and Sunshine and has no reason to hold
a credential that can delete the account's notebooks.

Verified in each closure:

```
p620:  1 notebooklm-go store paths
razer: 1 notebooklm-go store paths
p510:  0 notebooklm-go store paths
```

## Verification

Built from the p620 config; `--help` runs clean (exit 0), `$out/bin` contains
only `notebooklm` (no leaked examples), and the wrapper resolves
`google-chrome-152.0.7977.64/bin`. Both p620 and razer `toplevel` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB