### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -746,11 +746,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788392868,
-        "narHash": "sha256-Sp4H0E/QnQJoCVKgYg588QxNwFfUfV4AeU1HLuoBI7U=",
+        "lastModified": 1788457422,
+        "narHash": "sha256-PZklH2jf24HGHrczgc0Tlvnkh0PJjqSxNRdEDN2xCXE=",
         "owner": "ogulcancelik",
         "repo": "herdr",
-        "rev": "94f6d9c0d9bb9cf9ffae99d8bbfb09e9bf2fc9e0",
+        "rev": "b07ba9ced8b57099f038bc633ed1c9a5f5b3a1ed",
         "type": "github"
       },
       "original": {
@@ -787,11 +787,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788355065,
-        "narHash": "sha256-gAz5oTI7ur34CfuakQduiQd/2ZhO62Bn2XXg08nZYYQ=",
+        "lastModified": 1788458226,
+        "narHash": "sha256-UZTAlg8iKVEmyEXakzKmukrzFIKrXezYsRy9vajDrGw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d9d750e4fc11c10cab2da677bdd31e427f3a3a71",
+        "rev": "aa308770461dcf22c333a5e8a31c8bddbde5bee9",
         "type": "github"
       },
       "original": {
@@ -1302,11 +1302,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1788263502,
-        "narHash": "sha256-gyVqW5U9wy6A8voJNu6SiSYTKDplo/MDl31x7FszWlk=",
+        "lastModified": 1788434898,
+        "narHash": "sha256-9qRL95WUxlCae3U2hxbs1XmBaRkylKYqPN8QLzqnB2s=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "974d315e504e666eac4920d712e3ff6804dc1502",
+        "rev": "a6de5fa67cf18d733063894512f88157937de4dc",
         "type": "github"
       },
       "original": {
@@ -1387,11 +1387,11 @@
         "zen-browser": "zen-browser"
       },
       "locked": {
-        "lastModified": 1788390024,
-        "narHash": "sha256-ib38ReBn0mqPPmzBcpSV3S8H0zwh7UEUNL+VrrfXw2g=",
+        "lastModified": 1788464918,
+        "narHash": "sha256-N7QDq1A/M8wIH0qoMdtQIuBHELHB9X+ZrPwcHcAzaps=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "2010ff30b31496b5f76b9cadfc8590134d26f325",
+        "rev": "1e784782a23e83ba9a1f6accc21cd87b40b1e99c",
         "type": "github"
       },
       "original": {
@@ -1736,11 +1736,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788425621,
-        "narHash": "sha256-AemswQSHmnl1HQYKn+9stVJrk7xOnKDqst6+33OFzyU=",
+        "lastModified": 1788463104,
+        "narHash": "sha256-sofZL03roVC4gBoVila0xh7oOFGgEKIeAV6/SB+i4jY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d98759356aba818db7509c8b6d3f67b455767f39",
+        "rev": "54ad86dbb5be5be10d0b44d30130f01b9e2bebe0",
         "type": "github"
       },
       "original": {
@@ -1777,16 +1777,16 @@
     "omarchy": {
       "flake": false,
       "locked": {
-        "lastModified": 1787652758,
-        "narHash": "sha256-dj3etcMp2lpIP2pPvub2tiXFbZYMWl6RDeCHtTEksek=",
+        "lastModified": 1788130066,
+        "narHash": "sha256-DtaDI3gyvK7YVnul2vRmNHHGK86Hn64WfbAVeG4888Y=",
         "owner": "basecamp",
         "repo": "omarchy",
-        "rev": "13f18b2cb7286fb54f87daf571a031aa6af3d8f0",
+        "rev": "346e69e1cec6c4e8924531874af6ba010a1bc99e",
         "type": "github"
       },
       "original": {
         "owner": "basecamp",
-        "ref": "v4.0.1",
+        "ref": "v4.0.2",
         "repo": "omarchy",
         "type": "github"
       }
@@ -1975,11 +1975,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788419040,
-        "narHash": "sha256-Itdv4WV5z+U0VpseZ/f4uvYmULVPxsV3Hc2l9HrCyY4=",
+        "lastModified": 1788456718,
+        "narHash": "sha256-TxHC0sBjV2pmsBLKAX02JTXlye/EOLt6Do+WNtGofGw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1af4dd0db58d4adde06f0840ce28da90f9c66c50",
+        "rev": "0b20a18e84d9164464739189c2b2a1b00f6f0e4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=razer, scope=all).

Built and verified locally against nixosConfigurations.razer before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)