### PR TITLE
fix(home-manager): make backupCommand an executable, not a shell snippet (#1731)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -315,17 +315,25 @@
             ]
             ++ stylixModule
             ++ [
-              {
+              ({ pkgs, ... }: {
                 home-manager = {
                   useGlobalPkgs = true;
                   useUserPackages = true;
                   # Move a colliding file into a timestamped directory instead of
-                  # failing activation. `date -Is` rather than a +%Y%m%d format:
-                  # the % specifiers were expanded as systemd unit specifiers
-                  # (%d -> credentials dir, %S -> state dir), which is half of
-                  # why this never ran.
-                  backupCommand = ''
-                    backup_dir="$HOME/.hm-backups/$(date -Is)"
+                  # failing activation.
+                  #
+                  # This must be an EXECUTABLE, not a shell snippet: HM runs it as
+                  # argv ("$@" in home-manager.sh) with the file as $1, so a
+                  # multi-line string is word-split and its first token exec'd.
+                  # The option's own example is "${pkgs.trash-cli}/bin/trash".
+                  #
+                  # One directory per activation rather than a ".bak" suffix, so a
+                  # second collision on the same path cannot clobber the first
+                  # backup. `date -Is` avoids % entirely, which would otherwise be
+                  # eaten by systemd unit specifier expansion.
+                  backupCommand = pkgs.writeShellScript "hm-backup-file" ''
+                    set -euo pipefail
+                    backup_dir="''${HOME}/.hm-backups/$(date -Is)"
                     mkdir -p "$(dirname "$backup_dir/$1")"
                     mv "$1" "$backup_dir/$1"
                   '';
@@ -358,7 +366,7 @@
                     })
                     allUsers);
                 };
-              }
+              })
             ];
         };
     in


### PR DESCRIPTION
Follow-up to #1732, which was an incomplete fix for #1731.

#1732 corrected the shell *text* of `backupCommand` but left it the wrong **kind of thing**, and razer's third deploy still failed:

```
home-manager.sh: line 125: backup_dir="$HOME/.hm-backups/$(date: No such file or directory
```

## Root cause

HM runs `backupCommand` as **argv**, not through a shell — `home-manager.sh` line 125 is literally `"$@"`. The string is word-split and its first token executed as a program, with the colliding file as `$1`.

The option confirms it: `example = lib.literalExpression "${pkgs.trash-cli}/bin/trash"`, described as "On activation run this command on each existing file". It wants a path to a program. A three-line shell body could never work there, however correct the shell.

## Fix

`pkgs.writeShellScript`. That needs `pkgs` in scope, so the inline module becomes `{ pkgs, ... }: { ... }`.

## Verification

Built the derivation and invoked it the way HM does:

```
$ /nix/store/...-hm-backup-file ~/.config/nixi/KNOWLEDGE.md
-> exit 0
original gone? yes
backup: ~/.hm-backups/2026-09-09T10:46:24+01:00/.../.config/nixi/KNOWLEDGE.md
content: precious
```

The tell that #1732 never worked: `~/.hm-backups/` did not exist on razer after that deploy. No backup had ever been taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T