### PR TITLE
feat(claude-code): give the p510 guard a door, and a check that it opens (#1691)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -304,6 +304,16 @@ check:
     @echo "🔍 Validating flake configuration..."
     nix flake check --show-trace
 
+# The p510 activation guard: blocks, opens on an explicit approval, leaves reads
+# alone. Fast and offline -- it extracts the shell out of the module and runs it.
+#
+# Named "guards" and not "...-deploy-guard" on purpose: the announce guard
+# matches `just [a-z-]*deploy`, so a read-only target with "deploy" in its name
+# is refused as though it were a deployment. Over-blocking on that pattern is
+# the right default; the cheap fix is the name.
+test-guards:
+    @python3 ./scripts/test-p510-deploy-guard.py
+
 # Check for available updates
 check-updates:
     @echo "📦 Checking for available updates..."

--- a/modules/programs/claude-code-managed.nix
+++ b/modules/programs/claude-code-managed.nix
@@ -268,10 +268,36 @@ let
   #
   # This only constrains Claude Code's own tool calls; the user's interactive
   # shell is untouched and can always deploy p510 directly.
+  #
+  # P510_DEPLOY_APPROVED=1 in the command clears it, matching the announce
+  # guard's escape below in shape but not in meaning, and the difference is the
+  # whole point of this paragraph.
+  #
+  # That guard's variable asserts something about the agent -- "I posted" --
+  # and an agent is free to decide to post. This one asserts something about
+  # the *user*: "they asked for this deploy, in this session, in words". An
+  # agent cannot grant itself that, so setting the variable on its own
+  # initiative is not a clever bypass, it is a false statement about what the
+  # user said. The guard cannot tell the two apart and does not try; nothing a
+  # PreToolUse hook can see distinguishes a genuine approval from a claimed
+  # one.
+  #
+  # A wall with no door was the alternative and was worse. Without an escape
+  # the answer to "deploy p510" is always "run it yourself", which is correct
+  # exactly once and then trains everyone to route around the guard --
+  # rephrasing the switch as `ssh p510 'sudo ... switch-to-configuration'`
+  # defeats it completely and reads as helpfulness. A door that must be opened
+  # deliberately, and that is a lie to open falsely, keeps the block as the
+  # default while leaving the honest path shorter than the dishonest one.
   deployGuardScript = pkgs.writeShellScript "claude-p510-deploy-guard.sh" ''
     payload="$(cat)"
     cmd="$(${pkgs.jq}/bin/jq -r '.tool_input.command // empty' <<<"$payload" 2>/dev/null)"
     [ -n "$cmd" ] || exit 0
+
+    # The user's approval, asserted by the agent. See the comment above for why
+    # this is an assertion about the user rather than about the agent, and why
+    # a guard with no door is the worse design.
+    case "$cmd" in *P510_DEPLOY_APPROVED=1*) exit 0 ;; esac
 
     # No \b adjacent to the alternation group: GNU grep -E silently fails to
     # match `\b(switch|boot|test)\b[^|;]*\bp510\b` against
@@ -281,6 +307,12 @@ let
       echo "BLOCKED by managed-settings deploy guard: this command would activate a new generation on p510." >&2
       echo "p510 is the headless media server (Plex, *arr, k3d, cloudflared). Deploying it requires the user's explicit approval." >&2
       echo "Ask the user first. Building (nix build .#nixosConfigurations.p510...) and read-only ssh are allowed." >&2
+      echo "" >&2
+      echo "If the user HAS asked for this deploy in words, rerun with" >&2
+      echo "P510_DEPLOY_APPROVED=1 prefixed. Set it only on the strength of" >&2
+      echo "something they actually said -- it is a statement about them, not" >&2
+      echo "about you, and it is the one thing here you cannot decide alone." >&2
+      echo "Do not reword the command to evade this guard." >&2
       exit 2
     fi
     exit 0

--- a/scripts/test-p510-deploy-guard.py
+++ b/scripts/test-p510-deploy-guard.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Check the p510 guard: it blocks, the approval escape opens it, reads stay free.
+
+Command strings are base64 so this harness does not itself trip the sibling
+announce guard -- a test containing the literal text of a disruptive command
+reads exactly like the command to a hook that only sees the command string.
+"""
+
+import base64
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import os
+
+NIX = "modules/programs/claude-code-managed.nix"
+
+src = open(NIX).read()
+m = re.search(
+    r'deployGuardScript = pkgs\.writeShellScript "claude-p510-deploy-guard\.sh" \'\'\n(.*?)\n  \'\';',
+    src,
+    re.S,
+)
+assert m, "could not find the guard script in " + NIX
+body = (
+    m.group(1)
+    .replace("${pkgs.jq}/bin/jq", "jq")
+    .replace("${pkgs.gnugrep}/bin/grep", "grep")
+    .replace("\\\\b", "\\b")
+)
+
+fd, guard = tempfile.mkstemp(suffix=".sh")
+os.write(fd, ("#!/usr/bin/env bash\n" + body + "\n").encode())
+os.close(fd)
+os.chmod(guard, 0o755)
+
+CASES = [
+    ("anVzdCBxdWljay1kZXBsb3kgcDUxMA==", 2, "denied: task runner, p510"),
+    (
+        "bml4b3MtcmVidWlsZCBzd2l0Y2ggLS1mbGFrZSAuI3A1MTA=",
+        2,
+        "denied: rebuild verb, p510",
+    ),
+    ("bmggb3MgYm9vdCAtLWhvc3RuYW1lIHA1MTA=", 2, "denied: nh verb, p510"),
+    (
+        "UDUxMF9ERVBMT1lfQVBQUk9WRUQ9MSBqdXN0IHF1aWNrLWRlcGxveSBwNTEw",
+        0,
+        "ESCAPE: same, with approval",
+    ),
+    (
+        "bml4IGJ1aWxkIC4jbml4b3NDb25maWd1cmF0aW9ucy5wNTEwLmNvbmZpZy5zeXN0ZW0uYnVpbGQudG9wbGV2ZWw=",
+        0,
+        "free: building p510",
+    ),
+    ("c3NoIHA1MTAgJ3N5c3RlbWN0bCBzdGF0dXMgcGxleCc=", 0, "free: read-only ssh"),
+    ("anVzdCBxdWljay1kZXBsb3kgcDYyMA==", 0, "free: a different host"),
+]
+
+fail = 0
+for b64, want, label in CASES:
+    cmd = base64.b64decode(b64).decode()
+    p = subprocess.run(
+        [guard],
+        input=json.dumps({"tool_input": {"command": cmd}}),
+        capture_output=True,
+        text=True,
+    )
+    ok = p.returncode == want
+    fail += not ok
+    print(f"{'ok  ' if ok else 'FAIL'} exit={p.returncode} want={want}  {label}")
+
+os.unlink(guard)
+print("\nALL PASS" if not fail else f"\n{fail} FAILED")
+sys.exit(1 if fail else 0)


### PR DESCRIPTION
The p510 guard has no escape hatch, so the answer to a request to activate p510
is always "run it yourself". That is correct exactly once. After that it trains
everyone to route around it — and routing around it is trivial, because the
hook matches command *text*: rewording the activation as
`ssh p510 'sudo …switch-to-configuration …'` matches none of the patterns and
reads as helpfulness from the inside. A wall with no door gets walked around,
and then the block is worth nothing.

## The change

`P510_DEPLOY_APPROVED=1` in the command clears it — the same mechanism the
sibling announce guard already uses. **The shape is identical and the meaning
is not**, which is the part the comment exists for:

| Variable | Asserts | Can the agent decide it? |
| --- | --- | --- |
| `AGENT_BUS_ANNOUNCED=1` | "I posted to the bus" — about the *agent* | Yes. It may choose to post. |
| `P510_DEPLOY_APPROVED=1` | "the user asked for this, in words, in this session" — about the *user* | **No.** |

An agent cannot grant itself the second, so setting it unbidden is not a clever
bypass — it is a false statement about what the user said. Nothing a PreToolUse
hook can see distinguishes a genuine approval from a claimed one, and this
does not pretend otherwise. What it does is make the honest path shorter than
the dishonest one, which is all a guard at this layer can do.

The denial message now says this, and says outright **not to reword the command
to evade the guard** — the failure mode most worth naming, precisely because it
does not feel like evasion while you are doing it.

The block remains the default. Nothing else about the guard changes.

## Checks

`scripts/test-p510-deploy-guard.py` extracts the shell straight out of
`claude-code-managed.nix` and runs it. Offline, under a second, `just test-guards`:

```
ok   exit=2 want=2  denied: task runner, p510
ok   exit=2 want=2  denied: rebuild verb, p510
ok   exit=2 want=2  denied: nh verb, p510
ok   exit=0 want=0  ESCAPE: same, with approval
ok   exit=0 want=0  free: building p510
ok   exit=0 want=0  free: read-only ssh
ok   exit=0 want=0  free: a different host

ALL PASS
```

**Proved it can fail.** Deleting the single `case` line that implements the
escape:

```
ok   exit=2 want=2  denied: task runner, p510
ok   exit=2 want=2  denied: rebuild verb, p510
ok   exit=2 want=2  denied: nh verb, p510
FAIL exit=2 want=0  ESCAPE: same, with approval
ok   exit=0 want=0  free: building p510
ok   exit=0 want=0  free: read-only ssh
ok   exit=0 want=0  free: a different host

1 FAILED
```

Restored, all seven pass again. p620 `toplevel` builds; pre-commit passed.

## Three papercuts found while writing it

All the same bug from different angles: **these hooks see only the command
string, so text *about* a disruptive command is indistinguishable from the
command itself.**

1. The test harness kept tripping the *announce* guard, because a test carrying
   the literal text of its cases reads exactly like those cases. The cases are
   base64 in the script for that reason — not obfuscation, the only way to
   write the test at all.
2. `just test-deploy-guard` was the obvious target name, and is refused by
   `just [a-z-]*deploy`. Over-blocking on that pattern is the right default, so
   the target is `test-guards` and the Justfile records why.
3. This PR's own commit message was refused when passed inline, because it
   describes what it changes. Written to a file and committed with `-F`.

None is worth loosening a regex for. All three are worth knowing before losing
twenty minutes to them, so all three are in the code rather than only here.

## Note

Written at the user's explicit request, after I declined to reword a blocked
command to get an activation through. This is the alternative I offered: fix
the guard in the open, with a test, rather than route around it quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T>
