### PR TITLE
chore(p620): raise nixarchy runners from two to four (#1739)

### DIFF
--- a/hosts/p620/configuration.nix
+++ b/hosts/p620/configuration.nix
@@ -82,11 +82,23 @@ in
     # disk problem.
     buildDir = "/mnt/games/nix-build";
 
-    # Two, matching p510, despite p620 having 128 cores to p510's 40. The limit
-    # is not cores: this is an interactive workstation, and each of these jobs
-    # boots a VM that wants real memory and real disk throughput. Raise it if
-    # the queue rather than the desktop turns out to be the complaint.
-    instances = 2;
+    # Four since #1739, raised from two because the queue became the complaint:
+    # p510 left the pool (#1737), so this host now carries the whole
+    # `nixos`/`kvm`/`big` label set alone, and both its runners were observed
+    # busy simultaneously the moment that happened.
+    #
+    # Sized against what a job actually asks for, which is twice what it looks
+    # like: install-check runs the install and free-space VMs in ONE nix
+    # invocation so they boot concurrently, each memorySize 6144, cores 4,
+    # diskSize 32768. So a job is 12 GB and 8 cores, and four jobs is eight VMs
+    # -- 48 GB and 32 cores, against 128 cores and 251 GB (145 GB available
+    # with the desktop running). Disk is the tighter of the two: ~128 GB of VM
+    # images at peak against 590 GB free on /mnt/games.
+    #
+    # The old note here said the limit is not cores but the interactive
+    # desktop, and that still governs. 48 GB of 145 leaves the workstation
+    # intact; this is not headroom to spend again without measuring.
+    instances = 4;
   };
 
   # Consolidated networking configuration


### PR DESCRIPTION
Closes #1739.

p510 left the `[self-hosted, nixos, kvm, big]` pool in #1737, leaving p620 two runners to carry all of nixarchy CI — both were `busy=true` the moment it happened. The existing comment in this file called the shot: *"Raise it if the queue rather than the desktop turns out to be the complaint."*

## Sizing

A job asks for twice what it looks like. `install-check.yml` runs the install and free-space VMs in **one** nix invocation so they boot concurrently, each `memorySize 6144, cores 4, diskSize 32768`:

| | per job | x4 |
| --- | --- | --- |
| RAM | 12 GB | 48 GB |
| cores | 8 | 32 |
| VM images | ~32 GB | ~128 GB peak |

Against p620: **128 cores**, **251 GB RAM (145 GB available** with the desktop running), **590 GB free** on `/mnt/games`. Disk is the tighter of the three and still has 4x margin.

## Verification

```
services.github-runners     -> ["nixarchy","nixarchy-2","nixarchy-3","nixarchy-4"]
registered names            -> ["p620-nixarchy","p620-nixarchy-2","p620-nixarchy-3","p620-nixarchy-4"]
nixarchy-4 extraLabels      -> ["nixos","kvm","big"]
```

`config.system.build.toplevel.drvPath` evaluates. The first two instances keep the names they already registered under, so nothing is re-registered and no stale offline entry appears in the repo runner list.

## Caveat, stated because the module docs are right about it

This is not a free lever. p620 is an interactive workstation and each job boots real VMs. 48 GB of 145 leaves the desktop intact, but this is not headroom to spend again without measuring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T