### PR TITLE
p620: ElevenLabs voice, and an offline brain fallback

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1478,11 +1478,11 @@
         "systems": "systems_9"
       },
       "locked": {
-        "lastModified": 1789201079,
-        "narHash": "sha256-/sk99zqc/nmLZjKjzf9REfnIlb7Vrn2kRExZP6IGYQA=",
+        "lastModified": 1789222409,
+        "narHash": "sha256-2Txs+MyVfKuPfIhwcFt7HyXlmHhiWZgObVJ1c2ePfgc=",
         "owner": "olafkfreund",
         "repo": "nixarchy-voice",
-        "rev": "079202c418268151b54497f20003921b237e28f9",
+        "rev": "79465305c2738dd6ba9de94d27ba016146e0cd07",
         "type": "github"
       },
       "original": {

--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -144,7 +144,15 @@
         # `wake ignored '...'` lines and add whatever spelling keeps coming
         # back as a second word -- "oma ohma" -- rather than arguing with the
         # transcriber about how it hears a name.
-        ears.wake_word = "oma";
+        # Wake word OFF. Not because it did not work -- it did -- but because
+        # of what it costs while nobody is talking: the listener transcribes
+        # every sound near the microphone to find out whether it was her name,
+        # and on this desk that was whisper sitting at 150-370% CPU whenever
+        # anything was playing. SUPER + M costs nothing at all until pressed.
+        #
+        # Set it back to "oma" if hands-free is worth a core; the machinery is
+        # all still here and tested.
+        ears.wake_word = "";
 
         # Speak through ElevenLabs, with Piper underneath.
         #

--- a/hosts/p620/nixos/nixarchy.nix
+++ b/hosts/p620/nixos/nixarchy.nix
@@ -110,6 +110,10 @@
       # service and not a rebuild.
       apiKeyFile = config.age.secrets."api-openai".path;
 
+      # The cloud voice. Optional in the strongest sense: unreadable is a
+      # warning, not a failure, and the local Piper voice carries on.
+      elevenLabsKeyFile = config.age.secrets."api-elevenlabs".path;
+
       settings = {
         # Spoken status lines, in the local piper voice. Not the voice she
         # answers in: that is [realtime] voice, which arrives from OpenAI as
@@ -141,6 +145,30 @@
         # back as a second word -- "oma ohma" -- rather than arguing with the
         # transcriber about how it hears a name.
         ears.wake_word = "oma";
+
+        # Speak through ElevenLabs, with Piper underneath.
+        #
+        # Tarquin, "Posh & English RP" -- a voice-library voice, which needs a
+        # paid plan: on free it is refused with "Free users cannot use library
+        # voices via the API" and every reply silently falls back to Piper. If
+        # the plan ever lapses that is exactly what happens, and the log says
+        # so rather than going quiet.
+        #
+        # The premade British voices work on any tier if you want one:
+        # Alice (clear, neutral)  Xb7hH8MSUJpSbSDYk0k2
+        # Lily  (warmer)          pFZP5JQG7iQjIQuC4Bku
+        elevenlabs.enabled = true;
+        elevenlabs.voice_id = "7cOBG34AiHrAzs842Rdi";
+
+        # The offline rung of the brain ladder. Claude Code answers whenever
+        # api.anthropic.com is reachable; when it is not, this is what answers
+        # instead, and a local endpoint is not asked for an API key.
+        #
+        # qwen3:14b rather than a coder model on purpose -- the planner asks
+        # for function calls, and qwen2.5-coder:14b returned the JSON as prose
+        # instead of calling anything. Measured, not assumed.
+        openai.base_url = "http://localhost:11434/v1";
+        openai.planner_model = "qwen3:14b";
 
         # The shell tool would let the model run arbitrary commands, on an
         # open microphone. What it needs for the desktop it gets through the

--- a/modules/secrets/api-keys.nix
+++ b/modules/secrets/api-keys.nix
@@ -54,6 +54,21 @@ in
         group = "users";
       };
 
+      # ElevenLabs, for omarchy-voice's cloud voice.
+      #
+      # 0400 and owned by the user, not 0644 root:users like the keys above.
+      # Those are read by shells and system services; this one is read by a
+      # systemd *user* service, so nothing needs it world-readable, and a
+      # metered TTS key that any local process can read is a bill waiting to
+      # happen. Losing access costs voice quality, not voice: omarchy-voice
+      # falls back to the local Piper voice and logs why.
+      api-elevenlabs = {
+        file = ../../secrets/api-elevenlabs.age;
+        mode = "0400";
+        owner = "olafkfreund";
+        group = "users";
+      };
+
       api-groq = {
         file = ../../secrets/api-groq.age;
         mode = "0644";

--- a/secrets.nix
+++ b/secrets.nix
@@ -22,6 +22,9 @@ in
   "secrets/api-openai.age".publicKeys = allUsers ++ allHosts;
   "secrets/api-gemini.age".publicKeys = allUsers ++ allHosts;
   "secrets/api-anthropic.age".publicKeys = allUsers ++ allHosts;
+  # ElevenLabs, for omarchy-voice's cloud TTS. The local Piper voice is the
+  # fallback, so losing this key costs voice quality rather than voice.
+  "secrets/api-elevenlabs.age".publicKeys = allUsers ++ allHosts;
   "secrets/api-groq.age".publicKeys = allUsers ++ allHosts;
   # Ollama cloud-models API key (Ollama Turbo / hosted models). Exposed to the
   # ollama systemd daemon on hosts that opt in via

--- a/secrets/api-elevenlabs.age
+++ b/secrets/api-elevenlabs.age
@@ -1,0 +1,11 @@
+age-encryption.org/v1
+-> ssh-ed25519 wgedHw kxlrmh1W5nR/NF2ZcpAnvLxrDTCkOYjOQaBaZNvS3Bw
+Ap82EH/qY86cAuMQQEblGIgk5JpfNi+e4psuvVGtNKE
+-> ssh-ed25519 NzeCSQ tbQ3gvZfhTZLktm9QSRPpQd41vE6vVmQJtkJXIRVWFY
+X7bu6zIXHTbc4qvMVPu83twqXwyJLLBIKP3Y7NkeyRI
+-> ssh-ed25519 UT51fQ FotSBPD+Dbekcz2qVplDjCGjz0Adv0J7bEsnQx5wW1o
+0hWbAXGxotTCWPUigHTACU/XXHpA4o4QNTUY2TjHLpw
+-> ssh-ed25519 tbxj3w FqlMdsfwYkA42Ry5/kRkXTIVVIRdGYO1T6t97bkrBXM
+WO9xSdPtr1Sac+Kn5sFm2iAG8H5Nv3VPTwTnk2OO1rs
+--- imHVo91iX3Q9Ft31NuDUoZb0xjm02CQpgS0P7GEIycs
+ΕSm.ΡΖ.ΓΉ%¬μόsGn7—Κo@­"‚#π‘Χψ2›V'ΘXφ…υ•h·f;y1_P<πέh[DαXgm1·¶²'ϊO­Ε0


### PR DESCRIPTION
Bumps `nixarchy-voice` 079202c..7946530 and configures what it brings.

## The voice

ElevenLabs as **Tarquin — "Posh & English RP"**, with the local Piper voice underneath. Every way the cloud can fail — no key, no network, quota gone, plan lapsed, `ffmpeg` missing — falls back to Piper and logs which voice you are hearing and why. **Degrade, never mute.**

Tarquin is a voice-library voice and needs a paid plan. On the free tier it is refused with `Free users cannot use library voices via the API` and every reply quietly becomes Piper. The premade British voices (Alice, Lily) are noted in the file for anyone on a free account.

## The key

New agenix secret `api-elevenlabs`, at **0400 owned by the user** rather than the `0644 root:users` the other API keys use. Those are read by shells and system services; this one is read by a systemd *user* service, so nothing needs it world-readable — and a metered TTS key any local process can read is a bill waiting to happen.

Unreadable is a **warning**, not a failure, unlike `apiKeyFile`. That key is the whole realtime engine; this one buys an accent.

## The brain

The typed path (`say` / `ask`) now runs on the **Claude subscription** when `api.anthropic.com` is reachable, and on this machine's own **Ollama** when it is not. A local endpoint is not asked for an API key, so the offline path does not depend on the account it exists to work around.

`qwen3:14b` rather than a coder model, and not by taste: the planner asks for function calls, and `qwen2.5-coder:14b` returned the JSON as prose instead of calling anything.

The realtime session is untouched and still OpenAI — speech-to-speech over a websocket protocol nothing else implements.

## Verified

- 476 tests upstream, both ladders mutation-tested
- Tarquin synthesised and played on this machine at HTTP 200 after the plan upgrade
- Offline rung proved against a dead port and the live Ollama
- Secret round-trips: `agenix -d` returns exactly the original key

## Note for reviewers

This branch is off `main`, which does **not** carry #1772 (the Hyprland pin for p620's third display). Anyone switching p620 from this branch alone would lose that fix. The two are independent and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149GX9t4CDLkXmjWX2pVUQS