### PR TITLE
fix(home-manager): repair backupCommand so collisions are not fatal (#1731)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -319,12 +319,15 @@
                 home-manager = {
                   useGlobalPkgs = true;
                   useUserPackages = true;
-                  # Use backup command to move files to timestamped directory
-                  # This prevents backup file collisions by using unique directories
+                  # Move a colliding file into a timestamped directory instead of
+                  # failing activation. `date -Is` rather than a +%Y%m%d format:
+                  # the % specifiers were expanded as systemd unit specifiers
+                  # (%d -> credentials dir, %S -> state dir), which is half of
+                  # why this never ran.
                   backupCommand = ''
-                    backup_dir = "$HOME/.hm-backups/$(date +%Y-%m-%d-%H%M%S)"
-                      mkdir - p "$(dirname "$backup_dir/$1 ")"
-                      mv "$1" "$backup_dir/$1"
+                    backup_dir="$HOME/.hm-backups/$(date -Is)"
+                    mkdir -p "$(dirname "$backup_dir/$1")"
+                    mv "$1" "$backup_dir/$1"
                   '';
                   # Shared modules for all users
                   sharedModules = [


### PR DESCRIPTION
Closes #1731.

`home-manager.backupCommand` has never run successfully. It is the mechanism that moves a colliding file aside so activation can continue — broken, it makes every imperative-file collision a **fatal** activation failure with automatic rollback.

## The four defects

```nix
backup_dir = "$HOME/.hm-backups/$(date +%Y-%m-%d-%H%M%S)"
  mkdir - p "$(dirname "$backup_dir/$1 ")"
```

1. Spaces around `=` — bash runs `backup_dir` as a command. `backup_dir: command not found`. A *runtime* error, not a parse error, so `bash -n` passes it and nothing caught it at build time.
2. `mkdir - p`
3. Stray space in `"$backup_dir/$1 "`
4. `%Y-%m-%d-%H%M%S` eaten by systemd specifier expansion (`%d` → credentials dir, `%S` → state dir)

## Why now

Two razer deploys failed today (#1729, #1730), both rolled back, both blamed on an "upstream regression" by the deploy script's canned message. Nothing upstream was involved. The colliding files were written imperatively by nixi's `install.py --all` on 2026-09-04; the new generation declares the same paths. Same family as #936.

## Verification

- `nix eval .#nixosConfigurations.razer.config.system.build.toplevel.drvPath` — succeeds
- Ran the new command standalone against a stand-in `~/.config/nixi/KNOWLEDGE.md`: file moved to `~/.hm-backups/2026-09-09T10:38:07+01:00/…` with contents intact, original gone. The old version fails with `command not found` and leaves the file in place.

`date -Is` is used rather than a `+%…` format so there is no `%` to escape, avoiding the question of whether the string lands in a systemd unit (needing `%%`) or a store script (not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T