### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1736,11 +1736,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788421645,
-        "narHash": "sha256-G9aE5H0ThKvB5qydt+0ATuYzwyQiDn0MB8G/Q7dKkJ8=",
+        "lastModified": 1788424128,
+        "narHash": "sha256-jZ6O/wuEYdxWsz0GCwcoGwhwNU55S/30rcUeJohxu6U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "661f90b06ec60a673e8941ad941bc8be96847f6f",
+        "rev": "6f05965b5868d1eb911756da4109a7c1443c1eba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=p620, scope=all).

Built and verified locally against nixosConfigurations.p620 before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)