### PR TITLE
p510: set nix.settings.build-dir, because TMPDIR stopped deciding it

### DIFF
--- a/hosts/p510/nixos/github-runner.nix
+++ b/hosts/p510/nixos/github-runner.nix
@@ -106,6 +106,21 @@ in
     # decides whether an ISO test finishes or wedges.
     systemd.services.nix-daemon.environment.TMPDIR = buildDir;
 
+    # ...and this, which is the one that actually decides it now. Nix grew a
+    # `build-dir` setting that defaults to /nix/var/nix/builds -- on the root
+    # filesystem -- and it takes precedence over TMPDIR. So the line above went
+    # quietly inert on the Nix bump: it still reads correctly, and every build
+    # went back to /. Measured on 2026-09-02, with the runner busy:
+    #
+    #   /home/nix-build        4.0K, 0 entries    <- never used
+    #   /nix/var/nix/builds    3.7G, 18 entries   <- everything, on /
+    #   /                      226G, 121M free    <- an install job had failed
+    #
+    # Both are set deliberately. TMPDIR still governs anything that asks the
+    # environment rather than the setting, and dropping it would move that half
+    # back to / without any error saying so.
+    nix.settings.build-dir = buildDir;
+
     # One runner runs one job. That is not a setting, it is what a runner is,
     # so "let p510 take two jobs at once" means two runner instances.
     #


### PR DESCRIPTION
`systemd.services.nix-daemon.environment.TMPDIR = /home/nix-build` has been set
on p510 for as long as the runner has existed, and **no build has ever run
there**.

Nix grew a `build-dir` setting that defaults to `/nix/var/nix/builds` — on the
root filesystem — and it takes precedence over TMPDIR. So the existing line went
inert on a Nix bump while still reading as correct.

## Measured, 2026-09-02, with the runner busy

| path | state |
|---|---|
| `/home/nix-build` | 4.0K, **0 entries** — the intended target, never used |
| `/nix/var/nix/builds` | 3.7G, 18 entries — everything, on `/` |
| `/` | 226G, **121M free**; one install job already `Failed` |
| `/home` | 916G, 827G free |

The symptom was not a config error. It was nixarchy CI dying of ENOSPC on a
machine with three disks at 4–5% used, plus a runner whose worker died mid-job
and left the listener wedged, so GitHub still reported it `online, busy=false`.

## Why both settings stay

TMPDIR still governs anything that reads the environment rather than the
setting. Dropping it would move that half back to `/` with no error saying so —
the same silence this PR fixes.

`/home` over `/mnt/img_pool` is unchanged and still right: the file's own note
records img_pool as SMR at ~9.5 MB/s.

Verified by evaluation — `nix.settings.build-dir` and the daemon's TMPDIR both
resolve to `/home/nix-build`.
