### PR TITLE
fix(omarchy): set_workspace takes a selector, not a table (#1517)

### DIFF
--- a/hosts/common/nixos/omarchy-workspaces.nix
+++ b/hosts/common/nixos/omarchy-workspaces.nix
@@ -77,7 +77,12 @@
 
     local function focus_group(group)
       for index, mon in ipairs(ordered_monitors()) do
-        mon:set_workspace({ workspace = member(index, group) })
+        -- A bare number, not { workspace = n }: HLMonitor:set_workspace wants
+        -- "a workspace object or selector" and rejects a table outright, so
+        -- every group switch raised a Lua runtime error and the monitors
+        -- never moved. Verified against the live compositor with
+        -- `hyprctl eval` before changing it.
+        mon:set_workspace(member(index, group))
       end
     end
 


### PR DESCRIPTION
Every `SUPER+1`..`0` press raised a Lua runtime error and the monitors never moved:

```
/home/olafkfreund/.config/hypr/workspace-groups.lua:49:
  HLMonitor.set_workspace: expected a workspace object or selector
```

`focus_group` passed `{ workspace = n }`. The API rejects a table outright and wants the workspace itself.

**Wrong since the file was written** (#1512/#1513, refined in #1517/#1518) — cross-display group switching has never worked. It only became visible now because Omarchy surfaces Lua runtime errors as desktop notifications.

## Why nothing caught it

The Hyprland stub types it as:

```lua
---@field set_workspace fun(self: HL.Monitor, ...): any
```

Variadic, no argument types. The file parses fine, evaluates fine, and deploys fine — nothing between writing it and pressing the key can see the mistake.

## Verified against the live compositor

Using `hyprctl eval` rather than reasoning from the stub:

| form | result |
|---|---|
| `m:set_workspace({ workspace = id })` | **raises** "expected a workspace object or selector" |
| `m:set_workspace(id)` — number | ok |
| `m:set_workspace("id")` — string | ok |
| `m:set_workspace(m.active_workspace)` — object | ok |

And functionally, not just "did not raise":

```
before: DP-1 ws=1
  ms[1]:set_workspace(2)
after : DP-1 ws=2   (wanted 2)
restored to 1
```

Confirmed by the user after deploy: all three displays now switch together, no error notification.

The `hyprctl eval` verification path is recorded as a comment at the call site, since no mechanical check would have caught this and the next person editing Hyprland Lua needs to know that's how you check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB