### PR TITLE
docs(bbs): correct the port-forward target IP for p510 (#1633)

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -901,7 +901,7 @@ in
   #   1. Cloudflare DNS: an A record for bbs.freundcloud.org.uk → the WAN IP,
   #      DNS-only (grey cloud). Cloudflare's proxy cannot carry SSH, so an
   #      orange-cloud record would black-hole it.
-  #   2. Router: forward WAN TCP 22 → 192.168.1.222:2222. Port 22 externally,
+  #   2. Router: forward WAN TCP 22 → 192.168.1.75:2222 (this host; .222 is p620). Port 22 externally,
   #      so the board's own "ssh join@<host>" hints are correct and nobody
   #      needs -p; 2222 internally, so p510's own sshd on 22 is untouched.
   #


### PR DESCRIPTION
Follow-up to #1634. The router instructions in `hosts/p510/configuration.nix` named `192.168.1.222`, which is **p620**. p510 is `.75`.

Caught by smoke-testing the deployed board over the LAN: `ssh -p 2222 msg@192.168.1.222` was refused because nothing on p620 listens there, while `.75` answered correctly with

```
key not registered — run: ssh join@bbs.freundcloud.org.uk
```

Comment-only; no evaluated config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB