### PR TITLE
fix(eval): adb-sync removal, and a dead gemini-cli overlay behind it

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1788580231,
-        "narHash": "sha256-bskwQSQCYzHaRfylelRDMmLGoGEiKyoE7gCCnqKATs4=",
+        "lastModified": 1788666871,
+        "narHash": "sha256-uKzj7V+NVJ5eIkpbgtLDX4B+WaQgTnXQRWemAw2AYX4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bf4d38d57a5d08ee54625b1b97b1db1d62841512",
+        "rev": "526ed4cde185a2dd5d135e6dc4112c43a510606f",
         "type": "github"
       },
       "original": {
@@ -746,11 +746,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788572365,
-        "narHash": "sha256-QkvWAW4xVyViNOROThK2ftRLsH37d+l3eWPOJ1aPjtw=",
+        "lastModified": 1788650826,
+        "narHash": "sha256-X0yb+XqNkqAFoKFJSxhtidun5gsKxrd0+84CFvQWv9o=",
         "owner": "ogulcancelik",
         "repo": "herdr",
-        "rev": "3a822e8106b45745f9d463d9167033f977353d9f",
+        "rev": "9e9bc8a144667a6b7debfd4f0c7a31ff0e11493a",
         "type": "github"
       },
       "original": {
@@ -787,11 +787,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788487777,
-        "narHash": "sha256-Ro/e1N4ZR8/XaFF+sF9SgfPK79HM5YNEppzFj8p+0Ak=",
+        "lastModified": 1788651960,
+        "narHash": "sha256-v9wJd32eZ2bvhBzVOd7TIjLQd011P7nwOhjKtWlci5I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "693e8ce0fb240a73c116a03cfd7b19269c87af88",
+        "rev": "2c0350c759688177331b8f5242311fae8877bdb3",
         "type": "github"
       },
       "original": {
@@ -1301,11 +1301,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1788518164,
-        "narHash": "sha256-vY71mJCu5NgR+n+V4zpcRzZc6KL6SU9WmyMGzd8kYIA=",
+        "lastModified": 1788636433,
+        "narHash": "sha256-iCLUJO5V2ZlEAlYxlkCZ5YLkyQrpkyXOMUTkPXjsdPk=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "fdfc1821a0eb76e44a13d206b72e6ca6961fbb7c",
+        "rev": "804cbac7a462aa0fa8bb60c3d2fc4ead0a62060f",
         "type": "github"
       },
       "original": {
@@ -1412,11 +1412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788596131,
-        "narHash": "sha256-jGFTW/3w6G+uY7L38/oIpMn4PvAtctoDuQj7ruy/08k=",
+        "lastModified": 1788659991,
+        "narHash": "sha256-SmoOk+Jr/tMHqoS3paYeODihh72hL9kRsuHxK8bTzuw=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "72ac246314fc61dd44c487ccaa624670e1d67a17",
+        "rev": "eddc6a044f8bbd64680442addd6abfb50e008cde",
         "type": "github"
       },
       "original": {
@@ -1446,11 +1446,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788531059,
-        "narHash": "sha256-hLD4l3QOGBQhkVp3mQ2lJ/YbEi99qUgKapb40KovZ88=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "801bef6abd86b91e51083066b83fb354a11fc640",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {
@@ -1471,11 +1471,11 @@
         "parts": "parts"
       },
       "locked": {
-        "lastModified": 1788590971,
-        "narHash": "sha256-i11TAc8wNbng7UxqAm+UX2Z9fGYcPmYH3Am27ehSIqs=",
+        "lastModified": 1788677986,
+        "narHash": "sha256-2Go9o5aEwX6ulMpyKiLAZ/o/lJARz7GueF2AAOyiFm0=",
         "owner": "moni-dz",
         "repo": "nixpkgs-f2k",
-        "rev": "3c05b9fa166286bdbf3dd01943d12ca17c9fe288",
+        "rev": "262742f9cf939cc395a5547e82bbe0e0c2077db2",
         "type": "github"
       },
       "original": {
@@ -1554,11 +1554,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1788405554,
-        "narHash": "sha256-r2f1oUwixlgq9zOdYLqJLfS/lWBT60/IITjhTKI59JU=",
+        "lastModified": 1788584326,
+        "narHash": "sha256-Fd3OB8J9JhgliQwOKcqx4M672CInxi1I5VnwsaXeSQo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a5cc6f2c37bf518436dc8d1c288ccd0c43c2f4c4",
+        "rev": "6713828a351efa628b025a1adf7f43cbf8597513",
         "type": "github"
       },
       "original": {
@@ -1570,11 +1570,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1788531059,
-        "narHash": "sha256-hLD4l3QOGBQhkVp3mQ2lJ/YbEi99qUgKapb40KovZ88=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "801bef6abd86b91e51083066b83fb354a11fc640",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {
@@ -1586,11 +1586,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1788404924,
-        "narHash": "sha256-lhEhY8X5EgkQ/eg6IFz4cc8jRuSYSvnxx1al7d1dvZ0=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0968519e14f7aa7d3e9b389682bd74d2b51c8ce8",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {
@@ -1739,11 +1739,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1788531059,
-        "narHash": "sha256-hLD4l3QOGBQhkVp3mQ2lJ/YbEi99qUgKapb40KovZ88=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "801bef6abd86b91e51083066b83fb354a11fc640",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {
@@ -1761,11 +1761,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788597517,
-        "narHash": "sha256-sz38eYBNt8MJE2fe0TiGbqLi9FViH/N7rZtM/BYYF/Q=",
+        "lastModified": 1788677617,
+        "narHash": "sha256-eNw9rzlUzgF/EFM1YOq5w8oPQpD0r+pi0P99eU93Jss=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3e09654ebac64df799562337fb16bce236060f34",
+        "rev": "be798f6b1eedc2e335ed682910587d3f74725806",
         "type": "github"
       },
       "original": {
@@ -2001,11 +2001,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788591095,
-        "narHash": "sha256-Vh+BeLWfbTT9AecazIsQ/Tkg/RzJeX3lEduANf256WA=",
+        "lastModified": 1788678114,
+        "narHash": "sha256-pcqbpV4ZI79al6KAlr+WJjaEo/PYfgctRlG43D5BSJM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c361047d3a538f547f1617bb6b410411929ac9cc",
+        "rev": "4748ec2f5ed4a881474ed4c98aa71a5308cdac8d",
         "type": "github"
       },
       "original": {
@@ -2522,11 +2522,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788405419,
-        "narHash": "sha256-wuGizAVEmY0u15MYrhgy7AoQdHg+4Y2QiC+v/mxA8dc=",
+        "lastModified": 1788672837,
+        "narHash": "sha256-FgtxJIiNZfqNkLeIz30/CDE6v6gbou0MhuiFLt2En7w=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "fdb83f8fce835213fab7eab52c375926fe1a32dc",
+        "rev": "ec2c94c95846c36130edb9872a8ca4c203028c84",
         "type": "github"
       },
       "original": {

--- a/modules/webcam/default.nix
+++ b/modules/webcam/default.nix
@@ -17,7 +17,7 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = with pkgs; [
       droidcam
-      adb-sync
+      better-adb-sync
     ];
   };
 }

--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -20,8 +20,6 @@ final: _prev: {
     in
     final.callPackage ../pkgs/splashboard { inherit rustPlatform; };
 
-  gemini-cli = final.callPackage ../home/development/gemini-cli { };
-
   # gogcli — Google Workspace CLI (`gog`). Built from the canonical openclaw
   # repo at the latest tag rather than nixpkgs' older steipete 0.11.0.
   gogcli = final.callPackage ../pkgs/gogcli { };


### PR DESCRIPTION
`nhs` aborted before it could build: the nixpkgs bump in this run removed `adb-sync`.

```
error: 'adb-sync' has been removed. Use 'better-adb-sync' instead.
```

`modules/webcam/default.nix` still listed it in `systemPackages`. Taking upstream's named successor fixes that — and immediately exposes a second failure the first was hiding:

```
error: Path 'home/development/gemini-cli' does not exist in Git repository
```

`overlays/custom-packages.nix` still called that directory, which #560 deleted when `antigravity-cli` replaced `gemini-cli`. The `callPackage` line was left behind and had never been reached, because eval stopped at `adb-sync` first.

Worth recording: **one eval error masks the next.** A tree that was green before a nixpkgs bump does not mean the bump introduced only the breakage it reports — it means everything after the first failure is unexamined. The dead overlay line predates this bump by some weeks.

One more trap, for whoever reads the next trace like this: the error names a store path that looks like a flake input (`/nix/store/lrhp…-source/modules/webcam/default.nix`). It is this repo, copied into the store.

## Verified

All three hosts evaluate to a toplevel again:

```
p620   ck0agyi2fhh6pw1ysdd9hgy17fh1cdkb-nixos-system-p620-...
razer  zksbshs24wkjs92cbfkghv9rvlf58l3v-nixos-system-razer-...
p510   3ki2cvydl8rdpb88dqqbjzysr73b9dsz-nixos-system-p510-...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T
