### PR TITLE
chore(flake): bump all inputs (nixarchy re-pins hyprland)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787400831,
-        "narHash": "sha256-H3MEkFDZf+UH+QrVgW8TdKrssPFltF8fBg/rh0J1zIc=",
+        "lastModified": 1788444081,
+        "narHash": "sha256-I8i97p9WBQaZQyyBaHFMt8e01VfgfFZSaO+vAUd0u0A=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "7ce889cb78b97979b83a4648509fc3ef405c3286",
+        "rev": "36b66db4ddd708ad19f5db850af6a478d8a19b2a",
         "type": "github"
       },
       "original": {
@@ -746,11 +746,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788737224,
-        "narHash": "sha256-L54SVSXGCsQzuP/typ6cQt96l0QDUWV2qTP7APl+bsQ=",
+        "lastModified": 1788798791,
+        "narHash": "sha256-c2mzI+/5Mr5dy29T5SI298uOjwTbDatnHSdGNAisiws=",
         "owner": "ogulcancelik",
         "repo": "herdr",
-        "rev": "4b5e9bda239a0b6903889062d756424578e94691",
+        "rev": "702aa1e45527509bec73dad9b8d443f449c0379b",
         "type": "github"
       },
       "original": {
@@ -945,17 +945,16 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1787612295,
-        "narHash": "sha256-K7sUeS1tKTSDu+aQK0ZwCxJCls+JzDj1qeTJRGk+CV8=",
+        "lastModified": 1788777480,
+        "narHash": "sha256-F33tKTtFrhst7rc5P20BkpgAJo4Qp3JQeyaHeVxZNJQ=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "0bd11c7a04a63d2785abd53363f09d552175d67d",
+        "rev": "7ebf13abb3c391604c60c9f627c7a403bcec8d17",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "0bd11c7a04a63d2785abd53363f09d552175d67d",
         "type": "github"
       }
     },
@@ -1412,11 +1411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788733875,
-        "narHash": "sha256-Qp8QAN9zppWNcWepHsVrFdF9M6rRL9JSCvAxJ+hQ0Co=",
+        "lastModified": 1788799604,
+        "narHash": "sha256-seqRzX6RUTEJK4KXbyF/fx/WZ2HOmv905mfcxHnD9Ms=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "ffc74293d3b31087c802d4e3b7d58f2a933834f1",
+        "rev": "25cc6a57e073b71c495064f7b5fb6e0012473b54",
         "type": "github"
       },
       "original": {
@@ -1446,16 +1445,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788614874,
-        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
-        "owner": "nixos",
+        "lastModified": 1754028485,
+        "narHash": "sha256-IiiXB3BDTi6UqzAZcf2S797hWEPCRZOwyNThJIYhUfk=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
+        "rev": "59e69648d345d6e8fef86158c555730fa12af9de",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1710,11 +1709,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1787360063,
-        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "lastModified": 1788404924,
+        "narHash": "sha256-lhEhY8X5EgkQ/eg6IFz4cc8jRuSYSvnxx1al7d1dvZ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "rev": "0968519e14f7aa7d3e9b389682bd74d2b51c8ce8",
         "type": "github"
       },
       "original": {
@@ -1761,11 +1760,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788768033,
-        "narHash": "sha256-IKhnVc//qhUgM994Y3C1jyQ/kBBeDghCJsodCnHO59M=",
+        "lastModified": 1788799605,
+        "narHash": "sha256-UXm9nkOvrJVIpKqNRunHV/BnmWJ+qEsWXF36wpPzg6Q=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2f49330f86073a330180256dbb3aa3595ab9b9b2",
+        "rev": "1bc6668201c8a94679aebc120f2be8882f03f0a7",
         "type": "github"
       },
       "original": {
@@ -1867,11 +1866,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784288435,
-        "narHash": "sha256-ReRHaLgr/uVqdD8afFSn+myXIfpHeOhP0yYe0TJqAA8=",
+        "lastModified": 1788267358,
+        "narHash": "sha256-nt+lUqYVpc9Y6JeMd2WmXzCDojasdadKo0mWcluvY2Y=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "43b3c1ab9d40fb1dbb008f451988a91e375825e9",
+        "rev": "27555e2624241fb116b49095df4caaee85a25691",
         "type": "github"
       },
       "original": {
@@ -2480,11 +2479,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786988229,
-        "narHash": "sha256-frEFLVRj8xXvBBDs44IRiqHo6R2PxsRpluygL7abjjI=",
+        "lastModified": 1788025068,
+        "narHash": "sha256-TBqronrrc/F2Ry/E37d/1TLldDLJDFNSwvJjgk+cXzU=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "59d429bf45aed4e2209043c0c36565ad8e2859a5",
+        "rev": "ba31964ee42b56bcb0d3b78a64ead5d8a1c3c6f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps agenix/nixpkgs, herdr, nixarchy (+ its hyprland subtree), nur.

The one that matters: **nixarchy 25cc6a5 restores its `hyprland` input**, which a revision earlier had removed in favour of nixpkgs. It now tracks the branch (`github:hyprwm/Hyprland`) instead of carrying a rev in the URL — that form was invisible to `nix flake update`, so it silently sat on 0.56.0 while nixpkgs reached 0.56.2.

It came back rather than staying on nixpkgs because hyprwm's binary cache only serves the compositor while `inputs.nixpkgs.follows` is left unset on it; overriding forfeits the cache and rebuilds from source.

So **no change is needed** in `hosts/common/nixos/omarchy-sole-hyprland.nix` — `inputs.nixarchy.inputs.hyprland` resolves again and remains the store path the session script actually runs, which is what that file exists to guarantee.

Verified: p620 and razer both build; `deja-0.4.1` present in the p620 closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T