### PR TITLE
chore(p510): remove the nixarchy self-hosted CI runners (#1737)

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -27,7 +27,6 @@ in
       ../common/nixos/host-class.nix
       ../common/nixos/zfs-import.nix
       ../common/nixos/inotify-limits.nix
-      ../../modules/services/nixarchy-runner.nix # Self-hosted CI for nixarchy's VM checks
       ./nixos/cpu.nix
       ./nixos/memory.nix
       ./nixos/resilience.nix # Watchdog + sshd limits + oomd (post-2026-07-08 freeze)
@@ -769,6 +768,10 @@ in
     "z /mnt/media/sonarr 0750 - - - -"
     "z /mnt/media/radarr 0750 - - - -"
     "z /mnt/media/lidarr 0750 - - - -"
+    # Nix's build directory (see nix.settings.build-dir below). Root-owned and
+    # 0755: the daemon writes here as root, and nix refuses a world-writable
+    # build directory outright.
+    "d /home/nix-build 0755 root root -"
   ];
 
   features.sqlite-backup = {
@@ -981,27 +984,28 @@ in
     keepalive.enable = true;
   };
 
-  # nixarchy's install and ISO checks need KVM, an hour, and 16 GB of build
-  # directory. See modules/services/nixarchy-runner.nix.
-  services.nixarchy-runner = {
-    enable = true;
-
-    # /home (/dev/sdd1, WD10EZEX, 7200 rpm CMR), NOT /mnt/img_pool. The pool
-    # has the most free space and is the worst possible target: /dev/sdb1 is an
-    # ST1000LM035, a drive-managed SMR disk that collapses to single-digit MB/s
-    # once its cache band is full, and a 16 GB VM install is exactly that
-    # sustained-write pattern. Pointing builds there would have reproduced the
-    # hang it was meant to prevent, with the disk as the cause instead of the
-    # free-space figure. Measured, same host, same day:
-    #
-    #                    sequential 512M    4M writes, O_DSYNC
-    #   /home            125 MB/s           59.4 MB/s
-    #   /mnt/img_pool    (SMR)              ~9.5 MB/s
-    #
-    # /home has its own history of filling up -- it is where per-commit
-    # container images have run away before -- so this shares a filesystem with
-    # something that needs watching. 16 GB against 825 GB free is not the thing
-    # that will fill it.
-    buildDir = "/home/nix-build";
-  };
+  # The nixarchy self-hosted runners were removed from this host (#1737); p620
+  # carries the whole [self-hosted, nixos, kvm, big] pool now.
+  #
+  # Their build directory stays. It arrived with the runners but is not about
+  # them: p510 still builds its own system, and this is the #1643 fix. Both
+  # lines are needed, and the second is the one that actually decides it —
+  # nix's `build-dir` defaults to /nix/var/nix/builds on the root filesystem
+  # and takes precedence over TMPDIR. When only TMPDIR was set it went quietly
+  # inert across a nix bump: /home/nix-build sat at zero entries for months
+  # while every build had moved back to /, and the failure surfaced four levels
+  # above the cause as a failed ESP assertion rather than an honest ENOSPC.
+  # TMPDIR still governs anything reading the environment rather than the
+  # setting, so dropping it would move that half back to / silently.
+  #
+  # /home (/dev/sdd1, WD10EZEX, 7200 rpm CMR), NOT /mnt/img_pool. The pool has
+  # the most free space and is the worst possible target: /dev/sdb1 is an
+  # ST1000LM035, a drive-managed SMR disk that collapses to single-digit MB/s
+  # once its cache band is full. Measured, same host, same day:
+  #
+  #                    sequential 512M    4M writes, O_DSYNC
+  #   /home            125 MB/s           59.4 MB/s
+  #   /mnt/img_pool    (SMR)              ~9.5 MB/s
+  systemd.services.nix-daemon.environment.TMPDIR = "/home/nix-build";
+  nix.settings.build-dir = "/home/nix-build";
 }


### PR DESCRIPTION
Closes #1737.

p510 leaves the runner pool. p620 two runners carry the whole `[self-hosted, nixos, kvm, big]` label set from now on.

## The non-obvious half: the build directory stays

`modules/services/nixarchy-runner.nix` does more than define runners:

```nix
systemd.services.nix-daemon.environment.TMPDIR = cfg.buildDir;
nix.settings.build-dir = cfg.buildDir;   # /home/nix-build
```

Deleting the block wholesale would have sent every p510 nix build back to `/nix/var/nix/builds` on `/` and reintroduced #1643. That is a bad failure to reintroduce: last time it went inert *silently* — `/home/nix-build` sat at zero entries for months while every build had quietly moved back to `/` — and it surfaced four levels above the cause as a failed ESP assertion rather than an honest ENOSPC.

p510 still builds its own system, and `/` has 93G free against `/home` 786G. So both lines and the tmpfiles rule move into the host config. The tmpfiles rule is appended to p510 existing `systemd.tmpfiles.rules` list rather than declaring a second one.

## Verification

```
p510 services.github-runners  -> []
p510 nix.settings.build-dir   -> /home/nix-build
p510 nix-daemon TMPDIR        -> /home/nix-build
p510 tmpfiles rule            -> "d /home/nix-build 0755 root root -"
p620 services.github-runners  -> ["nixarchy","nixarchy-2"]   (untouched)
```

`config.system.build.toplevel.drvPath` evaluates.

## Runtime state

Both units are already stopped on p510 (two in-flight `install` jobs were cancelled). They **cannot** be masked or disabled durably without this deploy: NixOS unit symlinks live in `/etc/systemd/system`, which outranks `/run/systemd/system`, and `systemctl disable` fails on the read-only store. They will restart on reboot until this lands.

## Follow-up

The registrations `p510-nixarchy` and `p510-nixarchy-2` still exist in the nixarchy repo runner list and should be deleted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T