### PR TITLE
fix(agent-bus): join the room in read_new instead of waiting for a 403 (#1665)

### DIFF
--- a/pkgs/agent-bus-mcp/agent_bus_mcp.py
+++ b/pkgs/agent-bus-mcp/agent_bus_mcp.py
@@ -356,13 +356,12 @@ def read_new(
         cursor = _get_cursor(name, room_id)
         if cursor:
             params["from"] = cursor
-        r = _retry_joined(
-            client,
-            room_id,
-            lambda: client.get(
-                f"/rooms/{quote(room_id, safe='')}/messages", params=params
-            ),
-        )
+        # Join up front rather than reacting to a 403: /messages answers a
+        # non-member with 200 and an empty chunk, so _retry_joined never fires
+        # and a session that reads before it posts sees an empty room forever.
+        # /join is idempotent, so this costs one call and nothing else.
+        _join(client, room_id)
+        r = client.get(f"/rooms/{quote(room_id, safe='')}/messages", params=params)
         r.raise_for_status()
         payload = r.json()
 

--- a/pkgs/agent-bus-mcp/test_agent_bus_mcp.py
+++ b/pkgs/agent-bus-mcp/test_agent_bus_mcp.py
@@ -132,4 +132,27 @@ with tempfile.TemporaryDirectory() as tmp:
     os.environ["AGENT_BUS_NAME"] = "codex-p620"
     assert m._session_name() == "codex-p620"
 
+    # --- read_new joins ---------------------------------------------------
+    # The bug this guards: /messages answers a non-member with 200 and an empty
+    # chunk, not 403, so a join that only reacts to 403 never happens and every
+    # fresh session reads an empty room forever while the room is in fact busy.
+    import httpx
+
+    seen = []
+
+    def handler(request):
+        seen.append(request.url.path)
+        if "/directory/room/" in request.url.path:
+            return httpx.Response(200, json={"room_id": "!r:example.org"})
+        if "/join/" in request.url.path:
+            return httpx.Response(200, json={"room_id": "!r:example.org"})
+        return httpx.Response(200, json={"chunk": [], "end": "t1"})
+
+    m._client = lambda name: httpx.Client(
+        base_url="http://x/_matrix/client/v3",
+        transport=httpx.MockTransport(handler),
+    )
+    m.read_new("#agents:example.org")
+    assert any("/join/" in path for path in seen), seen
+
 print("agent-bus-mcp self-check passed", file=sys.stderr)


### PR DESCRIPTION
Fixes #1665.

`read_new` reported `nothing new in #agents` to any session that had not posted
first, and `list_rooms` returned `[]` — indistinguishable from a dead room. The
room was busy: 16 messages from five sessions across p510 and p620, plus an
unanswered question from a human.

`_retry_joined` only joins on a **403**, but `/messages` answers a **non-member**
with **200 and an empty chunk**. The join never happened, and the empty chunk was
reported as "nothing new". `post` does 403 on send and joins correctly — hence the
selection effect where sessions that posted worked and sessions that only read gave
up.

Join up front in `read_new`; `/join` is idempotent.

The regression check uses an `httpx.MockTransport` answering 200-empty, because that
is precisely the response the old code could not tell apart from an empty room.
Reverting the fix makes it fail with the observed call sequence:

```
['/_matrix/client/v3/directory/room/#agents:example.org',
 '/_matrix/client/v3/rooms/!r:example.org/messages']
```

Note for deployers: this only takes effect after a rebuild **and** a Claude Code
restart, since MCP servers are read at session start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
