### PR TITLE
chore(flake): bump inputs, unbreaking eval on the ffmpeg_7 removal

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788529395,
-        "narHash": "sha256-Q1LFaHk1DU7yc+dsg9OC6dy6qZJWPInyRS0JV1CJiPU=",
+        "lastModified": 1788592425,
+        "narHash": "sha256-N6tHHlKKL0ErBZN0FRN47bFRGe7jzd5n/s0iv5codi8=",
         "owner": "jacopone",
         "repo": "antigravity-nix",
-        "rev": "096fd29b82352e773db6b233494bfff73fb0b561",
+        "rev": "6310713b4f3e0c1d6ac28b30c2fdd66bfcec9275",
         "type": "github"
       },
       "original": {
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1788490948,
-        "narHash": "sha256-d8fF/qfPC/4V0T/+FBK3jsLhl+HJ5IsUlbQonpAaWqI=",
+        "lastModified": 1788580231,
+        "narHash": "sha256-bskwQSQCYzHaRfylelRDMmLGoGEiKyoE7gCCnqKATs4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e5dd8d11067a0733efedfbaa3e6c17d2c855193a",
+        "rev": "bf4d38d57a5d08ee54625b1b97b1db1d62841512",
         "type": "github"
       },
       "original": {
@@ -746,11 +746,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788526445,
-        "narHash": "sha256-kDuOAXPifYWL0kRyeixNPxEud+p8OhVkQi27l0GXr/8=",
+        "lastModified": 1788572365,
+        "narHash": "sha256-QkvWAW4xVyViNOROThK2ftRLsH37d+l3eWPOJ1aPjtw=",
         "owner": "ogulcancelik",
         "repo": "herdr",
-        "rev": "6045fe6a8735609507ec8600fa07205227546e8b",
+        "rev": "3a822e8106b45745f9d463d9167033f977353d9f",
         "type": "github"
       },
       "original": {
@@ -830,11 +830,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786719456,
-        "narHash": "sha256-B74DLQs/VjlqyhnnX3tguWwghqJHWSJX30TKZuAljIg=",
+        "lastModified": 1788229478,
+        "narHash": "sha256-G0F2rFORVcFkEvVdE/qWQTnYekIc77YP5/vRF9nZlxU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "83b7606dcf44abe3a94b86e8bb2b3355d22e8797",
+        "rev": "1dc2d1f720ab17fc7981e087346bf54b26d284b1",
         "type": "github"
       },
       "original": {
@@ -1283,11 +1283,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1788488097,
-        "narHash": "sha256-dugBcQqUWItvuO3VYFANm/istcVwGilwzZ33cfaSW3g=",
+        "lastModified": 1788575406,
+        "narHash": "sha256-EjSyb5FcVnZOW0qFbcvxzor/je02duSe/RhJsL5p+14=",
         "owner": "utensils",
         "repo": "mcp-nixos",
-        "rev": "fde73229fb8b90a8b9f8f573fdf7d422289279be",
+        "rev": "6a517811658c21f97bd7703b35546085117fc310",
         "type": "github"
       },
       "original": {
@@ -1312,6 +1312,29 @@
       "original": {
         "owner": "astro",
         "repo": "microvm.nix",
+        "type": "github"
+      }
+    },
+    "microvm_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixarchy",
+          "nixpkgs"
+        ],
+        "spectrum": "spectrum_2"
+      },
+      "locked": {
+        "lastModified": 1788518164,
+        "narHash": "sha256-vY71mJCu5NgR+n+V4zpcRzZc6KL6SU9WmyMGzd8kYIA=",
+        "owner": "microvm-nix",
+        "repo": "microvm.nix",
+        "rev": "fdfc1821a0eb76e44a13d206b72e6ca6961fbb7c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "microvm-nix",
+        "repo": "microvm.nix",
+        "rev": "fdfc1821a0eb76e44a13d206b72e6ca6961fbb7c",
         "type": "github"
       }
     },
@@ -1377,6 +1400,7 @@
         "home-manager": "home-manager_3",
         "hypr-rdp": "hypr-rdp",
         "hyprland": "hyprland",
+        "microvm": "microvm_2",
         "nix-flatpak": "nix-flatpak",
         "nixpkgs": [
           "nixpkgs"
@@ -1387,11 +1411,11 @@
         "zen-browser": "zen-browser"
       },
       "locked": {
-        "lastModified": 1788528856,
-        "narHash": "sha256-eEptkIprZyUD4MS2fyowSDCop1c755jZT4hFZsa6cRc=",
+        "lastModified": 1788585621,
+        "narHash": "sha256-8S4wXg314/RgbuwFg5SpNxX+y1dB3nDmWH8MLnfCiq0=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "11a2eb724aa9906e369f29d1fa3d5903d52e2346",
+        "rev": "1c9268eb3e0179c21e7695c8666a605043bc826f",
         "type": "github"
       },
       "original": {
@@ -1421,11 +1445,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788316716,
-        "narHash": "sha256-bc7rSpXIdn9QWGNqfWcPZWOhEVF8NoeAZkWq0XWnf/k=",
+        "lastModified": 1788531059,
+        "narHash": "sha256-hLD4l3QOGBQhkVp3mQ2lJ/YbEi99qUgKapb40KovZ88=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3ed67ec0a4d3c7ab4ae1f04f8ee8df07bfa506a2",
+        "rev": "801bef6abd86b91e51083066b83fb354a11fc640",
         "type": "github"
       },
       "original": {
@@ -1446,11 +1470,11 @@
         "parts": "parts"
       },
       "locked": {
-        "lastModified": 1788505568,
-        "narHash": "sha256-aaW6OSBXUPfkx1GvboWSkWRZdBp1Sz6YDFNdmJhvkT4=",
+        "lastModified": 1788590971,
+        "narHash": "sha256-i11TAc8wNbng7UxqAm+UX2Z9fGYcPmYH3Am27ehSIqs=",
         "owner": "moni-dz",
         "repo": "nixpkgs-f2k",
-        "rev": "0d24284807af0ea65f926da476021c0d7922e8c8",
+        "rev": "3c05b9fa166286bdbf3dd01943d12ca17c9fe288",
         "type": "github"
       },
       "original": {
@@ -1545,11 +1569,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1788316716,
-        "narHash": "sha256-bc7rSpXIdn9QWGNqfWcPZWOhEVF8NoeAZkWq0XWnf/k=",
+        "lastModified": 1788531059,
+        "narHash": "sha256-hLD4l3QOGBQhkVp3mQ2lJ/YbEi99qUgKapb40KovZ88=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3ed67ec0a4d3c7ab4ae1f04f8ee8df07bfa506a2",
+        "rev": "801bef6abd86b91e51083066b83fb354a11fc640",
         "type": "github"
       },
       "original": {
@@ -1561,11 +1585,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1788316716,
-        "narHash": "sha256-bc7rSpXIdn9QWGNqfWcPZWOhEVF8NoeAZkWq0XWnf/k=",
+        "lastModified": 1788404924,
+        "narHash": "sha256-lhEhY8X5EgkQ/eg6IFz4cc8jRuSYSvnxx1al7d1dvZ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3ed67ec0a4d3c7ab4ae1f04f8ee8df07bfa506a2",
+        "rev": "0968519e14f7aa7d3e9b389682bd74d2b51c8ce8",
         "type": "github"
       },
       "original": {
@@ -1714,11 +1738,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1788316716,
-        "narHash": "sha256-bc7rSpXIdn9QWGNqfWcPZWOhEVF8NoeAZkWq0XWnf/k=",
+        "lastModified": 1788531059,
+        "narHash": "sha256-hLD4l3QOGBQhkVp3mQ2lJ/YbEi99qUgKapb40KovZ88=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3ed67ec0a4d3c7ab4ae1f04f8ee8df07bfa506a2",
+        "rev": "801bef6abd86b91e51083066b83fb354a11fc640",
         "type": "github"
       },
       "original": {
@@ -1736,11 +1760,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788529599,
-        "narHash": "sha256-Ns5E5bKi+h3L+VbdCWGq+ibs+XQY+5d4vzO4/C/dL60=",
+        "lastModified": 1788593931,
+        "narHash": "sha256-nEC/ilF5+qAtcvaguywNU/p1J13FPWAvrpsTAaCvhos=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "e088f2e9fa65f52aa8d1d98b54630334ec048657",
+        "rev": "8aca6c6b56dbf3a8a83991e29f0bf32b36ac14db",
         "type": "github"
       },
       "original": {
@@ -1975,11 +1999,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788505699,
-        "narHash": "sha256-PSPDCdbEBEbSDCWcqv5GkbyD2ACQ9Diz6vmEbWdy4dM=",
+        "lastModified": 1788591095,
+        "narHash": "sha256-Vh+BeLWfbTT9AecazIsQ/Tkg/RzJeX3lEduANf256WA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9eccf73c5b810052f08aa77ae0548c383259f17f",
+        "rev": "c361047d3a538f547f1617bb6b410411929ac9cc",
         "type": "github"
       },
       "original": {
@@ -2076,6 +2100,22 @@
       }
     },
     "spectrum": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1785761586,
+        "narHash": "sha256-MWOMVqJJERwjQGgRIv8d6rlEBqbLM3VZWxHkNKIIZNw=",
+        "ref": "refs/heads/main",
+        "rev": "a7762d6f54b40560dd5255ce902e6e6a5d980fe9",
+        "revCount": 1416,
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
+      }
+    },
+    "spectrum_2": {
       "flake": false,
       "locked": {
         "lastModified": 1785761586,
@@ -2481,11 +2521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787540616,
-        "narHash": "sha256-c+dIgStaq3qNaQxhAiiXY3upNTIdn7tCcqPnwsmKTmY=",
+        "lastModified": 1788405419,
+        "narHash": "sha256-wuGizAVEmY0u15MYrhgy7AoQdHg+4Y2QiC+v/mxA8dc=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "51df7b8cbb0fcba14a9b159531ef48d0cd69dde9",
+        "rev": "fdb83f8fce835213fab7eab52c375926fe1a32dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
nixpkgs `801bef6` dropped `ffmpeg_7`, and nixarchy's pinned zen-browser
(`51df7b8`) still passed it to `wrapFirefox`:

```
error: function 'anonymous lambda' called with unexpected argument 'ffmpeg_7'
at .../firefox/wrapper.nix:1:1 — Did you mean one of ffmpeg_8 or ffmpeg_9?
```

nixarchy re-exports `zen-browser` as a package attribute, so the whole set
failed to evaluate on hosts that never install Zen. The truncated trace only
named `environment.etc.dbus-1.source`, which points at nothing useful — the
caller only shows up in the last frames under `--show-trace`.

The node carries no rev in `original`, so `nix flake update nixarchy/zen-browser`
was the entire fix: `fdb83f8` takes `ffmpeg_8` with `ffmpeg_9 ? ffmpeg_8` and
fakes the version `wrapFirefox` reads.

Verified: `p620`, `razer` and `p510` `toplevel.drvPath` all evaluate.

Written up for the other agents in `#nixarchy-agents`; nixarchy itself should
bump its own lock so downstream consumers stop inheriting the broken pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T