### PR TITLE
fix(services): drop the /bin/bash activation symlink, which envfs owns now

### DIFF
--- a/modules/services/system/default.nix
+++ b/modules/services/system/default.nix
@@ -16,11 +16,4 @@
   services.hardware.bolt = {
     enable = true;
   };
-
-  system.activationScripts.binbash = {
-    deps = [ "binsh" ];
-    text = ''
-      ln -sf /bin/sh /bin/bash
-    '';
-  };
 }


### PR DESCRIPTION
Every deploy currently fails at activation and rolls back:

```
ln: failed to create symbolic link '/bin/bash': Read-only file system
Failed to run activate script
Activation (test) failed (exit status 2)
```

## Cause

`system.activationScripts.binbash` ran `ln -sf /bin/sh /bin/bash`. That worked
while /bin was an ordinary directory. It is not one any more — nixarchy's NixOS
module now sets `services.envfs.enable = lib.mkDefault true`, mounting /bin and
/usr/bin as a **read-only FUSE view of the caller's PATH**. The write cannot
succeed, and a failed activation script fails the whole switch.

## Why removal rather than a workaround

envfs solves the exact problem the symlink was solving — making `#!/bin/bash`
and `#!/usr/bin/env python` shebangs resolve where /bin holds only `sh`. Keeping
both means fighting the thing that replaced you.

Verified on the running system: `/bin/sh` is a symlink into `bash-interactive`
and `/bin/bash -c` runs (reports 5.3.15) even though `/bin/bash` cannot be
stat'd — envfs resolves on lookup, so there is nothing left to create.

## Scope

**Not a p620 problem.** `services.envfs.enable` evaluates `true` on p620, razer
*and* p510, so the next deploy of any of them fails identically. All three
toplevels build with the script removed.

## Diagnostic worth keeping

`findmnt /` reports `rw` while /bin refuses writes, because the read-only mount
is /bin itself (`SOURCE envfs, FSTYPE fuse, OPTIONS ro`). "Read-only file
system" here is **not** a disk that remounted itself, and the reflexive dmesg
hunt for ext4 errors finds nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T