### PR TITLE
feat(pkgs): package BrowserOS with a nightly autoupdate

### DIFF
--- a/.github/workflows/package-autoupdate.yml
+++ b/.github/workflows/package-autoupdate.yml
@@ -55,6 +55,14 @@ jobs:
             script: ./scripts/update-warp-terminal.sh
             paths: pkgs/warp-terminal
             verify: .#nixosConfigurations.p620.pkgs.warp-terminal
+          # BrowserOS publishes three tag series into one release list --
+          # the browser (v0.50.3), ext-agent/* and agent-server/*. The agent
+          # series ship most days, so `releases/latest` names the browser
+          # almost never; the script filters on the tag shape instead.
+          - pkg: browseros
+            script: ./scripts/update-browseros.sh
+            paths: pkgs/browseros
+            verify: .#nixosConfigurations.p620.pkgs.customPkgs.browseros
           # Every component must be verified through customPkgs. Bare
           # `pkgs.antigravity-cli` is the antigravity-nix FLAKE INPUT's
           # package, not ours — a different derivation at a different version

--- a/Users/olafkfreund/profile.nix
+++ b/Users/olafkfreund/profile.nix
@@ -168,6 +168,9 @@ in
     pkgs.customPkgs.antigravity-hub
     # GitHub Copilot desktop app — agent-native desktop experience (Tauri).
     pkgs.customPkgs.github-copilot-app
+    # BrowserOS — agentic Chromium fork (AppImage). Packaged in pkgs/browseros
+    # rather than via the browseros-ai flake input, which is 9 releases behind.
+    pkgs.customPkgs.browseros
     pkgs.customPkgs.kosli-cli
     pkgs.customPkgs.aurynk
     # glab-tui — terminal UI for GitLab on top of the `glab` CLI.

--- a/flake.lock
+++ b/flake.lock
@@ -1478,11 +1478,11 @@
         "systems": "systems_9"
       },
       "locked": {
-        "lastModified": 1789137217,
-        "narHash": "sha256-hvkSIsqcyy9zYjNZYZA1Yx75DaAmxgQYDUenYJRB0uI=",
+        "lastModified": 1789165838,
+        "narHash": "sha256-ng0ODGk33XEKhcmPkhLwNTtUHDRaAXjXH1pgX0Lsg/0=",
         "owner": "olafkfreund",
         "repo": "nixarchy-voice",
-        "rev": "e547f58dd8fbcfb2cbf4da0cb4fae80846e4cf7f",
+        "rev": "717a2cb960287b0f9709f7a1e2861b6ad6ce955d",
         "type": "github"
       },
       "original": {

--- a/pkgs/browseros/default.nix
+++ b/pkgs/browseros/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, appimageTools
+, fetchurl
+,
+}:
+# BrowserOS — agentic Chromium fork; the AI browser as a desktop app rather
+# than a tab. Upstream ships a Linux AppImage per release.
+# Bump: `gh api "repos/browseros-ai/BrowserOS/releases?per_page=100" -q
+# '.[] | select(.tag_name|test("^v[0-9]")) | .tag_name'` — the repo also tags
+# `ext-agent/*` and `agent-server/*` far more often, and those are not the
+# browser. Re-prefetch the x64 AppImage and update version+hash.
+let
+  pname = "browseros";
+  version = "0.50.3";
+
+  src = fetchurl {
+    url = "https://github.com/browseros-ai/BrowserOS/releases/download/v${version}/BrowserOS_v${version}_x64.AppImage";
+    hash = "sha256-Foln3alE/zGRYNF/p3hYL5CD5dvXapcouiClPej2DaQ=";
+  };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    install -m444 -D ${appimageContents}/${pname}.desktop \
+      -t $out/share/applications
+
+    # `Exec=AppRun %U` -> our wrapper, keeping %U. Without it the entry takes
+    # no argument and every x-scheme-handler/https hand-off opens a blank
+    # window instead of the link.
+    sed -i -E "s|^Exec=.*|Exec=${pname} %U|" \
+      "$out/share/applications/${pname}.desktop"
+
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  passthru.updateScript = ../../scripts/update-browseros.sh;
+
+  meta = {
+    description = "Agentic open-source browser, a privacy-first alternative to ChatGPT Atlas and Perplexity Comet";
+    homepage = "https://browseros.com/";
+    downloadPage = "https://github.com/browseros-ai/BrowserOS/releases";
+    license = lib.licenses.agpl3Only;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = pname;
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -83,6 +83,11 @@
   # github/app release tag (see header comment in the derivation).
   github-copilot-app = pkgs.callPackage ./github-copilot-app { };
 
+  # BrowserOS — agentic Chromium fork distributed as an AppImage. Packaged
+  # here rather than through the third-party browseros-ai flake, which pins
+  # 0.41.0 and drops %U from the desktop entry.
+  browseros = pkgs.callPackage ./browseros { };
+
   # okena — GPUI-based native terminal multiplexer (contember/okena).
   okena = pkgs.callPackage ./okena { };
 

--- a/scripts/update-browseros.sh
+++ b/scripts/update-browseros.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Bump pkgs/browseros/default.nix to the latest BrowserOS browser release.
+#
+# Modes:
+#   ./scripts/update-browseros.sh           # resolve latest, edit the derivation in place (idempotent)
+#   ./scripts/update-browseros.sh --check   # exit 0 if up-to-date, 1 if a bump is available; never edits
+#
+# Source of truth: the GitHub releases list for browseros-ai/BrowserOS.
+#
+# The one trap here, and the reason this cannot be a one-line `releases/latest`
+# call: that repo publishes THREE tag series into the same release list --
+# `v0.50.3` (the browser), `ext-agent/v0.0.156.0` and `agent-server/v0.0.164`.
+# The agent series ship most days and the browser every few weeks, so the
+# newest release is almost never the browser: on 2026-09-12 `releases[0]` was
+# ext-agent/v0.0.156.0 while the browser sat at v0.50.3, five days old. Hence
+# the `^v[0-9]` filter below. `releases/latest` is wrong for a second reason
+# as well -- it would answer with whichever series published last.
+#
+# Hashes: nix store prefetch-file --json | jq -r '.hash' (SRI-format).
+#
+# Wired into the derivation as passthru.updateScript, and run nightly by
+# .github/workflows/package-autoupdate.yml.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DRV="${ROOT_DIR}/pkgs/browseros/default.nix"
+
+CHECK_ONLY=0
+case "${1:-}" in
+  --check) CHECK_ONLY=1 ;;
+  "") ;;
+  *)
+    echo "usage: $0 [--check]" >&2
+    exit 2
+    ;;
+esac
+
+[ -f "${DRV}" ] || {
+  echo "error: ${DRV} not found" >&2
+  exit 1
+}
+
+for cmd in curl jq nix; do
+  command -v "$cmd" >/dev/null || {
+    echo "error: '$cmd' is required" >&2
+    exit 1
+  }
+done
+
+api() {
+  # GITHUB_TOKEN lifts the 60/hour anonymous rate limit in CI; optional locally.
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" "$@"
+  else
+    curl -fsSL "$@"
+  fi
+}
+
+# Newest browser release. Sorting is GitHub's (publish order, newest first),
+# so the first entry matching the browser tag shape is the one we want. Fetch
+# once and keep the release object: its asset list is also how the AppImage is
+# confirmed to exist, below.
+releases_json=$(mktemp)
+trap 'rm -f "${releases_json}"' EXIT
+api "https://api.github.com/repos/browseros-ai/BrowserOS/releases?per_page=100" >"${releases_json}"
+
+latest_release=$(
+  jq -c '[.[] | select(.prerelease == false) | select(.tag_name | test("^v[0-9]"))][0] // empty' \
+    "${releases_json}"
+)
+latest_version=$(printf '%s' "${latest_release}" | jq -r '.tag_name // empty' | sed 's/^v//')
+
+[ -n "${latest_version}" ] || {
+  echo "error: no browser release found (only ext-agent/agent-server tags?)" >&2
+  exit 1
+}
+
+current_version=$(sed -nE 's/^[[:space:]]*version = "([^"]+)";.*/\1/p' "${DRV}" | head -1)
+[ -n "${current_version}" ] || {
+  echo "error: could not read the current version from ${DRV}" >&2
+  exit 1
+}
+
+printf '  %-12s current=%s latest=%s\n' browseros "${current_version}" "${latest_version}"
+
+if [ "${current_version}" = "${latest_version}" ]; then
+  [ "${CHECK_ONLY}" -eq 1 ] && echo "up-to-date" || echo "up-to-date; no changes written"
+  exit 0
+fi
+
+if [ "${CHECK_ONLY}" -eq 1 ]; then
+  echo "outdated: BrowserOS ${latest_version} is available"
+  exit 1
+fi
+
+url="https://github.com/browseros-ai/BrowserOS/releases/download/v${latest_version}/BrowserOS_v${latest_version}_x64.AppImage"
+
+# Fail before editing if the asset is missing: a release can be tagged with the
+# macOS and Windows artefacts uploaded and the AppImage still building, and
+# rewriting the derivation then leaves a version that cannot be fetched.
+#
+# Asked of the API rather than with a HEAD on ${url}: that download URL
+# redirects to objects.githubusercontent.com, which rejects GitHub's own
+# Authorization header with 401. A token is always set in CI, so a HEAD check
+# through api() would have failed on every run and the nightly bump would
+# never have fired -- while the anonymous local run passed.
+asset_name="BrowserOS_v${latest_version}_x64.AppImage"
+printf '%s' "${latest_release}" \
+  | jq -e --arg n "${asset_name}" '[.assets[].name] | index($n)' >/dev/null || {
+  echo "error: release v${latest_version} has no ${asset_name} yet" >&2
+  exit 1
+}
+
+echo "    prefetching ${url} ..."
+hash=$(nix store prefetch-file --json --hash-type sha256 "${url}" | jq -r '.hash')
+[ -n "${hash}" ] && [ "${hash}" != "null" ] || {
+  echo "error: prefetch failed for ${url}" >&2
+  exit 1
+}
+
+tmp=$(mktemp)
+sed -E \
+  -e "s|^([[:space:]]*)version = \"[^\"]+\";|\1version = \"${latest_version}\";|" \
+  -e "s|^([[:space:]]*)hash = \"[^\"]+\";|\1hash = \"${hash}\";|" \
+  "${DRV}" >"${tmp}"
+
+# Both lines must have moved. A silent no-op edit is how a bump script starts
+# reporting success while pinning the old build forever.
+if ! grep -q "version = \"${latest_version}\";" "${tmp}" || ! grep -q "hash = \"${hash}\";" "${tmp}"; then
+  echo "error: rewrite did not take; ${DRV} left untouched" >&2
+  rm -f "${tmp}"
+  exit 1
+fi
+
+mv "${tmp}" "${DRV}"
+chmod 644 "${DRV}"
+echo "wrote ${DRV} (${current_version} -> ${latest_version})"


### PR DESCRIPTION
Adds `pkgs/browseros` (AppImage, `appimageTools.wrapType2`, same pattern as
`pkgs/github-copilot-app`), installs it via `Users/olafkfreund/profile.nix`
(p620 + razer, not p510), and wires `scripts/update-browseros.sh` into the
nightly `package-autoupdate` matrix.

**At 0.50.3**, the current release. The third-party `browseros-ai` flake this
started from pins **0.41.0** — nine browser releases and about six months
behind — and would have needed forking to bump anyway.

## Two defects not inherited from that flake

- `--replace 'Exec=AppRun' 'Exec="browseros"'` drops the `%U`, so the desktop
  entry takes no argument and every `x-scheme-handler/https` hand-off opens a
  blank window instead of the link.
- `pkgs = pkgs;` inside `wrapType2 rec { … }` is self-referential; it survives
  only because `wrapType2` never forces that attribute.

## Two traps the update script has to handle

Both found by testing, not by reading:

1. **Three tag series, one release list.** `v0.50.3` is the browser;
   `ext-agent/*` and `agent-server/*` are not, and the agent series ship most
   days. On 2026-09-12 `releases[0]` was `ext-agent/v0.0.156.0` while the
   browser sat five days old at `v0.50.3`. So `releases/latest` and "newest
   release" both answer wrongly; the script filters on `^v[0-9]`.
2. **The asset pre-flight asks the API, not `HEAD` on the download URL.** That
   URL redirects to `objects.githubusercontent.com`, which rejects GitHub's own
   `Authorization` header with **401** — and a token is always set in CI. The
   first draft used `HEAD`: it passed locally without a token and failed with
   one, which would have left the nightly job silently never bumping.

## Verification

- From a hand-stubbed `0.47.10` pin, the script reproduces the 0.50.3 version
  and hash **byte-for-byte identical** to the hand-written derivation, run with
  `GITHUB_TOKEN` set exactly as CI does
- `--check` exits 1 when behind, 0 when current, and writes nothing either way
- `shellcheck` and `actionlint` clean
- p620 and razer toplevels build
- the wrapper runs: `browseros --version` → `BrowserOS 151.0.8160.137`

Nothing is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T