### PR TITLE
fix(sunshine): build with CUDA so NVENC actually exists (#1588)

### DIFF
--- a/docs/applications/sunshine.md
+++ b/docs/applications/sunshine.md
@@ -32,7 +32,6 @@ features.sunshine = {
 | --- | --- | --- |
 | `enable` | `false` | Turn the streaming host on |
 | `openFirewall` | `true` | Open the Moonlight + web UI ports |
-| `capSysAdmin` | `true` | KMS capture capability on the binary |
 | `wakeDisplay` | `false` | Wake a DPMS-off output when a client connects |
 | `webOrigins` | `[ ]` | Origins allowed to POST to the web UI |
 
@@ -102,17 +101,47 @@ repository from then on.
 Credentials and client pairings are unaffected; those live in
 `~/.config/sunshine/sunshine_state.json`, which stays writable.
 
-## Known limitation
+## Hardware encoding
 
-Sunshine currently **software-encodes** on p510 despite the RTX 3070 Ti, tracked
-in [#1588](https://github.com/olafkfreund/nixos_config/issues/1588). The cause is
-a catch-22 around `capSysAdmin`: NixOS `security.wrappers` sets file
-capabilities, which makes the loader treat the process as `AT_SECURE` and drop
-`LD_LIBRARY_PATH` — the only route to `libcuda` on NixOS, since the binary's
-`DT_RUNPATH` is empty. Dropping the capability restores CUDA but loses KMS
-capture.
+Sunshine encodes on the RTX 3070 Ti, and getting there took one non-obvious
+change ([#1588](https://github.com/olafkfreund/nixos_config/issues/1588)).
 
-The untested candidate fix is `addDriverRunpath $out/bin/sunshine` in
-`postFixup`, keeping `capSysAdmin = true`, since `DT_RUNPATH` survives
-`AT_SECURE`. Verify it by confirming an NVENC encoder is *selected*, not merely
-by CUDA errors disappearing.
+nixpkgs builds Sunshine with `cudaSupport ? config.cudaSupport`, false by
+default, which passes `-DSUNSHINE_ENABLE_CUDA=false`. Every CUDA encode path in
+Sunshine sits behind that `#ifdef`, including the one in wlgrab's
+`wlr_vram_t::make_avcodec_encode_device`. Compiled out, the function falls
+through to a plain `avcodec_encode_device_t` — the *software* converter. ffmpeg
+still advertises `h264_nvenc`, Sunshine still creates it, and the software
+`sws_scale` in front of it then fails on the dmabuf frame:
+
+```text
+Info:  Creating encoder [h264_nvenc]
+Error: Couldn't scale frame: Invalid argument
+Info:  Encoder [nvenc] failed
+Info:  Found H.264 encoder: libx264 [software]
+```
+
+The module therefore builds `pkgs.sunshine.override { cudaSupport = true; }`.
+The binary goes from 0 CUDA symbols to 3989, and the log reads:
+
+```text
+Info: Found H.264 encoder: h264_nvenc [nvenc]
+Info: Found HEVC encoder: hevc_nvenc [nvenc]
+```
+
+AV1 is still rejected — that is Ampere, not this setting.
+
+Two earlier theories were wrong and are recorded so they are not retried:
+
+- **It is not `LD_LIBRARY_PATH` versus `AT_SECURE`.** That story was real but
+  incidental: `capSysAdmin` does make `security.wrappers` build a wrapper, the
+  process does run `AT_SECURE`, and the loader does drop `LD_LIBRARY_PATH`.
+  Writing the driver directory into `DT_RUNPATH` removed the
+  `Cannot load libcuda.so.1` errors and changed nothing else — the encoder was
+  still software, because the CUDA code was never in the binary.
+- **`capSysAdmin` is not worth keeping.** KMS capture is the only reason for
+  it, and on the NVIDIA proprietary driver kmsgrab enumerates no scanout plane
+  with a framebuffer. The monitor list comes back empty even while holding
+  `CAP_SYS_ADMIN`, and Sunshine exits with "Unable to initialize capture
+  method". The option has been removed; capture is Wayland screencopy, which
+  needs no privilege.

--- a/modules/desktop/sunshine.nix
+++ b/modules/desktop/sunshine.nix
@@ -85,21 +85,6 @@ in
       '';
     };
 
-    capSysAdmin = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Grant the Sunshine binary CAP_SYS_ADMIN, which is what KMS capture
-        needs on Wayland. Without it Sunshine falls back to a portal-based
-        path that Hyprland can serve but which re-prompts, or fails outright
-        with "Couldn't find any working capture method".
-
-        This is a real privilege on a real binary, and it is the reason this
-        option is spelled out instead of hardcoded: a host that would rather
-        take the portal route can turn it off in one line.
-      '';
-    };
-
     wakeDisplay = mkOption {
       type = types.bool;
       default = false;
@@ -160,42 +145,62 @@ in
   config = mkIf cfg.enable {
     services.sunshine = {
       enable = true;
-      inherit (cfg) openFirewall capSysAdmin;
+      inherit (cfg) openFirewall;
 
-      # Put the driver directory in the binary's RUNPATH so NVENC survives the
-      # capability wrapper (#1588).
+      # KMS capture is off, and this is not a default worth revisiting here.
       #
-      # capSysAdmin makes NixOS build /run/wrappers/bin/sunshine, so the
-      # process runs AT_SECURE. Sunshine's statically-linked ffmpeg reaches
-      # NVENC by dlopen'ing the bare soname "libcuda.so.1" at runtime, and
-      # under AT_SECURE the loader ignores LD_LIBRARY_PATH entirely --
-      # it searches the calling object's DT_RUNPATH and the trusted system
-      # directories, nothing else. libcuda.so.1 is in /run/opengl-driver/lib,
-      # which is in neither, so every hardware encoder fails and Sunshine
-      # silently settles on libx264:
+      # Upstream's module offers capSysAdmin because KMS capture needs it, and
+      # KMS capture is the only path to a hardware encoder for most GPUs. On
+      # the NVIDIA proprietary driver it is not a path at all: nvidia-drm
+      # enumerates no scanout planes with a framebuffer, so kmsgrab returns an
+      # empty monitor list even holding CAP_SYS_ADMIN (verified on p510 --
+      # "-------- Start of KMS monitor list --------" immediately followed by
+      # the end marker, no error in between). Sunshine then reports "Unable to
+      # initialize capture method" and exits.
       #
-      #   Error: [CUDA @ 0x...] Cannot load libcuda.so.1
+      # It is also actively harmful with the package built below: cudaSupport
+      # makes $out/bin/sunshine a wrapper script, and a file capability on a
+      # shell script is a trap rather than a feature.
+      #
+      # Wayland screencopy is what actually captures here, and it needs no
+      # privilege at all.
+      capSysAdmin = false;
+
+      # Build with CUDA, or NVENC is compiled out and cannot be reached (#1588).
+      #
+      # p510 streamed 1440p on libx264 while an RTX 3070 Ti idled, and the
+      # cause is upstream packaging, not configuration. nixpkgs takes
+      # `cudaSupport ? config.cudaSupport`, which is false by default, and
+      # passes -DSUNSHINE_ENABLE_CUDA=false. That undefines SUNSHINE_BUILD_CUDA,
+      # and every CUDA encode path in Sunshine sits behind that #ifdef --
+      # including the one in wlgrab's wlr_vram_t::make_avcodec_encode_device.
+      # With the block compiled out the function falls through and returns a
+      # plain avcodec_encode_device_t: the *software* converter. So ffmpeg
+      # still offers h264_nvenc, Sunshine still creates it, and then the
+      # software sws_scale in front of it fails on the dmabuf frame:
+      #
+      #   Info:  Creating encoder [h264_nvenc]
+      #   Error: Couldn't scale frame: Invalid argument
       #   Info:  Encoder [nvenc] failed
       #   Info:  Found H.264 encoder: libx264 [software]
       #
-      # DT_RUNPATH is honoured under AT_SECURE -- only LD_LIBRARY_PATH and
-      # LD_PRELOAD are dropped -- so writing the path into the ELF is what
-      # makes the two settings compatible. That is precisely what
-      # addDriverRunpath does, and autoAddDriverRunpath applies it to every
-      # ELF in the output from a setup hook.
+      # That error is the whole bug, and it is why the earlier attempts missed:
+      # neither the capture method nor the loader can affect it. The binary
+      # simply had no CUDA in it -- 0 cuda symbols before, 3989 after.
       #
-      # This deliberately does NOT use `sunshine.override { cudaSupport = true; }`,
-      # which is the obvious-looking alternative and wrong twice over: it
-      # builds the whole CUDA toolkit for a library that is dlopen'd from the
-      # driver at runtime anyway, and its postFixup replaces $out/bin/sunshine
-      # with a wrapProgram shell script -- which cannot carry a file
-      # capability, so security.wrappers would have nothing to attach to.
+      # With this the log reads "Found H.264 encoder: h264_nvenc [nvenc]" and
+      # "Found HEVC encoder: hevc_nvenc [nvenc]". AV1 is still rejected, which
+      # is the Ampere card and not this setting.
       #
-      # Harmless on a non-NVIDIA host: /run/opengl-driver/lib exists on every
-      # NixOS system and simply has no libcuda in it.
-      package = pkgs.sunshine.overrideAttrs (old: {
-        nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.autoAddDriverRunpath ];
-      });
+      # This also supersedes the DT_RUNPATH patch that #1588 first landed:
+      # nixpkgs' own cudaSupport path already adds autoAddDriverRunpath, and
+      # with capSysAdmin off there is no AT_SECURE to defeat LD_LIBRARY_PATH
+      # in the first place.
+      #
+      # Unconditional because p510 is the only host that enables this module
+      # and it is NVIDIA. A non-NVIDIA host would pull the CUDA toolkit for
+      # nothing; gate it then, not now.
+      package = pkgs.sunshine.override { cudaSupport = true; };
 
       settings =
         # Comma-separated, no spaces, as the option's own parser expects; an


### PR DESCRIPTION
Fixes #1588.

## Root cause

The DT_RUNPATH fix in 2ebf627c9 was real but incidental — it removed the `Cannot load libcuda.so.1` errors and changed nothing else, because **the CUDA code was never in the binary**.

nixpkgs takes `cudaSupport ? config.cudaSupport`, false by default, and passes `-DSUNSHINE_ENABLE_CUDA=false`. Every CUDA encode path in Sunshine sits behind that `#ifdef`, including the one in wlgrab's `wlr_vram_t::make_avcodec_encode_device`. Compiled out, the function falls through and returns a plain `avcodec_encode_device_t` — the *software* converter. ffmpeg still advertises `h264_nvenc`, Sunshine still creates it, and the software `sws_scale` in front of it then fails on the dmabuf frame:

```text
Info:  Creating encoder [h264_nvenc]
Error: Couldn't scale frame: Invalid argument
Info:  Encoder [nvenc] failed
Info:  Found H.264 encoder: libx264 [software]
```

That error was present in the original report too, under `capSysAdmin = false`, and was misread as a capture problem.

## Changes

- `package = pkgs.sunshine.override { cudaSupport = true; }` — 0 CUDA symbols → 3989.
- `capSysAdmin` **removed**. Its only purpose is KMS capture, and on the NVIDIA proprietary driver kmsgrab enumerates no scanout plane with a framebuffer: the monitor list comes back empty *while holding* `CAP_SYS_ADMIN`, and Sunshine exits with "Unable to initialize capture method". It would also be a trap, since `cudaSupport` makes `$out/bin/sunshine` a wrapper script and a file capability on a shell script is not a capability.
- The `autoAddDriverRunpath` override goes with it — nixpkgs' own `cudaSupport` path already adds it, and without the capability wrapper there is no `AT_SECURE` to defeat `LD_LIBRARY_PATH`.

## Verification

Built on p620, copied to p510, run against the live session on a spare port **without deploying**:

```text
Info: Screencasting with Wayland's protocol
Info: Found H.264 encoder: h264_nvenc [nvenc]
Info: Found HEVC encoder: hevc_nvenc [nvenc]
```

AV1 is still rejected — that is Ampere, not this change.

`nix build .#nixosConfigurations.p510...toplevel` succeeds, and the resulting `sunshine.service` ExecStarts that same store path directly, with no `/run/wrappers` indirection.

Still needs a p510 deploy to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB