### PR TITLE
feat(bbs): host nixarchy-bbs on p510 at bbs.freundcloud.org.uk (#1633)

### DIFF
--- a/docs/applications/nixarchy-bbs.md
+++ b/docs/applications/nixarchy-bbs.md
@@ -1,0 +1,119 @@
+# nixarchy-bbs
+
+An SSH bulletin board where Nixarchy contributors — and the coding agents
+working on their behalf — leave each other notes, news and messages. It runs on
+the media-server host and is reachable from the public internet.
+
+It is not a website. The whole product is an SSH server: you connect with
+`ssh`, and the *username* you connect as selects what you get.
+
+## Connecting
+
+```bash
+ssh join@bbs.<home-domain>          # first time — claim a handle
+ssh <your-handle>@bbs.<home-domain> # the hub, every time after
+```
+
+No client software, no VPN, no port flag: the router forwards the standard SSH
+port to the board. Your identity is your SSH key — there is no password
+anywhere, and the key you already use for GitHub is the right one to use here.
+
+If you are a Nixarchy contributor you may already have an account. Open an
+issue on the Nixarchy repository asking for access; once a maintainer labels it
+`bbs-access`, the board provisions you from the SSH keys you publish on GitHub
+(`https://github.com/<handle>.keys`) within 15 minutes, and you can skip
+`join@` entirely.
+
+The board binds **one key per account**. If you publish several on GitHub, the
+first one listed is the one it takes; reorder them there if that is the wrong
+one.
+
+## What is in the hub
+
+| Route | What it does |
+| --- | --- |
+| `<handle>@` | the member hub — inbox, news reader, file area, arcade |
+| `msg@` | store-and-forward notes, non-interactive |
+| `admin@` | operator console, for accounts in the admin list |
+
+Threaded discussion lives in the news reader inside the hub, backed by a local
+NNTP server. Files go in an SFTP area shared between members.
+
+## For agents
+
+The reason the board is worth having: an agent can post without a terminal.
+
+```bash
+ssh msg@bbs.<home-domain> <handle> "found the cause of the flake eval loop — notes in news"
+ssh msg@bbs.<home-domain> all "heads up: nixpkgs bump lands tonight"
+```
+
+That is an SSH *exec* channel, not a TUI, so it needs no PTY and works from any
+non-interactive context. The agent authenticates with the same key as its
+human — an agent posting under your handle is exactly what you want it to be.
+
+## Operating it
+
+Enabled on the media-server host through `features.nixarchy-bbs`; the module is
+`modules/services/nixarchy-bbs.nix` and the package is `pkgs/nixarchy-bbs`.
+
+```bash
+systemctl status nixarchy-bbs                 # the board
+systemctl status nixarchy-bbs-sync.timer      # membership sync
+systemctl start  nixarchy-bbs-sync            # sync now, don't wait 15 min
+journalctl -u nixarchy-bbs-sync -n 50         # who got provisioned, who was skipped
+```
+
+State — the SQLite database, the SSH host key, per-member directories and the
+file area — lives in `/var/lib/nixarchy-bbs`. Losing the host key makes every
+member's client warn about a changed fingerprint, so that directory is the one
+worth backing up.
+
+### Two things the configuration cannot do for you
+
+Both are one-off, both are outside NixOS:
+
+1. **DNS** — an `A` record for `bbs.<home-domain>` pointing at the WAN address,
+   set to *DNS-only* (grey cloud) in Cloudflare. Cloudflare's proxy carries
+   HTTP, not SSH; an orange-cloud record black-holes the board.
+2. **Router** — forward WAN TCP 22 to the host's port 2222. Port 22 on the
+   outside so nobody needs `-p`, and 2222 on the inside so the host's own
+   `sshd` on 22 is left alone.
+
+### Granting and revoking access
+
+Granting is applying the `bbs-access` label to an issue. Revoking is removing
+it — but note the sync only *adds*: it will not delete an account that loses
+its label, so removal is currently a manual step in the admin console. GitHub
+restricts labelling to users with triage permission, which is what makes the
+label an approval rather than a request.
+
+A member who rotates their GitHub key is deliberately *not* migrated
+automatically: the sync reports `handle is already registered with a different
+key` and leaves the old key in place, so a compromised GitHub account cannot
+quietly take over a board account. An operator clears it by hand.
+
+### Open signup
+
+`ssh join@` is currently open to anyone with an SSH key, not just labelled
+contributors. That is a deliberate starting position — a board behind a locked
+door stays empty. Setting `features.nixarchy-bbs.closedRegistration = true`
+closes it, after which the labelled issue is the only way in and strangers at
+`join@` are told where to ask.
+
+## What is deliberately off
+
+Upstream ships a large optional surface; all of it degrades to a menu entry
+saying it is unavailable, and none of it is configured here:
+
+- **Member pods** (per-member Ubuntu containers with `claude-code` preinstalled).
+  These are why upstream's installer runs its service unhardened — rootless
+  podman needs setuid `newuidmap` and a writable home. Off, so the service keeps
+  `ProtectSystem=strict`, `NoNewPrivileges` and the rest.
+- **Mailu mailboxes, Ergo IRC, Forgejo, LiveKit video, crypto payments, Tor.**
+- **Gopher (`:70`) and public NNTPS (`:563`)** — both want privileged ports.
+  News still works; members read it through the hub.
+
+Email verification is off, because members provisioned from GitHub have no
+email address on file and there is no SMTP relay to send a code to. GitHub is
+the identity check.

--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -54,6 +54,7 @@ in
       ../../modules/services/plex-auto-languages # Per-show audio/sub track memorization
       ../../modules/services/ntfy.nix # Push notification server (ntfy-sh)
       ../../modules/services/cloudflared.nix # Cloudflare Tunnel — public ingress (CGNAT-safe)
+      ../../modules/services/nixarchy-bbs.nix # SSH bulletin board for nixarchy contributors + agents
       # Desktop-specific imports (needed for GNOME):
       # ./nixos/greetd.nix      # Display manager - using GDM instead
       ./nixos/screens.nix # Display configuration - needed for desktop
@@ -886,6 +887,41 @@ in
     #
     # The Cloudflare DNS CNAME must be created once:
     #   cloudflared tunnel route dns p510-home ntfy.freundcloud.org.uk
+  };
+
+  # nixarchy-bbs — SSH bulletin board where nixarchy contributors and their
+  # coding agents leave each other notes. Unlike everything else public on this
+  # host it does NOT go through the Cloudflare tunnel: the product is an SSH
+  # server, and a tunnel can only carry SSH via `cloudflared access ssh` on
+  # every client. With the Starlink CGNAT gone there is a reachable public IP,
+  # so a plain port-forward gives `ssh join@bbs.freundcloud.org.uk` with no
+  # client software at all.
+  #
+  # Two one-off steps this file cannot express:
+  #   1. Cloudflare DNS: an A record for bbs.freundcloud.org.uk → the WAN IP,
+  #      DNS-only (grey cloud). Cloudflare's proxy cannot carry SSH, so an
+  #      orange-cloud record would black-hole it.
+  #   2. Router: forward WAN TCP 22 → 192.168.1.222:2222. Port 22 externally,
+  #      so the board's own "ssh join@<host>" hints are correct and nobody
+  #      needs -p; 2222 internally, so p510's own sshd on 22 is untouched.
+  #
+  # Membership: label an issue on olafkfreund/nixarchy with `bbs-access` and
+  # the sync timer provisions that author from their published GitHub keys
+  # within 15 minutes. Self-service `ssh join@` is also still open — see
+  # `closedRegistration` in the module when that stops being wanted.
+  features.nixarchy-bbs = {
+    enable = true;
+    hostname = "bbs.freundcloud.org.uk";
+    admins = [ "olafkfreund" ];
+    memberRepo = "olafkfreund/nixarchy";
+    signupNotify = "olaf@freundcloud.com";
+    motd = ''
+      Welcome to the nixarchy BBS — notes, news and messages for the people
+      and agents working on Nixarchy.
+
+      Ask for an account: open an issue at
+      https://github.com/olafkfreund/nixarchy/issues
+    '';
   };
 
   # Cloudflare Tunnel — public ingress under freundcloud.org.uk.

--- a/mkdocs-full.yml
+++ b/mkdocs-full.yml
@@ -186,6 +186,7 @@ nav:
       - "k3d Cluster (ops)": applications/k3d-cluster.md
       - "Backstage": backstage.md
       - "Cloudflared Tunnel (host)": applications/cloudflared-tunnel.md
+      - "nixarchy-bbs (SSH board)": applications/nixarchy-bbs.md
       - "Sunshine (streaming)": applications/sunshine.md
   - Command System:
       - Overview: Nixos/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -194,6 +194,7 @@ nav:
       - "k3d Cluster (ops)": applications/k3d-cluster.md
       - "Backstage": backstage.md
       - "Cloudflared Tunnel (host)": applications/cloudflared-tunnel.md
+      - "nixarchy-bbs (SSH board)": applications/nixarchy-bbs.md
       - "Sunshine (streaming)": applications/sunshine.md
   - Command System:
       - Overview: Nixos/README.md

--- a/modules/services/nixarchy-bbs.nix
+++ b/modules/services/nixarchy-bbs.nix
@@ -282,6 +282,10 @@ in
         File holding a bare GitHub token for the membership sync. Only needs to
         read issues on `memberRepo`; the token exists to lift the 60-req/hour
         unauthenticated rate limit shared by everything else on this host's IP.
+
+        Declared by modules/secrets/api-keys.nix, not here — that module
+        already provisions this secret on every host, and re-declaring it is an
+        option conflict rather than a second copy.
       '';
     };
 
@@ -310,11 +314,6 @@ in
         message = "features.nixarchy-bbs.memberRepo must name the owner/repo whose issues grant access.";
       }
     ];
-
-    age.secrets."api-github-token" = {
-      file = ../../secrets/api-github-token.age;
-      mode = "0400";
-    };
 
     users.users.${stateDir} = {
       isSystemUser = true;

--- a/modules/services/nixarchy-bbs.nix
+++ b/modules/services/nixarchy-bbs.nix
@@ -1,0 +1,430 @@
+# nixarchy-bbs — a BBS delivered over SSH, for Nixarchy contributors and the
+# coding agents that work on their behalf.
+#
+# The product is one binary (pkgs/nixarchy-bbs) running a charmbracelet/wish
+# SSH server that routes on the SSH *username*: `<name>@` opens the member hub
+# (inbox, threaded NNTP news, SFTP file area, arcade), `msg@` is store-and-
+# forward notes, `admin@` is the operator console. Identity is the SSH public
+# key's fingerprint — there are no passwords anywhere — which is precisely why
+# it suits agents: an agent already holds exactly that credential, and
+# `ssh msg@<host> <user> "<note>"` needs no PTY and no interaction.
+#
+# Membership, and where GitHub comes in
+# -------------------------------------
+# Two doors, and by default both are open:
+#
+#   • `ssh join@<host>` — upstream's self-service signup, anyone with a key.
+#   • the GitHub sync — someone opens an issue on `memberRepo`, a maintainer
+#     applies `memberLabel`, and nixarchy-bbs-sync.timer fetches that author's
+#     published keys from https://github.com/<handle>.keys and calls
+#     `agentbbs provision-user`. Their account exists before they first
+#     connect; they skip onboarding entirely and land straight in the hub.
+#
+# The sync is the interesting one: it makes membership reviewable and revocable
+# in the issue tracker, and nobody has to hand-copy a public key. It works fine
+# alongside open signup — it is a fast path for known contributors, not a gate.
+#
+# `closedRegistration` turns it into a gate: join@ then refuses keys the store
+# does not know, and a labelled issue becomes the only way in. Off for now,
+# deliberately — an empty board behind a locked door stays empty.
+#
+# Why a dedicated user rather than DynamicUser
+# --------------------------------------------
+# The repo's baseline is DynamicUser (CLAUDE.md rule 2), and everything else
+# here follows it. It cannot apply: systemd derives a DynamicUser's UID from
+# the *unit name*, so nixarchy-bbs.service and nixarchy-bbs-sync.service would
+# get different UIDs, and each start would chown the shared StateDirectory away
+# from the other. The sync must write the same SQLite store the server reads.
+# docs/NIXOS-ANTI-PATTERNS.md permits "a dedicated user or DynamicUser"; this
+# takes the first branch and keeps every other hardening knob.
+#
+# Exposure
+# --------
+# The SSH listener is deliberately public — that is the entire product. Every
+# other listener the binary starts (verify/health HTTP, games WebSocket, files
+# web, the loopback NNTP reader) binds 127.0.0.1 and is not reachable from
+# outside the host. Reaching the public listener needs a router port-forward to
+# `sshPort` and a DNS record; neither is expressible here, so both are in
+# docs/applications/nixarchy-bbs.md.
+{ config
+, lib
+, pkgs
+, ...
+}:
+let
+  cfg = config.features.nixarchy-bbs;
+
+  # Handles are lowercased before provisioning: GitHub allows uppercase and the
+  # board's SanitizeUsername does not. Anything else it rejects (under 3 chars,
+  # over 20, a reserved route name like `admin` or `msg`) makes provision-user
+  # exit 1, which the sync logs and steps over.
+  syncScript = pkgs.writeShellApplication {
+    name = "nixarchy-bbs-sync";
+    runtimeInputs = [ pkgs.gh pkgs.curl pkgs.coreutils pkgs.gnugrep ];
+    text = ''
+      GH_TOKEN="$(cat "$CREDENTIALS_DIRECTORY/github-token")"
+      export GH_TOKEN
+
+      granted=0
+      skipped=0
+
+      # `select(.pull_request == null)` because the issues endpoint returns PRs
+      # too, and a labelled PR is not an access request.
+      handles="$(gh api --paginate \
+        "repos/${cfg.memberRepo}/issues?state=all&labels=${cfg.memberLabel}" \
+        --jq '.[] | select(.pull_request == null) | .user.login' | sort -u)"
+
+      if [ -z "$handles" ]; then
+        echo "no issues labelled '${cfg.memberLabel}' on ${cfg.memberRepo} — nothing to provision"
+        exit 0
+      fi
+
+      for handle in $handles; do
+        name="$(printf '%s' "$handle" | tr '[:upper:]' '[:lower:]')"
+
+        # Fetch first, filter second. Piping curl straight into `grep -m1`
+        # would race: grep exits on the match, curl takes SIGPIPE, and
+        # pipefail turns a *successful* lookup into a failure.
+        if ! keys="$(curl -fsS --max-time 15 "https://github.com/$handle.keys")"; then
+          echo "skip $handle: could not read https://github.com/$handle.keys"
+          skipped=$((skipped + 1))
+          continue
+        fi
+
+        # First published key only. The board binds one key per account, so
+        # taking the top of the list leaves the choice with the member: they
+        # reorder their keys on GitHub.
+        key="$(printf '%s\n' "$keys" | grep -m1 -E '^(ssh|ecdsa)-' || true)"
+        if [ -z "$key" ]; then
+          echo "skip $handle: no usable public key published on GitHub"
+          skipped=$((skipped + 1))
+          continue
+        fi
+
+        # Idempotent: re-provisioning an unchanged handle+key is a no-op.
+        # A member who rotates their GitHub key trips ErrKeyMismatch here and
+        # stays on their old key until an operator clears it — deliberately, so
+        # a compromised GitHub account cannot silently take over an account.
+        if out="$(agentbbs provision-user --name "$name" --pubkey "$key" --kind member 2>&1)"; then
+          granted=$((granted + 1))
+        else
+          echo "skip $handle: $out"
+          skipped=$((skipped + 1))
+        fi
+      done
+
+      echo "provisioned/confirmed $granted, skipped $skipped"
+    '';
+  };
+
+  # Shared by both units. The server and the sync must agree on the data dir,
+  # and the sync opens the same SQLite store (WAL, 5s busy timeout) that the
+  # running server holds open.
+  commonEnvironment = {
+    AGENTBBS_DATA = "/var/lib/${stateDir}";
+  };
+
+  stateDir = "nixarchy-bbs";
+
+  hardening = {
+    ProtectSystem = "strict";
+    ProtectHome = true;
+    PrivateTmp = true;
+    PrivateDevices = true;
+    ProtectKernelTunables = true;
+    ProtectControlGroups = true;
+    ProtectKernelModules = true;
+    ProtectKernelLogs = true;
+    ProtectClock = true;
+    ProtectHostname = true;
+    NoNewPrivileges = true;
+    RestrictSUIDSGID = true;
+    RestrictRealtime = true;
+    RestrictNamespaces = true;
+    LockPersonality = true;
+    # Pure Go, no JIT and no native extensions mapping RWX — unlike the CPython
+    # services in this tree, which have to leave this off.
+    MemoryDenyWriteExecute = true;
+    SystemCallFilter = [ "@system-service" "~@privileged" ];
+    RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+  };
+in
+{
+  options.features.nixarchy-bbs = {
+    enable = lib.mkEnableOption "nixarchy-bbs — SSH bulletin board for contributors and their agents";
+
+    hostname = lib.mkOption {
+      type = lib.types.str;
+      example = "bbs.example.com";
+      description = ''
+        Public hostname of the board. Cosmetic only — it is what the banner and
+        every "reconnect with…" hint print, so getting it wrong sends members to
+        the wrong address rather than breaking anything.
+      '';
+    };
+
+    sshPort = lib.mkOption {
+      type = lib.types.port;
+      default = 2222;
+      description = ''
+        Port the BBS SSH server listens on, on all interfaces. This is the one
+        deliberately public listener; it does not touch the host's own sshd.
+        Reaching it from outside also needs a router port-forward — see
+        docs/applications/nixarchy-bbs.md.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Open `sshPort` on the host firewall. Default true because a board
+        nobody outside can reach is not a board. Set false to keep the service
+        tailnet-only while testing.
+      '';
+    };
+
+    httpPort = lib.mkOption {
+      type = lib.types.port;
+      default = 8088;
+      description = ''
+        Loopback HTTP endpoint (`/verify`, `/healthz`, `/irc-auth`). Not
+        exposed: email verification is off on this deployment, so this is a
+        health probe and nothing else.
+      '';
+    };
+
+    gameWsPort = lib.mkOption {
+      type = lib.types.port;
+      default = 8190;
+      description = ''
+        Loopback WebSocket endpoint for agent-vs-agent games. Upstream defaults
+        to 8090, which media-bot already holds on p510 — hence the remap.
+      '';
+    };
+
+    filesWebPort = lib.mkOption {
+      type = lib.types.port;
+      default = 8092;
+      description = "Loopback web file browser for the SFTP area.";
+    };
+
+    newsPort = lib.mkOption {
+      type = lib.types.port;
+      default = 1119;
+      description = ''
+        Loopback NNTP port backing the in-hub news reader. Public NNTPS (:563)
+        stays off: it needs a TLS keypair and members read news through the hub.
+      '';
+    };
+
+    admins = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "olafkfreund" ];
+      description = ''
+        Account names allowed into the `admin@` operator console. Safe to
+        declare before the accounts exist — the check is by name at connect
+        time, so naming a handle the sync has not provisioned yet grants
+        nothing until it does.
+      '';
+    };
+
+    closedRegistration = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Refuse keys the board does not already know at `join@`, making a
+        labelled issue on `memberRepo` the only way to get an account.
+
+        Off by default. With it on the board is invisible to anyone not
+        already approved, which is the wrong shape while it is still filling
+        up; turn it on when open signup starts costing more than it brings.
+
+        Needs the fork's AGENTBBS_CLOSED_REGISTRATION support
+        (olafkfreund/nixarchy-bbs#1) — upstream has no way to close signup.
+      '';
+    };
+
+    memberRepo = lib.mkOption {
+      type = lib.types.str;
+      example = "olafkfreund/nixarchy";
+      description = ''
+        `owner/repo` whose issue tracker is the membership register. Issues
+        carrying `memberLabel` grant their *author* an account.
+      '';
+    };
+
+    memberLabel = lib.mkOption {
+      type = lib.types.str;
+      default = "bbs-access";
+      description = ''
+        The label that grants access. Applying it is the approval, so it must be
+        a label only maintainers can apply — GitHub restricts labelling to users
+        with triage permission, which is exactly the property relied on here.
+      '';
+    };
+
+    syncInterval = lib.mkOption {
+      type = lib.types.str;
+      default = "15min";
+      description = ''
+        `OnUnitActiveSec` between membership syncs — the delay between a
+        maintainer applying the label and the account existing.
+      '';
+    };
+
+    githubTokenFile = lib.mkOption {
+      type = lib.types.path;
+      default = config.age.secrets."api-github-token".path;
+      defaultText = lib.literalExpression ''config.age.secrets."api-github-token".path'';
+      description = ''
+        File holding a bare GitHub token for the membership sync. Only needs to
+        read issues on `memberRepo`; the token exists to lift the 60-req/hour
+        unauthenticated rate limit shared by everything else on this host's IP.
+      '';
+    };
+
+    signupNotify = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      example = "you@example.com";
+      description = ''
+        Address the board notifies about signups. Nothing is actually sent —
+        SMTP is unconfigured — but leaving this unset means the binary falls
+        back to its upstream author's address, so set it to your own.
+      '';
+    };
+
+    motd = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = "Message of the day shown atop the hub menu.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.memberRepo != "";
+        message = "features.nixarchy-bbs.memberRepo must name the owner/repo whose issues grant access.";
+      }
+    ];
+
+    age.secrets."api-github-token" = {
+      file = ../../secrets/api-github-token.age;
+      mode = "0400";
+    };
+
+    users.users.${stateDir} = {
+      isSystemUser = true;
+      group = stateDir;
+      description = "nixarchy-bbs SSH bulletin board";
+    };
+    users.groups.${stateDir} = { };
+
+    systemd.services.nixarchy-bbs = {
+      description = "nixarchy-bbs — SSH bulletin board for contributors and their agents";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment = commonEnvironment // {
+        AGENTBBS_ADDR = ":${toString cfg.sshPort}";
+        AGENTBBS_HOST = cfg.hostname;
+        AGENTBBS_ADMINS = lib.concatStringsSep "," cfg.admins;
+
+        # Only consulted on the refusal path, so setting the message
+        # unconditionally is free. Both variables come from the fork's
+        # feat/closed-registration change.
+        AGENTBBS_CLOSED_REGISTRATION = if cfg.closedRegistration then "1" else "0";
+        AGENTBBS_CLOSED_REGISTRATION_MSG =
+          "This board is for ${cfg.memberRepo} contributors. "
+            + "Ask for an account: open an issue at https://github.com/${cfg.memberRepo}/issues "
+            + "and a maintainer will label it '${cfg.memberLabel}'. "
+            + "Your account is created from the SSH keys you publish on GitHub.";
+
+        # Not negotiable while the sync exists: provisioned members arrive with
+        # no email and there is no SMTP to send a code to, so requiring
+        # verification would lock out every member it just granted.
+        # Self-service joiners are still asked for an email, just not blocked
+        # on confirming it.
+        AGENTBBS_REQUIRE_VERIFIED_EMAIL = "0";
+
+        # The default MOTD source is upstream's own site, polled every 30
+        # minutes. `motd.Start` skips an empty URL, but the caller reads it
+        # through a helper that treats empty as unset and substitutes the
+        # default back — so the only way to stop the poll from outside the
+        # binary is to point it somewhere that fails instantly and locally.
+        AGENTBBS_MOTD_URL = "http://127.0.0.1:1/motd";
+        AGENTBBS_MOTD = cfg.motd;
+
+        # Upstream's default is anthony@profullstack.com.
+        AGENTBBS_SIGNUP_NOTIFY = cfg.signupNotify;
+
+        # The sandbox wraps *external* arcade binaries (doom) in bwrap, which
+        # needs the user namespaces RestrictNamespaces denies. Moot in practice:
+        # AGENTBBS_ASSETS is unset so no external binary exists, and the Go
+        # games (snake, hangman) run in-process either way.
+        AGENTBBS_SANDBOX = "none";
+
+        # Gopher wants :70 and public NNTPS wants :563 — both privileged, and
+        # neither worth an AmbientCapability. News still works: the hub reader
+        # talks to the loopback NNTP port below.
+        AGENTBBS_GOPHER = "0";
+
+        AGENTBBS_HTTP_ADDR = "127.0.0.1:${toString cfg.httpPort}";
+        AGENTBBS_GAME_WS_ADDR = "127.0.0.1:${toString cfg.gameWsPort}";
+        AGENTBBS_FILES_WEB_ADDR = "127.0.0.1:${toString cfg.filesWebPort}";
+        AGENTBBS_NEWS_ADDR = "127.0.0.1:${toString cfg.newsPort}";
+      };
+
+      serviceConfig = hardening // {
+        ExecStart = lib.getExe pkgs.customPkgs.nixarchy-bbs;
+        User = stateDir;
+        Group = stateDir;
+        StateDirectory = stateDir;
+        StateDirectoryMode = "0700";
+        Restart = "on-failure";
+        RestartSec = 5;
+        MemoryMax = "1G";
+        TasksMax = 256;
+      };
+    };
+
+    # Membership sync. Writes the same SQLite store the server holds open,
+    # which is safe: the store opens WAL with a 5s busy timeout.
+    systemd.services.nixarchy-bbs-sync = {
+      description = "Provision nixarchy-bbs members from labelled GitHub issues";
+      after = [ "network-online.target" "nixarchy-bbs.service" ];
+      wants = [ "network-online.target" ];
+
+      path = [ pkgs.customPkgs.nixarchy-bbs ];
+      environment = commonEnvironment;
+
+      serviceConfig = hardening // {
+        Type = "oneshot";
+        ExecStart = lib.getExe syncScript;
+        User = stateDir;
+        Group = stateDir;
+        StateDirectory = stateDir;
+        StateDirectoryMode = "0700";
+        # agenix decrypts the token root-owned at 0400; systemd copies it into
+        # the unit's credential directory where the service user can read it.
+        LoadCredential = [ "github-token:${cfg.githubTokenFile}" ];
+      };
+    };
+
+    systemd.timers.nixarchy-bbs-sync = {
+      description = "Periodic nixarchy-bbs membership sync from GitHub";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "2min";
+        OnUnitActiveSec = cfg.syncInterval;
+        Unit = "nixarchy-bbs-sync.service";
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.sshPort ];
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -112,6 +112,11 @@
   # renamed the binary but kept the repo name. Not in nixpkgs.
   obsidian-cli = pkgs.callPackage ./obsidian-cli { };
 
+  # nixarchy-bbs — a BBS delivered over SSH. Consumed only by
+  # modules/services/nixarchy-bbs.nix, so it stays in the customPkgs
+  # namespace rather than being lifted to top-level pkgs.*.
+  nixarchy-bbs = pkgs.callPackage ./nixarchy-bbs { };
+
   # Note: gnome-ext-* packages are NOT registered here. They're exposed
   # at top-level pkgs.* via overlays/custom-packages.nix so that home
   # configs can reference them with `with pkgs;` (matching the rudra /

--- a/pkgs/nixarchy-bbs/default.nix
+++ b/pkgs/nixarchy-bbs/default.nix
@@ -1,0 +1,68 @@
+# nixarchy-bbs — a BBS delivered over SSH, for Nixarchy contributors and their
+# coding agents. Fork of profullstack/agentbbs.
+#
+# The whole product is one binary running a charmbracelet/wish SSH server that
+# routes on the SSH *username*: `join@` onboards, `<name>@` opens the member
+# hub, `msg@` is store-and-forward notes, `admin@` is the operator console.
+# Identity is the SSH public key's fingerprint — no passwords anywhere — which
+# is why it suits agents: they already hold exactly that credential.
+#
+# Only cmd/agentbbs is built. The repo has two other main packages that are
+# not wanted here: cmd/ascii-live shells out to ffmpeg and yt-dlp at runtime,
+# and cmd/lkpublish is a LiveKit development tool. Building all three would put
+# both in $out/bin for no benefit.
+#
+# CGO is off deliberately, matching upstream CI. The only thing that would
+# normally demand cgo is SQLite, and this uses modernc.org/sqlite — a pure-Go
+# transpilation — so the binary is static and the closure stays small.
+#
+# Upstream publishes no tags, so `version` follows the nixpkgs unstable-date
+# convention and the rev is pinned explicitly. Bump: pick a new commit, update
+# rev + hash, set vendorHash to lib.fakeHash and take the value nix reports.
+# The dependency tree is large (LiveKit/pion/gRPC come in through the optional
+# video routes), so the vendor fetch is slow and the build wants ~1.5 GB.
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule {
+  pname = "nixarchy-bbs";
+  version = "0-unstable-2026-08-28";
+
+  src = fetchFromGitHub {
+    owner = "olafkfreund";
+    repo = "nixarchy-bbs";
+    rev = "0f92a6f6bcd8c18d7dad9f9e984d0a447433a718";
+    hash = "sha256-h1X8baxJQ+SU+/HOWrWhRlYUu/HDBxNp2JQ6EDXnzyI=";
+  };
+
+  vendorHash = "sha256-pP2bFbR2MqHnQNTdqjy0K5w9Mug/xF7Zlw6D9HoYmWU=";
+
+  subPackages = [ "cmd/agentbbs" ];
+
+  env.CGO_ENABLED = "0";
+
+  ldflags = [ "-s" "-w" ];
+
+  meta = {
+    description = "BBS over SSH for humans and coding agents";
+    longDescription = ''
+      An SSH-native bulletin board: register with `ssh join@host`, then reach
+      a bubbletea hub with an inbox, threaded NNTP news, an SFTP file area and
+      an arcade. Agents skip the TUI entirely and post with
+      `ssh msg@host <user> "<note>"`, authenticating with the same SSH key
+      they already use for git.
+
+      Runs standalone. The optional integrations upstream ships — Mailu
+      mailboxes, Ergo IRC, Forgejo, LiveKit video, crypto payments, rootless
+      podman member pods — all degrade to a menu entry saying they are
+      unavailable when their environment variables are unset.
+    '';
+    homepage = "https://github.com/olafkfreund/nixarchy-bbs";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    mainProgram = "agentbbs";
+  };
+}


### PR DESCRIPTION
Closes #1633.

An SSH bulletin board on p510 where nixarchy contributors and their coding agents leave each other notes. Identity is the SSH public key's fingerprint — the credential an agent already holds — so a human gets a bubbletea hub and an agent posts over an exec channel with no PTY:

```bash
ssh msg@bbs.freundcloud.org.uk olafkfreund "found the cause of the eval loop"
```

## Not behind the tunnel

Unlike everything else public on p510. The product is an SSH server, and a Cloudflare tunnel can only carry SSH via `cloudflared access ssh` on every client — friction that lands squarely on the people this is for. With the Starlink CGNAT gone there is a reachable public IP, so a port-forward gives plain `ssh join@bbs.freundcloud.org.uk`.

Two one-off steps outside NixOS, documented in `docs/applications/nixarchy-bbs.md`:

1. Cloudflare DNS: `A` for `bbs.freundcloud.org.uk` → WAN IP, **DNS-only (grey cloud)** — the proxy would black-hole SSH.
2. Router: forward WAN TCP **22** → `192.168.1.222:2222`. Port 22 outside so nobody needs `-p` and the board's own hints are correct; 2222 inside so p510's own sshd is untouched.

## Membership from GitHub

Label an issue on `olafkfreund/nixarchy` with `bbs-access` (label created) and `nixarchy-bbs-sync.timer` provisions that author from the keys they publish at `github.com/<handle>.keys`, via the binary's `provision-user`. Reviewable and revocable in the issue tracker; nobody hand-copies a key. A rotated GitHub key deliberately does *not* auto-migrate, so a compromised GitHub account cannot take over a board account.

Self-service `ssh join@` stays open for now. `features.nixarchy-bbs.closedRegistration = true` makes the labelled issue the only way in — that needs olafkfreund/nixarchy-bbs#1, which is not merged yet, so the flag is a no-op until the pinned rev is bumped.

## Scope

Standalone and hardened. Upstream's installer runs its service without `NoNewPrivileges` or `ProtectSystem` because rootless-podman member pods need setuid `newuidmap`; dropping pods is what buys the hardening back. Mailu, Ergo IRC, Forgejo, LiveKit, Tor, Caddy, gopher (`:70`) and public NNTPS (`:563`) are all off. Every listener except the BBS SSH port binds loopback.

## Two deviations worth review

- **A dedicated system user rather than `DynamicUser`** (CLAUDE.md rule 2). systemd derives a DynamicUser's UID from the *unit name*, so `nixarchy-bbs.service` and `nixarchy-bbs-sync.service` would get different UIDs and each start would chown the shared `StateDirectory` away from the other — and the sync must write the SQLite store the server reads. `docs/NIXOS-ANTI-PATTERNS.md` permits "a dedicated user or DynamicUser"; every other hardening knob is kept, plus `MemoryDenyWriteExecute = true` (safe for Go).
- **Games WebSocket moved 8090 → 8190.** `media-bot` already holds 8090 on p510; upstream's default would have collided silently.

## Verification

- `nix build .#nixosConfigurations.p510.pkgs.customPkgs.nixarchy-bbs` — builds (CGO off; SQLite is pure-Go `modernc`).
- `nix build .#nixosConfigurations.p510.config.system.build.toplevel` — builds.
- Sync script passes `writeShellApplication`'s shellcheck; the GitHub query and key fetch were dry-run against the live repo.
- deadnix, typos, markdownlint, nixpkgs-fmt clean.

Post-deploy: `systemctl status nixarchy-bbs`, `ss -tlnp | grep 2222`, then `ssh -p 2222 join@127.0.0.1` on the host before the DNS and router steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB