### PR TITLE
fix(desktop): stop razer forcing GNOME portals into the Hyprland session (#1668)

### DIFF
--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -150,13 +150,6 @@ in
     autoInstall = true;
   };
 
-  # Enable XDG portal for GNOME screen sharing
-  modules.services.xdg-portal = {
-    enable = true;
-    backend = "gnome";
-    enableScreencast = true;
-  };
-
   # Use the new features system instead of multiple lib.mkForce calls
   features = {
     development = {


### PR DESCRIPTION
Fixes #1668.

The `GDK backend forced via env var` warning on razer was a symptom, not the disease.
All three hosts share the same `GDK_BACKEND=wayland,x11,*` (set upstream by Omarchy),
yet only razer warned — because the warning requires `xdg-desktop-portal-gnome` to be
*running*, and only razer routed portals to GNOME.

razer uniquely enabled `modules.services.xdg-portal` with `backend = "gnome"`, a
leftover from its GNOME days. That writes `/etc/xdg/xdg-desktop-portal/portals.conf`
(`default=gnome;gtk`), and since xdg-desktop-portal searches `/etc/xdg` before
`$XDG_DATA_DIRS`, it outranked the `hyprland-portals.conf` that
`omarchy-sole-hyprland.nix` deliberately supplies — the very file whose comment warns
that losing it is "the classic screen-sharing failure on this machine".

## Verification

- `/etc/xdg/xdg-desktop-portal/` is absent from the newly built razer system, as it
  already is on p620
- `xdg.portal.config` evaluates to `{ }` on p620, p510 **and** razer now
- `xdg.portal.enable` still true; `configPackages = [ hyprland gnome-session ]`, so
  `hyprland-portals.conf` routes ScreenCast under `XDG_CURRENT_DESKTOP=Hyprland`

## Note

`modules/services/xserver/xdg-portal.nix` writes
`"org.freedesktop.impl.portal.Screencast"` (lowercase `c`; the interface is
`ScreenCast`), so that line has never had any effect. With this change no host uses
the module at all — worth deciding separately whether to delete it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
