### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -746,11 +746,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788650826,
-        "narHash": "sha256-X0yb+XqNkqAFoKFJSxhtidun5gsKxrd0+84CFvQWv9o=",
+        "lastModified": 1788701795,
+        "narHash": "sha256-HvfD235uwVUPaKjgNKUQ/LaF2ydIS1qPu8bLcH/fDjg=",
         "owner": "ogulcancelik",
         "repo": "herdr",
-        "rev": "9e9bc8a144667a6b7debfd4f0c7a31ff0e11493a",
+        "rev": "5a64e8da4551990367dd26d77cf3b654dfa27a73",
         "type": "github"
       },
       "original": {
@@ -1412,11 +1412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788659991,
-        "narHash": "sha256-SmoOk+Jr/tMHqoS3paYeODihh72hL9kRsuHxK8bTzuw=",
+        "lastModified": 1788699560,
+        "narHash": "sha256-I03QnPXmSqk2Ybnys5POBAlWspYp+XA2JCPmisf+Hlc=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "eddc6a044f8bbd64680442addd6abfb50e008cde",
+        "rev": "2aa2076ce278f7a68bbf20b32d5e2bbc76ff871a",
         "type": "github"
       },
       "original": {
@@ -1761,11 +1761,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788690199,
-        "narHash": "sha256-LqCCTYCzaw2eTazqXaWY4Q8xK5qxVztUnGf/FPchjEg=",
+        "lastModified": 1788701896,
+        "narHash": "sha256-rdfL6Hfx3eiMtg5Nwkjr5ttwg/mjcQllcCF4dP5gJMQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "664ba080c1226aad6afcf661f0e68c639be6bb25",
+        "rev": "397174398f7cb4e3cfd5b3f445ab65331cb1976f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=razer, scope=all).

Built and verified locally against nixosConfigurations.razer before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)