### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -746,11 +746,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788879119,
-        "narHash": "sha256-Ae6L/g9+/TKQ1ZNPmN0hWuR9TpRddmXZjfXhAMHk2ZQ=",
+        "lastModified": 1788903125,
+        "narHash": "sha256-ZuFQ+4hVVbEsBuex6E64otx9HLevh+DNisgfP8KWFVE=",
         "owner": "ogulcancelik",
         "repo": "herdr",
-        "rev": "68c7b78ec237034cbb0e21c8666842ed7991641d",
+        "rev": "8be4cf765afddfd9cf3206602ba4dab682a29fa1",
         "type": "github"
       },
       "original": {
@@ -1400,6 +1400,7 @@
         "hyprland": "hyprland",
         "microvm": "microvm_2",
         "nix-flatpak": "nix-flatpak",
+        "nixi": "nixi",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": [
           "nixpkgs"
@@ -1412,16 +1413,38 @@
         ]
       },
       "locked": {
-        "lastModified": 1788878908,
-        "narHash": "sha256-dJDj7eSc6uea+JTHvlQN8G8FbVc9NnupPS8zOLp6soM=",
+        "lastModified": 1788895518,
+        "narHash": "sha256-PUffaEQo2tXRpFgEwCtfXfuxxbfOyI98Gjb3uTPb8UY=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "cf8117490a0872c61ba12864722f06ae5033f78f",
+        "rev": "54618b1b7285ca5ab1b7e5b36ba7bc853d5d2d57",
         "type": "github"
       },
       "original": {
         "owner": "olafkfreund",
         "repo": "nixarchy",
+        "type": "github"
+      }
+    },
+    "nixi": {
+      "inputs": {
+        "nixpkgs": [
+          "nixarchy",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788522028,
+        "narHash": "sha256-GPa6Rm/xZIOdCc4sTHM2t8NYgEGtitoTC2K+pBM7IUQ=",
+        "owner": "olafkfreund",
+        "repo": "nixi-nixarchy",
+        "rev": "a141b1689fb69f9f7462ba5cbbe1945abfa0901a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "olafkfreund",
+        "repo": "nixi-nixarchy",
+        "rev": "a141b1689fb69f9f7462ba5cbbe1945abfa0901a",
         "type": "github"
       }
     },
@@ -1782,11 +1805,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788878084,
-        "narHash": "sha256-v7QZQEbYFJHMB7coGfTS6OQ7HULIrOkCYXhUZlD66Mw=",
+        "lastModified": 1788904871,
+        "narHash": "sha256-xuEZXWd6JhU1NpQDYXVN6yrxXVskUJzMlnZRW6+TvOU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2a38eeccf3fd6ed377ac6a97f44d53cc9a45ad1",
+        "rev": "b9aa94fd0da47a64f73d5d175d9e3d9317cb460c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=p620, scope=all).

Built and verified locally against nixosConfigurations.p620 before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)