### PR TITLE
chore(p510): remove the duplicate k3d factory cluster (#1747)

### DIFF
--- a/hosts/p510/configuration.nix
+++ b/hosts/p510/configuration.nix
@@ -41,7 +41,6 @@ in
       ../../modules/services/plex-mcp.nix # Plex MCP server (HTTP transport, tailnet-only)
       ../../modules/services/sqlite-backup.nix # sqlite snapshots off the failing media disk
       ../../modules/services/backstage.nix # Backstage developer portal (epic #731, disabled by default)
-      ../../modules/containers/k3d.nix # k3d (k3s in Docker) cluster — ArgoCD + Tailscale operator (see docs/applications/k3d-cluster.md)
       ../../modules/services/arr-suite-mcp.nix # *arr suite MCP server (SSE bridge, tailnet-only)
       ../../modules/services/audiobookbay-automated.nix # AudioBookBay search → Transmission
       ../../modules/services/torrent-vpn.nix # Transmission confined to a ProtonVPN namespace
@@ -508,41 +507,13 @@ in
     dataRoot = "/home/docker";
   };
 
-  # k3d cluster — runs ArgoCD, watches github.com/olafkfreund/factory-gitops
-  # for App-of-Apps manifests. Tailnet exposure for in-cluster services uses
-  # the Tailscale SIDECAR pattern (not the operator): the bootstrap unit
-  # seeds a `tailscale-auth-key` Secret into each consuming namespace
-  # (argocd, factory) so Pods can mount `TS_AUTHKEY` into a sidecar
-  # `tailscale` container that registers a tailnet node.
-  # See docs/applications/k3d-cluster.md for ops, docs/architecture/k3d-architecture.md
-  # for the design, and docs/guides/factory-gitops.md for the sidecar pattern.
-  modules.containers.k3d = {
-    enable = true;
-    # PV backing store follows Docker off the SMR pool onto /home. The
-    # module default (/mnt/img_pool/k3d/storage) was chosen to keep cluster
-    # PVCs away from the media library's IOPS, which still holds — /home is
-    # simply the faster of the two non-media disks.
-    storageDir = "/home/k3d/storage";
-    argocd.enable = true;
-    tailscaleAuthKey.enable = true;
-    factorySecrets.enable = true; # #807: durably seed all factory ns Secrets from agenix
-    # Without this /home fills with per-commit factory images: 651GB reclaimed
-    # by hand on 2026-08-13 (83% -> 8%). Sunday 04:00 keeps the churn off the
-    # media server's evening peak.
-    imageGc = {
-      enable = true;
-      dates = "Sun 04:00";
-    };
-    # Bind kube API to p510's tailnet IP so kubectl from any tailnet
-    # device can drive the cluster directly (`kubectl get nodes` against
-    # https://100.118.96.32:6443). k3d 5.x's port-publishing logic
-    # doesn't honour `0.0.0.0` correctly (empty Docker PortBindings),
-    # so an explicit IP is required. Posture: tailnet ACL is default-
-    # open + host firewall disabled; auth gates on the kubeconfig
-    # bearer token. p510's tailnet IP is stable per-device — Tailscale
-    # doesn't renumber unless you delete + re-add the node.
-    apiHostBind = "100.118.96.32";
-  };
+  # No k3d here. The factory cluster moved to p620 (#1747, completing the
+  # migration whose Phase 2 stood it up there), and this host ran a duplicate
+  # of it until 2026-09-10 — two ArgoCD controllers reconciling the same
+  # factory-gitops repo, p510's cronjobs erroring continuously while p620's
+  # completed on schedule. Deleting it returned 58 GB of /home (81G -> 23G).
+  #
+  # Docker itself stays, above: it is not only a k3d substrate.
 
   # Claude Code managed-settings baseline (mirrors p620 + razer): PARR
   # protocol reminder hook + apiKeyHelper baseline. Read-only at


### PR DESCRIPTION
Closes #1747.

p510 was running a **duplicate** of the `factory` k3d cluster. p620 has run the live one for five days — its own config calls it *"Phase 2 of the p510→p620 migration"* — so p510's copy was pure overhead, and worse than idle.

## Two ArgoCD controllers, one GitOps repo

Identical namespace sets on both (`argocd`, `factory`, `fides`, `fides-reporter`, `keda`, `kyverno`, `tailscale`), both reconciling `factory-gitops`:

| | p510 | p620 |
| --- | --- | --- |
| Running pods | ~20 | 39 |
| `aifactory` | Running | Running 2/2, restarted 10m prior |
| `cfactory` / `cfactory-frontend` | absent | present |
| `argocd-drift` cronjobs | Error | Completed 7m / 12m ago |

p510 also threw continuous `audit-anchor-alert` and `audit-siem-forward` errors — which is what two controllers fighting over drift detection looks like.

## Disk

Deleting the cluster returned **58 GB** of `/home` (81G → 23G used, 10% → 3%), nearly all of it one docker volume (`c0eed86d…`, 59 GB — the k3s containerd store). A further 438 MB of orphaned images pruned after. Docker is now 0 containers, 0 volumes, 0 images.

## Why the config change is required

`k3d-cluster-bootstrap.service` is `enabled`/`linked` and would rebuild the entire cluster on the next boot. Same lesson as #1737: a runtime-only teardown on NixOS comes back, because `/etc/systemd/system` outranks `/run` and `systemctl disable` fails on the read-only store. Only removing the module makes it stick.

## Kept deliberately

- `modules.containers.docker` with `dataRoot = "/home/docker"` — Docker is not only a k3d substrate.
- `hosts/p510/nixos/resilience.nix` — its comments name k3d, but the tuning (oomd on Docker's cgroup, surviving a nixos-rebuild) targets Docker generally.

## Verification

```
p510 modules.containers.k3d      -> option no longer exists (module not imported)
p510 k3d systemd units           -> []
p510 virtualisation.docker       -> true
p620 modules.containers.k3d      -> true   (untouched)
```

`config.system.build.toplevel.drvPath` evaluates.

## Noticed, not fixed here

`docs/plans/2026-08-20-k3d-p510-to-p620-migration.md` is cited from both hosts' configs and **does not exist**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T
