### PR TITLE
fix(networking): stop emitting a stub systemd-resolved unit

### DIFF
--- a/modules/common/networking.nix
+++ b/modules/common/networking.nix
@@ -30,10 +30,18 @@ let inherit (lib) mkOption mkIf mkEnableOption mkForce mkMerge types; in {
     # visible symptom). Keep them running across a switch; new DNS config applies
     # at next boot/logout. Root fix — supersedes the per-service ollama guard.
     {
-      systemd.services.systemd-resolved.restartIfChanged =
-        mkIf config.services.resolved.enable false;
-      systemd.services.NetworkManager.restartIfChanged =
-        mkIf config.networking.networkmanager.enable false;
+      # The mkIf must wrap the whole attrset: defining
+      # systemd.services.<name>.* at all makes NixOS emit a unit file, so an
+      # inner mkIf leaves a stub with no ExecStart ("bad-setting" on razer,
+      # where resolved is off).
+      systemd.services = mkMerge [
+        (mkIf config.services.resolved.enable {
+          systemd-resolved.restartIfChanged = false;
+        })
+        (mkIf config.networking.networkmanager.enable {
+          NetworkManager.restartIfChanged = false;
+        })
+      ];
     }
 
     # TCP / qdisc baseline for the high-jitter Starlink uplink (all hosts).


### PR DESCRIPTION
## Problem

razer logs this on every boot and every `nixos-rebuild switch`:

```
systemd-resolved.service: Service has no ExecStart=, ExecStop=, or SuccessAction=. Refusing.
```

`systemctl status systemd-resolved` reports `Loaded: bad-setting`. Found while sweeping journals across all three hosts. It never shows in `systemctl --failed`, which is why it went unnoticed.

## Root cause

`modules/common/networking.nix` had the `mkIf` *inside* the service attrset:

```nix
systemd.services.systemd-resolved.restartIfChanged =
  mkIf config.services.resolved.enable false;
```

Defining anything under `systemd.services.<name>` makes NixOS emit a unit file — the inner `mkIf` removes the value, not the unit. razer has `services.resolved.enable = false`, so it got a unit with no `ExecStart`. This is the mirror of the `mkIf cond true` anti-pattern in CLAUDE.md.

## Fix

Wrap the whole attrset instead. Same treatment for the NetworkManager sibling, which had the identical shape (harmless today only because NM is enabled everywhere).

## Verification

- `nix eval .#nixosConfigurations.razer.config.systemd.units."systemd-resolved.service".name` — returns the unit before the change, attribute gone after
- Same eval on p620 (resolved enabled) still returns the unit, so the hosts that use resolved are unaffected
- `just test-host razer` passes in 68s (unit-file regeneration only, no package rebuilds)

DNS behaviour is unchanged on every host: razer resolves via resolvconf/Tailscale and the stub never ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T