### PR TITLE
fix(p620): remove the competing fstab /tmp so it actually lands on disk (#1635)

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -794,7 +794,18 @@ in
 
     tmpfsOptimization = {
       enable = true;
-      tmpSize = "16G"; # Large temp space for AI workloads and complex builds
+      # tmpSize = "" on purpose: /tmp stays on disk.
+      #
+      # This module writes fileSystems."/tmp", which becomes an /etc/fstab entry
+      # and a generated tmp.mount -- and that BEATS boot.tmp.useTmpfs in
+      # hosts/p620/nixos/boot.nix. Two subsystems were declaring /tmp and only
+      # one could win, which is how setting useTmpfs = false in #1636 silently
+      # shrank /tmp from 32G to this 16G rather than moving it to disk.
+      #
+      # Builds go in $TMPDIR and this machine unpacks cef-binary and friends a
+      # dozen at a time, so /tmp wants the 916G NVMe, not a slice of RAM.
+      # /var/tmp and /dev/shm keep their tmpfs; neither is a build directory.
+      tmpSize = "";
       varTmpSize = "2G";
       devShmSize = "50%";
     };


### PR DESCRIPTION
Follow-up to #1636, which did not work — and made things worse. Worth stating plainly: after that PR, `/tmp` went from **32 GB to 16 GB**, the opposite of the intent. It only became visible after a reboot, which is why it looked fine at the time.

## Two subsystems were declaring /tmp

| Source | Mechanism |
|---|---|
| `hosts/p620/nixos/boot.nix` — `boot.tmp.useTmpfs` | NixOS's own `tmp.mount`. What #1636 changed. |
| `modules/storage/performance-optimization.nix` — `fileSystems."/tmp"`, driven by `tmpfsOptimization.tmpSize = "16G"` in `hosts/p620/configuration.nix` | `/etc/fstab` → `systemd-fstab-generator` `tmp.mount`. **This one wins.** |

So `useTmpfs = false` didn't move `/tmp` to disk — it just handed it to the 16 GB fstab entry:

```
$ findmnt /tmp -o SOURCE,FSTYPE,SIZE
tmpfs  tmpfs  16G
$ systemctl cat tmp.mount
# /run/systemd/generator/tmp.mount
# Automatically generated by systemd-fstab-generator
SourcePath=/etc/fstab
```

## Fix

`tmpSize = ""` drops the `fileSystems` entry entirely (the module already guards with `mkIf (tmpSize != "")`), so `/tmp` falls through to the 916 GB NVMe as #1636 intended. `/var/tmp` and `/dev/shm` keep their tmpfs — neither is a build directory.

## Verification

```
$ nix eval …p620.config.fileSystems --apply 'x: x ? "/tmp"'
  → "/tmp not declared - lands on / (correct)"
$ grep /tmp <newsystem>/etc/fstab
  → no /tmp line in fstab
$ nix build …p620.config.system.build.toplevel
  → NIX_EXIT=0
```

Applied with `nixos-rebuild boot` rather than `switch`: a live `switch` tries to unmount `/tmp` out from under the running desktop, which is what broke D-Bus mid-activation during #1636 and left `/run/current-system` stale. This change genuinely needs the reboot, so staging it for the next one is the honest way to apply it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB