### PR TITLE
p620: wake on "oma", rather than reaching for the key

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1478,11 +1478,11 @@
         "systems": "systems_9"
       },
       "locked": {
-        "lastModified": 1789165838,
-        "narHash": "sha256-ng0ODGk33XEKhcmPkhLwNTtUHDRaAXjXH1pgX0Lsg/0=",
+        "lastModified": 1789201079,
+        "narHash": "sha256-/sk99zqc/nmLZjKjzf9REfnIlb7Vrn2kRExZP6IGYQA=",
         "owner": "olafkfreund",
         "repo": "nixarchy-voice",
-        "rev": "717a2cb960287b0f9709f7a1e2861b6ad6ce955d",
+        "rev": "079202c418268151b54497f20003921b237e28f9",
         "type": "github"
       },
       "original": {

--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -123,6 +123,24 @@
         # off until `omarchy-voice doctor` says what the devices here are.
         ears.barge_in = false;
 
+        # Start a session by saying her name, rather than reaching for the key.
+        #
+        # This keeps a microphone open locally whenever listening is *not* on,
+        # which is the thing being chosen here. Nothing reaches OpenAI until
+        # the word is heard: the audio goes to whisper.cpp on this CPU, and
+        # only once somebody actually speaks -- a silent room is never
+        # transcribed at all, let alone uploaded.
+        #
+        # It is also what makes leaving listening switched on unnecessary,
+        # which was the expensive habit: streamed room audio bills at the same
+        # rate whether anyone is talking or not.
+        #
+        # Short names get misheard. Check `omarchy-voice log` for the
+        # `wake ignored '...'` lines and add whatever spelling keeps coming
+        # back as a second word -- "oma ohma" -- rather than arguing with the
+        # transcriber about how it hears a name.
+        ears.wake_word = "oma";
+
         # The shell tool would let the model run arbitrary commands, on an
         # open microphone. What it needs for the desktop it gets through the
         # omarchy CLI and Hyprland dispatchers instead.
@@ -131,8 +149,12 @@
 
       # Not the upstream SUPER + SHIFT + V. On razer all three V slots were
       # taken; this machine was not checked, so confirm with
-      # `hyprctl binds -j` before binding it in bindings.lua. The module only
-      # prints the snippet as a build warning -- it writes nothing.
+      # `hyprctl binds -j` before trusting it.
+      #
+      # The module writes this to ~/.config/hypr/voice-binds.lua now rather
+      # than printing it as a warning to paste. bindings.lua still has to load
+      # it, with `pcall(require, "hypr.voice-binds")` -- activation says so
+      # while that line is missing, and stops saying it once it is there.
       keybinding = "SUPER + M";
     };
   };


### PR DESCRIPTION
Bumps `nixarchy-voice` 717a2cb..079202c and turns on the wake word it brings.

## What this changes on p620

`ears.wake_word = "oma"`. The daemon listens locally while listening is **off**: audio goes to whisper.cpp on this CPU, and only once somebody actually speaks, so a silent room is never transcribed at all and nothing reaches OpenAI until the word is heard.

The point is cost rather than convenience. The expensive habit was leaving listening switched on, and streamed room audio bills at the same rate whether or not anyone is talking.

The trade being made deliberately: this holds a microphone open locally whenever listening is not on. Upstream defaults it off for exactly that reason.

## Two comments corrected

- The keybinding is no longer printed as a build warning to paste by hand. The module writes `~/.config/hypr/voice-binds.lua`, and activation says how to load it — once, while the line is missing. The old warning fired on every evaluation of every host, forever.
- `bindings.lua` still needs `pcall(require, "hypr.voice-binds")` added and its hand-pasted voice block removed, or `SUPER + M` ends up bound twice. Not done here; that file is user-owned.

## Verified on the machine

```
wake    listening locally for 'oma'
wake    ignored 'You know, almost 250 years ago, ...'
```

The recorder drops to 16 kHz while muted (the local one, not the realtime 24 kHz), and ambient speech is transcribed locally and correctly rejected.

## Worth knowing for the next settings change

This needed a manual `systemctl --user restart omarchy-voice` to take effect. Home Manager restarts a user service when its *unit* changes, and `settings` changes the file the unit points at instead — so the daemon kept running on the old config while `omarchy-voice doctor`, which reads config.toml fresh, reported the wake word as active. Fixed upstream in 079202c with `X-Restart-Triggers`, which this lock bump brings in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149GX9t4CDLkXmjWX2pVUQS