### PR TITLE
fix(desktop): install the share picker Omarchy's config asks for

### DIFF
--- a/hosts/common/nixos/omarchy-sole-hyprland.nix
+++ b/hosts/common/nixos/omarchy-sole-hyprland.nix
@@ -72,7 +72,23 @@ in
   # different versions (0.56.0 vs 0.56.2) and it is the nixarchy one the
   # session script runs, so a mismatched start-hyprland and compositor is
   # exactly what we would be reintroducing.
-  environment.systemPackages = [ hyprland ];
+  # hyprland-preview-share-picker is the share picker Omarchy's own config
+  # asks for. It seeds ~/.config/hypr/xdph.conf with
+  #   custom_picker_binary = hyprland-preview-share-picker
+  # and lists that binary in share/omarchy/install/omarchy-base.packages --
+  # its *Arch* list, which pacman installs and which nothing consumes here. So
+  # the config shipped pointing at a binary nothing provided: the portal ran a
+  # command that did not exist, the picker returned selection -1, and the
+  # session was destroyed before any dialog appeared.
+  #
+  # From the application's side that is indistinguishable from screen sharing
+  # simply not working -- Teams, Chrome, anything using ScreenCast got nothing
+  # and no error. The tell is in the portal log:
+  #   xdg-desktop-portal-hyprland: [screencopy] SHAREDATA returned selection -1
+  #
+  # Install the picker rather than edit the seeded config: the config is
+  # upstream's and would come back on the next Omarchy bump.
+  environment.systemPackages = [ hyprland pkgs.hyprland-preview-share-picker ];
   environment.pathsToLink = [ "/share/hypr" ];
 
   # cap_sys_nice, as programs.hyprland sets it. /run/wrappers/bin precedes the


### PR DESCRIPTION
Screen sharing has been silently broken on **every host running the Omarchy session**. Teams, Chrome, anything using ScreenCast got nothing — no dialog, no error, just a share that never starts.

## Root cause

Omarchy seeds `~/.config/hypr/xdph.conf` with:

```
screencopy {
    allow_token_by_default = true
    custom_picker_binary = hyprland-preview-share-picker
}
```

and lists that binary in `share/omarchy/install/omarchy-base.packages` — its **Arch** package list. On Arch, pacman installs it and config and binary arrive together. Here nothing consumes that list, so the config shipped pointing at a binary nothing provided.

The portal ran a command that did not exist, the picker returned no selection, and the session was torn down before any dialog appeared:

```
xdg-desktop-portal-hyprland: [screencopy] restore data invalid / missing, prompting
xdg-desktop-portal-hyprland: [screencopy] SHAREDATA returned selection -1
xdg-desktop-portal-hyprland: [screencopy] Session destroyed
```

**Everything else in the chain was already correct**, which is why this hid so well — the app launches with `WebRTCPipeWireCapturer`, the portal offers `ScreenCast` v6, routing reaches the hyprland backend, and the backend prompts. Only the picker was missing.

## Provenance

Not from this repo. The live `~/.config/hypr/xdph.conf` is a **verbatim copy** of the one in the omarchy package, seeded on first login and dated 28 Aug. Checked nixarchy at the pinned revision (`2010ff3`): it has no `xdph.conf` and no reference to `custom_picker_binary`. The config is upstream Omarchy's, vendored by nixarchy, with the dependency never translated into a Nix package.

Worth reporting upstream — it will affect any NixOS user of the Omarchy session.

## Fix

Install `hyprland-preview-share-picker` (nixpkgs 0.2.1) in `hosts/common/nixos/omarchy-sole-hyprland.nix`, which all three hosts import — the same file that already exists to keep ScreenCast routing correct.

Installing the picker rather than editing the seeded config, because the config is upstream's and would return on the next Omarchy bump.

Added to the file's existing `environment.systemPackages` list rather than a second assignment — a second one is an eval error (`attribute 'environment.systemPackages' already defined`), which the first attempt hit.

## Verification

```
nix eval …{p620,razer,p510}…environment.systemPackages → picker present ✓ on all three
nix build …{p620,razer}…toplevel                       → NIX_EXIT=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)