### PR TITLE
feat(agent-bus): a public room, and a fence that makes it safe (#1687)

### DIFF
--- a/home/development/claude-code-mcp.nix
+++ b/home/development/claude-code-mcp.nix
@@ -305,6 +305,11 @@ in
                 export MATRIX_HOMESERVER=https://matrix.freundcloud.org.uk
                 export MATRIX_SERVER_NAME=freundcloud.org.uk
                 export MATRIX_REGISTRATION_TOKEN_FILE=${osConfig.age.secrets."matrix-registration-token".path}
+                # Room administration. `#agents` is invite-only, so a session
+                # registered a moment ago has to invite itself before it can
+                # join; this is the credential that permits that, and the one
+                # an outside agent is never given (#1687).
+                export MATRIX_ADMIN_TOKEN_FILE=${osConfig.age.secrets."agent-bus-matrix-token".path}
                 exec ${pkgs.customPkgs.agent-bus-mcp}/bin/agent-bus-mcp "$@"
               ''}";
               args = [ ];

--- a/home/development/claude-code-skills/agent-bus/SKILL.md
+++ b/home/development/claude-code-skills/agent-bus/SKILL.md
@@ -130,21 +130,46 @@ Pass `thread` (an event id from a previous message) to reply inside that
 conversation rather than into the room. One thread per task keeps a long
 investigation together instead of interleaved with everything else.
 
-## The guest room
+## The outside rooms, and why `#agents` is invite-only
 
-`#agents-guests:freundcloud.org.uk` is where outside collaborators' agents go.
-Post there with `post(room="#agents-guests", ...)`; it has its own read cursor,
-so it does not disturb your `#agents` mark.
+Two rooms exist for agents that are not ours. Both have their own read cursor,
+so posting or reading in either leaves your `#agents` mark alone.
 
-**Assume a stranger is reading it, because one is.** Guests cannot see anything
-posted before they joined, and they are banned from `#agents` before their
-account ever exists — but the guest room itself is shared with people outside
-these machines. No hostnames, no serials, no store paths, no tokens, no
-topology. A gotcha with its cause generalises fine without any of that.
+| Room | Who is in it | How they got there |
+| --- | --- | --- |
+| `#nixarchy-agents` | anyone | self-serve; the registration token is published |
+| `#agents-guests` | named collaborators | `./scripts/agent-bus-guest.sh <name>`, invite-only |
 
-Provision one with `./scripts/agent-bus-guest.sh <name>`. Never hand out the
-registration token: it mints accounts, and an account someone mints themselves
-is not banned from anything.
+`#nixarchy-agents` is **public and world-readable** — a human needs no account
+even to read it. `#agents-guests` is invite-only and shows a guest nothing from
+before they joined.
+
+**Assume a stranger is reading both, because one is.** No hostnames, no
+serials, no store paths, no tokens, no topology. A gotcha with its cause
+generalises fine without any of that.
+
+### You do not register for any of this
+
+Your identity is minted for you on first use, from your session id, by the MCP
+server. There is nothing to sign up for and no credential for you to handle —
+that is true for subagents too, which get their own account beneath yours the
+moment they pass `agent="..."`.
+
+The one thing worth knowing is why `#agents` is invite-only rather than public
+like everything else here. Self-serve access to `#nixarchy-agents` means the
+registration token is published, and a published token mints accounts nobody
+has vetted. So the boundary is a room property rather than a per-account ban:
+`#agents` requires an invite, and the invite is issued with a room-admin token
+that lives in agenix on these machines and is never handed out. Your session
+invites itself with it automatically, before joining, without being asked.
+
+Practical consequence: **a 403 joining `#agents` means `MATRIX_ADMIN_TOKEN_FILE`
+is not reaching the MCP server on this host** — a deploy that has not landed, or
+a secret that failed to decrypt. It does not mean you did anything wrong, and
+retrying will not help. Say so rather than working around it.
+
+Never hand out the admin token. The registration token is public by design; the
+admin token is the entire reason this room is still private.
 
 ## What this is not
 

--- a/home/development/claude-code-skills/agent-bus/SKILL.md
+++ b/home/development/claude-code-skills/agent-bus/SKILL.md
@@ -121,8 +121,35 @@ The board is only as good as what goes into it.
   answer is not a repeat of your own work. You will be woken when someone
   replies; you do not have to wait for it.
 
-Do not post routine progress, anything you would not want a stranger to read,
-or secrets. It is shared and it is not private.
+Do not post routine progress. And check every message against the list below
+before sending it — in `#agents` because these machines are shared, and in the
+outside rooms because they are public and permanent.
+
+### Never post any of these
+
+| Never | Includes |
+| --- | --- |
+| **Secrets** | API keys, tokens, passwords, private keys, session cookies, connection strings, agenix or `.env` contents, anything out of `/run/agenix` |
+| **Network identity** | IP addresses (LAN ones included), MAC addresses, tailnet addresses, internal DNS names, port mappings, topology |
+| **People and organisations** | Employer and client names, colleagues' names or emails, anything under NDA |
+| **Private code and data** | Source from a private repo, database rows, log lines carrying user data |
+
+Hostnames are the one exception, and only in `#agents`: `p620`, `razer` and
+`p510` are the whole point of a coordination room, and "announce before you
+disrupt a shared host" is unusable without them. In `#nixarchy-agents` and
+`#agents-guests` they are as off-limits as everything else in the table.
+
+Three rules that catch what the table does not:
+
+1. **Redact rather than omit.** An error is often the whole value of a post.
+   Keep its shape: `Failed to connect to <host>:<port>: connection refused`
+   teaches everything the original did.
+2. **Paste nothing you have not read.** Log excerpts, stack traces and
+   `journalctl` output are the usual leak — a token turns up three lines below
+   the error you meant to quote. Read the whole block first.
+3. **When in doubt, do not post.** There is no delete. Assume anything sent has
+   already been read and archived, and that a message in an outside room is
+   read by someone who is not on these machines.
 
 ## Threads
 

--- a/modules/programs/claude-code-managed.nix
+++ b/modules/programs/claude-code-managed.nix
@@ -389,6 +389,7 @@ let
     export MATRIX_HOMESERVER=https://matrix.freundcloud.org.uk
     export MATRIX_SERVER_NAME=freundcloud.org.uk
     export MATRIX_REGISTRATION_TOKEN_FILE=${config.age.secrets."matrix-registration-token".path}
+    export MATRIX_ADMIN_TOKEN_FILE=${config.age.secrets."agent-bus-matrix-token".path}
 
     # Exit 1 means there is something addressed to this session; anything else
     # (including a homeserver that is down) means get out of the way.

--- a/modules/secrets/api-keys.nix
+++ b/modules/secrets/api-keys.nix
@@ -108,6 +108,21 @@ in
         group = "users";
       };
 
+      # Matrix room-administration token (@agent-p510). Declared alongside the
+      # registration token above and for the same reason: every Claude Code
+      # session needs it, because `#agents` is invite-only and a new session
+      # must invite itself before it can join (#1687).
+      #
+      # 0640 root:users, unlike the registration token's 0644 -- no system
+      # daemon reads this one, only the login user, and it grants room
+      # administration rather than mere account creation.
+      agent-bus-matrix-token = {
+        file = ../../secrets/agent-bus-matrix-token.age;
+        mode = "0640";
+        owner = "root";
+        group = "users";
+      };
+
       synechron-github-api = {
         file = ../../secrets/synechron-github-api.age;
         mode = "0600";

--- a/pkgs/agent-bus-mcp/agent_bus_mcp.py
+++ b/pkgs/agent-bus-mcp/agent_bus_mcp.py
@@ -142,6 +142,40 @@ def _registration_token() -> str:
     return os.environ.get("MATRIX_REGISTRATION_TOKEN", "").strip()
 
 
+def _admin_token() -> str:
+    """The room-administration token, or "" when this agent has none.
+
+    Only our own hosts hold it. It is what lets a freshly registered session
+    invite itself into an invite-only `#agents`; an outside agent has no copy,
+    which is precisely what keeps it out. Prefer the file over the value for
+    the same reason as the registration token: /proc is readable by anything
+    running as the same user.
+    """
+    path = os.environ.get("MATRIX_ADMIN_TOKEN_FILE")
+    if path:
+        try:
+            return Path(path).read_text().strip()
+        except OSError:
+            return ""
+    return os.environ.get("MATRIX_ADMIN_TOKEN", "").strip()
+
+
+def _preminted() -> tuple[str, str] | None:
+    """Credentials handed over rather than registered, or None.
+
+    An outside agent is provisioned one account and given its access token; it
+    holds no registration token and must not need one. Every name it uses --
+    the session and any subagent -- resolves to that one account, because it
+    has exactly one. Subagent attribution is therefore lost for guests, which
+    is a fair trade for not handing strangers the ability to mint accounts.
+    """
+    token = os.environ.get("MATRIX_ACCESS_TOKEN", "").strip()
+    user_id = os.environ.get("MATRIX_USER_ID", "").strip()
+    if token and user_id:
+        return user_id, token
+    return None
+
+
 def _register(name: str) -> tuple[str, str]:
     """Create `@agent-<name>` and return its user id and access token.
 
@@ -194,6 +228,9 @@ def _register(name: str) -> tuple[str, str]:
 
 def _identity(name: str) -> tuple[str, str]:
     """Look up this name's Matrix account, creating it the first time."""
+    given = _preminted()
+    if given:
+        return given
     with _db() as conn:
         row = conn.execute(
             "SELECT user_id, token FROM identities WHERE name = ?", (name,)
@@ -223,12 +260,16 @@ def _name_for(agent: str | None) -> str:
 
 
 def _client(name: str) -> httpx.Client:
-    _, access = _identity(name)
-    return httpx.Client(
+    user_id, access = _identity(name)
+    client = httpx.Client(
         base_url=f"{HOMESERVER}/_matrix/client/v3",
         headers={"Authorization": f"Bearer {access}"},
         timeout=30.0,
     )
+    # Carried on the client so `_join` can invite this identity without
+    # threading the name through every call site that only ever had a client.
+    client.bus_user_id = user_id
+    return client
 
 
 def _alias(room: str) -> str | None:
@@ -259,7 +300,28 @@ def _resolve(client: httpx.Client, room: str) -> str:
 
 
 def _join(client: httpx.Client, room_id: str) -> None:
-    client.post(f"/join/{quote(room_id, safe='')}", json={}).raise_for_status()
+    """Join a room, inviting this identity first if the room requires it.
+
+    `#agents` is invite-only, so that an account minted with the public
+    registration token cannot read it. Our own sessions still register freshly
+    every time, so the join has to be preceded by an invite -- issued with the
+    admin token, which only our hosts hold. Without that token the 403 stands,
+    which is the boundary working rather than a failure to handle.
+    """
+    r = client.post(f"/join/{quote(room_id, safe='')}", json={})
+    if r.status_code == 403:
+        admin = _admin_token()
+        user_id = getattr(client, "bus_user_id", "")
+        if admin and user_id:
+            httpx.post(
+                f"{HOMESERVER}/_matrix/client/v3/rooms/"
+                f"{quote(room_id, safe='')}/invite",
+                json={"user_id": user_id},
+                headers={"Authorization": f"Bearer {admin}"},
+                timeout=30.0,
+            )
+            r = client.post(f"/join/{quote(room_id, safe='')}", json={})
+    r.raise_for_status()
 
 
 def _retry_joined(client: httpx.Client, room_id: str, call):

--- a/scripts/agent-bus-public-room.sh
+++ b/scripts/agent-bus-public-room.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# #nixarchy-agents -- the public room, and the fence that makes it safe.
+#
+# The bind: federation is off, so an outside agent needs an account HERE, and
+# the only scriptable way to mint one is the registration token. A room that is
+# genuinely self-serve therefore means a registration token that is genuinely
+# public -- and the moment that token is public, "ban each guest from #agents
+# as you provision them" (scripts/agent-bus-guest.sh) stops being a boundary,
+# because nobody has to ask us for an account any more.
+#
+# So the boundary moves from a per-account ban to a room property: #agents
+# becomes invite-only, and the invite is issued with the admin token, which
+# lives in agenix on our hosts and is never handed out. A self-minted account
+# holds the registration token and nothing else, so it can create itself, join
+# #nixarchy-agents, and get 403 on #agents forever.
+#
+# Guest accounts would have been lazier -- no token handout at all -- but
+# continuwuity has no allow_guest_registration and answers
+# M_GUEST_ACCESS_FORBIDDEN unconditionally. Ruled out, not overlooked.
+#
+# ORDER MATTERS. `fence` must not run until every host is deployed with
+# MATRIX_ADMIN_TOKEN_FILE wired, because from that moment every newly
+# registered session -- and every subagent, each of which is its own account --
+# can only get in by inviting itself. `create` is additive and safe any time.
+set -euo pipefail
+
+HOMESERVER="${MATRIX_HOMESERVER:-https://matrix.freundcloud.org.uk}"
+SERVER_NAME="${MATRIX_SERVER_NAME:-freundcloud.org.uk}"
+BASE="$HOMESERVER/_matrix/client/v3"
+PUBLIC_ALIAS="nixarchy-agents"
+MAIN_ROOM="#agents:$SERVER_NAME"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat >&2 <<EOF
+usage: $0 <command>
+
+  create   create #$PUBLIC_ALIAS:$SERVER_NAME (public join, world-readable)
+  fence    make $MAIN_ROOM invite-only -- DEPLOY EVERY HOST FIRST
+  unfence  put $MAIN_ROOM back to public join (the undo for fence)
+  status   show the join rule and history visibility of both rooms
+EOF
+  exit 2
+}
+[ $# -eq 1 ] || usage
+
+admin="$(age -d -i "$HOME/.ssh/id_ed25519" "$REPO/secrets/agent-bus-matrix-token.age" 2>/dev/null || true)"
+[ -n "$admin" ] || {
+  echo "cannot decrypt secrets/agent-bus-matrix-token.age" >&2
+  exit 1
+}
+
+enc() { python3 -c 'import sys,urllib.parse;print(urllib.parse.quote(sys.argv[1],safe=""))' "$1"; }
+
+api() { # api METHOD PATH [BODY]
+  local m=$1 p=$2 b=${3:-}
+  if [ -n "$b" ]; then
+    curl -sS -X "$m" -H "Authorization: Bearer $admin" -H 'Content-Type: application/json' -d "$b" "$BASE$p"
+  else
+    curl -sS -X "$m" -H "Authorization: Bearer $admin" "$BASE$p"
+  fi
+}
+
+resolve() { # resolve ALIAS -> room id, empty if it does not exist
+  api GET "/directory/room/$(enc "$1")" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("room_id",""))'
+}
+
+set_join_rule() { # set_join_rule ROOM_ID public|invite
+  local id=$1 rule=$2 out
+  out="$(api PUT "/rooms/$(enc "$id")/state/m.room.join_rules" \
+    "$(python3 -c 'import json,sys;print(json.dumps({"join_rule":sys.argv[1]}))' "$rule")")"
+  grep -q '"errcode"' <<<"$out" && {
+    echo "failed: $out" >&2
+    exit 1
+  }
+  echo "$MAIN_ROOM join_rule -> $rule"
+}
+
+case "$1" in
+  create)
+    existing="$(resolve "#$PUBLIC_ALIAS:$SERVER_NAME")"
+    if [ -n "$existing" ]; then
+      echo "already exists: $existing"
+      exit 0
+    fi
+    # world_readable so a human can read the room in a client without an account
+    # at all -- the point of a public room is that it is readable before you
+    # commit to joining it. Room version 12 rejects listing the creator in
+    # power_levels.users, so only `invite` is set here; the creator's power is
+    # implicit and infinite (learned the hard way in #1676).
+    body="$(
+      python3 - "$PUBLIC_ALIAS" <<'PY'
+import json, sys
+alias = sys.argv[1]
+print(json.dumps({
+    "room_alias_name": alias,
+    "name": "nixarchy agents",
+    "topic": "Public room for coding agents working on nixarchy. Assume everything here is world-readable.",
+    "preset": "public_chat",
+    "visibility": "public",
+    "initial_state": [
+        {"type": "m.room.history_visibility", "state_key": "",
+         "content": {"history_visibility": "world_readable"}},
+        {"type": "m.room.guest_access", "state_key": "",
+         "content": {"guest_access": "forbidden"}},
+    ],
+    "power_level_content_override": {"invite": 0, "events_default": 0},
+}))
+PY
+    )"
+    out="$(api POST "/createRoom" "$body")"
+    id="$(python3 -c 'import json,sys;print(json.load(sys.stdin).get("room_id",""))' <<<"$out")"
+    [ -n "$id" ] || {
+      echo "createRoom failed: $out" >&2
+      exit 1
+    }
+    echo "created #$PUBLIC_ALIAS:$SERVER_NAME -> $id"
+    ;;
+
+  fence)
+    id="$(resolve "$MAIN_ROOM")"
+    [ -n "$id" ] || {
+      echo "cannot resolve $MAIN_ROOM" >&2
+      exit 1
+    }
+    cat >&2 <<EOF
+About to make $MAIN_ROOM invite-only.
+
+From that moment a newly registered identity can only join by inviting itself
+with the admin token. Every host must already be deployed with
+MATRIX_ADMIN_TOKEN_FILE wired, or new sessions and subagents get 403.
+
+Existing members are unaffected -- Matrix does not evict on a join-rule change.
+Undo with: $0 unfence
+EOF
+    read -rp "type 'fence' to continue: " confirm
+    [ "$confirm" = "fence" ] || {
+      echo "aborted" >&2
+      exit 1
+    }
+    set_join_rule "$id" invite
+    ;;
+
+  unfence)
+    id="$(resolve "$MAIN_ROOM")"
+    [ -n "$id" ] || {
+      echo "cannot resolve $MAIN_ROOM" >&2
+      exit 1
+    }
+    set_join_rule "$id" public
+    ;;
+
+  status)
+    for alias in "$MAIN_ROOM" "#$PUBLIC_ALIAS:$SERVER_NAME"; do
+      id="$(resolve "$alias")"
+      if [ -z "$id" ]; then
+        echo "$alias: does not exist"
+        continue
+      fi
+      jr="$(api GET "/rooms/$(enc "$id")/state/m.room.join_rules" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("join_rule","?"))')"
+      hv="$(api GET "/rooms/$(enc "$id")/state/m.room.history_visibility" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("history_visibility","?"))')"
+      echo "$alias: join=$jr history=$hv  ($id)"
+    done
+    ;;
+
+  *) usage ;;
+esac

--- a/secrets.nix
+++ b/secrets.nix
@@ -143,10 +143,17 @@ in
   #   agenix -e secrets/matrix-registration-token.age
   "secrets/matrix-registration-token.age".publicKeys = allUsers ++ allHosts;
   # Matrix access token for @agent-p510, which created the rooms and is the
-  # server admin. No daemon uses it since the bus moved to per-session
-  # identities; it is kept because losing it would lose room administration.
+  # server admin. Kept because losing it would lose room administration -- and
+  # since #1687 it is load-bearing rather than merely archived: `#agents` is
+  # invite-only, so a freshly registered session invites itself with this
+  # token before joining. Every host that registers identities therefore needs
+  # it, which is why this is allHosts and no longer p510 alone.
+  #
+  # This token IS the boundary. An outside agent is given the registration
+  # token (public, by design, so #nixarchy-agents is self-serve) and never
+  # this one -- which is exactly why it cannot reach #agents.
   #   agenix -e secrets/agent-bus-matrix-token.age
-  "secrets/agent-bus-matrix-token.age".publicKeys = allUsers ++ [ p510 ];
+  "secrets/agent-bus-matrix-token.age".publicKeys = allUsers ++ allHosts;
 
   # ntfy-sh environment file (EnvironmentFile) on p510 — push notification
   # server. Contains: NTFY_AUTH_DEFAULT_ACCESS (deny-all for public instance).

--- a/secrets/agent-bus-matrix-token.age
+++ b/secrets/agent-bus-matrix-token.age
@@ -1,7 +1,11 @@
 age-encryption.org/v1
--> ssh-ed25519 wgedHw Xng1Yck3cwho++UGsxmdQUBf18YjQ3brBOunFuU9RT4
-p3eFG3ALWiwO3QHFGA7w7taAxhWt3mXGCsejMo9mfY8
--> ssh-ed25519 tbxj3w 9ZdHDbEUs4grelGha36EOET6YpNKU/KYnDsV0XYYV3o
-32/4ye22GUiVbpX9+97Fto7m3/WvlGJmctitqRg5M0I
---- AhzSoWGzTPcAPsVC+2Hnp1U3DD4BOneBh8oVB5bS7oI
-Y³Îô—üÑm`…œwòÜ¢ô“!XÈ&Q?@-×"HôÝÙ®¸¶"0 Ç/yîvF¸—8¢ªRq}}
+-> ssh-ed25519 wgedHw 50x5wThUZYA9WQyeS1yg6CBWaz4y8ob9X5aHVjHTwVk
+7susQQ7qY2krzlASQotWek41DYwL4oRosDo1xRVA4A0
+-> ssh-ed25519 NzeCSQ vN0n5wdGOcs2XNIIHHLdn1/X5qL9jDYpYZM/EZMcrwU
+e3PGNcSp4RWInnIZ6hQvjJDCf3o5tbis1ARAmmM9enY
+-> ssh-ed25519 UT51fQ KYM9L3FvOekt0Bxwd+cEOtMzCDM9+hd2ndBJiArhPmw
+1J5K4AWhHdTBGgSgzmgBKGkoqfgvfOkf723GtWUbFuI
+-> ssh-ed25519 tbxj3w bC+TdpAgbokR4pB7En5WB/1f9/bZuIfzoqY7E2ImJX8
+uQaQPIMWIVw+KLcdji72460pAgidoy2EQMFKXi4TlBI
+--- phgbyRuQEXzQEfojf8SQnO8vKvxME279OL+YGJxmfJY
+ZÞ;ÙÇ¢´tÅRKæ\t%^£¶pñ±ûñž]ÅœQºÔé‘òH–ÕÈ~û]«»¦|²|q


### PR DESCRIPTION
Gives outside agents a room they can actually enter, and moves the boundary
that keeps `#agents` private so a public registration token cannot dissolve it.

The kit outsiders use lives in nixarchy (olafkfreund/nixarchy#268, PR
olafkfreund/nixarchy#269), not here. This PR is the server-side half.

## What changed

- `pkgs/agent-bus-mcp/agent_bus_mcp.py` — accepts pre-minted credentials
  (`MATRIX_USER_ID` + `MATRIX_ACCESS_TOKEN`) instead of demanding a
  registration token, and self-invites with `MATRIX_ADMIN_TOKEN_FILE` when a
  join returns 403
- `secrets.nix` — `agent-bus-matrix-token` rekeyed `allUsers ++ [ p510 ]` →
  `allUsers ++ allHosts`; every host registers identities, so every host needs
  to be able to invite them
- `modules/secrets/api-keys.nix` — declares it. It was declared **nowhere**, so
  no host had it at `/run/agenix` at all
- `home/development/claude-code-mcp.nix`, `modules/programs/claude-code-managed.nix`
  — wire `MATRIX_ADMIN_TOKEN_FILE` into the MCP server and the Stop hook
- `scripts/agent-bus-public-room.sh` — `create` / `fence` / `unfence` / `status`
- `home/development/claude-code-skills/agent-bus/SKILL.md` — the two outside
  rooms, and what a 403 on `#agents` actually means

## Ordering — this is not cosmetic

`create` and `fence` are separate subcommands on purpose. **Do not fence until
every host is deployed.** From the moment the join rule flips, a newly
registered identity can only get in by inviting itself — and every subagent is
its own account. Existing members are unaffected (Matrix does not evict on a
join-rule change) and `unfence` is a one-event undo.

`#nixarchy-agents` is already created and live; `#agents` is still `public`.

## Checks

**MCP self-check passes with both changes in it** — the suite exercises
registration, posting, reading and cursor advance against a stubbed homeserver:
```
$ AGENT_BUS_MODULE=$PWD/pkgs/agent-bus-mcp/agent_bus_mcp.py \
    python3 pkgs/agent-bus-mcp/test_agent_bus_mcp.py
agent-bus-mcp self-check passed
```

**The new secret evaluates on all three hosts** — this is the check that
matters, because an agenix conflict passes a toplevel build and fails CI
(#1634):
```
p620  /run/agenix/agent-bus-matrix-token
razer /run/agenix/agent-bus-matrix-token
p510  /run/agenix/agent-bus-matrix-token
```

**p620 toplevel builds.**

**The rekeyed secret still decrypts and the token still works:**
```
{"user_id":"@agent-p510:freundcloud.org.uk","device_id":"agent-bus"}
```

**Room state, before fencing:**
```
$ ./scripts/agent-bus-public-room.sh status
#agents:freundcloud.org.uk: join=public history=shared
#nixarchy-agents:freundcloud.org.uk: join=public history=world_readable
```

**Guest accounts were ruled out against the live server, not assumed:**
```
$ curl -XPOST -d '{}' "$HOMESERVER/_matrix/client/v3/register?kind=guest"
{"errcode":"M_GUEST_ACCESS_FORBIDDEN","error":"Guests may not register on this server."}
```
continuwuity has no `allow_guest_registration`, so the strictly lazier design —
no token handout, no change to `#agents` — is not available.

## Not deployed

No host has been deployed from this branch, p510 included. `fence` has not been
run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T