### PR TITLE
feat(omarchy): add psmisc for `fuser`, needed by shell plugins

### DIFF
--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -77,7 +77,11 @@
   # so a value set here is preserved and searched. systemPackages is what puts
   # the multimedia backend under /run/current-system/sw/lib/qt-6/plugins, which
   # QT_PLUGIN_PATH already covers; only the QML path needs saying out loud.
-  environment.systemPackages = [ pkgs.qt6.qtmultimedia ];
+  # psmisc is here for `fuser`, which Omarchy shell plugins call to find who
+  # holds a lock or a device -- omachord's routine runner needs it and nothing
+  # else in the closure pulls psmisc in, so the plugin fails at runtime rather
+  # than at install with a message about a missing binary.
+  environment.systemPackages = [ pkgs.qt6.qtmultimedia pkgs.psmisc ];
   environment.sessionVariables.NIXPKGS_QT6_QML_IMPORT_PATH =
     "${pkgs.qt6.qtmultimedia}/lib/qt-6/qml";
 

--- a/hosts/razer/nixos/nixarchy.nix
+++ b/hosts/razer/nixos/nixarchy.nix
@@ -38,6 +38,13 @@
   # it the session starts but never sees a keypress.
   programs.nixarchy.user = "olafkfreund";
 
+  # psmisc is here for `fuser`, which Omarchy shell plugins call to find who
+  # holds a lock or a device -- omachord's routine runner needs it and nothing
+  # else in the closure pulls psmisc in, so the plugin fails at runtime rather
+  # than at install with a message about a missing binary. p620 carries the
+  # same line for the same reason.
+  environment.systemPackages = [ pkgs.psmisc ];
+
   # nixarchy pins its own Hyprland and does not defer -- nixpkgs defines
   # programs.hyprland.portalPackage at mkDefault priority, so matching it would
   # tie rather than yield, hence the force.


### PR DESCRIPTION
Groundwork for [anothaDev/omachord](https://github.com/anothaDev/omachord), a shortcut/routine composer plugin for the Omarchy shell.

It lists `fuser` among its runtime requirements and **nothing in either closure pulls `psmisc` in**:

```
p620   fuser: MISSING
razer  fuser: MISSING
```

So the plugin would install cleanly with `omarchy plugin add` and then fail at runtime — the worst place to find out a binary is absent.

## Placement

Declared next to `qt6.qtmultimedia` on p620, which is there for the same class of reason: a session runtime dependency the desktop needs and the package set doesn't imply. razer gains its first `systemPackages` entry in this file for the same purpose.

Deliberately **not** a new shared module — one package doesn't warrant `hosts/common/nixos/omarchy-shell-tools.nix`, and both files already carry per-host session deps with an explanatory comment.

## This does not make omachord work

Being explicit, because it would be easy to read this PR as "omachord is now installable". It isn't:

| Requirement | Have |
|---|---|
| Omarchy **4.0.2** | 4.0.1 |
| Hyprland **0.56.2** | 0.56.0 |
| Quickshell 0.3.1 | 0.3.1 ✅ |
| `fuser` | **this PR** ✅ |

Both version bounds are pinned in nixarchy's `flake.nix` (`basecamp/omarchy/v4.0.1`, Hyprland commit `0bd11c7a`), not in this repo — so clearing them means a nixarchy bump, not a change here. Hyprland 0.56.2 is already in nixpkgs, so it's a pin rather than an availability problem.

Whether those bounds are real or conservative is untested. This removes the one blocker that is ours to remove.

## Verification

```
nix eval …{p620,razer}.config.environment.systemPackages   → psmisc present (both)
nix build …{p620,razer}.config.system.build.toplevel       → NIX_EXIT=0 (both)
test -e <newsystem>/sw/bin/fuser                            → present (both)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB