### PR TITLE
fix(flake): pin zen-browser at the root so an update stops reverting it

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -824,7 +824,6 @@
     "home-manager_4": {
       "inputs": {
         "nixpkgs": [
-          "nixarchy",
           "zen-browser",
           "nixpkgs"
         ]
@@ -1408,7 +1407,9 @@
         "omarchy": "omarchy",
         "sops-nix": "sops-nix",
         "systems": "systems_8",
-        "zen-browser": "zen-browser"
+        "zen-browser": [
+          "zen-browser"
+        ]
       },
       "locked": {
         "lastModified": 1788585621,
@@ -1445,16 +1446,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788531059,
-        "narHash": "sha256-hLD4l3QOGBQhkVp3mQ2lJ/YbEi99qUgKapb40KovZ88=",
-        "owner": "nixos",
+        "lastModified": 1754028485,
+        "narHash": "sha256-IiiXB3BDTi6UqzAZcf2S797hWEPCRZOwyNThJIYhUfk=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "801bef6abd86b91e51083066b83fb354a11fc640",
+        "rev": "59e69648d345d6e8fef86158c555730fa12af9de",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1760,11 +1761,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788593931,
-        "narHash": "sha256-nEC/ilF5+qAtcvaguywNU/p1J13FPWAvrpsTAaCvhos=",
+        "lastModified": 1788595291,
+        "narHash": "sha256-CsrUUCNs3uvGwj6Rh+vuiQR25VCwti6VYIVJPSZFkmg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "8aca6c6b56dbf3a8a83991e29f0bf32b36ac14db",
+        "rev": "6fb8be30b6bce3b56d616f596fdd14f0bb9e336c",
         "type": "github"
       },
       "original": {
@@ -1909,6 +1910,7 @@
         "spicetify-nix": "spicetify-nix",
         "stylix": "stylix",
         "yt-x": "yt-x",
+        "zen-browser": "zen-browser",
         "zjstatus": "zjstatus"
       }
     },
@@ -2516,7 +2518,6 @@
       "inputs": {
         "home-manager": "home-manager_4",
         "nixpkgs": [
-          "nixarchy",
           "nixpkgs"
         ]
       },

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,20 @@
     nixarchy = {
       url = "github:olafkfreund/nixarchy";
       inputs.nixpkgs.follows = "nixpkgs";
+      # nixarchy re-exports zen-browser as a package attribute, so its pin is a
+      # hard eval dependency for us even though no host installs Zen. Its lock
+      # sat on 51df7b8, which passes ffmpeg_7 to wrapFirefox after nixpkgs
+      # removed it — every host closure died on an error naming only
+      # `environment.etc.dbus-1.source`. Bumping the child node alone is not
+      # enough: a full flake update re-resolves it from nixarchy's own lock and
+      # puts the broken pin straight back. Drop this once nixarchy's lock is
+      # ahead of fdb83f8.
+      inputs.zen-browser.follows = "zen-browser";
+    };
+
+    zen-browser = {
+      url = "github:0xc000022070/zen-browser-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
 
 


### PR DESCRIPTION
Follow-up to #1697. The `ffmpeg_7` eval failure came straight back on the next
update run.

`nix flake update nixarchy/zen-browser` does not stick: a **full** update
re-resolves nixarchy's children from nixarchy's own lock, which still points at
`51df7b8` — the rev that passes `ffmpeg_7` to `wrapFirefox`.

Declaring `zen-browser` as a root input and pointing `nixarchy.inputs.zen-browser`
at it makes our lock the authority, so the bump survives an update.

Verified **after** a full `nix flake update`: `zen-browser` stays on `fdb83f8`,
and `p620` / `razer` / `p510` `toplevel.drvPath` all evaluate.

Both the input and the `follows` come out once nixarchy's own lock is ahead of
`fdb83f8`; the comment in `flake.nix` says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T