### PR TITLE
feat(zsh): swap built-in autosuggestion for deja

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -66,6 +66,9 @@
   home.sessionVariables.CLAUDE_CODE_SKIP_UPDATE_CHECK = "1";
 
   home.packages = [
+    # Predictive inline zsh autosuggestions. Wired up in home/shell/zsh.nix,
+    # which turns zsh's own autosuggestion widget off in favour of this.
+    pkgs.deja
     inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.opencode
     (pkgs.callPackage ../pkgs/weather-popup/default.nix { })
 

--- a/home/shell/zsh.nix
+++ b/home/shell/zsh.nix
@@ -65,12 +65,10 @@ in
         };
       };
 
-      # Enhanced autosuggestions
-      autosuggestion = {
-        enable = true;
-        strategy = [ "history" "completion" ];
-        highlight = "fg=#${colors.base03}";
-      };
+      # Inline autosuggestions come from deja (see initContent), not zsh's own
+      # widget. Both draw into the same inline slot and bind the same keys, so
+      # running them together leaves two engines fighting over one suggestion.
+      autosuggestion.enable = false;
 
       # zplug removed (2026-06): it cost ~290ms of startup just to load the one
       # github-copilot plugin, which is now loaded natively via the `plugins`
@@ -154,6 +152,18 @@ in
 
         # Safe sourcing of external configs
         [[ -f ~/.openai.sh ]] && source ~/.openai.sh
+
+        # deja: predictive inline autosuggestions (replaces zsh's own widget).
+        # `deja init zsh` does not print the integration — it writes
+        # ~/.local/share/deja/init.zsh and prints a source line for it, which
+        # keeps a ~25-36ms binary launch off every shell start. deja refreshes
+        # that file itself when the binary changes, so the eval below is only
+        # the first-run bootstrap, for before the file exists.
+        if [[ -r "$HOME/.local/share/deja/init.zsh" ]]; then
+          source "$HOME/.local/share/deja/init.zsh"
+        else
+          eval "$(deja init zsh)"
+        fi
 
 
         # Enhanced history management


### PR DESCRIPTION
`pkgs.deja` (nixpkgs 0.4.1) — predictive inline zsh suggestions from a Go daemon with fuzzy matching.

It draws into the same inline slot and binds the same keys as zsh's own autosuggestion widget, so the two cannot both be on: this is a swap, not an addition. `autosuggestion.enable = false` accordingly.

Added to the shared `home.packages`, so p620/razer/p510 all get it.

Verified: all three hosts eval clean; `autosuggestion.enable` is `false` in the built config; the deja block lands in the generated `initContent`.

Follow-up: `deja import` once per host after deploy to seed from existing history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T