### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1782,11 +1782,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788851750,
-        "narHash": "sha256-Z4RtPJe2FMUXrb7HdxKshlWEYKMUTMJa1/RqEugx/AM=",
+        "lastModified": 1788855041,
+        "narHash": "sha256-W9VJ85D/i6b6fu4cvCyatxYke+6S0VBOFQsW7lMckW0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b34dcdf978c2ead8a3609cd09ab49218b785a03a",
+        "rev": "1beb7ca02403b1f942e43ea19631d0d183d23475",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=razer, scope=all).

Built and verified locally against nixosConfigurations.razer before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)