### PR TITLE
fix(razer): put /tmp on disk, matching p620 (#1635)

### DIFF
--- a/hosts/razer/nixos/memory.nix
+++ b/hosts/razer/nixos/memory.nix
@@ -10,10 +10,24 @@
     "vm.max_map_count" = 262144; # For applications that use many memory mappings
   };
 
-  # Create a larger /tmp on tmpfs - using updated option names
+  # /tmp on disk, not in RAM.
+  #
+  # This was a 16G tmpfs, which is a quarter of this laptop's memory handed to
+  # a build directory -- and nix builds in $TMPDIR, so a large rebuild both
+  # fills it and eats the RAM it was meant to leave free. p620 hit exactly that
+  # twice (#1635): the failure reads as a full disk while `df /` reports
+  # hundreds of gigabytes free, because the thing that filled is RAM.
+  #
+  # / is a 938G NVMe with 460G+ free. cleanOnBoot restores the clear-on-restart
+  # behaviour tmpfs gave for free -- it was off here because tmpfs made it
+  # redundant, and on disk it is not.
+  #
+  # razer builds through p620 (`just deploy-via-p620 razer`) so it rarely
+  # unpacks the big derivations itself, which is why this never bit here. That
+  # is a habit, not a guarantee.
   boot.tmp = {
-    useTmpfs = true; # Previously boot.tmpOnTmpfs
-    tmpfsSize = "16G"; # Previously boot.tmpOnTmpfsSize
+    useTmpfs = false;
+    cleanOnBoot = true;
   };
 
   # Optional: zram for better memory management


### PR DESCRIPTION
razer carried the same 16 GB tmpfs `/tmp` that cost p620 two failed rebuilds tonight (#1635, #1636, #1644). On a 62 GB laptop that reserves a **quarter of memory** for a build directory — and since nix builds in `$TMPDIR`, a large rebuild both fills it and eats the RAM it was meant to leave free. The failure mode is the confusing one: ENOSPC while `df /` reports hundreds of gigabytes free, because what filled was RAM.

It never bit here only because razer builds through p620 (`just deploy-via-p620 razer`) and rarely unpacks the big derivations itself. That's a habit, not a guarantee.

## Checked for the mistake I made on p620

p620's fix failed the first time because **two** subsystems declared `/tmp` and I changed the losing one, silently shrinking it 32 → 16 GB. So I enumerated them here before touching anything:

```
boot.tmp            → { useTmpfs = true; tmpfsSize = "16G"; cleanOnBoot = false; }
fileSystems."/tmp"  → not declared
```

Only one declaration, so `useTmpfs = false` genuinely takes effect. After the change:

```
boot.tmp            → { useTmpfs = false; cleanOnBoot = true; }
fileSystems."/tmp"  → not declared - /tmp lands on / (correct)
<newsystem>/etc/fstab → no /tmp line
nix build …razer…toplevel → NIX_EXIT=0
```

`cleanOnBoot` goes on because tmpfs was providing clear-on-restart for free and disk isn't.

`/` on razer: 938 GB, **464 GB free**.

Takes effect at razer's next reboot — a live `switch` would try to unmount `/tmp` under the running session, which is what broke D-Bus on p620.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB