### PR TITLE
feat(desktop): add whisper-cpp to p620 and razer for nixi voice input (#1670)

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -645,6 +645,10 @@ in
     vim
     wally-cli
     nix-doc # Interactive Nix documentation tool
+    # whisper-cli, for nixi's local push-to-talk transcription. Also ships
+    # whisper-cpp-download-ggml-model, which fetches the model nixi expects
+    # at ~/.local/share/nixi/models/ggml-base.en.bin.
+    whisper-cpp
     customPkgs.rmux # Rust tmux-compatible multiplexer + typed SDK for agent orchestration
     # Remote desktop
     rustdesk-flutter

--- a/hosts/razer/configuration.nix
+++ b/hosts/razer/configuration.nix
@@ -562,6 +562,10 @@ in
       # qwen-code disabled due to npm registry network errors (HTTP/2 framing layer issue)
       # (callPackage ../../home/development/qwen-code/default.nix { })
       nix-doc # Interactive Nix documentation tool
+      # whisper-cli, for nixi's local push-to-talk transcription. Also ships
+      # whisper-cpp-download-ggml-model, which fetches the model nixi expects
+      # at ~/.local/share/nixi/models/ggml-base.en.bin.
+      whisper-cpp
       customPkgs.rmux # Rust tmux-compatible multiplexer + typed SDK for agent orchestration
       # Remote desktop
       rustdesk-flutter


### PR DESCRIPTION
Fixes #1670.

nixi 0.9.7 ships push-to-talk voice input but it has been inert since the update —
`whisper-cli` was not installed on either host.

`whisper-cpp` 1.9.2 provides `whisper-cli` and `whisper-cpp-download-ggml-model`.
`pw-record` already comes from PipeWire.

## Verification

- Both toplevels build; `sw/bin/whisper-cli` present on p620 and razer
- p510's toplevel verified **not** to contain it
- nixi's unit PATH already includes `/run/current-system/sw/bin`, so a system package
  is sufficient — no Home Manager change

## Follow-up not included

The model is a runtime download, so it cannot be declared here. One command per host
after deploy:

```
mkdir -p ~/.local/share/nixi/models && \
  whisper-cpp-download-ggml-model base.en ~/.local/share/nixi/models
```

nixi's own `nix/hm-module.nix` (`services.nixi.voice.enable`) would wire the model
path declaratively; that is a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
