### PR TITLE
fix(mcp): restore the ~/.claude.json reconciliation lost from main (#1642)

### DIFF
--- a/home/development/claude-code-mcp.nix
+++ b/home/development/claude-code-mcp.nix
@@ -268,6 +268,58 @@ in
       fi
     '';
 
+    # Reconcile the shared MCP servers into ~/.claude.json on every activation.
+    #
+    # This exists because the seed above no longer reaches Claude Code. It
+    # writes ~/.claude/settings.local.json, and Claude Code reads its MCP
+    # servers from ~/.claude.json -- a different file, one directory up. On
+    # p620 the seeded file holds zero servers while ~/.claude.json holds
+    # fifteen, so anything added to the Nix template alone lands nowhere.
+    #
+    # Merge rather than seed, because that file is Claude Code's: it rewrites
+    # it constantly (accepted permissions, `claude mcp add`, caches). Adding
+    # one key and leaving the rest untouched is the only safe edit. It is also
+    # idempotent and self-healing -- if the entry is deleted or its URL drifts,
+    # the next rebuild puts it back.
+    #
+    # Per-host on purpose: syncthing replicates ~/.claude/, and ~/.claude.json
+    # sits beside that directory rather than inside it, so every host has to be
+    # told separately. This is what does the telling.
+    home.activation.claudeSharedMcpServers = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      target="$HOME/.claude.json"
+      desired=${
+        pkgs.writeText "claude-shared-mcp.json" (builtins.toJSON {
+          mcpServers = {
+            agent-bus = {
+              type = "sse";
+              url = "http://p510:3013/sse";
+            };
+          };
+        })
+      }
+
+      if [ ! -e "$target" ]; then
+        $DRY_RUN_CMD install -m 0600 "$desired" "$target"
+      else
+        # `*` deep-merges with the right-hand side winning, so the declared
+        # entries are corrected and every other key is carried through.
+        if ! ${pkgs.jq}/bin/jq -e --slurpfile d "$desired" \
+             '.mcpServers as $m | ($d[0].mcpServers | to_entries | all(.value == $m[.key]))' \
+             "$target" >/dev/null 2>&1; then
+          tmp=$(mktemp)
+          if ${pkgs.jq}/bin/jq -s '.[0] * .[1]' "$target" "$desired" > "$tmp" 2>/dev/null \
+             && [ -s "$tmp" ]; then
+            $DRY_RUN_CMD cp --preserve=mode "$target" "$target.bak"
+            $DRY_RUN_CMD mv "$tmp" "$target"
+            $DRY_RUN_CMD echo "Reconciled shared MCP servers into $target"
+          else
+            rm -f "$tmp"
+            $DRY_RUN_CMD echo "WARNING: could not merge MCP servers into $target; left unchanged"
+          fi
+        fi
+      fi
+    '';
+
     # Documentation file: Claude Code never reads it, never writes it,
     # so a nix-store symlink is fine.
     home.file.".claude/MCP-README.md".text = ''


### PR DESCRIPTION
Restores the change from #1658, which merged and then vanished from `main`.

## What happened

#1658 merged at 08:17. A `chore(flake): bump all` commit landed on `main` afterwards and **replaced** the squash commit rather than building on it — local and remote ended up one commit apart in each direction, and the reconciliation was gone from the remote tree:

```
git show origin/main:home/development/claude-code-mcp.nix    | grep -c claudeSharedMcpServers → 0
git show origin/main:home/development/claude-code-skills/... | grep -c agent-bus              → 2
```

The skill (merged earlier in #1654) survived; the MCP reconciliation did not. That is the `nhs` divergence pattern — it commits a lock bump straight to `main`, and work landing in the same window can be swept out with it.

This branch is the original commit rebased onto the current `origin/main`, sitting on top of the flake bump rather than competing with it.

## What it does, unchanged from #1658

An activation entry that merges the shared MCP servers into `~/.claude.json` — the file Claude Code actually reads — rather than `~/.claude/settings.local.json`, which the Nix template seeds and which Claude Code does not consult for MCP servers (p620: 15 servers in the former, 0 in the latter).

Merge rather than seed, because Claude Code owns that file and rewrites it constantly. Idempotent and self-healing: a `jq -e` guard skips when the entries already match, and deleting the entry or drifting its URL is repaired on the next rebuild.

## Verification

Rebuilt against the **new** nixpkgs from the bump, not the old one:

```
nix build …p620…toplevel → NIX_EXIT=0
```

The mechanism is already proven live — the deploy from #1658 ran before the loss and did exactly what it should:

```
before: 15 servers, agent-bus: False
after : 16 servers, agent-bus: {'type':'sse','url':'http://p510:3013/sse'}
```

p620 therefore already has the entry; this restores the *declaration* so razer, p510 and every future rebuild get it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWnRHxqQDh3a5i6ZjZmNsB