### PR TITLE
feat(agents): require announcing on the bus before disrupting a shared host

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,13 @@ Home Manager profiles live in `home/profiles/{developer,server-admin}`. Home Man
    `builtins.readFile` a secret; that puts it in the Nix store.
 4. **No `mkIf cond true`** — assign the boolean directly.
 5. **Explicit imports only** — no `readDir` auto-discovery.
+6. **Announce before you disrupt a shared host.** Several agents work these
+   machines at once. Before a deploy, a garbage collection, a store optimise, a
+   service restart or a reboot: `read_new("#agents:freundcloud.org.uk")` to see
+   whether anyone has a job in flight, `post` what you are about to do and
+   roughly how long it will take, then rerun with `AGENT_BUS_ANNOUNCED=1`.
+   A PreToolUse hook enforces this — see `modules/programs/claude-code-managed.nix`.
+   If the bus says someone else is mid-flight, wait or ask rather than proceeding.
 
 ## Module shape
 

--- a/home/development/claude-code-skills/agent-bus/SKILL.md
+++ b/home/development/claude-code-skills/agent-bus/SKILL.md
@@ -55,6 +55,24 @@ useful question is "what did I miss", and that is the one `read_new` answers.
 - **When something surprises you.** If a build fails in a way that makes no
   sense, check whether it has already made no sense to someone else.
 
+## Announce before you disrupt a shared host
+
+This is a rule, not a suggestion, and a PreToolUse hook enforces it. Before a
+deploy, a garbage collection, a store optimise, a service restart or a reboot:
+
+1. `read_new` the room — is anyone mid-flight on that machine?
+2. `post` what you are about to do, on which host, and roughly how long.
+3. Rerun the command with `AGENT_BUS_ANNOUNCED=1` prefixed.
+
+If someone else has a job running, wait or ask the user. Proceeding anyway is
+the thing this exists to prevent: one night saw a deploy restart logind and
+take a desktop session with it, a garbage collection run against a disk a CI
+VM test was building on, and a daemon restart land mid-build — each
+individually reasonable, each breaking work someone else had in flight.
+
+Read-only work needs no announcement: `nix build`, `systemctl status`, `just
+validate`, plain ssh.
+
 ## What is worth posting
 
 The board is only as good as what goes into it.

--- a/modules/programs/claude-code-managed.nix
+++ b/modules/programs/claude-code-managed.nix
@@ -286,6 +286,80 @@ let
     exit 0
   '';
 
+  # Announce-before-you-disrupt, enforced rather than remembered.
+  #
+  # Several agents work these machines at once, and tonight three of them
+  # collided: a deploy restarted logind and took a desktop session with it, a
+  # garbage collection ran against a disk a CI VM test was building on, and a
+  # daemon restart landed mid-build. Each was individually reasonable and each
+  # broke work someone else had in flight.
+  #
+  # The convention "say what you are about to do, and look whether anyone
+  # objects" is the fix, and the p510 guard below is the proof that a
+  # convention needs a mechanism: it held only as long as the model remembered
+  # it. So this is the same shape -- PreToolUse can veto, exit 2 denies and
+  # hands the reason back to the model, which then has the bus tools to do the
+  # announcing with.
+  #
+  # It is a prompt, not a wall. AGENT_BUS_ANNOUNCED=1 in the command clears it,
+  # which an agent sets *after* posting. That is deliberate: these are our own
+  # agents, so the goal is a reliable interruption at the right moment rather
+  # than a control someone has to defeat. Anyone who sets the variable without
+  # posting has decided to, which is different from forgetting.
+  #
+  # Read-only inspection stays frictionless -- `nix build`, `systemctl status`,
+  # plain ssh -- and the user's own shell is untouched.
+  busAnnounceScript = pkgs.writeShellScript "claude-bus-announce-guard.sh" ''
+    payload="$(cat)"
+    cmd="$(${pkgs.jq}/bin/jq -r '.tool_input.command // empty' <<<"$payload" 2>/dev/null)"
+    [ -n "$cmd" ] || exit 0
+
+    # The agent's own escape hatch, set after it has posted.
+    case "$cmd" in *AGENT_BUS_ANNOUNCED=1*) exit 0 ;; esac
+
+    # Activating a generation, reclaiming disk, restarting shared services, or
+    # taking a machine down. Note `nix build` and `systemctl status` are absent
+    # on purpose.
+    disruptive='nixos-rebuild[[:space:]]+[^|;]*(switch|boot|test)'
+    disruptive="$disruptive"'|nh[[:space:]]+os[[:space:]]+(switch|boot|test)'
+    disruptive="$disruptive"'|(^|[[:space:]])nhs([[:space:]]|$)'
+    # `just deploy-*` and also `just <host>`: the deploy recipes here are
+    # named after the machine (`just p510`), so a deploy-only pattern misses
+    # the most common way anyone actually deploys.
+    disruptive="$disruptive"'|just[[:space:]]+[a-z-]*deploy'
+    disruptive="$disruptive"'|just[[:space:]]+(p510|p620|razer)([[:space:]]|$)'
+    disruptive="$disruptive"'|nix-collect-garbage|nix[[:space:]]+store[[:space:]]+optimise'
+    disruptive="$disruptive"'|systemctl[[:space:]]+[^|;]*(restart|stop)'
+    disruptive="$disruptive"'|(^|[[:space:]])(reboot|poweroff|shutdown)([[:space:]]|$)'
+
+    if printf '%s' "$cmd" | ${pkgs.gnugrep}/bin/grep -qE "($disruptive)"; then
+      echo "BLOCKED: this would disrupt a host other agents may be working on." >&2
+      echo "" >&2
+      echo "Before running it:" >&2
+      echo "  1. read_new(\"#agents:freundcloud.org.uk\") -- check whether anyone has" >&2
+      echo "     claimed this host or has a long job in flight." >&2
+      echo "  2. post(...) what you are about to do, on which host, and roughly" >&2
+      echo "     how long it will take." >&2
+      echo "  3. rerun with AGENT_BUS_ANNOUNCED=1 prefixed." >&2
+      echo "" >&2
+      echo "If the bus says someone else is mid-flight, wait or ask the user" >&2
+      echo "rather than proceeding -- that is the whole point of checking." >&2
+      exit 2
+    fi
+    exit 0
+  '';
+
+  busAnnounceHooks = lib.optionalAttrs cfg.busAnnounceGuard.enable {
+    PreToolUse = [{
+      matcher = "Bash";
+      hooks = [{
+        type = "command";
+        command = toString busAnnounceScript;
+        timeout = 5;
+      }];
+    }];
+  };
+
   deployGuardHooks = lib.optionalAttrs cfg.deployGuard.enable {
     PreToolUse = [{
       matcher = "Bash";
@@ -432,6 +506,7 @@ let
         notifyHooks
         formatHooks
         deployGuardHooks
+        busAnnounceHooks
         subagentHooks
         tmuxCcmHooks
       ];
@@ -514,6 +589,24 @@ in
 
         Building (`nix build .#nixosConfigurations.p510...`) and read-only ssh
         are unaffected, as is the user's own interactive shell.
+      '';
+    };
+
+    busAnnounceGuard.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Require an agent to announce on the agent bus before running a command
+        that disrupts a shared host -- deploys, garbage collection, store
+        optimise, service restarts, reboots.
+
+        Denies the call with instructions rather than silently allowing it, so
+        the rule holds whether or not the model remembers it. The agent posts
+        its intent with the bus MCP tools, then reruns with
+        AGENT_BUS_ANNOUNCED=1.
+
+        Read-only work is unaffected: `nix build`, `systemctl status` and plain
+        ssh never match, and the user's own interactive shell is untouched.
       '';
     };
 


### PR DESCRIPTION
A rule that agents actually obey, rather than one they remember.

## Why

Several agents work these machines at once. In one night three of them collided:

- a deploy restarted `logind` and took a desktop session with it
- a garbage collection ran against a disk a CI VM test was building on
- a daemon restart landed mid-build

Each was individually reasonable. Each broke work someone else had in flight.

## The mechanism, and why it isn't just documentation

The deploy guard alongside this makes the argument itself:

> The standing rule … **until now lived only in CLAUDE.md and agent memory — i.e. it held only as long as the model remembered it.** PreToolUse can veto a call, so this turns the convention into an actual guardrail.

Same shape here. `PreToolUse` vetoes, `exit 2` hands the reason back to the model, and the model already has the bus MCP tools to do the announcing with:

```
BLOCKED: this would disrupt a host other agents may be working on.

Before running it:
  1. read_new("#agents:freundcloud.org.uk") -- check whether anyone has
     claimed this host or has a long job in flight.
  2. post(...) what you are about to do, on which host, and roughly
     how long it will take.
  3. rerun with AGENT_BUS_ANNOUNCED=1 prefixed.
```

## A prompt, not a wall

`AGENT_BUS_ANNOUNCED=1` clears it, set *after* posting. Deliberate: these are our own agents, so the goal is a reliable interruption at the right moment rather than a control someone has to defeat. Setting the variable without posting is a decision; forgetting is not.

## Verified against the built script

| Command | |
|---|---|
| the three host deploy recipes | **BLOCKED** |
| `nhs` | **BLOCKED** |
| `sudo reboot` | **BLOCKED** |
| `nix-collect-garbage -d`, `nix store optimise` | **BLOCKED** |
| `systemctl restart …` | **BLOCKED** |
| announced form (`AGENT_BUS_ANNOUNCED=1 …`) | allowed |
| `nix build …`, `validate`, `test-host`, `systemctl status`, plain ssh | allowed |

Testing caught a real bug: the first pattern matched `just *deploy` and missed `just <host>`, which is how deploys actually happen in this repo.

## Also

`CLAUDE.md` rule 6 and the `agent-bus` skill both state the rule, so an agent knows *why* it was stopped rather than only *that* it was.

## One thing worth knowing

The existing p510 guard matches on the whole command string, so it blocks a `git commit` whose **message merely mentions** deploying that host — it stopped this PR's own commit twice. Harmless but surprising; worth a follow-up if it becomes annoying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)