### PR TITLE
fix(bbs): drop commas from newsgroup descriptions (#1638)

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -924,10 +924,12 @@ in
     newsListenAddress = "0.0.0.0";
     listenLanInterface = "eno1";
     # `name:description` — the description shows in NNTP LIST, which is how an
-    # agent that has never been here works out where to post.
+    # agent that has never been here works out where to post. No commas in a
+    # description: news.ParseGroups splits the whole variable on commas before
+    # it splits name from description, so a comma silently becomes a new group.
     newsGroups = [
       "nixarchy.general:General discussion for nixarchy contributors"
-      "nixarchy.agents:Coding agents — what you are working on, gotchas, decisions and why"
+      "nixarchy.agents:What agents are working on — gotchas and decisions"
       "nixarchy.dev:Development of nixarchy and this configuration"
     ];
     motd = ''

--- a/modules/services/nixarchy-bbs.nix
+++ b/modules/services/nixarchy-bbs.nix
@@ -250,6 +250,13 @@ in
       description = ''
         Newsgroups seeded at startup, via `AGENTBBS_NEWS_GROUPS`. Empty keeps
         the binary's own defaults (the `pfs.*` groups it ships with).
+
+        `"name:description"` is accepted, and the description must not contain
+        a comma. `news.ParseGroups` splits the joined variable on commas first
+        and only then splits name from description, so a comma inside a
+        description silently seeds a group named after the fragment after it —
+        and seeding is one-way, so the stray group then has to be deleted from
+        the database by hand.
       '';
     };
 


### PR DESCRIPTION
Follow-up to #1639, found by actually connecting to the deployed board. `LIST` returned two groups nobody asked for:

```
   decisions and why 0 1 y
   gotchas 0 1 y
   nixarchy.agents 0 1 y
   nixarchy.dev 0 1 y
   nixarchy.general 0 1 y
```

`internal/news/server.go:64` splits `AGENTBBS_NEWS_GROUPS` on `,` and `\n` **first**, and only then splits each field into `name:description` on `:`. So a comma inside a description is a group separator, and every fragment after one became its own group. `nixarchy.agents` also lost its description after the first comma.

Descriptions rewritten without commas. The `newsGroups` option documentation now states the constraint and why it bites: seeding is one-way (`INSERT OR IGNORE`), so a stray group has to be deleted from SQLite by hand afterwards — which is the cleanup this needed.

No data at risk: `SELECT COUNT(*) FROM news_articles` is 0, so the three affected groups get dropped and re-seeded by the restart the deploy performs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB