### PR TITLE
fix(bash): re-exec into bashInteractive when a dev shell hands us a readline-less bash

### DIFF
--- a/hosts/common/nixos/bash-devshell-readline.nix
+++ b/hosts/common/nixos/bash-devshell-readline.nix
@@ -1,0 +1,35 @@
+{ lib, pkgs, ... }:
+# Hand an interactive shell to a bash that can actually be one.
+#
+# nixpkgs ships two builds: bashInteractive, and the plain `bash`, built
+# without readline. `nix develop` and devenv put the plain one first on PATH,
+# so typing `bash` inside a project shell gets a shell with no `bind` and no
+# `complete` builtin, no progcomp/dirspell shopts, and no interpretation of
+# the \[ \] non-printing markers in PS1 — the prompt renders them literally.
+# Every rc that follows then errors its way down the screen: Omarchy's
+# `bind -f inputrc`, bash-completion, our own line-editor bindings.
+#
+# This has to live in /etc/bashrc rather than in ~/.bashrc: bash reads the
+# system file first, and Omarchy's rc is sourced from there, so a guard in the
+# user file arrives several errors too late. mkBefore puts it ahead of that
+# source line — verified against the generated /etc/bashrc, not assumed.
+#
+# Re-exec rather than stub the missing builtins: stubbing silences the errors
+# and still leaves a shell with no history search, no completion and a broken
+# prompt. `exec` keeps the project environment — same PATH, same variables,
+# same directory — and swaps only the interpreter.
+#
+# The loop guard is the marker variable, not the readline test: if the target
+# ever lacked readline too, the test alone would exec forever.
+{
+  programs.bash.interactiveShellInit = lib.mkBefore ''
+    if [ -z "''${__NIXOS_BASH_READLINE_REEXEC:-}" ] && ! type -t bind >/dev/null 2>&1; then
+      export __NIXOS_BASH_READLINE_REEXEC=1
+      if shopt -q login_shell; then
+        exec ${pkgs.bashInteractive}/bin/bash -l
+      else
+        exec ${pkgs.bashInteractive}/bin/bash
+      fi
+    fi
+  '';
+}

--- a/hosts/p510/nixos/nixarchy.nix
+++ b/hosts/p510/nixos/nixarchy.nix
@@ -25,6 +25,7 @@
     inputs.nixarchy.nixosModules.nixarchy
     ../../../nixarchy-apps.nix
     ../../common/nixos/omarchy-input.nix
+    ../../common/nixos/bash-devshell-readline.nix
     ../../common/nixos/omarchy-sddm.nix
     ../../common/nixos/omarchy-workspaces.nix
     ../../common/nixos/omarchy-gog.nix

--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -24,6 +24,7 @@
     inputs.nixarchy.nixosModules.nixarchy
     ../../../nixarchy-apps.nix
     ../../common/nixos/omarchy-input.nix
+    ../../common/nixos/bash-devshell-readline.nix
     ../../common/nixos/omarchy-sddm.nix
     ../../common/nixos/omarchy-workspaces.nix
     ../../common/nixos/omarchy-gog.nix

--- a/hosts/razer/nixos/nixarchy.nix
+++ b/hosts/razer/nixos/nixarchy.nix
@@ -24,6 +24,7 @@
     inputs.nixarchy.nixosModules.nixarchy
     ../../../nixarchy-apps.nix
     ../../common/nixos/omarchy-input.nix
+    ../../common/nixos/bash-devshell-readline.nix
     ../../common/nixos/omarchy-sddm.nix
     ../../common/nixos/omarchy-workspaces.nix
     ../../common/nixos/omarchy-gog.nix


### PR DESCRIPTION
Typing `bash` inside a `nix develop` / devenv shell produced:

```
bash: command not found: complete
bash: command not found: bind
bash: shopt: dirspell: invalid shell option name
bash: shopt: progcomp: invalid shell option name
```

plus a prompt rendering `\[` and `\]` as literal text.

## Cause

nixpkgs ships two builds: `bashInteractive`, and the plain `bash`, built
**without readline**. A dev shell puts the plain one first on PATH, so `bash`
there has no `bind`/`complete` builtins, no `progcomp`/`dirspell` shopts, and no
interpretation of the `\[ \]` non-printing markers in PS1. Every rc that follows
errors its way down the screen — Omarchy's `bind -f inputrc` first, ours after.

## The guard belongs in /etc/bashrc, not ~/.bashrc

My first attempt put it in `home/shell/bash.nix` and **did nothing**: bash reads
the system file first and Omarchy's rc is sourced from there, so the user file
arrives several errors too late. Instrumenting the rc is what showed it — the
errors printed *before* a probe on line 4 of `~/.bashrc`.

`mkBefore` puts this ahead of that source line, verified by reading the
generated `/etc/bashrc` (guard at line 16, omarchy's `source` at line 25) rather
than by trusting the ordering.

## Re-exec, not stubs

Stubbing `bind`/`complete` silences the errors and still leaves a shell with no
history search, no completion and a broken prompt. `exec` keeps the project
environment — same PATH, variables, directory — and swaps only the interpreter.

The loop guard is the **marker variable**, not the readline test: if the exec
target ever lacked readline too, the test alone would exec forever.

## Verification

An `exec` in a shell rc that misfires takes every shell on the machine with it,
so this was tested against the built `/etc/bashrc` **before** deploying:

| case | result |
|---|---|
| readline-less bash | execs ✅ |
| same bash, marker already set | does **not** exec — no loop ✅ |
| `bashInteractive` | untouched ✅ |

Then for real on p620: `nix develop -c bash -i` now reports
`BASH=bash-interactive-5.3p15` with the marker set and **not one error line**.
Non-interactive `bash -c` is unaffected — it never reads the interactive section.

All three hosts build and all three import it; they all have nixarchy and dev
shells alike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xrwWuysgnXK36pzfWL98T