### PR TITLE
fix(nix): put /tmp on disk, and stop auto-optimise racing the collector (#1635)

### DIFF
--- a/hosts/p620/nixos/boot.nix
+++ b/hosts/p620/nixos/boot.nix
@@ -15,10 +15,21 @@
   boot.kernelPackages = pkgs.linuxPackages_latest; # Use the beta kernel for better hardware support
   boot.plymouth.enable = true;
 
-  # Configure tmpfs size for large builds
+  # /tmp in RAM, sized for what actually gets built here.
+  #
+  # 32G was generous once and is not any more: nix builds in $TMPDIR, `max-jobs
+  # = auto` on 128 threads runs a dozen unpacks at a time, and several packages
+  # in this closure are large on their own -- cef-binary is ~1.9G unpacked,
+  # ctranslate2 and antigravity-ide are the same order. A full rebuild put four
+  # of them in flight together and every one died with ENOSPC (#1635), which
+  # reads as a disk problem and is not: / had 289G free throughout.
+  #
+  # 128G against 251G of RAM. tmpfs is lazily allocated, so this is a ceiling
+  # rather than a reservation and costs nothing when /tmp is near-empty, which
+  # is almost always.
   boot.tmp = {
     useTmpfs = true;
-    tmpfsSize = "32G"; # Allocate 32GB of RAM for /tmp (increased for LibreOffice and large builds)
+    tmpfsSize = "128G";
   };
   # OBS Virtual Cam Support - v4l2loopback setup
   boot.kernelModules = [ "v4l2loopback" ];

--- a/hosts/p620/nixos/boot.nix
+++ b/hosts/p620/nixos/boot.nix
@@ -15,21 +15,22 @@
   boot.kernelPackages = pkgs.linuxPackages_latest; # Use the beta kernel for better hardware support
   boot.plymouth.enable = true;
 
-  # /tmp in RAM, sized for what actually gets built here.
+  # /tmp on disk, not in RAM.
   #
-  # 32G was generous once and is not any more: nix builds in $TMPDIR, `max-jobs
-  # = auto` on 128 threads runs a dozen unpacks at a time, and several packages
-  # in this closure are large on their own -- cef-binary is ~1.9G unpacked,
-  # ctranslate2 and antigravity-ide are the same order. A full rebuild put four
-  # of them in flight together and every one died with ENOSPC (#1635), which
-  # reads as a disk problem and is not: / had 289G free throughout.
+  # This was a 32G tmpfs, then a 128G one, and a full rebuild exhausted both
+  # (#1635). Raising the number was the wrong shape of fix: tmpfs is RAM, RAM is
+  # finite, and `max-jobs = auto` across 128 threads will unpack as much as you
+  # give it -- cef-binary alone is ~1.9G, and a dozen of those land together.
+  # The 128G cap also meant half of this machine's memory could disappear into
+  # a build directory.
   #
-  # 128G against 251G of RAM. tmpfs is lazily allocated, so this is a ceiling
-  # rather than a reservation and costs nothing when /tmp is near-empty, which
-  # is almost always.
+  # / is a 916G NVMe with 300G+ free, so builds get somewhere effectively
+  # unbounded and fast, and ENOSPC stops being a thing that looks like a full
+  # disk while `df /` says otherwise. cleanOnBoot keeps the clear-on-restart
+  # behaviour tmpfs gave for free.
   boot.tmp = {
-    useTmpfs = true;
-    tmpfsSize = "128G";
+    useTmpfs = false;
+    cleanOnBoot = true;
   };
   # OBS Virtual Cam Support - v4l2loopback setup
   boot.kernelModules = [ "v4l2loopback" ];

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -425,7 +425,8 @@ in
     settings = {
       max-jobs = lib.mkDefault 16; # i7-10875H has 8 cores/16 threads
       cores = lib.mkDefault 16; # Use all threads
-      auto-optimise-store = true;
+      # auto-optimise-store: see modules/nix/nix.nix -- it races the in-build
+      # collector; nix.optimise runs the same deduplication on a timer.
     };
     extraOptions = ''
       keep-outputs = true

--- a/modules/nix/flake-settings.nix
+++ b/modules/nix/flake-settings.nix
@@ -7,8 +7,10 @@
       # Accept flake configurations automatically
       accept-flake-config = true;
 
-      # Optimize store to save space
-      auto-optimise-store = true;
+      # auto-optimise-store is deliberately NOT set here: it races the in-build
+      # collector enabled by min-free/max-free in ./nix.nix and leaves invalid
+      # store paths behind. Deduplication happens on a timer instead --
+      # `nix.optimise` in ./nix.nix.
     };
 
     # Garbage collection settings

--- a/modules/nix/nix.nix
+++ b/modules/nix/nix.nix
@@ -27,7 +27,15 @@
     warn-dirty = false;
     log-lines = 50;
     sandbox = "relaxed";
-    auto-optimise-store = true;
+    # auto-optimise-store is deliberately NOT set. It deduplicates by hardlink
+    # immediately after each build, which races the in-build garbage collector
+    # that min-free/max-free below enables: the collector deletes a path while
+    # the optimiser is linking into it, and the build dies with
+    #   renaming "/nix/store/.tmp-link-...": No such file or directory
+    #   error: path '...' is required, but there is no substituter that can build it
+    # -- leaving genuinely invalid store paths behind. It cost p620 a rebuild and
+    # one corrupted path (zerovec-derive) on 2026-09-02. nix.optimise.automatic
+    # below does the same deduplication on a timer, when nothing else is running.
     max-jobs = "auto";
     cores = 0;
 
@@ -62,6 +70,17 @@
     # Example: "your-username.cachix.org"
     # To use: uncomment and add your cachix auth token via:
     # $ cachix authtoken YOUR_TOKEN
+  };
+
+  # Store deduplication on a timer instead of after every build.
+  #
+  # Replaces `nix.settings.auto-optimise-store`, which raced the in-build
+  # collector (see the note above). Same hardlinking, same saving -- it was
+  # already reclaiming 18.8 GiB on p510 -- but run when it cannot collide with
+  # a build's own paths being deleted underneath it.
+  nix.optimise = {
+    automatic = true;
+    dates = [ "Sun 05:00" ];
   };
 
   # Package permissions - security-focused configuration


### PR DESCRIPTION
Closes #1635. **This PR changed shape after the first fix failed** — it originally raised p620's tmpfs 32G → 128G. That was wrong and the history is worth keeping honest.

## Fault 1: /tmp was in RAM

The 128G tmpfs was exhausted too, by a full rebuild an hour ago:

```
zlib> error: unable to unpack tarball to temporary directory: WriteFailed
error: unable to copy directory '/nix/store/...': NoSpaceLeft
note: build failure may have been caused by lack of free disk space
```

Raising the number was never the fix. tmpfs is RAM, RAM is finite, and `max-jobs = auto` across 128 threads unpacks as much as it is given — `cef-binary` alone is ~1.9 GB unpacked and a dozen of those land together. The 128G cap also meant half of a 251 GiB machine could disappear into a build directory.

`/` is a 916 GB NVMe with 300 GB+ free. `useTmpfs = false` + `cleanOnBoot = true` gives builds somewhere effectively unbounded and keeps the clear-on-restart behaviour tmpfs provided for free.

## Fault 2: auto-optimise racing the in-build collector

The same run produced a stranger set of errors:

```
error: renaming "/nix/store/.tmp-link-2508168-879002997" to ".../derives.rs": No such file or directory
error: path '/nix/store/...-zerovec-derive-0.11.3' is required, but there is no substituter that can build it
```

`auto-optimise-store` hardlinks duplicates immediately after each build. `min-free`/`max-free` (in `modules/nix/nix.nix`) run the garbage collector *during* builds. Together the collector deletes a path while the optimiser is linking into it. **It left a genuinely invalid store path behind** — I verified and repaired it:

```
$ nix path-info …zerovec-derive-0.11.3   → INVALID
$ sudo nix-store --repair-path …          → copying from cache.nixos.org
$ nix path-info …                         → VALID
```

It was set in **three** places, only one of which was obvious — `modules/nix/nix.nix`, `modules/nix/flake-settings.nix` (the one actually reaching p620, via `modules/core.nix`), and `hosts/razer/configuration.nix`. All three removed; `nix.optimise.automatic` now runs the same deduplication on a Sunday timer when nothing can collide with it. The saving is real and kept — hardlinking is currently reclaiming 18.8 GiB on p510.

The four microvm guests still set it. They have no `min-free` collector, so the race does not apply there.

## Verification

```
$ nix eval …p620.config.boot.tmp.useTmpfs                     → false
$ for h in p620 razer p510: nix.settings."auto-optimise-store" → false, false, false
$ nix eval …p620.config.nix.optimise.automatic                 → true
$ nix build …{p620,razer}.config.system.build.toplevel         → NIX_EXIT=0 (both)
```

Takes effect on the next rebuild; `/tmp` moves off tmpfs at the next reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB