### PR TITLE
chore(flake): bump all (nixpkgs unchanged)

### DIFF
--- a/Users/olafkfreund/p620_home.nix
+++ b/Users/olafkfreund/p620_home.nix
@@ -26,12 +26,10 @@
   # GitLab runner enabled on the workstation (AC-powered)
   development.gitlab.runner.enable = true;
 
-  # AI-powered shell command suggestions (Ctrl+G)
-  programs.zshAiCmd = {
-    enable = true;
-    triggerKey = "^G";
-    debug = false;
-  };
+  # AI-powered shell command suggestions (Ctrl+G). Off: it only worked by
+  # exporting ANTHROPIC_API_KEY into every interactive shell, and bash's
+  # flyline agent mode covers the same ground (#1751).
+  programs.zshAiCmd.enable = false;
 
   # splashboard — terminal splash screen on shell startup + cd. User config
   # under ~/.splashboard/ (not nix-managed). Opt out per-shell with

--- a/flake.lock
+++ b/flake.lock
@@ -585,7 +585,7 @@
     },
     "flake-utils_7": {
       "inputs": {
-        "systems": "systems_12"
+        "systems": "systems_13"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -603,7 +603,7 @@
     },
     "flake-utils_8": {
       "inputs": {
-        "systems": "systems_13"
+        "systems": "systems_14"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -1470,6 +1470,27 @@
         "type": "github"
       }
     },
+    "nixarchy-voice": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_9"
+      },
+      "locked": {
+        "lastModified": 1789124217,
+        "narHash": "sha256-4k4Bnt5wtud0lj3RBP399bP53Bhfb89un3j3r1JWSXE=",
+        "owner": "olafkfreund",
+        "repo": "nixarchy-voice",
+        "rev": "76ad17ce1cd471ce24402c12497f07b8906dc165",
+        "type": "github"
+      },
+      "original": {
+        "owner": "olafkfreund",
+        "repo": "nixarchy-voice",
+        "type": "github"
+      }
+    },
     "nixi": {
       "inputs": {
         "nixpkgs": [
@@ -2004,6 +2025,7 @@
         "nix-index-database": "nix-index-database",
         "nix-snapd": "nix-snapd",
         "nixarchy": "nixarchy",
+        "nixarchy-voice": "nixarchy-voice",
         "nixos-hardware": "nixos-hardware_2",
         "nixpkgs": "nixpkgs_9",
         "nixpkgs-f2k": "nixpkgs-f2k",
@@ -2241,7 +2263,7 @@
     "spicetify-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_11",
-        "systems": "systems_10"
+        "systems": "systems_11"
       },
       "locked": {
         "lastModified": 1788683578,
@@ -2270,7 +2292,7 @@
           "nixpkgs"
         ],
         "nur": "nur_2",
-        "systems": "systems_11",
+        "systems": "systems_12",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
@@ -2306,6 +2328,7 @@
       }
     },
     "systems_10": {
+      "flake": false,
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -2322,6 +2345,21 @@
     },
     "systems_11": {
       "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_12": {
+      "locked": {
         "lastModified": 1774449309,
         "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",
         "owner": "nix-systems",
@@ -2336,7 +2374,7 @@
         "type": "github"
       }
     },
-    "systems_12": {
+    "systems_13": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -2351,7 +2389,7 @@
         "type": "github"
       }
     },
-    "systems_13": {
+    "systems_14": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -2472,18 +2510,17 @@
       }
     },
     "systems_9": {
-      "flake": false,
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default",
+        "repo": "default-linux",
         "type": "github"
       }
     },
@@ -2647,7 +2684,7 @@
           "seance",
           "nixpkgs"
         ],
-        "systems": "systems_9"
+        "systems": "systems_10"
       },
       "locked": {
         "lastModified": 1775609538,

--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789024546,
-        "narHash": "sha256-SDb9pBhpLBR8X6f8RsaihBZeRTpreXFWSR9Kz/eYOQQ=",
+        "lastModified": 1789110902,
+        "narHash": "sha256-dGqG5oE8BPhLSk08d1UBrTo0dhOIcbNtGeGT7hWZsXE=",
         "owner": "jacopone",
         "repo": "antigravity-nix",
-        "rev": "55bc1024a2aae270102e42e5f5f21f2cac7fb790",
+        "rev": "af9b4b138af1b0805720564f825bbdd715e5acf5",
         "type": "github"
       },
       "original": {
@@ -286,11 +286,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1789012948,
-        "narHash": "sha256-ix6Ro1D1diVJxH3R/OoIlvfTEgWSsvDVh2UwFgoGIyg=",
+        "lastModified": 1789099099,
+        "narHash": "sha256-2iMUkiZZU63dDpbr6bcVp7zfgKvncznGZ7AnxEbZsvY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3eaebc4b830a25358876e1840e68939d6df8af1e",
+        "rev": "0e6614b0bc20cf531402b20b0f0b072195a1712b",
         "type": "github"
       },
       "original": {
@@ -766,11 +766,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789087886,
-        "narHash": "sha256-/D9EEyr0A6wl0sbwYRQuR5Z+onECT5w5J3DXQBCku0s=",
+        "lastModified": 1789162737,
+        "narHash": "sha256-ACzb5WjoD3eiHQ/xjyTcHXOG60vNEXPcmHZgloi14Vs=",
         "owner": "ogulcancelik",
         "repo": "herdr",
-        "rev": "61ca85d5895bb530b59da85beeccdd767f4720d2",
+        "rev": "9ad65d9031e8cb16a7b553c0e6f74809e9811e92",
         "type": "github"
       },
       "original": {
@@ -829,11 +829,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789099078,
-        "narHash": "sha256-zzHj2wl69724lzx7DLAVziWbL75wRIk+xJ3duD0Bgrc=",
+        "lastModified": 1789150619,
+        "narHash": "sha256-Vsgv5atXkGWOOdLOL8oQLnZSGt1h140synPfFdwbyjU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f10b3f2ad4aae9259617a1ff518cc921e3394228",
+        "rev": "e4345d5ae8aa1def34378d2a60ac5e6e4c8fd7c1",
         "type": "github"
       },
       "original": {
@@ -1457,11 +1457,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789080708,
-        "narHash": "sha256-4O8+Sg0/ZSRs546SXNYrO/1r7Ei+y1uOPOw4z2T0xPM=",
+        "lastModified": 1789164853,
+        "narHash": "sha256-I/oruIkYRAD1ceauYMrjpt4IO89Q+J3GxyTYOiCMElQ=",
         "owner": "olafkfreund",
         "repo": "nixarchy",
-        "rev": "50e7a9f1becabd172025ddfab2f3705495c08395",
+        "rev": "d8f0a91e7cbe6a6953cdf40ca0c41b2447c77fc7",
         "type": "github"
       },
       "original": {
@@ -1478,11 +1478,11 @@
         "systems": "systems_9"
       },
       "locked": {
-        "lastModified": 1789124217,
-        "narHash": "sha256-4k4Bnt5wtud0lj3RBP399bP53Bhfb89un3j3r1JWSXE=",
+        "lastModified": 1789137217,
+        "narHash": "sha256-hvkSIsqcyy9zYjNZYZA1Yx75DaAmxgQYDUenYJRB0uI=",
         "owner": "olafkfreund",
         "repo": "nixarchy-voice",
-        "rev": "76ad17ce1cd471ce24402c12497f07b8906dc165",
+        "rev": "e547f58dd8fbcfb2cbf4da0cb4fae80846e4cf7f",
         "type": "github"
       },
       "original": {
@@ -1539,11 +1539,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1788942796,
-        "narHash": "sha256-CLoJCCRi9sogsyGXYn8rOCWBLKAntfKUB9Rli/YXgEY=",
+        "lastModified": 1789127271,
+        "narHash": "sha256-vL/Fpo7Zxa7wvO8V5FAToUBvP+K3XsMB1wUglTtd/J0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "83bbc895120516d6e86885a188c04beced6535d9",
+        "rev": "24cfdc1f9344b90a1eee329a3906e2f39f4d0f1e",
         "type": "github"
       },
       "original": {
@@ -1580,11 +1580,11 @@
         "parts": "parts"
       },
       "locked": {
-        "lastModified": 1789024182,
-        "narHash": "sha256-aZv3N6sR6DBkO6Z9llFzx73ZPfff5p5QexXr9SN3jxU=",
+        "lastModified": 1789110560,
+        "narHash": "sha256-oaxAAkQuBHiT7vx6WMaLsXuCf9KbXzX0DdXTn0Pj9cU=",
         "owner": "moni-dz",
         "repo": "nixpkgs-f2k",
-        "rev": "a1b63d707e8ef787827ef15b880ff02d5a09a004",
+        "rev": "d21aab347e61bcbf0aefecc3e8322a51db48a9c5",
         "type": "github"
       },
       "original": {
@@ -1679,11 +1679,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1788921488,
-        "narHash": "sha256-8+xWRxEkD6l217cIUdRxfeUGS9lQX0hVtUuNVsBaDzk=",
+        "lastModified": 1789009968,
+        "narHash": "sha256-GB16oaxpsrnGNnGIE+0uYBqMRzB9X6FYDUvjvnJAYew=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6aefcda9401be8acc2b74244fb3b37520ea1f0a8",
+        "rev": "d58a46e3bc02d91ebe04667f8397752a749c0024",
         "type": "github"
       },
       "original": {
@@ -1711,11 +1711,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1788881743,
-        "narHash": "sha256-2V9GZGvPfrNzxFozhI9dcqV+c3QdA8YZrvAAzqEB+dI=",
+        "lastModified": 1789006805,
+        "narHash": "sha256-xB8mKMOx1IA9vTDNLmJZ6n4wCMq/cuWBBOzGCRnqxrU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d6524aaca2ff07876657ae2b323f24be4874944b",
+        "rev": "8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe",
         "type": "github"
       },
       "original": {
@@ -1886,11 +1886,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789107110,
-        "narHash": "sha256-6t9Yx9GGvX4hE+YoTrSjaw9+JZCFo8sJqswa3Cnvm2U=",
+        "lastModified": 1789157924,
+        "narHash": "sha256-Fv++1V+mSmyJnyXbh+PLlO1m7qxZmcaGIQ1BCrFjZk0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c518b54d5c0d625079b0bcea2596d645f9370f1e",
+        "rev": "126a6f5ef07dad92e34d8b222e7834de14ebc5a4",
         "type": "github"
       },
       "original": {
@@ -2128,11 +2128,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789024335,
-        "narHash": "sha256-kCy/MVLRIr95DJ4vspVzWj+kO/x+JuwSHmYZCvShg8w=",
+        "lastModified": 1789110695,
+        "narHash": "sha256-llh6ZJN8/G4QCED9m6nHEfWhz2ONOzkKyvWHivNqW7A=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "577bb1e1fc5af0713169176c5c76622c21fa3ec0",
+        "rev": "ab777f900c3de943e117eb4814ddff6f645b28ad",
         "type": "github"
       },
       "original": {
@@ -2664,11 +2664,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789052017,
-        "narHash": "sha256-eMVl0S4U91QZqTHKpykeUhwiXV6U9X2UB6JxYtHLDG8=",
+        "lastModified": 1789133576,
+        "narHash": "sha256-wJJGLMs78PDdbdXd0f50vq7s+xpKOuAUMZPsyDgXyew=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "36f84edf5f170d460ab3a1723b9283f169b817c7",
+        "rev": "975870eb40a0cb6dc1baf6d63a704f9cfd5d4f27",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,14 @@
       inputs.zen-browser.follows = "zen-browser";
     };
 
+    # Oma, voice control for the Omarchy desktop. Follows this flake's nixpkgs
+    # for the same reason nixarchy does: the package wraps ~10 desktop tools
+    # onto PATH, and a second nixpkgs would be a second copy of every one.
+    nixarchy-voice = {
+      url = "github:olafkfreund/nixarchy-voice";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     zen-browser = {
       url = "github:0xc000022070/zen-browser-flake";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/home/shell/zsh-ai-cmd.nix
+++ b/home/shell/zsh-ai-cmd.nix
@@ -73,14 +73,6 @@ in
       # ZSH AI Command Suggestions Configuration
       # ========================================
 
-      # Load Anthropic API key from agenix secret
-      if [[ -f "/run/agenix/api-anthropic" ]]; then
-        export ANTHROPIC_API_KEY="$(cat /run/agenix/api-anthropic)"
-      else
-        echo "WARNING: Anthropic API key not found at /run/agenix/api-anthropic" >&2
-        echo "zsh-ai-cmd will not function without an API key" >&2
-      fi
-
       # Configure Claude model (if not using default)
       ${optionalString (cfg.model != "claude-haiku-4-5") ''
       export ZSH_AI_CMD_MODEL="${cfg.model}"

--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -7,7 +7,8 @@
 # This host offers exactly two sessions, Omarchy and GNOME. The greetd/
 # DankMaterialShell greeter, niri and the DMS sessions this comment used to
 # describe are all gone.
-{ inputs
+{ config
+, inputs
 , lib
 , pkgs
 , ...
@@ -86,7 +87,53 @@
     "${pkgs.qt6.qtmultimedia}/lib/qt-6/qml";
 
   home-manager.users.olafkfreund = {
-    imports = [ inputs.nixarchy.homeManagerModules.nixarchy ];
+    imports = [
+      inputs.nixarchy.homeManagerModules.nixarchy
+      inputs.nixarchy-voice.homeModules.default
+    ];
     programs.nixarchy.enable = true;
+
+    # Oma: speech to speech against the OpenAI Realtime API, driving Hyprland.
+    #
+    # The microphone starts off and only the toggle key opens it. While it is
+    # open, room audio streams continuously to OpenAI; toggling off stops the
+    # recorder rather than capturing and discarding.
+    #
+    # Set up on razer first and copied here unchanged. The one setting that is
+    # a guess for this machine is barge_in, below.
+    programs.omarchy-voice = {
+      enable = true;
+
+      # The key itself rather than a KEY=value file, which is what agenix
+      # decrypts to. Read at start-up, so rotating it is a restart of the user
+      # service and not a rebuild.
+      apiKeyFile = config.age.secrets."api-openai".path;
+
+      settings = {
+        # Spoken status lines, in the local piper voice. Not the voice she
+        # answers in: that is [realtime] voice, which arrives from OpenAI as
+        # audio and never passes through piper.
+        mouth.speak = true;
+
+        # Off, which is right for speakers and merely cautious for headphones.
+        # With it on and a speaker as the output, her own voice crosses the
+        # room into the microphone, the server reads it as a new user turn and
+        # cancels her reply mid-word: she never finishes a sentence. That was
+        # measured on razer. This machine's audio was not checked, so it stays
+        # off until `omarchy-voice doctor` says what the devices here are.
+        ears.barge_in = false;
+
+        # The shell tool would let the model run arbitrary commands, on an
+        # open microphone. What it needs for the desktop it gets through the
+        # omarchy CLI and Hyprland dispatchers instead.
+        hands.allow_shell = false;
+      };
+
+      # Not the upstream SUPER + SHIFT + V. On razer all three V slots were
+      # taken; this machine was not checked, so confirm with
+      # `hyprctl binds -j` before binding it in bindings.lua. The module only
+      # prints the snippet as a build warning -- it writes nothing.
+      keybinding = "SUPER + M";
+    };
   };
 }

--- a/hosts/razer/nixos/nixarchy.nix
+++ b/hosts/razer/nixos/nixarchy.nix
@@ -7,7 +7,8 @@
 #
 # The three settings below are what `nix run github:olafkfreund/nixarchy#doctor`
 # printed for this machine. Each is here for a reason it named:
-{ inputs
+{ config
+, inputs
 , lib
 , pkgs
 , ...
@@ -75,7 +76,49 @@
   # splash, so stylix keeps this machine on 'stylix' with no mkForce needed.
 
   home-manager.users.olafkfreund = {
-    imports = [ inputs.nixarchy.homeManagerModules.nixarchy ];
+    imports = [
+      inputs.nixarchy.homeManagerModules.nixarchy
+      inputs.nixarchy-voice.homeModules.default
+    ];
     programs.nixarchy.enable = true;
+
+    # Oma: speech to speech against the OpenAI Realtime API, driving Hyprland.
+    #
+    # The microphone starts off and only the toggle key opens it. While it is
+    # open, room audio streams continuously to OpenAI; toggling off stops the
+    # recorder rather than capturing and discarding, so nothing is picked up
+    # while it is off.
+    programs.omarchy-voice = {
+      enable = true;
+
+      # The key itself rather than a KEY=value file, which is what agenix
+      # decrypts to. Read at start-up, so rotating it is a restart of the user
+      # service and not a rebuild.
+      apiKeyFile = config.age.secrets."api-openai".path;
+
+      settings = {
+        # Spoken status lines, in the local piper voice. Not the voice she
+        # answers in: that is [realtime] voice, which arrives from OpenAI as
+        # audio and never passes through piper.
+        mouth.speak = true;
+
+        # Off, and it has to stay off while a speaker rather than headphones
+        # is the output. Her voice crosses the room back into the microphone,
+        # the server reads it as a new user turn and cancels her reply
+        # mid-word, and she never finishes a sentence. Headphones or
+        # PipeWire's echo-cancel module make it safe to turn on.
+        ears.barge_in = false;
+
+        # The shell tool would let the model run arbitrary commands, on an
+        # open microphone. What it needs for the desktop it gets through the
+        # omarchy CLI and Hyprland dispatchers instead.
+        hands.allow_shell = false;
+      };
+
+      # SUPER + SHIFT + V, the upstream default, is taken on this machine --
+      # as are SUPER + V and SUPER + CTRL + V. This is only printed as a build
+      # warning: bindings.lua is hand-written and not ours to generate.
+      keybinding = "SUPER + M";
+    };
   };
 }


### PR DESCRIPTION
Auto-PR from `scripts/update-commit-deploy.sh` (target=p620, scope=all).

Built and verified locally against nixosConfigurations.p620 before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)