### PR TITLE
chore(flake): bump nixarchy for the nixarchy-bbs agent skill (#1633)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -843,6 +843,28 @@
         "type": "github"
       }
     },
+    "hypr-rdp": {
+      "inputs": {
+        "nixpkgs": [
+          "nixarchy",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787094885,
+        "narHash": "sha256-yrC8fITJofWJ2wpZMiaX06UVCMFI4GRg9pGyaTdosHg=",
+        "owner": "MuNeNiCK",
+        "repo": "hypr-rdp",
+        "rev": "cf3fbd82e2176070c0860bd53eb87d0b098decd4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "MuNeNiCK",
+        "ref": "v0.1.5",
+        "repo": "hypr-rdp",
+        "type": "github"
+      }
+    },
     "hyprcursor": {
       "inputs": {
         "hyprlang": [
@@ -1353,21 +1375,23 @@
       "inputs": {
         "disko": "disko",
         "home-manager": "home-manager_3",
+        "hypr-rdp": "hypr-rdp",
         "hyprland": "hyprland",
         "nix-flatpak": "nix-flatpak",
         "nixpkgs": [
           "nixpkgs"
         ],
         "omarchy": "omarchy",
+        "sops-nix": "sops-nix",
         "systems": "systems_8",
         "zen-browser": "zen-browser"
       },
       "locked": {
-        "lastModified": 1788333207,
-        "narHash": "sha256-33KKQPIYF1s0gU9pGOPgvU83hyEKmSyfA/harq8ZhM0=",
+        "lastModified": 1788375929,
+        "narHash": "sha256-+hroEHvFZfXw3ElU29iisQqcWBYO4XPRLy0PnfG50sU=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "e89b00f2e80e1e9b779903fa6f1e1ac04548db14",
+        "rev": "e05ca95dc6995d55bae355da08d89b2c09c5f9b6",
         "type": "github"
       },
       "original": {
@@ -1857,7 +1881,7 @@
         "nur": "nur",
         "rust-overlay": "rust-overlay_4",
         "seance": "seance",
-        "sops-nix": "sops-nix",
+        "sops-nix": "sops-nix_2",
         "spicetify-nix": "spicetify-nix",
         "stylix": "stylix",
         "yt-x": "yt-x",
@@ -2010,6 +2034,28 @@
       }
     },
     "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixarchy",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786629091,
+        "narHash": "sha256-gkig4nPi1CWc4Z50GBsjE4ygSE7hMpl/TwID2an2Cck=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "a8627b21b9107c5711c96b84f32a9a4b3d45295f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "a8627b21b9107c5711c96b84f32a9a4b3d45295f",
+        "type": "github"
+      }
+    },
+    "sops-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"


### PR DESCRIPTION
Picks up [olafkfreund/nixarchy#185](https://github.com/olafkfreund/nixarchy/pull/185), which ships the `nixarchy-bbs` skill. `omarchy-provision-user` symlinks every skill in the package into `~/.claude/skills`, `~/.agents/skills`, `~/.codex/skills` and `~/.pi/agent/skills`, so this is what puts the board's instructions in front of every agent on p620 and razer — Codex and Pi included — rather than only the session that wrote them.

Verified in the built closure rather than assumed:

```
$ ls $omarchy/share/omarchy/default/agents/skills/
devenv diagnose-crash nixarchy nixarchy-bbs nixos nixos-ai nixos-config-repo
nixos-doctor nixos-gpu nixos-performance nixos-secrets nixos-security nixos-services
```

## One real behaviour change

Nine other commits come with the bump. Only one changes how these machines behave: **#168/#169 gate `nixarchy-config-repo` on `/etc/nixarchy/managed`**, a marker set only by the installer's host module. I checked — neither host imports `installer/host.nix`, and `/etc/nixarchy` here holds only template symlinks. So after the switch:

- `nixarchy config repo` refuses to touch `~/.config/nixos` and exits 1 (`--force` does not lift it)
- the post-boot backup nudge goes quiet
- `System > Back up configuration` and `nixarchy-home-backup` do not appear in the menu

That is the fix working, not a regression: this repo predates nixarchy, is driven by git/`just`/`nhs`, and deploys a host nixarchy knows nothing about — precisely the "configuration it did not write" case #168 was for. Nothing in this tree references that command.

**sops-nix (#184)** arrives imported but inert. Its one sharp edge — nixarchy never enables sshd, so `sops.age.sshKeyPaths` is empty and declaring a secret fails at evaluation — cannot fire here: we are agenix throughout (~75 `.age` files) and declare no sops secrets.

The rest (Plymouth chrome, free-space installer, snapper detection, hypr-rdp pin, AGENTS.md) are installer-side, cosmetic, or inert on an installed machine.

## Verification

Both hosts build: `nix build .#nixosConfigurations.{p620,razer}.config.system.build.toplevel`, exit 0.

```
$ nvd diff /run/current-system <new>
Added:   nixarchy-dev-init, nixarchy-devenv-presets, notebooklm-go
Removed: notebooklm-py, python3.14-markdownify
Closure size: 5584 -> 5586 (delta +2, disk usage +425.7MiB)
```

The notebooklm swap is unrelated and arrived on `main` separately.

Note for whoever switches: p620's `/tmp` is a 32 GB tmpfs and this closure exhausted it earlier today (#1635/#1636). I remounted it to 128 GB before building. #1636 makes that permanent but needs a reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB